### PR TITLE
Bus tracking improvements: ETA fix, drag reorder, stopName dropdown, route visibility

### DIFF
--- a/src/app/api/bus-tracking/routes/reorder/route.ts
+++ b/src/app/api/bus-tracking/routes/reorder/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { withAuth } from '@/lib/api/withAuth';
+import { db } from '@/lib/db/client';
+import { busRoutes } from '@/lib/db/schema';
+import { invalidateCache } from '@/lib/cache/redis';
+
+export async function POST(request: NextRequest) {
+  return withAuth(async () => {
+    try {
+      const body = await request.json() as { id: string; sortOrder: number }[];
+
+      if (!Array.isArray(body) || body.some(item => !item.id || typeof item.sortOrder !== 'number')) {
+        return NextResponse.json({ error: 'Invalid reorder payload' }, { status: 400 });
+      }
+
+      await db.transaction(async (tx) => {
+        for (const { id, sortOrder } of body) {
+          await tx.update(busRoutes)
+            .set({ sortOrder, updatedAt: new Date() })
+            .where(eq(busRoutes.id, id));
+        }
+      });
+
+      await invalidateCache('bus:*');
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      console.error('Failed to reorder bus routes:', error);
+      return NextResponse.json({ error: 'Failed to reorder routes' }, { status: 500 });
+    }
+  }, { permission: 'canModifySettings' });
+}

--- a/src/app/api/bus-tracking/routes/route.ts
+++ b/src/app/api/bus-tracking/routes/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from 'next/server';
+import { asc } from 'drizzle-orm';
 import { requireAuth } from '@/lib/auth';
 import { withAuth } from '@/lib/api/withAuth';
 import { db } from '@/lib/db/client';
@@ -11,7 +12,8 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
 
   try {
-    const routes = await db.select().from(busRoutes).orderBy(busRoutes.label);
+    const routes = await db.select().from(busRoutes)
+      .orderBy(asc(busRoutes.sortOrder), asc(busRoutes.label));
     return NextResponse.json(routes);
   } catch (error) {
     console.error('Failed to fetch bus routes:', error);
@@ -43,6 +45,7 @@ export async function POST(request: NextRequest) {
         stopName: validation.data.stopName,
         schoolName: validation.data.schoolName,
         enabled: validation.data.enabled,
+        sortOrder: validation.data.sortOrder,
       }).returning();
 
       await invalidateCache('bus:*');

