### PR TITLE
fix(weather): include provider in cache key

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -61,11 +61,14 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const location = await resolveLocation(searchParams.get('location'));
 
-    // Create a cache key based on location
+    // Cache key includes the provider so switching WEATHER_PROVIDER doesn't
+    // serve a stale response shaped by the previous provider (different
+    // condition strings, descriptions, and forecast fields).
+    const provider = process.env.WEATHER_PROVIDER ?? 'meteo';
     const locationKey = typeof location === 'string'
       ? location.toLowerCase().replace(/\s+/g, '-')
       : `${location.lat.toFixed(2)},${location.lon.toFixed(2)}`;
-    const cacheKey = `weather:${locationKey}`;
+    const cacheKey = `weather:${provider}:${locationKey}`;
 
     // Get from cache or fetch fresh
     const weatherData = await getCached(


### PR DESCRIPTION
## Summary

Switching `WEATHER_PROVIDER` (which I just hit moving from `openweather` → `meteo` at v1.7.0) used to serve a stale response shaped by the previous provider — different condition strings, descriptions, and forecast fields — until the 10-minute cache TTL expired. Manual mitigation was \`docker exec prism-redis redis-cli DEL weather:<location>\`.

The cache key now embeds the active provider, so a provider change naturally produces a non-colliding key (e.g. \`weather:openweather:Springfield,il,us\` → \`weather:meteo:Springfield,il,us\`). Old entries TTL out on their own.

## Test plan

- [ ] CI green (lint, type-check, jest)
- [ ] Manual: change \`WEATHER_PROVIDER\` and confirm the next \`/api/weather\` response reflects the new provider's shape without a manual cache flush
