### PR TITLE
chore(db): regenerate 02-schema.sql with travel_trips + weekend_* tables

### DIFF
--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -6,6 +6,14 @@
 -- Dumped from database version 15.15
 -- Dumped by pg_dump version 15.15
 
+
+
+--
+
+
+--
+
+
 --
 -- Name: update_updated_at_column(); Type: FUNCTION; Schema: public; Owner: -
 --
@@ -19,6 +27,9 @@ BEGIN
 END;
 $$;
 
+
+
+
 --
 -- Name: __prism_migrations; Type: TABLE; Schema: public; Owner: -
 --
@@ -29,11 +40,12 @@ CREATE TABLE IF NOT EXISTS public.__prism_migrations (
     applied_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: __prism_migrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.__prism_migrations_id_seq
+CREATE SEQUENCE IF NOT EXISTS public.__prism_migrations_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -41,11 +53,13 @@ CREATE SEQUENCE public.__prism_migrations_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
 --
 -- Name: __prism_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.__prism_migrations_id_seq OWNED BY public.__prism_migrations.id;
+
 
 --
 -- Name: api_credentials; Type: TABLE; Schema: public; Owner: -
@@ -60,6 +74,7 @@ CREATE TABLE IF NOT EXISTS public.api_credentials (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: api_tokens; Type: TABLE; Schema: public; Owner: -
 --
@@ -73,6 +88,7 @@ CREATE TABLE IF NOT EXISTS public.api_tokens (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     scopes jsonb DEFAULT '["*"]'::jsonb NOT NULL
 );
+
 
 --
 -- Name: audit_logs; Type: TABLE; Schema: public; Owner: -
@@ -89,6 +105,7 @@ CREATE TABLE IF NOT EXISTS public.audit_logs (
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: babysitter_info; Type: TABLE; Schema: public; Owner: -
 --
@@ -102,6 +119,7 @@ CREATE TABLE IF NOT EXISTS public.babysitter_info (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: birthdays; Type: TABLE; Schema: public; Owner: -
@@ -118,6 +136,7 @@ CREATE TABLE IF NOT EXISTS public.birthdays (
     google_calendar_source character varying(50),
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: bus_geofence_log; Type: TABLE; Schema: public; Owner: -
@@ -136,6 +155,7 @@ CREATE TABLE IF NOT EXISTS public.bus_geofence_log (
     raw_data jsonb,
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: bus_routes; Type: TABLE; Schema: public; Owner: -
@@ -159,6 +179,7 @@ CREATE TABLE IF NOT EXISTS public.bus_routes (
     sort_order integer DEFAULT 0 NOT NULL
 );
 
+
 --
 -- Name: calendar_groups; Type: TABLE; Schema: public; Owner: -
 --
@@ -174,6 +195,7 @@ CREATE TABLE IF NOT EXISTS public.calendar_groups (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: calendar_notes; Type: TABLE; Schema: public; Owner: -
 --
@@ -186,6 +208,7 @@ CREATE TABLE IF NOT EXISTS public.calendar_notes (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: calendar_sources; Type: TABLE; Schema: public; Owner: -
@@ -212,6 +235,7 @@ CREATE TABLE IF NOT EXISTS public.calendar_sources (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: chore_completions; Type: TABLE; Schema: public; Owner: -
 --
@@ -228,6 +252,7 @@ CREATE TABLE IF NOT EXISTS public.chore_completions (
     notes text
 );
 
+
 --
 -- Name: chores; Type: TABLE; Schema: public; Owner: -
 --
@@ -243,14 +268,15 @@ CREATE TABLE IF NOT EXISTS public.chores (
     start_day character varying(10),
     last_completed timestamp without time zone,
     next_due date,
-    next_due_time character varying(5),
     point_value integer DEFAULT 0 NOT NULL,
     requires_approval boolean DEFAULT false NOT NULL,
     enabled boolean DEFAULT true NOT NULL,
     created_by uuid,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    next_due_time character varying(5)
 );
+
 
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: -
@@ -276,6 +302,7 @@ CREATE TABLE IF NOT EXISTS public.events (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: family_messages; Type: TABLE; Schema: public; Owner: -
 --
@@ -290,6 +317,7 @@ CREATE TABLE IF NOT EXISTS public.family_messages (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: gift_ideas; Type: TABLE; Schema: public; Owner: -
@@ -310,6 +338,7 @@ CREATE TABLE IF NOT EXISTS public.gift_ideas (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: goal_achievements; Type: TABLE; Schema: public; Owner: -
 --
@@ -321,6 +350,7 @@ CREATE TABLE IF NOT EXISTS public.goal_achievements (
     period_start date NOT NULL,
     achieved_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: goals; Type: TABLE; Schema: public; Owner: -
@@ -341,6 +371,7 @@ CREATE TABLE IF NOT EXISTS public.goals (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: layouts; Type: TABLE; Schema: public; Owner: -
 --
@@ -360,6 +391,7 @@ CREATE TABLE IF NOT EXISTS public.layouts (
     font_scale integer
 );
 
+
 --
 -- Name: maintenance_completions; Type: TABLE; Schema: public; Owner: -
 --
@@ -373,6 +405,7 @@ CREATE TABLE IF NOT EXISTS public.maintenance_completions (
     vendor character varying(255),
     notes text
 );
+
 
 --
 -- Name: maintenance_reminders; Type: TABLE; Schema: public; Owner: -
@@ -394,6 +427,7 @@ CREATE TABLE IF NOT EXISTS public.maintenance_reminders (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: meals; Type: TABLE; Schema: public; Owner: -
 --
@@ -412,15 +446,16 @@ CREATE TABLE IF NOT EXISTS public.meals (
     week_of date NOT NULL,
     day_of_week character varying(20) NOT NULL,
     meal_type character varying(20) NOT NULL,
-    meal_time character varying(5),
     cooked_at timestamp without time zone,
     cooked_by uuid,
     source character varying(50) DEFAULT 'internal'::character varying NOT NULL,
     source_id character varying(255),
     created_by uuid,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    meal_time character varying(5)
 );
+
 
 --
 -- Name: photo_sources; Type: TABLE; Schema: public; Owner: -
@@ -440,6 +475,7 @@ CREATE TABLE IF NOT EXISTS public.photo_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: photos; Type: TABLE; Schema: public; Owner: -
@@ -462,8 +498,10 @@ CREATE TABLE IF NOT EXISTS public.photos (
     usage character varying(100) DEFAULT 'wallpaper,gallery,screensaver'::character varying NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     latitude numeric(9,6),
-    longitude numeric(10,6)
+    longitude numeric(10,6),
+    is_external boolean DEFAULT false NOT NULL
 );
+
 
 --
 -- Name: recipes; Type: TABLE; Schema: public; Owner: -
@@ -494,6 +532,7 @@ CREATE TABLE IF NOT EXISTS public.recipes (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: settings; Type: TABLE; Schema: public; Owner: -
 --
@@ -504,6 +543,7 @@ CREATE TABLE IF NOT EXISTS public.settings (
     value jsonb NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: shopping_items; Type: TABLE; Schema: public; Owner: -
@@ -531,6 +571,7 @@ CREATE TABLE IF NOT EXISTS public.shopping_items (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: shopping_list_sources; Type: TABLE; Schema: public; Owner: -
 --
@@ -552,6 +593,7 @@ CREATE TABLE IF NOT EXISTS public.shopping_list_sources (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: shopping_lists; Type: TABLE; Schema: public; Owner: -
 --
@@ -571,6 +613,7 @@ CREATE TABLE IF NOT EXISTS public.shopping_lists (
     visible_categories jsonb
 );
 
+
 --
 -- Name: task_lists; Type: TABLE; Schema: public; Owner: -
 --
@@ -584,6 +627,7 @@ CREATE TABLE IF NOT EXISTS public.task_lists (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: task_sources; Type: TABLE; Schema: public; Owner: -
@@ -605,6 +649,7 @@ CREATE TABLE IF NOT EXISTS public.task_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: tasks; Type: TABLE; Schema: public; Owner: -
@@ -631,6 +676,7 @@ CREATE TABLE IF NOT EXISTS public.tasks (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: travel_pin_photos; Type: TABLE; Schema: public; Owner: -
 --
@@ -642,6 +688,7 @@ CREATE TABLE IF NOT EXISTS public.travel_pin_photos (
     linked_manually boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: travel_pins; Type: TABLE; Schema: public; Owner: -
@@ -670,8 +717,36 @@ CREATE TABLE IF NOT EXISTS public.travel_pins (
     stops jsonb DEFAULT '[]'::jsonb NOT NULL,
     national_parks jsonb DEFAULT '[]'::jsonb NOT NULL,
     parent_id uuid,
-    pin_type character varying(20) DEFAULT 'location'::character varying NOT NULL
+    pin_type character varying(20) DEFAULT 'location'::character varying NOT NULL,
+    trip_id uuid,
+    is_hub boolean DEFAULT false NOT NULL
 );
+
+
+--
+-- Name: travel_trips; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS public.travel_trips (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    trip_style character varying(20) NOT NULL,
+    status character varying(20) DEFAULT 'want_to_go'::character varying NOT NULL,
+    is_bucket_list boolean DEFAULT false NOT NULL,
+    color character varying(7),
+    emoji character varying(10),
+    visited_date date,
+    visited_end_date date,
+    year integer,
+    member_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    created_by uuid,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
@@ -690,6 +765,50 @@ CREATE TABLE IF NOT EXISTS public.users (
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     sort_order integer DEFAULT 0 NOT NULL
 );
+
+
+--
+-- Name: weekend_places; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS public.weekend_places (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    latitude numeric(9,6),
+    longitude numeric(10,6),
+    place_name character varying(255),
+    address character varying(500),
+    url character varying(1000),
+    status character varying(20) DEFAULT 'backlog'::character varying NOT NULL,
+    is_favorite boolean DEFAULT false NOT NULL,
+    rating integer,
+    notes text,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    source_provider character varying(20),
+    source_id character varying(100),
+    last_visited_date character varying(10),
+    visit_count integer DEFAULT 0 NOT NULL,
+    created_by uuid,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: weekend_visits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS public.weekend_visits (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    place_id uuid NOT NULL,
+    visited_by uuid,
+    visited_on character varying(10) NOT NULL,
+    rating integer,
+    notes text,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
 
 --
 -- Name: wish_item_sources; Type: TABLE; Schema: public; Owner: -
@@ -711,6 +830,7 @@ CREATE TABLE IF NOT EXISTS public.wish_item_sources (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
+
 
 --
 -- Name: wish_items; Type: TABLE; Schema: public; Owner: -
@@ -734,11 +854,13 @@ CREATE TABLE IF NOT EXISTS public.wish_items (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
+
 --
 -- Name: __prism_migrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.__prism_migrations ALTER COLUMN id SET DEFAULT nextval('public.__prism_migrations_id_seq'::regclass);
+
 
 --
 -- Name: __prism_migrations __prism_migrations_name_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -747,12 +869,14 @@ ALTER TABLE ONLY public.__prism_migrations ALTER COLUMN id SET DEFAULT nextval('
 ALTER TABLE ONLY public.__prism_migrations
     ADD CONSTRAINT __prism_migrations_name_key UNIQUE (name);
 
+
 --
 -- Name: __prism_migrations __prism_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.__prism_migrations
     ADD CONSTRAINT __prism_migrations_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: api_credentials api_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -761,12 +885,14 @@ ALTER TABLE ONLY public.__prism_migrations
 ALTER TABLE ONLY public.api_credentials
     ADD CONSTRAINT api_credentials_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: api_credentials api_credentials_service_unique; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.api_credentials
     ADD CONSTRAINT api_credentials_service_unique UNIQUE (service);
+
 
 --
 -- Name: api_tokens api_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -775,12 +901,14 @@ ALTER TABLE ONLY public.api_credentials
 ALTER TABLE ONLY public.api_tokens
     ADD CONSTRAINT api_tokens_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: audit_logs audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.audit_logs
     ADD CONSTRAINT audit_logs_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: babysitter_info babysitter_info_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -789,12 +917,14 @@ ALTER TABLE ONLY public.audit_logs
 ALTER TABLE ONLY public.babysitter_info
     ADD CONSTRAINT babysitter_info_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: birthdays birthdays_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: bus_geofence_log bus_geofence_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -803,12 +933,14 @@ ALTER TABLE ONLY public.birthdays
 ALTER TABLE ONLY public.bus_geofence_log
     ADD CONSTRAINT bus_geofence_log_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: bus_routes bus_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.bus_routes
     ADD CONSTRAINT bus_routes_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: calendar_groups calendar_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -817,12 +949,14 @@ ALTER TABLE ONLY public.bus_routes
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: calendar_notes calendar_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.calendar_notes
     ADD CONSTRAINT calendar_notes_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: calendar_sources calendar_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -831,12 +965,14 @@ ALTER TABLE ONLY public.calendar_notes
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: chore_completions chore_completions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: chores chores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -845,12 +981,14 @@ ALTER TABLE ONLY public.chore_completions
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: family_messages family_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -859,12 +997,14 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: gift_ideas gift_ideas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: goal_achievements goal_achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -873,12 +1013,14 @@ ALTER TABLE ONLY public.gift_ideas
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: goals goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.goals
     ADD CONSTRAINT goals_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: layouts layouts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -887,12 +1029,14 @@ ALTER TABLE ONLY public.goals
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: layouts layouts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_slug_key UNIQUE (slug);
+
 
 --
 -- Name: maintenance_completions maintenance_completions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -901,12 +1045,14 @@ ALTER TABLE ONLY public.layouts
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: maintenance_reminders maintenance_reminders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: meals meals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -915,12 +1061,14 @@ ALTER TABLE ONLY public.maintenance_reminders
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: photo_sources photo_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.photo_sources
     ADD CONSTRAINT photo_sources_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: photos photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -929,12 +1077,14 @@ ALTER TABLE ONLY public.photo_sources
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: recipes recipes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.recipes
     ADD CONSTRAINT recipes_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: settings settings_key_unique; Type: CONSTRAINT; Schema: public; Owner: -
@@ -943,12 +1093,14 @@ ALTER TABLE ONLY public.recipes
 ALTER TABLE ONLY public.settings
     ADD CONSTRAINT settings_key_unique UNIQUE (key);
 
+
 --
 -- Name: settings settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.settings
     ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: shopping_items shopping_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -957,12 +1109,14 @@ ALTER TABLE ONLY public.settings
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: shopping_list_sources shopping_list_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: shopping_lists shopping_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -971,12 +1125,14 @@ ALTER TABLE ONLY public.shopping_list_sources
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: task_lists task_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.task_lists
     ADD CONSTRAINT task_lists_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: task_sources task_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -985,12 +1141,14 @@ ALTER TABLE ONLY public.task_lists
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: tasks tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: travel_pin_photos travel_pin_photos_pin_photo_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -999,12 +1157,14 @@ ALTER TABLE ONLY public.tasks
 ALTER TABLE ONLY public.travel_pin_photos
     ADD CONSTRAINT travel_pin_photos_pin_photo_key UNIQUE (pin_id, photo_id);
 
+
 --
 -- Name: travel_pin_photos travel_pin_photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.travel_pin_photos
     ADD CONSTRAINT travel_pin_photos_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: travel_pins travel_pins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -1013,12 +1173,38 @@ ALTER TABLE ONLY public.travel_pin_photos
 ALTER TABLE ONLY public.travel_pins
     ADD CONSTRAINT travel_pins_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: travel_trips travel_trips_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.travel_trips
+    ADD CONSTRAINT travel_trips_pkey PRIMARY KEY (id);
+
+
 --
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: weekend_places weekend_places_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.weekend_places
+    ADD CONSTRAINT weekend_places_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: weekend_visits weekend_visits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.weekend_visits
+    ADD CONSTRAINT weekend_visits_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: wish_item_sources wish_item_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -1027,6 +1213,7 @@ ALTER TABLE ONLY public.users
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: wish_items wish_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
@@ -1034,11 +1221,13 @@ ALTER TABLE ONLY public.wish_item_sources
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: api_tokens_created_by_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS api_tokens_created_by_idx ON public.api_tokens USING btree (created_by);
+
 
 --
 -- Name: api_tokens_token_hash_idx; Type: INDEX; Schema: public; Owner: -
@@ -1046,11 +1235,13 @@ CREATE INDEX IF NOT EXISTS api_tokens_created_by_idx ON public.api_tokens USING 
 
 CREATE UNIQUE INDEX IF NOT EXISTS api_tokens_token_hash_idx ON public.api_tokens USING btree (token_hash);
 
+
 --
 -- Name: audit_logs_created_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON public.audit_logs USING btree (created_at);
+
 
 --
 -- Name: audit_logs_entity_type_idx; Type: INDEX; Schema: public; Owner: -
@@ -1058,11 +1249,13 @@ CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON public.audit_logs USING 
 
 CREATE INDEX IF NOT EXISTS audit_logs_entity_type_idx ON public.audit_logs USING btree (entity_type);
 
+
 --
 -- Name: audit_logs_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS audit_logs_user_id_idx ON public.audit_logs USING btree (user_id);
+
 
 --
 -- Name: babysitter_info_section_idx; Type: INDEX; Schema: public; Owner: -
@@ -1070,11 +1263,13 @@ CREATE INDEX IF NOT EXISTS audit_logs_user_id_idx ON public.audit_logs USING btr
 
 CREATE INDEX IF NOT EXISTS babysitter_info_section_idx ON public.babysitter_info USING btree (section);
 
+
 --
 -- Name: babysitter_info_sort_order_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS babysitter_info_sort_order_idx ON public.babysitter_info USING btree (sort_order);
+
 
 --
 -- Name: birthdays_name_event_type_idx; Type: INDEX; Schema: public; Owner: -
@@ -1082,11 +1277,13 @@ CREATE INDEX IF NOT EXISTS babysitter_info_sort_order_idx ON public.babysitter_i
 
 CREATE UNIQUE INDEX IF NOT EXISTS birthdays_name_event_type_idx ON public.birthdays USING btree (name, event_type);
 
+
 --
 -- Name: bus_geofence_log_event_time_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS bus_geofence_log_event_time_idx ON public.bus_geofence_log USING btree (event_time);
+
 
 --
 -- Name: bus_geofence_log_gmail_message_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1094,11 +1291,13 @@ CREATE INDEX IF NOT EXISTS bus_geofence_log_event_time_idx ON public.bus_geofenc
 
 CREATE UNIQUE INDEX IF NOT EXISTS bus_geofence_log_gmail_message_id_idx ON public.bus_geofence_log USING btree (gmail_message_id);
 
+
 --
 -- Name: bus_geofence_log_route_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS bus_geofence_log_route_id_idx ON public.bus_geofence_log USING btree (route_id);
+
 
 --
 -- Name: bus_geofence_log_trip_date_idx; Type: INDEX; Schema: public; Owner: -
@@ -1106,11 +1305,13 @@ CREATE INDEX IF NOT EXISTS bus_geofence_log_route_id_idx ON public.bus_geofence_
 
 CREATE INDEX IF NOT EXISTS bus_geofence_log_trip_date_idx ON public.bus_geofence_log USING btree (trip_date);
 
+
 --
 -- Name: bus_routes_enabled_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS bus_routes_enabled_idx ON public.bus_routes USING btree (enabled);
+
 
 --
 -- Name: bus_routes_trip_direction_idx; Type: INDEX; Schema: public; Owner: -
@@ -1118,11 +1319,13 @@ CREATE INDEX IF NOT EXISTS bus_routes_enabled_idx ON public.bus_routes USING btr
 
 CREATE UNIQUE INDEX IF NOT EXISTS bus_routes_trip_direction_idx ON public.bus_routes USING btree (trip_id, direction);
 
+
 --
 -- Name: calendar_groups_type_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS calendar_groups_type_idx ON public.calendar_groups USING btree (type);
+
 
 --
 -- Name: calendar_notes_date_idx; Type: INDEX; Schema: public; Owner: -
@@ -1130,11 +1333,13 @@ CREATE INDEX IF NOT EXISTS calendar_groups_type_idx ON public.calendar_groups US
 
 CREATE UNIQUE INDEX IF NOT EXISTS calendar_notes_date_idx ON public.calendar_notes USING btree (date);
 
+
 --
 -- Name: calendar_sources_enabled_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS calendar_sources_enabled_idx ON public.calendar_sources USING btree (enabled);
+
 
 --
 -- Name: calendar_sources_user_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1142,11 +1347,13 @@ CREATE INDEX IF NOT EXISTS calendar_sources_enabled_idx ON public.calendar_sourc
 
 CREATE INDEX IF NOT EXISTS calendar_sources_user_id_idx ON public.calendar_sources USING btree (user_id);
 
+
 --
 -- Name: chore_completions_approved_by_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS chore_completions_approved_by_idx ON public.chore_completions USING btree (approved_by);
+
 
 --
 -- Name: chore_completions_chore_approved_by_idx; Type: INDEX; Schema: public; Owner: -
@@ -1154,11 +1361,13 @@ CREATE INDEX IF NOT EXISTS chore_completions_approved_by_idx ON public.chore_com
 
 CREATE INDEX IF NOT EXISTS chore_completions_chore_approved_by_idx ON public.chore_completions USING btree (chore_id, approved_by);
 
+
 --
 -- Name: chore_completions_chore_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS chore_completions_chore_id_idx ON public.chore_completions USING btree (chore_id);
+
 
 --
 -- Name: chore_completions_completed_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -1166,11 +1375,13 @@ CREATE INDEX IF NOT EXISTS chore_completions_chore_id_idx ON public.chore_comple
 
 CREATE INDEX IF NOT EXISTS chore_completions_completed_at_idx ON public.chore_completions USING btree (completed_at);
 
+
 --
 -- Name: chores_assigned_to_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS chores_assigned_to_idx ON public.chores USING btree (assigned_to);
+
 
 --
 -- Name: chores_next_due_idx; Type: INDEX; Schema: public; Owner: -
@@ -1178,11 +1389,13 @@ CREATE INDEX IF NOT EXISTS chores_assigned_to_idx ON public.chores USING btree (
 
 CREATE INDEX IF NOT EXISTS chores_next_due_idx ON public.chores USING btree (next_due);
 
+
 --
 -- Name: events_calendar_source_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS events_calendar_source_idx ON public.events USING btree (calendar_source_id);
+
 
 --
 -- Name: events_end_time_idx; Type: INDEX; Schema: public; Owner: -
@@ -1190,11 +1403,13 @@ CREATE INDEX IF NOT EXISTS events_calendar_source_idx ON public.events USING btr
 
 CREATE INDEX IF NOT EXISTS events_end_time_idx ON public.events USING btree (end_time);
 
+
 --
 -- Name: events_source_external_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX IF NOT EXISTS events_source_external_unique ON public.events USING btree (calendar_source_id, external_event_id);
+
 
 --
 -- Name: events_start_time_idx; Type: INDEX; Schema: public; Owner: -
@@ -1202,11 +1417,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS events_source_external_unique ON public.events
 
 CREATE INDEX IF NOT EXISTS events_start_time_idx ON public.events USING btree (start_time);
 
+
 --
 -- Name: family_messages_created_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS family_messages_created_at_idx ON public.family_messages USING btree (created_at);
+
 
 --
 -- Name: family_messages_expires_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -1214,11 +1431,13 @@ CREATE INDEX IF NOT EXISTS family_messages_created_at_idx ON public.family_messa
 
 CREATE INDEX IF NOT EXISTS family_messages_expires_at_idx ON public.family_messages USING btree (expires_at);
 
+
 --
 -- Name: gift_ideas_created_by_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS gift_ideas_created_by_idx ON public.gift_ideas USING btree (created_by);
+
 
 --
 -- Name: gift_ideas_for_user_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1226,11 +1445,13 @@ CREATE INDEX IF NOT EXISTS gift_ideas_created_by_idx ON public.gift_ideas USING 
 
 CREATE INDEX IF NOT EXISTS gift_ideas_for_user_id_idx ON public.gift_ideas USING btree (for_user_id);
 
+
 --
 -- Name: gift_ideas_for_user_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS gift_ideas_for_user_idx ON public.gift_ideas USING btree (for_user_id);
+
 
 --
 -- Name: goal_achievements_goal_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1238,11 +1459,13 @@ CREATE INDEX IF NOT EXISTS gift_ideas_for_user_idx ON public.gift_ideas USING bt
 
 CREATE INDEX IF NOT EXISTS goal_achievements_goal_id_idx ON public.goal_achievements USING btree (goal_id);
 
+
 --
 -- Name: goal_achievements_goal_user_period_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX IF NOT EXISTS goal_achievements_goal_user_period_idx ON public.goal_achievements USING btree (goal_id, user_id, period_start);
+
 
 --
 -- Name: goal_achievements_unique_idx; Type: INDEX; Schema: public; Owner: -
@@ -1250,11 +1473,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS goal_achievements_goal_user_period_idx ON publ
 
 CREATE UNIQUE INDEX IF NOT EXISTS goal_achievements_unique_idx ON public.goal_achievements USING btree (goal_id, user_id, period_start);
 
+
 --
 -- Name: goal_achievements_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS goal_achievements_user_id_idx ON public.goal_achievements USING btree (user_id);
+
 
 --
 -- Name: goals_active_idx; Type: INDEX; Schema: public; Owner: -
@@ -1262,11 +1487,13 @@ CREATE INDEX IF NOT EXISTS goal_achievements_user_id_idx ON public.goal_achievem
 
 CREATE INDEX IF NOT EXISTS goals_active_idx ON public.goals USING btree (active);
 
+
 --
 -- Name: goals_active_priority_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS goals_active_priority_idx ON public.goals USING btree (active, priority);
+
 
 --
 -- Name: layouts_slug_unique_idx; Type: INDEX; Schema: public; Owner: -
@@ -1274,11 +1501,13 @@ CREATE INDEX IF NOT EXISTS goals_active_priority_idx ON public.goals USING btree
 
 CREATE UNIQUE INDEX IF NOT EXISTS layouts_slug_unique_idx ON public.layouts USING btree (slug) WHERE (slug IS NOT NULL);
 
+
 --
 -- Name: maintenance_reminders_next_due_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS maintenance_reminders_next_due_idx ON public.maintenance_reminders USING btree (next_due);
+
 
 --
 -- Name: meals_day_of_week_idx; Type: INDEX; Schema: public; Owner: -
@@ -1286,11 +1515,13 @@ CREATE INDEX IF NOT EXISTS maintenance_reminders_next_due_idx ON public.maintena
 
 CREATE INDEX IF NOT EXISTS meals_day_of_week_idx ON public.meals USING btree (day_of_week);
 
+
 --
 -- Name: meals_week_of_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS meals_week_of_idx ON public.meals USING btree (week_of);
+
 
 --
 -- Name: photos_favorite_idx; Type: INDEX; Schema: public; Owner: -
@@ -1298,11 +1529,13 @@ CREATE INDEX IF NOT EXISTS meals_week_of_idx ON public.meals USING btree (week_o
 
 CREATE INDEX IF NOT EXISTS photos_favorite_idx ON public.photos USING btree (favorite);
 
+
 --
 -- Name: photos_source_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS photos_source_id_idx ON public.photos USING btree (source_id);
+
 
 --
 -- Name: photos_taken_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -1310,11 +1543,13 @@ CREATE INDEX IF NOT EXISTS photos_source_id_idx ON public.photos USING btree (so
 
 CREATE INDEX IF NOT EXISTS photos_taken_at_idx ON public.photos USING btree (taken_at);
 
+
 --
 -- Name: photos_usage_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS photos_usage_idx ON public.photos USING btree (usage);
+
 
 --
 -- Name: recipes_favorite_idx; Type: INDEX; Schema: public; Owner: -
@@ -1322,11 +1557,13 @@ CREATE INDEX IF NOT EXISTS photos_usage_idx ON public.photos USING btree (usage)
 
 CREATE INDEX IF NOT EXISTS recipes_favorite_idx ON public.recipes USING btree (is_favorite);
 
+
 --
 -- Name: recipes_name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS recipes_name_idx ON public.recipes USING btree (name);
+
 
 --
 -- Name: recipes_source_type_idx; Type: INDEX; Schema: public; Owner: -
@@ -1334,11 +1571,13 @@ CREATE INDEX IF NOT EXISTS recipes_name_idx ON public.recipes USING btree (name)
 
 CREATE INDEX IF NOT EXISTS recipes_source_type_idx ON public.recipes USING btree (source_type);
 
+
 --
 -- Name: shopping_items_category_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS shopping_items_category_idx ON public.shopping_items USING btree (category);
+
 
 --
 -- Name: shopping_items_checked_idx; Type: INDEX; Schema: public; Owner: -
@@ -1346,11 +1585,13 @@ CREATE INDEX IF NOT EXISTS shopping_items_category_idx ON public.shopping_items 
 
 CREATE INDEX IF NOT EXISTS shopping_items_checked_idx ON public.shopping_items USING btree (checked);
 
+
 --
 -- Name: shopping_items_external_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS shopping_items_external_id_idx ON public.shopping_items USING btree (external_id);
+
 
 --
 -- Name: shopping_items_list_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1358,11 +1599,13 @@ CREATE INDEX IF NOT EXISTS shopping_items_external_id_idx ON public.shopping_ite
 
 CREATE INDEX IF NOT EXISTS shopping_items_list_id_idx ON public.shopping_items USING btree (list_id);
 
+
 --
 -- Name: shopping_items_shopping_list_source_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS shopping_items_shopping_list_source_id_idx ON public.shopping_items USING btree (shopping_list_source_id);
+
 
 --
 -- Name: shopping_items_source_idx; Type: INDEX; Schema: public; Owner: -
@@ -1370,11 +1613,13 @@ CREATE INDEX IF NOT EXISTS shopping_items_shopping_list_source_id_idx ON public.
 
 CREATE INDEX IF NOT EXISTS shopping_items_source_idx ON public.shopping_items USING btree (shopping_list_source_id);
 
+
 --
 -- Name: shopping_list_sources_shopping_list_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS shopping_list_sources_shopping_list_idx ON public.shopping_list_sources USING btree (shopping_list_id);
+
 
 --
 -- Name: shopping_list_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
@@ -1382,11 +1627,13 @@ CREATE INDEX IF NOT EXISTS shopping_list_sources_shopping_list_idx ON public.sho
 
 CREATE INDEX IF NOT EXISTS shopping_list_sources_user_provider_idx ON public.shopping_list_sources USING btree (user_id, provider);
 
+
 --
 -- Name: task_sources_task_list_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS task_sources_task_list_idx ON public.task_sources USING btree (task_list_id);
+
 
 --
 -- Name: task_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
@@ -1394,11 +1641,13 @@ CREATE INDEX IF NOT EXISTS task_sources_task_list_idx ON public.task_sources USI
 
 CREATE INDEX IF NOT EXISTS task_sources_user_provider_idx ON public.task_sources USING btree (user_id, provider);
 
+
 --
 -- Name: tasks_assigned_to_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS tasks_assigned_to_idx ON public.tasks USING btree (assigned_to);
+
 
 --
 -- Name: tasks_completed_idx; Type: INDEX; Schema: public; Owner: -
@@ -1406,11 +1655,13 @@ CREATE INDEX IF NOT EXISTS tasks_assigned_to_idx ON public.tasks USING btree (as
 
 CREATE INDEX IF NOT EXISTS tasks_completed_idx ON public.tasks USING btree (completed);
 
+
 --
 -- Name: tasks_due_date_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS tasks_due_date_idx ON public.tasks USING btree (due_date);
+
 
 --
 -- Name: tasks_external_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1418,11 +1669,13 @@ CREATE INDEX IF NOT EXISTS tasks_due_date_idx ON public.tasks USING btree (due_d
 
 CREATE INDEX IF NOT EXISTS tasks_external_id_idx ON public.tasks USING btree (external_id);
 
+
 --
 -- Name: tasks_list_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS tasks_list_id_idx ON public.tasks USING btree (list_id);
+
 
 --
 -- Name: tasks_task_source_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1430,11 +1683,13 @@ CREATE INDEX IF NOT EXISTS tasks_list_id_idx ON public.tasks USING btree (list_i
 
 CREATE INDEX IF NOT EXISTS tasks_task_source_id_idx ON public.tasks USING btree (task_source_id);
 
+
 --
 -- Name: tasks_task_source_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS tasks_task_source_idx ON public.tasks USING btree (task_source_id);
+
 
 --
 -- Name: travel_pin_photos_photo_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1442,11 +1697,13 @@ CREATE INDEX IF NOT EXISTS tasks_task_source_idx ON public.tasks USING btree (ta
 
 CREATE INDEX IF NOT EXISTS travel_pin_photos_photo_id_idx ON public.travel_pin_photos USING btree (photo_id);
 
+
 --
 -- Name: travel_pin_photos_pin_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS travel_pin_photos_pin_id_idx ON public.travel_pin_photos USING btree (pin_id);
+
 
 --
 -- Name: travel_pins_parent_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1454,11 +1711,27 @@ CREATE INDEX IF NOT EXISTS travel_pin_photos_pin_id_idx ON public.travel_pin_pho
 
 CREATE INDEX IF NOT EXISTS travel_pins_parent_id_idx ON public.travel_pins USING btree (parent_id);
 
+
+--
+-- Name: travel_pins_trip_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS travel_pins_trip_id_idx ON public.travel_pins USING btree (trip_id);
+
+
 --
 -- Name: travel_pins_year_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS travel_pins_year_idx ON public.travel_pins USING btree (year);
+
+
+--
+-- Name: travel_trips_year_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS travel_trips_year_idx ON public.travel_trips USING btree (year);
+
 
 --
 -- Name: users_email_idx; Type: INDEX; Schema: public; Owner: -
@@ -1466,11 +1739,41 @@ CREATE INDEX IF NOT EXISTS travel_pins_year_idx ON public.travel_pins USING btre
 
 CREATE INDEX IF NOT EXISTS users_email_idx ON public.users USING btree (email);
 
+
+--
+-- Name: weekend_places_favorite_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS weekend_places_favorite_idx ON public.weekend_places USING btree (is_favorite);
+
+
+--
+-- Name: weekend_places_last_visited_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS weekend_places_last_visited_idx ON public.weekend_places USING btree (last_visited_date);
+
+
+--
+-- Name: weekend_places_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS weekend_places_status_idx ON public.weekend_places USING btree (status);
+
+
+--
+-- Name: weekend_visits_place_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS weekend_visits_place_id_idx ON public.weekend_visits USING btree (place_id, visited_on);
+
+
 --
 -- Name: wish_item_sources_member_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_item_sources_member_idx ON public.wish_item_sources USING btree (member_id);
+
 
 --
 -- Name: wish_item_sources_unique_idx; Type: INDEX; Schema: public; Owner: -
@@ -1478,11 +1781,13 @@ CREATE INDEX IF NOT EXISTS wish_item_sources_member_idx ON public.wish_item_sour
 
 CREATE UNIQUE INDEX IF NOT EXISTS wish_item_sources_unique_idx ON public.wish_item_sources USING btree (user_id, member_id, provider);
 
+
 --
 -- Name: wish_item_sources_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_item_sources_user_id_idx ON public.wish_item_sources USING btree (user_id);
+
 
 --
 -- Name: wish_item_sources_user_provider_idx; Type: INDEX; Schema: public; Owner: -
@@ -1490,11 +1795,13 @@ CREATE INDEX IF NOT EXISTS wish_item_sources_user_id_idx ON public.wish_item_sou
 
 CREATE INDEX IF NOT EXISTS wish_item_sources_user_provider_idx ON public.wish_item_sources USING btree (user_id, provider);
 
+
 --
 -- Name: wish_items_added_by_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_items_added_by_idx ON public.wish_items USING btree (added_by);
+
 
 --
 -- Name: wish_items_claimed_idx; Type: INDEX; Schema: public; Owner: -
@@ -1502,11 +1809,13 @@ CREATE INDEX IF NOT EXISTS wish_items_added_by_idx ON public.wish_items USING bt
 
 CREATE INDEX IF NOT EXISTS wish_items_claimed_idx ON public.wish_items USING btree (claimed);
 
+
 --
 -- Name: wish_items_external_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_items_external_id_idx ON public.wish_items USING btree (external_id);
+
 
 --
 -- Name: wish_items_member_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -1514,17 +1823,20 @@ CREATE INDEX IF NOT EXISTS wish_items_external_id_idx ON public.wish_items USING
 
 CREATE INDEX IF NOT EXISTS wish_items_member_id_idx ON public.wish_items USING btree (member_id);
 
+
 --
 -- Name: wish_items_source_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_items_source_idx ON public.wish_items USING btree (wish_item_source_id);
 
+
 --
 -- Name: wish_items_wish_item_source_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX IF NOT EXISTS wish_items_wish_item_source_id_idx ON public.wish_items USING btree (wish_item_source_id);
+
 
 --
 -- Name: api_tokens api_tokens_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1533,12 +1845,14 @@ CREATE INDEX IF NOT EXISTS wish_items_wish_item_source_id_idx ON public.wish_ite
 ALTER TABLE ONLY public.api_tokens
     ADD CONSTRAINT api_tokens_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: audit_logs audit_logs_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.audit_logs
     ADD CONSTRAINT audit_logs_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: birthdays birthdays_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1547,12 +1861,14 @@ ALTER TABLE ONLY public.audit_logs
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: birthdays birthdays_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.birthdays
     ADD CONSTRAINT birthdays_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: bus_geofence_log bus_geofence_log_route_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1561,12 +1877,14 @@ ALTER TABLE ONLY public.birthdays
 ALTER TABLE ONLY public.bus_geofence_log
     ADD CONSTRAINT bus_geofence_log_route_id_fkey FOREIGN KEY (route_id) REFERENCES public.bus_routes(id) ON DELETE CASCADE;
 
+
 --
 -- Name: bus_routes bus_routes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.bus_routes
     ADD CONSTRAINT bus_routes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: calendar_groups calendar_groups_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1575,12 +1893,14 @@ ALTER TABLE ONLY public.bus_routes
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: calendar_groups calendar_groups_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.calendar_groups
     ADD CONSTRAINT calendar_groups_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: calendar_notes calendar_notes_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1589,12 +1909,14 @@ ALTER TABLE ONLY public.calendar_groups
 ALTER TABLE ONLY public.calendar_notes
     ADD CONSTRAINT calendar_notes_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: calendar_sources calendar_sources_group_id_calendar_groups_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_group_id_calendar_groups_id_fk FOREIGN KEY (group_id) REFERENCES public.calendar_groups(id) ON DELETE SET NULL;
+
 
 --
 -- Name: calendar_sources calendar_sources_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1603,12 +1925,14 @@ ALTER TABLE ONLY public.calendar_sources
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.calendar_groups(id) ON DELETE SET NULL;
 
+
 --
 -- Name: calendar_sources calendar_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: calendar_sources calendar_sources_user_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1617,12 +1941,14 @@ ALTER TABLE ONLY public.calendar_sources
 ALTER TABLE ONLY public.calendar_sources
     ADD CONSTRAINT calendar_sources_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: chore_completions chore_completions_approved_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_approved_by_fkey FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: chore_completions chore_completions_approved_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1631,12 +1957,14 @@ ALTER TABLE ONLY public.chore_completions
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_approved_by_users_id_fk FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: chore_completions chore_completions_chore_id_chores_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_chore_id_chores_id_fk FOREIGN KEY (chore_id) REFERENCES public.chores(id) ON DELETE CASCADE;
+
 
 --
 -- Name: chore_completions chore_completions_chore_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1645,12 +1973,14 @@ ALTER TABLE ONLY public.chore_completions
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_chore_id_fkey FOREIGN KEY (chore_id) REFERENCES public.chores(id) ON DELETE CASCADE;
 
+
 --
 -- Name: chore_completions chore_completions_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: chore_completions chore_completions_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1659,12 +1989,14 @@ ALTER TABLE ONLY public.chore_completions
 ALTER TABLE ONLY public.chore_completions
     ADD CONSTRAINT chore_completions_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: chores chores_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: chores chores_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1673,12 +2005,14 @@ ALTER TABLE ONLY public.chores
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: chores chores_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: chores chores_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1687,12 +2021,14 @@ ALTER TABLE ONLY public.chores
 ALTER TABLE ONLY public.chores
     ADD CONSTRAINT chores_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: events events_calendar_source_id_calendar_sources_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_calendar_source_id_calendar_sources_id_fk FOREIGN KEY (calendar_source_id) REFERENCES public.calendar_sources(id) ON DELETE CASCADE;
+
 
 --
 -- Name: events events_calendar_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1701,12 +2037,14 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_calendar_source_id_fkey FOREIGN KEY (calendar_source_id) REFERENCES public.calendar_sources(id) ON DELETE CASCADE;
 
+
 --
 -- Name: events events_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: events events_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1715,12 +2053,14 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: family_messages family_messages_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: family_messages family_messages_author_id_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1729,12 +2069,14 @@ ALTER TABLE ONLY public.family_messages
 ALTER TABLE ONLY public.family_messages
     ADD CONSTRAINT family_messages_author_id_users_id_fk FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: gift_ideas gift_ideas_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: gift_ideas gift_ideas_for_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1743,12 +2085,14 @@ ALTER TABLE ONLY public.gift_ideas
 ALTER TABLE ONLY public.gift_ideas
     ADD CONSTRAINT gift_ideas_for_user_id_fkey FOREIGN KEY (for_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: goal_achievements goal_achievements_goal_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_goal_id_fkey FOREIGN KEY (goal_id) REFERENCES public.goals(id) ON DELETE CASCADE;
+
 
 --
 -- Name: goal_achievements goal_achievements_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1757,12 +2101,14 @@ ALTER TABLE ONLY public.goal_achievements
 ALTER TABLE ONLY public.goal_achievements
     ADD CONSTRAINT goal_achievements_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: layouts layouts_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: layouts layouts_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1771,12 +2117,14 @@ ALTER TABLE ONLY public.layouts
 ALTER TABLE ONLY public.layouts
     ADD CONSTRAINT layouts_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: maintenance_completions maintenance_completions_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: maintenance_completions maintenance_completions_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1785,12 +2133,14 @@ ALTER TABLE ONLY public.maintenance_completions
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: maintenance_completions maintenance_completions_reminder_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_reminder_id_fkey FOREIGN KEY (reminder_id) REFERENCES public.maintenance_reminders(id) ON DELETE CASCADE;
+
 
 --
 -- Name: maintenance_completions maintenance_completions_reminder_id_maintenance_reminders_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1799,12 +2149,14 @@ ALTER TABLE ONLY public.maintenance_completions
 ALTER TABLE ONLY public.maintenance_completions
     ADD CONSTRAINT maintenance_completions_reminder_id_maintenance_reminders_id_fk FOREIGN KEY (reminder_id) REFERENCES public.maintenance_reminders(id) ON DELETE CASCADE;
 
+
 --
 -- Name: maintenance_reminders maintenance_reminders_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: maintenance_reminders maintenance_reminders_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1813,12 +2165,14 @@ ALTER TABLE ONLY public.maintenance_reminders
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: maintenance_reminders maintenance_reminders_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: maintenance_reminders maintenance_reminders_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1827,12 +2181,14 @@ ALTER TABLE ONLY public.maintenance_reminders
 ALTER TABLE ONLY public.maintenance_reminders
     ADD CONSTRAINT maintenance_reminders_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: meals meals_cooked_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_cooked_by_fkey FOREIGN KEY (cooked_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: meals meals_cooked_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1841,12 +2197,14 @@ ALTER TABLE ONLY public.meals
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_cooked_by_users_id_fk FOREIGN KEY (cooked_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: meals meals_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: meals meals_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1855,12 +2213,14 @@ ALTER TABLE ONLY public.meals
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: meals meals_recipe_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.meals
     ADD CONSTRAINT meals_recipe_id_fkey FOREIGN KEY (recipe_id) REFERENCES public.recipes(id) ON DELETE SET NULL;
+
 
 --
 -- Name: photos photos_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1869,12 +2229,14 @@ ALTER TABLE ONLY public.meals
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_source_id_fkey FOREIGN KEY (source_id) REFERENCES public.photo_sources(id) ON DELETE CASCADE;
 
+
 --
 -- Name: photos photos_source_id_photo_sources_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.photos
     ADD CONSTRAINT photos_source_id_photo_sources_id_fk FOREIGN KEY (source_id) REFERENCES public.photo_sources(id) ON DELETE CASCADE;
+
 
 --
 -- Name: recipes recipes_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1883,12 +2245,14 @@ ALTER TABLE ONLY public.photos
 ALTER TABLE ONLY public.recipes
     ADD CONSTRAINT recipes_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: shopping_items shopping_items_added_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_added_by_fkey FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: shopping_items shopping_items_added_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1897,12 +2261,14 @@ ALTER TABLE ONLY public.shopping_items
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_added_by_users_id_fk FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: shopping_items shopping_items_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_list_id_fkey FOREIGN KEY (list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
+
 
 --
 -- Name: shopping_items shopping_items_list_id_shopping_lists_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1911,12 +2277,14 @@ ALTER TABLE ONLY public.shopping_items
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_list_id_shopping_lists_id_fk FOREIGN KEY (list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
 
+
 --
 -- Name: shopping_items shopping_items_shopping_list_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_items
     ADD CONSTRAINT shopping_items_shopping_list_source_id_fkey FOREIGN KEY (shopping_list_source_id) REFERENCES public.shopping_list_sources(id) ON DELETE SET NULL;
+
 
 --
 -- Name: shopping_list_sources shopping_list_sources_shopping_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1925,12 +2293,14 @@ ALTER TABLE ONLY public.shopping_items
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_shopping_list_id_fkey FOREIGN KEY (shopping_list_id) REFERENCES public.shopping_lists(id) ON DELETE CASCADE;
 
+
 --
 -- Name: shopping_list_sources shopping_list_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_list_sources
     ADD CONSTRAINT shopping_list_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: shopping_lists shopping_lists_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1939,12 +2309,14 @@ ALTER TABLE ONLY public.shopping_list_sources
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: shopping_lists shopping_lists_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: shopping_lists shopping_lists_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1953,12 +2325,14 @@ ALTER TABLE ONLY public.shopping_lists
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: shopping_lists shopping_lists_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.shopping_lists
     ADD CONSTRAINT shopping_lists_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: task_lists task_lists_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1967,12 +2341,14 @@ ALTER TABLE ONLY public.shopping_lists
 ALTER TABLE ONLY public.task_lists
     ADD CONSTRAINT task_lists_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: task_sources task_sources_task_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_task_list_id_fkey FOREIGN KEY (task_list_id) REFERENCES public.task_lists(id) ON DELETE CASCADE;
+
 
 --
 -- Name: task_sources task_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1981,12 +2357,14 @@ ALTER TABLE ONLY public.task_sources
 ALTER TABLE ONLY public.task_sources
     ADD CONSTRAINT task_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: tasks tasks_assigned_to_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: tasks tasks_assigned_to_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -1995,12 +2373,14 @@ ALTER TABLE ONLY public.tasks
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_assigned_to_users_id_fk FOREIGN KEY (assigned_to) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: tasks tasks_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_completed_by_fkey FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: tasks tasks_completed_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2009,12 +2389,14 @@ ALTER TABLE ONLY public.tasks
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_completed_by_users_id_fk FOREIGN KEY (completed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: tasks tasks_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: tasks tasks_created_by_users_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2023,12 +2405,14 @@ ALTER TABLE ONLY public.tasks
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_created_by_users_id_fk FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: tasks tasks_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_list_id_fkey FOREIGN KEY (list_id) REFERENCES public.task_lists(id) ON DELETE CASCADE;
+
 
 --
 -- Name: tasks tasks_task_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2037,12 +2421,14 @@ ALTER TABLE ONLY public.tasks
 ALTER TABLE ONLY public.tasks
     ADD CONSTRAINT tasks_task_source_id_fkey FOREIGN KEY (task_source_id) REFERENCES public.task_sources(id) ON DELETE SET NULL;
 
+
 --
 -- Name: travel_pin_photos travel_pin_photos_photo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.travel_pin_photos
     ADD CONSTRAINT travel_pin_photos_photo_id_fkey FOREIGN KEY (photo_id) REFERENCES public.photos(id) ON DELETE CASCADE;
+
 
 --
 -- Name: travel_pin_photos travel_pin_photos_pin_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2051,12 +2437,14 @@ ALTER TABLE ONLY public.travel_pin_photos
 ALTER TABLE ONLY public.travel_pin_photos
     ADD CONSTRAINT travel_pin_photos_pin_id_fkey FOREIGN KEY (pin_id) REFERENCES public.travel_pins(id) ON DELETE CASCADE;
 
+
 --
 -- Name: travel_pins travel_pins_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.travel_pins
     ADD CONSTRAINT travel_pins_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: travel_pins travel_pins_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2065,12 +2453,54 @@ ALTER TABLE ONLY public.travel_pins
 ALTER TABLE ONLY public.travel_pins
     ADD CONSTRAINT travel_pins_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.travel_pins(id) ON DELETE CASCADE;
 
+
+--
+-- Name: travel_pins travel_pins_trip_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.travel_pins
+    ADD CONSTRAINT travel_pins_trip_id_fkey FOREIGN KEY (trip_id) REFERENCES public.travel_trips(id) ON DELETE CASCADE;
+
+
+--
+-- Name: travel_trips travel_trips_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.travel_trips
+    ADD CONSTRAINT travel_trips_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: weekend_places weekend_places_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.weekend_places
+    ADD CONSTRAINT weekend_places_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: weekend_visits weekend_visits_place_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.weekend_visits
+    ADD CONSTRAINT weekend_visits_place_id_fkey FOREIGN KEY (place_id) REFERENCES public.weekend_places(id) ON DELETE CASCADE;
+
+
+--
+-- Name: weekend_visits weekend_visits_visited_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.weekend_visits
+    ADD CONSTRAINT weekend_visits_visited_by_fkey FOREIGN KEY (visited_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
 --
 -- Name: wish_item_sources wish_item_sources_member_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_member_id_fkey FOREIGN KEY (member_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: wish_item_sources wish_item_sources_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2079,12 +2509,14 @@ ALTER TABLE ONLY public.wish_item_sources
 ALTER TABLE ONLY public.wish_item_sources
     ADD CONSTRAINT wish_item_sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
 --
 -- Name: wish_items wish_items_added_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_added_by_fkey FOREIGN KEY (added_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
 
 --
 -- Name: wish_items wish_items_claimed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2093,12 +2525,14 @@ ALTER TABLE ONLY public.wish_items
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES public.users(id) ON DELETE SET NULL;
 
+
 --
 -- Name: wish_items wish_items_member_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_member_id_fkey FOREIGN KEY (member_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
 
 --
 -- Name: wish_items wish_items_wish_item_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -2107,6 +2541,9 @@ ALTER TABLE ONLY public.wish_items
 ALTER TABLE ONLY public.wish_items
     ADD CONSTRAINT wish_items_wish_item_source_id_fkey FOREIGN KEY (wish_item_source_id) REFERENCES public.wish_item_sources(id) ON DELETE SET NULL;
 
+
 --
 -- PostgreSQL database dump complete
 --
+
+


### PR DESCRIPTION
## Summary

The fresh-install schema snapshot (\`src/lib/db/init/02-schema.sql\`) was 3 tables behind master:

- \`travel_trips\` (v1.4 — Travel Map)
- \`weekend_places\` (v1.5 — Weekend Ideas)
- \`weekend_visits\` (v1.5 — Weekend Ideas)

Anyone running \`scripts/test-fresh-install.sh\` or installing from scratch would have missed these tables until the incremental drizzle migrations ran on top. Now they're created cleanly on first init.

Also normalized \`CREATE SEQUENCE\` to \`IF NOT EXISTS\` for consistency with the rest of the file (\`CREATE TABLE\` / \`CREATE INDEX\` already had it).

## How regenerated

\`\`\`
docker exec prism-db pg_dump -U prism -d prism --schema-only --no-owner --no-privileges --no-comments > /tmp/dump.sql
\`\`\`

Then stripped \`SET\`, \`SELECT pg_catalog\`, \`\restrict\`/\`\unrestrict\`, and \`CREATE EXTENSION\` lines (those live in \`01-init.sql\`), and applied \`IF NOT EXISTS\` to \`CREATE TABLE\` / \`CREATE INDEX\` / \`CREATE SEQUENCE\`.

## Verification

- ✅ Fresh apply: created an empty \`prism_schemacheck\` DB, ran \`01-init.sql\` then the new \`02-schema.sql\` — no errors, 40 tables created.
- ✅ Table list matches live prism DB exactly (\`diff\` empty).
- ✅ \`CREATE OR REPLACE FUNCTION\` preserved for \`update_updated_at_column()\`.
- Diff: +444 / -7 lines (net add for 3 new tables + their indexes/constraints).

## Test plan

- [ ] CI green (lint, type-check, jest, migration-replay, e2e-modality)
- [ ] \`test-fresh-install.sh\` workflow passes against the new snapshot