### PR TITLE
fix(e2e): support isolated test DB and unauthenticated /api/family

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -4,6 +4,12 @@ export interface FamilyMember {
   id: string;
   name: string;
   role: string;
+  /**
+   * Present on the unauthenticated `/api/family` response. Used as a fallback
+   * for `loginViaAPI` when the caller has no session yet — the public response
+   * intentionally redacts real UUIDs (id is '') and exposes loginIndex instead.
+   */
+  loginIndex?: number;
 }
 
 /**
@@ -85,9 +91,14 @@ export async function loginViaUI(page: Page, name: string, pin = DEFAULT_PIN) {
 export async function loginViaAPI(page: Page, name: string, pin = DEFAULT_PIN) {
   const member = await findMember(page, name);
 
-  const response = await page.request.post('/api/auth/login', {
-    data: { userId: member.id, pin },
-  });
+  // The public /api/family response redacts real UUIDs and returns loginIndex
+  // instead — fall back to memberIndex when we don't have a real id.
+  const data: Record<string, unknown> = { pin };
+  if (member.id) data.userId = member.id;
+  else if (typeof member.loginIndex === 'number') data.memberIndex = member.loginIndex;
+  else throw new Error(`Member "${name}" has neither id nor loginIndex`);
+
+  const response = await page.request.post('/api/auth/login', { data });
 
   if (!response.ok()) {
     throw new Error(`Login failed for ${name}: ${response.status()}`);

--- a/e2e/helpers/reset.ts
+++ b/e2e/helpers/reset.ts
@@ -10,8 +10,9 @@ import { tmpdir } from 'os';
 function runSQL(sql: string) {
   const tmpFile = join(tmpdir(), `prism-e2e-${Date.now()}.sql`);
   writeFileSync(tmpFile, sql, 'utf-8');
+  const dbName = process.env.E2E_DB_NAME || 'prism';
   try {
-    execSync(`docker exec -i prism-db psql -U prism -d prism < "${tmpFile}"`, {
+    execSync(`docker exec -i prism-db psql -U prism -d ${dbName} < "${tmpFile}"`, {
       stdio: 'pipe',
       shell: 'cmd.exe',
     });

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -54,8 +54,9 @@ import { resetAll } from './helpers/reset';
  * DB sidesteps the issue and keeps the parent's name out of the test source.
  */
 function getSeededParentName(): string {
+  const dbName = process.env.E2E_DB_NAME || 'prism';
   const out = execSync(
-    `docker exec prism-db psql -U prism -d prism -At -c "SELECT name FROM users WHERE role = 'parent' ORDER BY created_at LIMIT 1"`,
+    `docker exec prism-db psql -U prism -d ${dbName} -At -c "SELECT name FROM users WHERE role = 'parent' ORDER BY created_at LIMIT 1"`,
     { encoding: 'utf-8' },
   ).trim();
   if (!out) throw new Error('No seeded parent in DB — did seeds run?');


### PR DESCRIPTION
## Summary

Three fixes surfaced while attempting visual-regression baseline capture against a separate `prism_e2e` database (so the live `prism` DB is never touched).

- **helpers/reset.ts**: `runSQL` reads `E2E_DB_NAME` env (default `prism`) so `resetAll()` can target a synthetic-seed test database instead of hardcoded `prism`.
- **visual-regression.spec.ts**: `getSeededParentName()` picks up the same `E2E_DB_NAME` override.
- **helpers/auth.ts**: `loginViaAPI` now falls back to `memberIndex` when `/api/family` returns the redacted public response (`id: ''` + `loginIndex`). Without this, every caller hits a chicken-and-egg: `/api/family` only returns real UUIDs to authenticated requests, but the spec needs to log in from a fresh page.

## Why this is needed

The visual-regression spec hard-requires `E2E_HAS_TEST_DB=1` and a synthetic-seed DB (per its docstring's PII contract). Targeting a separate `prism_e2e` database lets baseline capture run without disturbing live data — but every helper that talked to the DB by name was hardcoded to `prism`.

Visual-regression baselines themselves are **not** part of this PR — capturing them needs a longer follow-up because Next.js dev-mode SSR bails to client-side rendering on the dashboard route, which makes the spec's 800 ms post-`networkidle` wait insufficient. That work continues separately.

## Test plan

- [ ] CI green (lint, type-check, jest, migration-replay, e2e-modality reverse-proxy)
- [ ] Existing e2e specs (auth, calendar, chores, etc.) still pass since they default to `prism` when `E2E_DB_NAME` is unset
- [ ] Manual: visual-regression spec runs against `prism_e2e` with `E2E_DB_NAME=prism_e2e E2E_HAS_TEST_DB=1` (verified during baseline capture attempt — login + reset both targeted the synthetic DB correctly)