--- a/src/app/settings/sections/BusTrackingSection.tsx
+++ b/src/app/settings/sections/BusTrackingSection.tsx
@@ -1,6 +1,23 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import {
   Bus,
   Plus,
@@ -50,6 +67,7 @@ interface BusRoute {
   stopName: string | null;
   schoolName: string | null;
   enabled: boolean;
+  sortOrder: number;
 }
 
 interface ConnectionStatus {
@@ -69,6 +87,11 @@ export function BusTrackingSection() {
   const [disconnecting, setDisconnecting] = useState(false);
   const [discovering, setDiscovering] = useState(false);
   const [gmailLabel, setGmailLabel] = useState('');
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -113,7 +136,6 @@ export function BusTrackingSection() {
   const handleDiscover = async () => {
     setDiscovering(true);
     try {
-      // Step 1: Scan emails for routes
       const discoverRes = await fetch('/api/bus-tracking/discover', { method: 'POST' });
       const discoverData = await discoverRes.json();
 
@@ -127,7 +149,6 @@ export function BusTrackingSection() {
         return;
       }
 
-      // Step 2: Auto-create the discovered routes
       const createRes = await fetch('/api/bus-tracking/discover', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -210,6 +231,30 @@ export function BusTrackingSection() {
     }
   };
 
+  const handleRouteDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = routes.findIndex(r => r.id === active.id);
+    const newIndex = routes.findIndex(r => r.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = arrayMove(routes, oldIndex, newIndex).map((r, i) => ({ ...r, sortOrder: i }));
+    setRoutes(reordered); // optimistic
+
+    try {
+      const res = await fetch('/api/bus-tracking/routes/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reordered.map(r => ({ id: r.id, sortOrder: r.sortOrder }))),
+      });
+      if (!res.ok) throw new Error('Reorder failed');
+    } catch {
+      toast({ title: 'Failed to save route order', variant: 'destructive' });
+      fetchData(); // revert
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -219,7 +264,6 @@ export function BusTrackingSection() {
         </p>
       </div>
 
-      {/* Gmail Connection Card */}
       <GmailConnectionCard
         connection={connection}
         syncing={syncing}
@@ -230,7 +274,6 @@ export function BusTrackingSection() {
         onSaveLabel={handleSaveLabel}
       />
 
-      {/* Bus Routes Card */}
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -261,22 +304,30 @@ export function BusTrackingSection() {
               No bus routes configured yet. Add a route to start tracking.
             </p>
           ) : (
-            <div className="space-y-2">
-              {routes.map(route => (
-                <RouteRow
-                  key={route.id}
-                  route={route}
-                  onEdit={() => { setEditingRoute(route); setShowRouteDialog(true); }}
-                  onDelete={() => handleDeleteRoute(route.id)}
-                  onToggle={() => handleToggleRoute(route)}
-                />
-              ))}
-            </div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              modifiers={[restrictToVerticalAxis]}
+              onDragEnd={handleRouteDragEnd}
+            >
+              <SortableContext items={routes.map(r => r.id)} strategy={verticalListSortingStrategy}>
+                <div className="space-y-2">
+                  {routes.map(route => (
+                    <SortableRouteRow
+                      key={route.id}
+                      route={route}
+                      onEdit={() => { setEditingRoute(route); setShowRouteDialog(true); }}
+                      onDelete={() => handleDeleteRoute(route.id)}
+                      onToggle={() => handleToggleRoute(route)}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           )}
         </CardContent>
       </Card>
 
-      {/* Route Add/Edit Dialog */}
       {showRouteDialog && (
         <RouteDialog
           route={editingRoute}
@@ -317,7 +368,6 @@ function GmailConnectionCard({
   const [labelInput, setLabelInput] = useState(gmailLabel);
   const labelDirty = labelInput.trim() !== gmailLabel;
 
-  // Sync external changes
   useEffect(() => { setLabelInput(gmailLabel); }, [gmailLabel]);
 
   return (
@@ -390,7 +440,7 @@ function GmailConnectionCard({
 }
 
 
-function RouteRow({
+function SortableRouteRow({
   route,
   onEdit,
   onDelete,
@@ -401,11 +451,25 @@ function RouteRow({
   onDelete: () => void;
   onToggle: () => void;
 }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: route.id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
   const geofenceCount = route.checkpoints?.length || 0;
 
   return (
-    <div className="flex items-center justify-between p-3 rounded-lg border">
+    <div ref={setNodeRef} style={style} className="flex items-center justify-between p-3 rounded-lg border">
       <div className="flex items-center gap-3 min-w-0">
+        <button
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing touch-none p-0.5 text-muted-foreground hover:text-foreground flex-shrink-0"
+          style={{ touchAction: 'none' }}
+        >
+          <GripVertical className="h-5 w-5" />
+        </button>
         <Bus className="h-5 w-5 text-muted-foreground flex-shrink-0" />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -415,7 +479,7 @@ function RouteRow({
           <div className="text-xs text-muted-foreground">
             Trip {route.tripId} &middot; {route.scheduledTime}
             {geofenceCount > 0 && <> &middot; {geofenceCount} geofence{geofenceCount !== 1 ? 's' : ''}</>}
-            {route.stopName && <> &middot; Stop</>}
+            {route.stopName && <> &middot; Stop: {route.stopName}</>}
             {route.schoolName && <> &middot; School</>}
           </div>
         </div>
@@ -429,6 +493,58 @@ function RouteRow({
           <Trash2 className="h-4 w-4" />
         </Button>
       </div>
+    </div>
+  );
+}
+
+
+function SortableCheckpointItem({
+  cp,
+  index,
+  onNameChange,
+  onRemove,
+  isStop,
+}: {
+  cp: { name: string; sortOrder: number };
+  index: number;
+  onNameChange: (index: number, name: string) => void;
+  onRemove: (index: number) => void;
+  isStop: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: cp.name || `cp-${index}` });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2 p-1.5 rounded border text-sm">
+      <button
+        {...attributes}
+        {...listeners}
+        className="cursor-grab active:cursor-grabbing touch-none flex-shrink-0 text-muted-foreground hover:text-foreground"
+        style={{ touchAction: 'none' }}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="text-xs text-muted-foreground w-5 flex-shrink-0">{index + 1}.</span>
+      <Input
+        value={cp.name}
+        onChange={e => onNameChange(index, e.target.value)}
+        className="flex-1 h-7 text-sm"
+      />
+      {isStop && (
+        <Badge variant="outline" className="text-[10px] flex-shrink-0">stop</Badge>
+      )}
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-6 w-6 text-destructive flex-shrink-0"
+        onClick={() => onRemove(index)}
+      >
+        <X className="h-3 w-3" />
+      </Button>
     </div>
   );
 }
@@ -460,6 +576,13 @@ function RouteDialog({
   });
   const [newCheckpointName, setNewCheckpointName] = useState('');
 
+  const checkpointSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
+
+  const checkpointIds = form.checkpoints.map((cp, i) => cp.name || `cp-${i}`);
+
   const addCheckpoint = () => {
     if (!newCheckpointName.trim()) return;
     setForm(prev => ({
@@ -473,22 +596,47 @@ function RouteDialog({
   };
 
   const removeCheckpoint = (index: number) => {
-    setForm(prev => ({
-      ...prev,
-      checkpoints: prev.checkpoints
+    setForm(prev => {
+      const updated = prev.checkpoints
         .filter((_, i) => i !== index)
-        .map((cp, i) => ({ ...cp, sortOrder: i })),
-    }));
+        .map((cp, i) => ({ ...cp, sortOrder: i }));
+      // If stopName referenced the removed checkpoint, clear it
+      const removedName = prev.checkpoints[index]?.name;
+      return {
+        ...prev,
+        checkpoints: updated,
+        stopName: prev.stopName === removedName ? '' : prev.stopName,
+      };
+    });
   };
 
-  const moveCheckpoint = (index: number, direction: -1 | 1) => {
-    const newIndex = index + direction;
-    if (newIndex < 0 || newIndex >= form.checkpoints.length) return;
+  const handleCheckpointNameChange = (index: number, name: string) => {
     setForm(prev => {
-      const cps = [...prev.checkpoints];
-      [cps[index], cps[newIndex]] = [cps[newIndex]!, cps[index]!];
-      return { ...prev, checkpoints: cps.map((cp, i) => ({ ...cp, sortOrder: i })) };
+      const oldName = prev.checkpoints[index]?.name;
+      const updated = prev.checkpoints.map((cp, i) =>
+        i === index ? { ...cp, name } : cp
+      );
+      return {
+        ...prev,
+        checkpoints: updated,
+        // Keep stopName in sync if it referenced the renamed checkpoint
+        stopName: prev.stopName === oldName ? name : prev.stopName,
+      };
     });
+  };
+
+  const handleCheckpointDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = checkpointIds.indexOf(String(active.id));
+    const newIndex = checkpointIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    setForm(prev => ({
+      ...prev,
+      checkpoints: arrayMove(prev.checkpoints, oldIndex, newIndex).map((cp, i) => ({ ...cp, sortOrder: i })),
+    }));
   };
 
   const handleSave = async () => {
@@ -526,6 +674,8 @@ function RouteDialog({
       setSaving(false);
     }
   };
+
+  const checkpointNames = form.checkpoints.map(cp => cp.name).filter(Boolean);
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
@@ -597,12 +747,32 @@ function RouteDialog({
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <Label>Stop Name</Label>
-              <Input
-                value={form.stopName}
-                onChange={e => setForm(p => ({ ...p, stopName: e.target.value }))}
-                placeholder="Bus stop name"
-              />
+              <Label>Your Stop</Label>
+              {checkpointNames.length > 0 ? (
+                <Select
+                  value={form.stopName}
+                  onValueChange={v => setForm(p => ({ ...p, stopName: v }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select checkpoint" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {checkpointNames.map(name => (
+                      <SelectItem key={name} value={name}>{name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={form.stopName}
+                  onChange={e => setForm(p => ({ ...p, stopName: e.target.value }))}
+                  placeholder="Add checkpoints first"
+                  disabled={checkpointNames.length === 0}
+                />
+              )}
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                ETA target — select the checkpoint where your child gets off.
+              </p>
             </div>
             <div>
               <Label>School Name</Label>
@@ -618,59 +788,31 @@ function RouteDialog({
           <div>
             <Label>Geofence Checkpoints (in order)</Label>
             <p className="text-xs text-muted-foreground mb-2">
-              Add the ordered geofence labels from FirstView. These are the distance-based notification zones.
+              Add the ordered geofence labels from FirstView. Drag to reorder.
             </p>
 
             {form.checkpoints.length > 0 && (
-              <div className="space-y-1 mb-2">
-                {form.checkpoints.map((cp, i) => (
-                  <div key={i} className="flex items-center gap-2 p-1.5 rounded border text-sm">
-                    <GripVertical className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                    <span className="text-xs text-muted-foreground w-5">{i + 1}.</span>
-                    <Input
-                      value={cp.name}
-                      onChange={e => {
-                        const newName = e.target.value;
-                        setForm(prev => ({
-                          ...prev,
-                          checkpoints: prev.checkpoints.map((c, j) =>
-                            j === i ? { ...c, name: newName } : c
-                          ),
-                        }));
-                      }}
-                      className="flex-1 h-7 text-sm"
-                    />
-                    <div className="flex gap-0.5 flex-shrink-0">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-6 w-6"
-                        disabled={i === 0}
-                        onClick={() => moveCheckpoint(i, -1)}
-                      >
-                        <span className="text-xs">&uarr;</span>
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-6 w-6"
-                        disabled={i === form.checkpoints.length - 1}
-                        onClick={() => moveCheckpoint(i, 1)}
-                      >
-                        <span className="text-xs">&darr;</span>
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-6 w-6 text-destructive"
-                        onClick={() => removeCheckpoint(i)}
-                      >
-                        <X className="h-3 w-3" />
-                      </Button>
-                    </div>
+              <DndContext
+                sensors={checkpointSensors}
+                collisionDetection={closestCenter}
+                modifiers={[restrictToVerticalAxis]}
+                onDragEnd={handleCheckpointDragEnd}
+              >
+                <SortableContext items={checkpointIds} strategy={verticalListSortingStrategy}>
+                  <div className="space-y-1 mb-2">
+                    {form.checkpoints.map((cp, i) => (
+                      <SortableCheckpointItem
+                        key={cp.name || `cp-${i}`}
+                        cp={cp}
+                        index={i}
+                        onNameChange={handleCheckpointNameChange}
+                        onRemove={removeCheckpoint}
+                        isStop={cp.name === form.stopName}
+                      />
+                    ))}
                   </div>
-                ))}
-              </div>
+                </SortableContext>
+              </DndContext>
             )}
 
             <div className="flex gap-2">

--- a/src/components/widgets/BusTrackingWidget.tsx
+++ b/src/components/widgets/BusTrackingWidget.tsx
@@ -57,8 +57,12 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
   const statusColor = getStatusColor(p);
   const statusText = getStatusText(p);
   const checkpoints = route.checkpoints || [];
+  // stopName may reference a checkpoint by name (new behavior) or be an implicit terminal (legacy)
+  const stopIsInCheckpoints = route.stopName
+    ? checkpoints.some(cp => cp.name === route.stopName)
+    : false;
   // PM routes: school is origin, not destination — don't count it as a progress dot
-  const totalDots = checkpoints.length + (route.stopName ? 1 : 0)
+  const totalDots = checkpoints.length + (route.stopName && !stopIsInCheckpoints ? 1 : 0)
     + (route.direction === 'AM' && route.schoolName ? 1 : 0);
 
   return (
@@ -88,12 +92,13 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
                   index={i}
                   name={cp.name}
                   prediction={p}
-                  isStop={false}
+                  isStop={cp.name === route.stopName}
                   isSchool={false}
                   compact={compact}
                 />
               ))}
-              {route.stopName && (
+              {/* Legacy: stopName not in checkpoints list — show as implicit terminal dot */}
+              {route.stopName && !stopIsInCheckpoints && (
                 <CheckpointDot
                   index={checkpoints.length}
                   name={route.stopName}
@@ -105,7 +110,7 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
               )}
               {route.schoolName && (
                 <CheckpointDot
-                  index={checkpoints.length + (route.stopName ? 1 : 0)}
+                  index={checkpoints.length + (route.stopName && !stopIsInCheckpoints ? 1 : 0)}
                   name={route.schoolName}
                   prediction={p}
                   isStop={false}
@@ -123,12 +128,13 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
                   index={i}
                   name={cp.name}
                   prediction={p}
-                  isStop={false}
+                  isStop={cp.name === route.stopName}
                   isSchool={false}
                   compact={compact}
                 />
               ))}
-              {route.stopName && (
+              {/* Legacy: stopName not in checkpoints list */}
+              {route.stopName && !stopIsInCheckpoints && (
                 <CheckpointDot
                   index={checkpoints.length}
                   name={route.stopName}

--- a/src/components/widgets/BusTrackingWidget.tsx
+++ b/src/components/widgets/BusTrackingWidget.tsx
@@ -57,7 +57,9 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
   const statusColor = getStatusColor(p);
   const statusText = getStatusText(p);
   const checkpoints = route.checkpoints || [];
-  const totalDots = checkpoints.length + (route.stopName ? 1 : 0) + (route.schoolName ? 1 : 0);
+  // PM routes: school is origin, not destination — don't count it as a progress dot
+  const totalDots = checkpoints.length + (route.stopName ? 1 : 0)
+    + (route.direction === 'AM' && route.schoolName ? 1 : 0);
 
   return (
     <div className="space-y-1.5">
@@ -71,40 +73,72 @@ function RouteStatusCard({ route, compact }: { route: BusRouteStatus; compact: b
 
       {/* Status text with color indicator */}
       <div className="flex items-center gap-2">
-        <div className={cn('h-2 w-2 rounded-full flex-shrink-0', statusColor)} />
+        <div data-keep-bg className={cn('h-2 w-2 rounded-full flex-shrink-0', statusColor)} />
         <span className="text-xs text-muted-foreground">{statusText}</span>
       </div>
 
       {/* Progress dots */}
-      {!compact && totalDots > 0 && (
-        <div className="flex items-center gap-1.5 py-1">
-          {checkpoints.map((cp, i) => (
-            <CheckpointDot
-              key={cp.name}
-              index={i}
-              name={cp.name}
-              prediction={p}
-              isStop={false}
-              isSchool={false}
-            />
-          ))}
-          {route.stopName && (
-            <CheckpointDot
-              index={checkpoints.length}
-              name={route.stopName}
-              prediction={p}
-              isStop={true}
-              isSchool={false}
-            />
-          )}
-          {route.schoolName && (
-            <CheckpointDot
-              index={checkpoints.length + (route.stopName ? 1 : 0)}
-              name={route.schoolName}
-              prediction={p}
-              isStop={false}
-              isSchool={true}
-            />
+      {totalDots > 0 && (
+        <div className={cn('flex items-center py-1', compact ? 'gap-1' : 'gap-1.5')}>
+          {route.direction === 'AM' ? (
+            <>
+              {checkpoints.map((cp, i) => (
+                <CheckpointDot
+                  key={cp.name}
+                  index={i}
+                  name={cp.name}
+                  prediction={p}
+                  isStop={false}
+                  isSchool={false}
+                  compact={compact}
+                />
+              ))}
+              {route.stopName && (
+                <CheckpointDot
+                  index={checkpoints.length}
+                  name={route.stopName}
+                  prediction={p}
+                  isStop={true}
+                  isSchool={false}
+                  compact={compact}
+                />
+              )}
+              {route.schoolName && (
+                <CheckpointDot
+                  index={checkpoints.length + (route.stopName ? 1 : 0)}
+                  name={route.schoolName}
+                  prediction={p}
+                  isStop={false}
+                  isSchool={true}
+                  compact={compact}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {/* PM: checkpoints → stop (school is origin, not shown as destination) */}
+              {checkpoints.map((cp, i) => (
+                <CheckpointDot
+                  key={cp.name}
+                  index={i}
+                  name={cp.name}
+                  prediction={p}
+                  isStop={false}
+                  isSchool={false}
+                  compact={compact}
+                />
+              ))}
+              {route.stopName && (
+                <CheckpointDot
+                  index={checkpoints.length}
+                  name={route.stopName}
+                  prediction={p}
+                  isStop={true}
+                  isSchool={false}
+                  compact={compact}
+                />
+              )}
+            </>
           )}
         </div>
       )}
@@ -125,12 +159,14 @@ function CheckpointDot({
   prediction,
   isStop,
   isSchool,
+  compact,
 }: {
   index: number;
   name: string;
   prediction: BusPrediction;
   isStop: boolean;
   isSchool: boolean;
+  compact?: boolean;
 }) {
   const isReached = index <= prediction.lastCheckpointIndex;
   const isCurrent = index === prediction.lastCheckpointIndex;
@@ -146,8 +182,10 @@ function CheckpointDot({
   return (
     <div className="group relative flex flex-col items-center">
       <div
+        data-keep-bg
         className={cn(
-          'h-3 w-3 border-2 transition-all',
+          compact ? 'h-2.5 w-2.5 border-2' : 'h-3 w-3 border-2',
+          'transition-all',
           shapeClass,
           isReached
             ? cn('border-current', statusColor.replace('bg-', 'text-'), 'bg-current')

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -1,4 +1,13 @@
--- Tables for Prism (extensions and functions are in 01-init.sql)
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 15.15
+-- Dumped by pg_dump version 15.15
+
+--
+-- Name: api_credentials; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.api_credentials (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -9,6 +18,10 @@ CREATE TABLE IF NOT EXISTS public.api_credentials (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: api_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.api_tokens (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(100) NOT NULL,
@@ -17,6 +30,10 @@ CREATE TABLE IF NOT EXISTS public.api_tokens (
     last_used_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: audit_logs; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.audit_logs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -29,6 +46,10 @@ CREATE TABLE IF NOT EXISTS public.audit_logs (
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: babysitter_info; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.babysitter_info (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     section character varying(50) NOT NULL,
@@ -38,6 +59,10 @@ CREATE TABLE IF NOT EXISTS public.babysitter_info (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: birthdays; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.birthdays (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -50,6 +75,10 @@ CREATE TABLE IF NOT EXISTS public.birthdays (
     google_calendar_source character varying(50),
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: bus_geofence_log; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.bus_geofence_log (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -65,6 +94,10 @@ CREATE TABLE IF NOT EXISTS public.bus_geofence_log (
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: bus_routes; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.bus_routes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     student_name character varying(100) NOT NULL,
@@ -79,8 +112,13 @@ CREATE TABLE IF NOT EXISTS public.bus_routes (
     school_name character varying(255),
     enabled boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL
 );
+
+--
+-- Name: calendar_groups; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.calendar_groups (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -93,6 +131,10 @@ CREATE TABLE IF NOT EXISTS public.calendar_groups (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: calendar_notes; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.calendar_notes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     date date NOT NULL,
@@ -101,6 +143,10 @@ CREATE TABLE IF NOT EXISTS public.calendar_notes (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: calendar_sources; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.calendar_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -123,6 +169,10 @@ CREATE TABLE IF NOT EXISTS public.calendar_sources (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: chore_completions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.chore_completions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     chore_id uuid NOT NULL,
@@ -134,6 +184,10 @@ CREATE TABLE IF NOT EXISTS public.chore_completions (
     photo_url text,
     notes text
 );
+
+--
+-- Name: chores; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.chores (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -153,6 +207,10 @@ CREATE TABLE IF NOT EXISTS public.chores (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: events; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -174,6 +232,10 @@ CREATE TABLE IF NOT EXISTS public.events (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: family_messages; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.family_messages (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     message text NOT NULL,
@@ -184,6 +246,10 @@ CREATE TABLE IF NOT EXISTS public.family_messages (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: gift_ideas; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.gift_ideas (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -200,6 +266,10 @@ CREATE TABLE IF NOT EXISTS public.gift_ideas (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: goal_achievements; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.goal_achievements (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     goal_id uuid NOT NULL,
@@ -207,6 +277,10 @@ CREATE TABLE IF NOT EXISTS public.goal_achievements (
     period_start date NOT NULL,
     achieved_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: goals; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.goals (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -223,6 +297,10 @@ CREATE TABLE IF NOT EXISTS public.goals (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: layouts; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.layouts (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(100) NOT NULL,
@@ -237,6 +315,10 @@ CREATE TABLE IF NOT EXISTS public.layouts (
     orientation character varying(20) DEFAULT 'landscape'::character varying
 );
 
+--
+-- Name: maintenance_completions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.maintenance_completions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     reminder_id uuid NOT NULL,
@@ -246,6 +328,10 @@ CREATE TABLE IF NOT EXISTS public.maintenance_completions (
     vendor character varying(255),
     notes text
 );
+
+--
+-- Name: maintenance_reminders; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.maintenance_reminders (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -262,6 +348,10 @@ CREATE TABLE IF NOT EXISTS public.maintenance_reminders (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: meals; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.meals (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -286,6 +376,10 @@ CREATE TABLE IF NOT EXISTS public.meals (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: photo_sources; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.photo_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     type character varying(20) NOT NULL,
@@ -300,6 +394,10 @@ CREATE TABLE IF NOT EXISTS public.photo_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: photos; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.photos (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -318,6 +416,10 @@ CREATE TABLE IF NOT EXISTS public.photos (
     usage character varying(100) DEFAULT 'wallpaper,gallery,screensaver'::character varying NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: recipes; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.recipes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -344,12 +446,20 @@ CREATE TABLE IF NOT EXISTS public.recipes (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: settings; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.settings (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     key character varying(100) NOT NULL,
     value jsonb NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: shopping_items; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.shopping_items (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -373,6 +483,10 @@ CREATE TABLE IF NOT EXISTS public.shopping_items (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: shopping_list_sources; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.shopping_list_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,
@@ -390,6 +504,10 @@ CREATE TABLE IF NOT EXISTS public.shopping_list_sources (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: shopping_lists; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.shopping_lists (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(100) NOT NULL,
@@ -405,6 +523,10 @@ CREATE TABLE IF NOT EXISTS public.shopping_lists (
     visible_categories jsonb
 );
 
+--
+-- Name: task_lists; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.task_lists (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(255) NOT NULL,
@@ -414,6 +536,10 @@ CREATE TABLE IF NOT EXISTS public.task_lists (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: task_sources; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.task_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -431,6 +557,10 @@ CREATE TABLE IF NOT EXISTS public.task_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: tasks; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.tasks (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -453,6 +583,10 @@ CREATE TABLE IF NOT EXISTS public.tasks (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS public.users (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying(100) NOT NULL,
@@ -466,6 +600,10 @@ CREATE TABLE IF NOT EXISTS public.users (
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     sort_order integer DEFAULT 0 NOT NULL
 );
+
+--
+-- Name: wish_item_sources; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.wish_item_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -483,6 +621,10 @@ CREATE TABLE IF NOT EXISTS public.wish_item_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
+--
+-- Name: wish_items; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS public.wish_items (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -502,489 +644,1233 @@ CREATE TABLE IF NOT EXISTS public.wish_items (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+--
+-- Name: api_credentials api_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.api_credentials
     ADD CONSTRAINT api_credentials_pkey PRIMARY KEY (id);
+
+--
+-- Name: api_credentials api_credentials_service_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.api_credentials
     ADD CONSTRAINT api_credentials_service_unique UNIQUE (service);
 
+--
+-- Name: api_tokens api_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.api_tokens
     ADD CONSTRAINT api_tokens_pkey PRIMARY KEY (id);
+
+--
+-- Name: audit_logs audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.audit_logs
     ADD CONSTRAINT audit_logs_pkey PRIMARY KEY (id);
 
+--
+-- Name: babysitter_info babysitter_info_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.babysitter_info
     ADD CONSTRAINT babysitter_info_pkey PRIMARY KEY (id);
+
+--
+-- Name: birthdays birthdays_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_pkey PRIMARY KEY (id);
 
+--
+-- Name: bus_geofence_log bus_geofence_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bus_geofence_log
     ADD CONSTRAINT bus_geofence_log_pkey PRIMARY KEY (id);
+
+--
+-- Name: bus_routes bus_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bus_routes
     ADD CONSTRAINT bus_routes_pkey PRIMARY KEY (id);
 
+--
+-- Name: calendar_groups calendar_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_pkey PRIMARY KEY (id);
+
+--
+-- Name: calendar_notes calendar_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.calendar_notes
     ADD CONSTRAINT calendar_notes_pkey PRIMARY KEY (id);
 
+--
+-- Name: calendar_sources calendar_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_pkey PRIMARY KEY (id);
+
+--
+-- Name: chore_completions chore_completions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_pkey PRIMARY KEY (id);
 
+--
+-- Name: chores chores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_pkey PRIMARY KEY (id);
+
+--
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_pkey PRIMARY KEY (id);
 
+--
+-- Name: family_messages family_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_pkey PRIMARY KEY (id);
+
+--
+-- Name: gift_ideas gift_ideas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_pkey PRIMARY KEY (id);
 
+--
+-- Name: goal_achievements goal_achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_pkey PRIMARY KEY (id);
+
+--
+-- Name: goals goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.goals
     ADD CONSTRAINT goals_pkey PRIMARY KEY (id);
 
+--
+-- Name: layouts layouts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_pkey PRIMARY KEY (id);
+
+--
+-- Name: layouts layouts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_slug_key UNIQUE (slug);
 
+--
+-- Name: maintenance_completions maintenance_completions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_pkey PRIMARY KEY (id);
+
+--
+-- Name: maintenance_reminders maintenance_reminders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_pkey PRIMARY KEY (id);
 
+--
+-- Name: meals meals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_pkey PRIMARY KEY (id);
+
+--
+-- Name: photo_sources photo_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.photo_sources
     ADD CONSTRAINT photo_sources_pkey PRIMARY KEY (id);
 
+--
+-- Name: photos photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_pkey PRIMARY KEY (id);
+
+--
+-- Name: recipes recipes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.recipes
     ADD CONSTRAINT recipes_pkey PRIMARY KEY (id);
 
+--
+-- Name: settings settings_key_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.settings
     ADD CONSTRAINT settings_key_unique UNIQUE (key);
+
+--
+-- Name: settings settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.settings
     ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
 
+--
+-- Name: shopping_items shopping_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_pkey PRIMARY KEY (id);
+
+--
+-- Name: shopping_list_sources shopping_list_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_pkey PRIMARY KEY (id);
 
+--
+-- Name: shopping_lists shopping_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_pkey PRIMARY KEY (id);
+
+--
+-- Name: task_lists task_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.task_lists
     ADD CONSTRAINT task_lists_pkey PRIMARY KEY (id);
 
+--
+-- Name: task_sources task_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_pkey PRIMARY KEY (id);
+
+--
+-- Name: tasks tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
 
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+--
+-- Name: wish_item_sources wish_item_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_pkey PRIMARY KEY (id);
 
+--
+-- Name: wish_items wish_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_pkey PRIMARY KEY (id);
 
+--
+-- Name: api_tokens_created_by_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS api_tokens_created_by_idx ON public.api_tokens USING btree (created_by);
+
+--
+-- Name: api_tokens_token_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS api_tokens_token_hash_idx ON public.api_tokens USING btree (token_hash);
 
+--
+-- Name: audit_logs_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON public.audit_logs USING btree (created_at);
+
+--
+-- Name: audit_logs_entity_type_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS audit_logs_entity_type_idx ON public.audit_logs USING btree (entity_type);
 
+--
+-- Name: audit_logs_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS audit_logs_user_id_idx ON public.audit_logs USING btree (user_id);
+
+--
+-- Name: babysitter_info_section_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS babysitter_info_section_idx ON public.babysitter_info USING btree (section);
 
+--
+-- Name: babysitter_info_sort_order_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS babysitter_info_sort_order_idx ON public.babysitter_info USING btree (sort_order);
+
+--
+-- Name: birthdays_name_event_type_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS birthdays_name_event_type_idx ON public.birthdays USING btree (name, event_type);
 
+--
+-- Name: bus_geofence_log_event_time_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS bus_geofence_log_event_time_idx ON public.bus_geofence_log USING btree (event_time);
+
+--
+-- Name: bus_geofence_log_gmail_message_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS bus_geofence_log_gmail_message_id_idx ON public.bus_geofence_log USING btree (gmail_message_id);
 
+--
+-- Name: bus_geofence_log_route_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS bus_geofence_log_route_id_idx ON public.bus_geofence_log USING btree (route_id);
+
+--
+-- Name: bus_geofence_log_trip_date_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS bus_geofence_log_trip_date_idx ON public.bus_geofence_log USING btree (trip_date);
 
+--
+-- Name: bus_routes_enabled_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS bus_routes_enabled_idx ON public.bus_routes USING btree (enabled);
+
+--
+-- Name: bus_routes_trip_direction_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS bus_routes_trip_direction_idx ON public.bus_routes USING btree (trip_id, direction);
 
+--
+-- Name: calendar_groups_type_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS calendar_groups_type_idx ON public.calendar_groups USING btree (type);
+
+--
+-- Name: calendar_notes_date_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS calendar_notes_date_idx ON public.calendar_notes USING btree (date);
 
+--
+-- Name: calendar_sources_enabled_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS calendar_sources_enabled_idx ON public.calendar_sources USING btree (enabled);
+
+--
+-- Name: calendar_sources_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS calendar_sources_user_id_idx ON public.calendar_sources USING btree (user_id);
 
+--
+-- Name: chore_completions_approved_by_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS chore_completions_approved_by_idx ON public.chore_completions USING btree (approved_by);
+
+--
+-- Name: chore_completions_chore_approved_by_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS chore_completions_chore_approved_by_idx ON public.chore_completions USING btree (chore_id, approved_by);
 
+--
+-- Name: chore_completions_chore_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS chore_completions_chore_id_idx ON public.chore_completions USING btree (chore_id);
+
+--
+-- Name: chore_completions_completed_at_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS chore_completions_completed_at_idx ON public.chore_completions USING btree (completed_at);
 
+--
+-- Name: chores_assigned_to_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS chores_assigned_to_idx ON public.chores USING btree (assigned_to);
+
+--
+-- Name: chores_next_due_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS chores_next_due_idx ON public.chores USING btree (next_due);
 
+--
+-- Name: events_calendar_source_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS events_calendar_source_idx ON public.events USING btree (calendar_source_id);
+
+--
+-- Name: events_end_time_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS events_end_time_idx ON public.events USING btree (end_time);
 
+--
+-- Name: events_source_external_unique; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX IF NOT EXISTS events_source_external_unique ON public.events USING btree (calendar_source_id, external_event_id);
+
+--
+-- Name: events_start_time_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS events_start_time_idx ON public.events USING btree (start_time);
 
+--
+-- Name: family_messages_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS family_messages_created_at_idx ON public.family_messages USING btree (created_at);
+
+--
+-- Name: family_messages_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS family_messages_expires_at_idx ON public.family_messages USING btree (expires_at);
 
+--
+-- Name: gift_ideas_created_by_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS gift_ideas_created_by_idx ON public.gift_ideas USING btree (created_by);
+
+--
+-- Name: gift_ideas_for_user_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS gift_ideas_for_user_idx ON public.gift_ideas USING btree (for_user_id);
 
+--
+-- Name: goal_achievements_goal_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS goal_achievements_goal_id_idx ON public.goal_achievements USING btree (goal_id);
+
+--
+-- Name: goal_achievements_goal_user_period_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX IF NOT EXISTS goal_achievements_goal_user_period_idx ON public.goal_achievements USING btree (goal_id, user_id, period_start);
 
+--
+-- Name: goal_achievements_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS goal_achievements_user_id_idx ON public.goal_achievements USING btree (user_id);
+
+--
+-- Name: goals_active_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS goals_active_idx ON public.goals USING btree (active);
 
+--
+-- Name: goals_active_priority_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS goals_active_priority_idx ON public.goals USING btree (active, priority);
+
+--
+-- Name: maintenance_reminders_next_due_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS maintenance_reminders_next_due_idx ON public.maintenance_reminders USING btree (next_due);
 
+--
+-- Name: meals_day_of_week_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS meals_day_of_week_idx ON public.meals USING btree (day_of_week);
+
+--
+-- Name: meals_week_of_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS meals_week_of_idx ON public.meals USING btree (week_of);
 
+--
+-- Name: photos_favorite_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS photos_favorite_idx ON public.photos USING btree (favorite);
+
+--
+-- Name: photos_source_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS photos_source_id_idx ON public.photos USING btree (source_id);
 
+--
+-- Name: photos_taken_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS photos_taken_at_idx ON public.photos USING btree (taken_at);
+
+--
+-- Name: photos_usage_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS photos_usage_idx ON public.photos USING btree (usage);
 
+--
+-- Name: recipes_favorite_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS recipes_favorite_idx ON public.recipes USING btree (is_favorite);
+
+--
+-- Name: recipes_name_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS recipes_name_idx ON public.recipes USING btree (name);
 
+--
+-- Name: recipes_source_type_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS recipes_source_type_idx ON public.recipes USING btree (source_type);
+
+--
+-- Name: shopping_items_category_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS shopping_items_category_idx ON public.shopping_items USING btree (category);
 
+--
+-- Name: shopping_items_checked_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS shopping_items_checked_idx ON public.shopping_items USING btree (checked);
+
+--
+-- Name: shopping_items_external_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS shopping_items_external_id_idx ON public.shopping_items USING btree (external_id);
 
+--
+-- Name: shopping_items_list_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS shopping_items_list_id_idx ON public.shopping_items USING btree (list_id);
+
+--
+-- Name: shopping_items_source_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS shopping_items_source_idx ON public.shopping_items USING btree (shopping_list_source_id);
 
+--
+-- Name: shopping_list_sources_shopping_list_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS shopping_list_sources_shopping_list_idx ON public.shopping_list_sources USING btree (shopping_list_id);
+
+--
+-- Name: shopping_list_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS shopping_list_sources_user_provider_idx ON public.shopping_list_sources USING btree (user_id, provider);
 
+--
+-- Name: task_sources_task_list_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS task_sources_task_list_idx ON public.task_sources USING btree (task_list_id);
+
+--
+-- Name: task_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS task_sources_user_provider_idx ON public.task_sources USING btree (user_id, provider);
 
+--
+-- Name: tasks_assigned_to_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS tasks_assigned_to_idx ON public.tasks USING btree (assigned_to);
+
+--
+-- Name: tasks_completed_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS tasks_completed_idx ON public.tasks USING btree (completed);
 
+--
+-- Name: tasks_due_date_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS tasks_due_date_idx ON public.tasks USING btree (due_date);
+
+--
+-- Name: tasks_external_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS tasks_external_id_idx ON public.tasks USING btree (external_id);
 
+--
+-- Name: tasks_list_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS tasks_list_id_idx ON public.tasks USING btree (list_id);
+
+--
+-- Name: tasks_task_source_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS tasks_task_source_idx ON public.tasks USING btree (task_source_id);
 
+--
+-- Name: users_email_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS users_email_idx ON public.users USING btree (email);
+
+--
+-- Name: wish_item_sources_member_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS wish_item_sources_member_idx ON public.wish_item_sources USING btree (member_id);
 
+--
+-- Name: wish_item_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS wish_item_sources_user_provider_idx ON public.wish_item_sources USING btree (user_id, provider);
+
+--
+-- Name: wish_items_claimed_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS wish_items_claimed_idx ON public.wish_items USING btree (claimed);
 
+--
+-- Name: wish_items_external_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS wish_items_external_id_idx ON public.wish_items USING btree (external_id);
+
+--
+-- Name: wish_items_member_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX IF NOT EXISTS wish_items_member_id_idx ON public.wish_items USING btree (member_id);
 
+--
+-- Name: wish_items_source_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX IF NOT EXISTS wish_items_source_idx ON public.wish_items USING btree (wish_item_source_id);
+
+--
+-- Name: api_tokens api_tokens_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.api_tokens
     ADD CONSTRAINT api_tokens_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: audit_logs audit_logs_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.audit_logs
     ADD CONSTRAINT audit_logs_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: birthdays birthdays_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: birthdays birthdays_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: bus_geofence_log bus_geofence_log_route_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bus_geofence_log
     ADD CONSTRAINT bus_geofence_log_route_id_fkey FOREIGN KEY (route_id) REFERENCES public.bus_routes(id) ON DELETE CASCADE;
 
+--
+-- Name: bus_routes bus_routes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bus_routes
     ADD CONSTRAINT bus_routes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: calendar_groups calendar_groups_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: calendar_groups calendar_groups_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: calendar_notes calendar_notes_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.calendar_notes
     ADD CONSTRAINT calendar_notes_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: calendar_sources calendar_sources_group_id_calendar_groups_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_group_id_calendar_groups_id_fk FOREIGN KEY (group_id) REFERENCES public.calendar_groups(id) ON DELETE SET NULL;
+
+--
+-- Name: calendar_sources calendar_sources_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.calendar_groups(id) ON DELETE SET NULL;
 
+--
+-- Name: calendar_sources calendar_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: calendar_sources calendar_sources_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: chore_completions chore_completions_approved_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_approved_by_fkey FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: chore_completions chore_completions_approved_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_approved_by_users_id_fk FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: chore_completions chore_completions_chore_id_chores_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_chore_id_chores_id_fk FOREIGN KEY (chore_id) REFERENCES public.chores(id) ON DELETE CASCADE;
+
+--
+-- Name: chore_completions chore_completions_chore_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_chore_id_fkey FOREIGN KEY (chore_id) REFERENCES public.chores(id) ON DELETE CASCADE;
 
+--
+-- Name: chore_completions chore_completions_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: chore_completions chore_completions_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: chores chores_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: chores chores_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: chores chores_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: chores chores_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: events events_calendar_source_id_calendar_sources_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_calendar_source_id_calendar_sources_id_fk FOREIGN KEY (calendar_source_id) REFERENCES public.calendar_sources(id) ON DELETE CASCADE;
+
+--
+-- Name: events events_calendar_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_calendar_source_id_fkey FOREIGN KEY (calendar_source_id) REFERENCES public.calendar_sources(id) ON DELETE CASCADE;
 
+--
+-- Name: events events_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: events events_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: family_messages family_messages_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: family_messages family_messages_author_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_author_id_users_id_fk FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: gift_ideas gift_ideas_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: gift_ideas gift_ideas_for_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_for_user_id_fkey FOREIGN KEY (for_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: goal_achievements goal_achievements_goal_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_goal_id_fkey FOREIGN KEY (goal_id) REFERENCES public.goals(id) ON DELETE CASCADE;
+
+--
+-- Name: goal_achievements goal_achievements_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: layouts layouts_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: layouts layouts_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: maintenance_completions maintenance_completions_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: maintenance_completions maintenance_completions_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: maintenance_completions maintenance_completions_reminder_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_reminder_id_fkey FOREIGN KEY (reminder_id) REFERENCES public.maintenance_reminders(id) ON DELETE CASCADE;
+
+--
+-- Name: maintenance_completions maintenance_completions_reminder_id_maintenance_reminders_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_reminder_id_maintenance_reminders_id_fk FOREIGN KEY (reminder_id) REFERENCES public.maintenance_reminders(id) ON DELETE CASCADE;
 
+--
+-- Name: maintenance_reminders maintenance_reminders_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: maintenance_reminders maintenance_reminders_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: maintenance_reminders maintenance_reminders_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: maintenance_reminders maintenance_reminders_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: meals meals_cooked_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_cooked_by_fkey FOREIGN KEY (cooked_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: meals meals_cooked_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_cooked_by_users_id_fk FOREIGN KEY (cooked_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: meals meals_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: meals meals_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: meals meals_recipe_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_recipe_id_fkey FOREIGN KEY (recipe_id) REFERENCES public.recipes(id) ON DELETE SET NULL;
+
+--
+-- Name: photos photos_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_source_id_fkey FOREIGN KEY (source_id) REFERENCES public.photo_sources(id) ON DELETE CASCADE;
 
+--
+-- Name: photos photos_source_id_photo_sources_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_source_id_photo_sources_id_fk FOREIGN KEY (source_id) REFERENCES public.photo_sources(id) ON DELETE CASCADE;
+
+--
+-- Name: recipes recipes_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.recipes
     ADD CONSTRAINT recipes_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: shopping_items shopping_items_added_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_added_by_fkey FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: shopping_items shopping_items_added_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_added_by_users_id_fk FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: shopping_items shopping_items_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_list_id_fkey FOREIGN KEY (list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
+
+--
+-- Name: shopping_items shopping_items_list_id_shopping_lists_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_list_id_shopping_lists_id_fk FOREIGN KEY (list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
 
+--
+-- Name: shopping_items shopping_items_shopping_list_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_shopping_list_source_id_fkey FOREIGN KEY (shopping_list_source_id) REFERENCES public.shopping_list_sources(id) ON DELETE SET NULL;
+
+--
+-- Name: shopping_list_sources shopping_list_sources_shopping_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_shopping_list_id_fkey FOREIGN KEY (shopping_list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
 
+--
+-- Name: shopping_list_sources shopping_list_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: shopping_lists shopping_lists_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: shopping_lists shopping_lists_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: shopping_lists shopping_lists_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: shopping_lists shopping_lists_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: task_lists task_lists_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.task_lists
     ADD CONSTRAINT task_lists_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: task_sources task_sources_task_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_task_list_id_fkey FOREIGN KEY (task_list_id) REFERENCES public.task_lists(id) ON DELETE CASCADE;
+
+--
+-- Name: task_sources task_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: tasks tasks_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: tasks tasks_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: tasks tasks_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: tasks tasks_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: tasks tasks_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: tasks tasks_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: tasks tasks_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_list_id_fkey FOREIGN KEY (list_id) REFERENCES public.task_lists(id) ON DELETE CASCADE;
+
+--
+-- Name: tasks tasks_task_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_task_source_id_fkey FOREIGN KEY (task_source_id) REFERENCES public.task_sources(id) ON DELETE SET NULL;
 
+--
+-- Name: wish_item_sources wish_item_sources_member_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_member_id_fkey FOREIGN KEY (member_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+--
+-- Name: wish_item_sources wish_item_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: wish_items wish_items_added_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_added_by_fkey FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+--
+-- Name: wish_items wish_items_claimed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+--
+-- Name: wish_items wish_items_member_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_member_id_fkey FOREIGN KEY (member_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+--
+-- Name: wish_items wish_items_wish_item_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_wish_item_source_id_fkey FOREIGN KEY (wish_item_source_id) REFERENCES public.wish_item_sources(id) ON DELETE SET NULL;
+
+--
+-- PostgreSQL database dump complete
+--
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1278,6 +1278,7 @@ export const busRoutes = pgTable('bus_routes', {
   schoolName: varchar('school_name', { length: 255 }),
 
   enabled: boolean('enabled').default(true).notNull(),
+  sortOrder: integer('sort_order').default(0).notNull(),
 
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/src/lib/hooks/useBusTracking.ts
+++ b/src/lib/hooks/useBusTracking.ts
@@ -26,6 +26,7 @@ export interface BusRouteStatus {
   studentName: string;
   direction: 'AM' | 'PM';
   scheduledTime: string;
+  activeDays: number[];
   checkpoints: BusCheckpoint[];
   stopName: string | null;
   schoolName: string | null;
@@ -35,6 +36,25 @@ export interface BusRouteStatus {
 interface BusStatusResponse {
   routes: BusRouteStatus[];
   connected: boolean;
+}
+
+const DISPLAY_WINDOW_MS = 60 * 60 * 1000; // ±60 min of scheduledTime
+
+/** Returns true if the route should be visible right now. */
+function isRouteVisible(route: BusRouteStatus): boolean {
+  const now = new Date();
+  // Check activeDays (1=Mon..5=Fri; getDay() is 0=Sun..6=Sat)
+  const todayDow = now.getDay();
+  if (!route.activeDays?.includes(todayDow)) return false;
+
+  // Check ±60 min window around scheduledTime
+  const parts = route.scheduledTime.split(':').map(Number);
+  const hours = parts[0] ?? 0;
+  const minutes = parts[1] ?? 0;
+  const scheduled = new Date(now);
+  scheduled.setHours(hours, minutes, 0, 0);
+  const diffMs = Math.abs(now.getTime() - scheduled.getTime());
+  return diffMs <= DISPLAY_WINDOW_MS;
 }
 
 /**
@@ -50,16 +70,7 @@ function getPollingInterval(routes: BusRouteStatus[]): number {
   if (routes.length === 0) return 0;
 
   // Check if any route is within its bus window
-  const now = new Date();
-  const activeRoutes = routes.filter(route => {
-    const parts = route.scheduledTime.split(':').map(Number);
-    const hours = parts[0] ?? 0;
-    const minutes = parts[1] ?? 0;
-    const scheduled = new Date(now);
-    scheduled.setHours(hours, minutes, 0, 0);
-    const diffMs = Math.abs(now.getTime() - scheduled.getTime());
-    return diffMs <= 30 * 60 * 1000; // within ±30 min
-  });
+  const activeRoutes = routes.filter(isRouteVisible);
 
   if (activeRoutes.length === 0) return 0; // Outside bus window
 
@@ -112,8 +123,11 @@ export function useBusTracking() {
     fetchStatus();
   }, [fetchStatus]);
 
+  // Filter to routes that are active today and within the ±60 min display window
+  const visibleRoutes = useMemo(() => routes.filter(isRouteVisible), [routes]);
+
   // Adaptive polling
-  const pollingInterval = useMemo(() => getPollingInterval(routes), [routes]);
+  const pollingInterval = useMemo(() => getPollingInterval(visibleRoutes), [visibleRoutes]);
   useVisibilityPolling(fetchStatus, pollingInterval);
 
   const refresh = useCallback(() => {
@@ -121,5 +135,5 @@ export function useBusTracking() {
     fetchStatus();
   }, [fetchStatus]);
 
-  return { routes, connected, loading, error, refresh };
+  return { routes: visibleRoutes, connected, loading, error, refresh };
 }

--- a/src/lib/services/bus-arrival-predictor.ts
+++ b/src/lib/services/bus-arrival-predictor.ts
@@ -88,7 +88,11 @@ export async function predictArrival(routeId: string): Promise<ArrivalPrediction
   const lastCheckpointTime = latest.eventTime;
   const minutesSince = (Date.now() - lastCheckpointTime.getTime()) / 60000;
 
-  // If bus has reached stop or school, we're done
+  const direction = route.direction as 'AM' | 'PM';
+
+  // Terminal states depend on direction:
+  // AM: school is the final destination
+  // PM: stop is the final destination (school is the origin)
   if (latest.eventType === 'arrived_at_stop') {
     return {
       status: 'at_stop',
@@ -104,17 +108,21 @@ export async function predictArrival(routeId: string): Promise<ArrivalPrediction
   }
 
   if (latest.eventType === 'arrived_at_school') {
-    return {
-      status: 'at_school',
-      etaMinutes: 0,
-      etaRangeLow: 0,
-      etaRangeHigh: 0,
-      lastCheckpointName,
-      lastCheckpointTime,
-      lastCheckpointIndex,
-      totalCheckpoints,
-      minutesSinceLastCheckpoint: Math.round(minutesSince),
-    };
+    if (direction === 'AM') {
+      // AM: school is the destination — trip complete
+      return {
+        status: 'at_school',
+        etaMinutes: 0,
+        etaRangeLow: 0,
+        etaRangeHigh: 0,
+        lastCheckpointName,
+        lastCheckpointTime,
+        lastCheckpointIndex,
+        totalCheckpoints,
+        minutesSinceLastCheckpoint: Math.round(minutesSince),
+      };
+    }
+    // PM: school is the origin — bus is starting its route, treat as in-transit
   }
 
   // Bus is in transit — try to predict remaining time

--- a/src/lib/services/bus-arrival-predictor.ts
+++ b/src/lib/services/bus-arrival-predictor.ts
@@ -52,8 +52,20 @@ export async function predictArrival(routeId: string): Promise<ArrivalPrediction
   }
 
   const checkpoints = (route.checkpoints as { name: string; sortOrder: number }[]) || [];
-  // Total checkpoints = user-defined + stop + school
-  const totalCheckpoints = checkpoints.length + (route.stopName ? 1 : 0) + (route.schoolName ? 1 : 0);
+
+  // ETA target: find the stopName checkpoint within the named list.
+  // stopName is now selected from checkpoint names (e.g. "Home"), so ETA
+  // targets that index rather than the implicit school terminal.
+  const stopIdx = route.stopName
+    ? checkpoints.findIndex(cp => cp.name === route.stopName)
+    : -1;
+  // Upper bound for ETA segment calculation
+  const etaTargetCount = stopIdx >= 0
+    ? stopIdx + 1
+    : checkpoints.length + (route.stopName ? 1 : 0);  // fallback: implicit stop after named checkpoints
+
+  // Full display count (includes school for AM — used by widget progress display)
+  const totalCheckpoints = checkpoints.length + (route.stopName && stopIdx < 0 ? 1 : 0) + (route.schoolName ? 1 : 0);
 
   // Check if today is an active day for this route (default weekdays [1-5])
   const activeDays = (route.activeDays as number[]) || [1, 2, 3, 4, 5];
@@ -125,8 +137,8 @@ export async function predictArrival(routeId: string): Promise<ArrivalPrediction
     // PM: school is the origin — bus is starting its route, treat as in-transit
   }
 
-  // Bus is in transit — try to predict remaining time
-  const segments = await getSegmentStats(routeId, lastCheckpointIndex, totalCheckpoints);
+  // Bus is in transit — try to predict remaining time up to the ETA target
+  const segments = await getSegmentStats(routeId, lastCheckpointIndex, etaTargetCount);
 
   // Check if we have enough data for prediction
   const hasEnoughData = segments.every(s => s.sampleCount >= MIN_SAMPLES_FOR_PREDICTION);

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -261,6 +261,7 @@ export const createBusRouteSchema = z.object({
   stopName: z.string().max(255).optional(),
   schoolName: z.string().max(255).optional(),
   enabled: z.boolean().optional().default(true),
+  sortOrder: z.number().int().min(0).optional().default(0),
 });
 
 export const updateBusRouteSchema = createBusRouteSchema.partial();


### PR DESCRIPTION
## Summary

- **ETA target fix**: Predictor now targets `stopName` checkpoint (e.g. \"Home\") instead of school. `stopName` is selected from a dropdown of named checkpoints rather than freeform text.
- **Route visibility**: Routes are now auto-hidden outside ±60 min of `scheduledTime` or when today is not an active day (per `activeDays`). Widget and mobile card only show relevant routes.
- **Drag reorder for routes**: Routes list in Settings now uses dnd-kit sortable drag-and-drop with a new `sortOrder` DB column. New `POST /api/bus-tracking/routes/reorder` batch endpoint.
- **Drag reorder for checkpoints**: Fixed the non-functional `GripVertical` handle in the RouteDialog checkpoint list — now wired to dnd-kit SortableContext.
- **Widget backward compatibility**: Progress dots handle both new style (stopName matches a named checkpoint → shown as square in place) and legacy style (stopName is an implicit terminal dot after the list).
- **Schema**: Added `sort_order integer DEFAULT 0` to `bus_routes` table. Applied via `ALTER TABLE` and regenerated `02-schema.sql`.

## Test plan

- [x] Open a bus route in Settings → edit → verify checkpoint drag handles work
- [x] Verify Stop dropdown is populated from checkpoint names
- [x] Drag routes in the routes list to reorder; confirm order persists on reload
- [x] Check widget only shows routes active today and within ±60 min window
- [ ] Verify ETA counts down to \"Home\" stop, not school