### PR TITLE
fix(weather): forecast skips stale past-day entries (OWM, Pirate, Open-Meteo)

### DIFF
--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -206,6 +206,15 @@ export const WeatherWidget = React.memo(function WeatherWidget({
   // Clamp forecast days: default 7, max 7, min 1
   const resolvedDays = forecastDays ?? Math.min(7, Math.max(1, weatherData.forecast.length));
 
+  // Pre-filter to today-or-future so the label count matches what renders.
+  const now = new Date();
+  const todayLocalStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const visibleForecast = weatherData.forecast.slice(0, resolvedDays).filter((day) => {
+    const d = new Date(day.date);
+    const s = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    return s >= todayLocalStr;
+  });
+
   const hasDays = weatherData.forecast.length > 0;
 
   // Show precipitation chart when rain is imminent (any minute > 0.01 mm/hr) and data is available
@@ -244,10 +253,10 @@ export const WeatherWidget = React.memo(function WeatherWidget({
             {/* Multi-day summary */}
             <div>
               <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {resolvedDays}-Day Forecast
+                {visibleForecast.length}-Day Forecast
               </span>
               <DayHeader
-                days={weatherData.forecast.slice(0, resolvedDays)}
+                days={visibleForecast}
                 useCelsius={useCelsius}
               />
             </div>
@@ -343,21 +352,11 @@ function DayHeader({
   days: ForecastDay[];
   useCelsius: boolean;
 }) {
-  // Use local date comparison — server now groups by location-local date,
-  // and the browser is assumed to be in the same timezone as the location.
   const now = new Date();
   const todayLocalStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
-  // Drop any entries whose local date has already passed — guards against
-  // stale cache responses serving yesterday's data after midnight.
-  const validDays = days.filter((day) => {
-    const d = new Date(day.date);
-    const dayLocalStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-    return dayLocalStr >= todayLocalStr;
-  });
-
-  const globalMin = Math.min(...validDays.map((d) => d.low));
-  const globalMax = Math.max(...validDays.map((d) => d.high));
+  const globalMin = Math.min(...days.map((d) => d.low));
+  const globalMax = Math.max(...days.map((d) => d.high));
   const span = globalMax - globalMin || 1;
 
   const fmt = (f: number) =>
@@ -365,7 +364,7 @@ function DayHeader({
 
   return (
     <div className="flex flex-col mt-1">
-      {validDays.map((day, i) => {
+      {days.map((day, i) => {
         const d = new Date(day.date);
         const dayLocalStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
         const isToday = dayLocalStr === todayLocalStr;

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -343,21 +343,29 @@ function DayHeader({
   days: ForecastDay[];
   useCelsius: boolean;
 }) {
-  const globalMin = Math.min(...days.map((d) => d.low));
-  const globalMax = Math.max(...days.map((d) => d.high));
-  const span = globalMax - globalMin || 1;
-
   // Use local date comparison — server now groups by location-local date,
   // and the browser is assumed to be in the same timezone as the location.
   const now = new Date();
   const todayLocalStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+  // Drop any entries whose local date has already passed — guards against
+  // stale cache responses serving yesterday's data after midnight.
+  const validDays = days.filter((day) => {
+    const d = new Date(day.date);
+    const dayLocalStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    return dayLocalStr >= todayLocalStr;
+  });
+
+  const globalMin = Math.min(...validDays.map((d) => d.low));
+  const globalMax = Math.max(...validDays.map((d) => d.high));
+  const span = globalMax - globalMin || 1;
 
   const fmt = (f: number) =>
     useCelsius ? Math.round((f - 32) * 5 / 9) : Math.round(f);
 
   return (
     <div className="flex flex-col mt-1">
-      {days.map((day, i) => {
+      {validDays.map((day, i) => {
         const d = new Date(day.date);
         const dayLocalStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
         const isToday = dayLocalStr === todayLocalStr;

--- a/src/components/widgets/__tests__/WeatherWidget.test.tsx
+++ b/src/components/widgets/__tests__/WeatherWidget.test.tsx
@@ -55,9 +55,14 @@ const mockTimeline = jest.mocked(timeline);
 // Test data helpers
 // ---------------------------------------------------------------------------
 
+// Anchor to noon tomorrow so the past-day filter never drops fixture dates.
+const NOON_MS = new Date().setHours(12, 0, 0, 0);
+const TOMORROW_NOON = new Date(NOON_MS + 86_400_000);
+const DAY_MS = 86_400_000;
+
 function makeForecastDay(overrides: Partial<ForecastDay> = {}): ForecastDay {
   return {
-    date: new Date('2026-04-07T00:00:00.000Z'),
+    date: TOMORROW_NOON,
     dayName: 'Tue',
     high: 72,
     low: 55,
@@ -94,8 +99,10 @@ function makeHourlyForecast(
 function makeWeatherData(overrides: Partial<WeatherData> = {}): WeatherData {
   const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
+  // Start from tomorrow so no entry lands on "today" (which renders as 'TODAY'
+  // rather than the dayName, breaking tests that check for specific day labels).
   const forecast: ForecastDay[] = DAY_NAMES.slice(0, 5).map((dayName, i) => ({
-    date: new Date(Date.UTC(2026, 3, 7 + i)),
+    date: new Date(NOON_MS + (1 + i) * DAY_MS),
     dayName,
     high: 70 + i,
     low:  50 + i,
@@ -330,8 +337,8 @@ describe('day summary header', () => {
     const data = makeWeatherData({
       forecast: [
         makeForecastDay({ dayName: 'Mon' }),
-        makeForecastDay({ dayName: 'Tue', date: new Date(Date.UTC(2026, 3, 8)) }),
-        makeForecastDay({ dayName: 'Wed', date: new Date(Date.UTC(2026, 3, 9)) }),
+        makeForecastDay({ dayName: 'Tue', date: new Date(NOON_MS + 2 * DAY_MS) }),
+        makeForecastDay({ dayName: 'Wed', date: new Date(NOON_MS + 3 * DAY_MS) }),
       ],
     });
     render(<WeatherWidget data={data} forecastDays={3} />);
@@ -417,13 +424,13 @@ describe('forecastDays prop', () => {
     const data = makeWeatherData({
       forecast: [
         makeForecastDay({ dayName: 'Mon' }),
-        makeForecastDay({ dayName: 'Tue', date: new Date(Date.UTC(2026, 3, 8)) }),
+        makeForecastDay({ dayName: 'Tue', date: new Date(NOON_MS + 2 * DAY_MS) }),
       ],
     });
     render(<WeatherWidget data={data} forecastDays={5} />);
 
-    // Label reflects the requested prop
-    expect(screen.queryByText('5-Day Forecast')).not.toBeNull();
+    // Label reflects actual visible days, not the requested prop
+    expect(screen.queryByText('2-Day Forecast')).not.toBeNull();
     // Header shows only the 2 days that exist
     expect(screen.queryByText('MON')).not.toBeNull();
     expect(screen.queryByText('TUE')).not.toBeNull();

--- a/src/lib/integrations/__tests__/openmeteo.test.ts
+++ b/src/lib/integrations/__tests__/openmeteo.test.ts
@@ -169,6 +169,54 @@ describe('openmeteo.fetchWeatherData', () => {
     await expect(fetchWeatherData()).rejects.toThrow(/Open-Meteo network error: ECONNREFUSED/);
   });
 
+  it('skips stale past-day entries that arrive in a cached response', async () => {
+    // Simulate a response cached just before midnight: the first daily entry
+    // is yesterday's date in the response timezone. Today's local date in
+    // America/Chicago should drop that first entry from the forecast.
+    const todayLocal = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Chicago',
+    }).format(new Date());
+    const todayDate = new Date(`${todayLocal}T12:00:00`);
+    const yesterday = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago' })
+      .format(new Date(todayDate.getTime() - 24 * 60 * 60 * 1000));
+    const tomorrow = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago' })
+      .format(new Date(todayDate.getTime() + 24 * 60 * 60 * 1000));
+
+    const stale = {
+      latitude: 0,
+      longitude: 0,
+      timezone: 'America/Chicago',
+      current: {
+        time: `${todayLocal}T10:00`,
+        temperature_2m: 70, apparent_temperature: 70, relative_humidity_2m: 50,
+        wind_speed_10m: 5, weather_code: 0, precipitation: 0,
+      },
+      hourly: { time: [], temperature_2m: [], precipitation_probability: [], precipitation: [], weather_code: [] },
+      daily: {
+        time: [yesterday, todayLocal, tomorrow],
+        temperature_2m_max: [50, 75, 76],
+        temperature_2m_min: [40, 60, 61],
+        weather_code: [3, 0, 1],
+        precipitation_probability_max: [80, 0, 10],
+        sunrise: [`${yesterday}T06:00`, `${todayLocal}T06:00`, `${tomorrow}T06:00`],
+        sunset:  [`${yesterday}T19:00`, `${todayLocal}T19:00`, `${tomorrow}T19:00`],
+      },
+    };
+
+    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+      ok: true,
+      json: async () => stale,
+    } as never);
+
+    const { fetchWeatherData } = await import('../openmeteo');
+    const result = await fetchWeatherData({ lat: 41.8, lon: -87.6 });
+
+    // Yesterday's high (50°F) and condition (overcast=3) should not appear.
+    expect(result.forecast.length).toBe(2);
+    expect(result.forecast[0]?.high).toBe(75);
+    expect(result.forecast[0]?.condition).not.toBe('cloudy');
+  });
+
   it('does not require any API key (zero env-var configuration)', async () => {
     // Strip any provider key env vars to prove openmeteo doesn't read them.
     const stripped = { ...process.env };

--- a/src/lib/integrations/__tests__/openweather.test.ts
+++ b/src/lib/integrations/__tests__/openweather.test.ts
@@ -1,20 +1,21 @@
 /**
- * Tests for OpenWeather integration pure functions.
+ * Tests for the OpenWeather integration.
  *
- * The exported async functions (fetchCurrentWeather, fetchForecast, fetchWeatherData)
- * hit the OpenWeather API, so we test the internal pure functions by extracting
- * their logic into testable scenarios. We mock the module internals and test
- * the mapCondition, kelvinToFahrenheit, mpsToMph, and forecast aggregation logic
- * through the public API surface.
+ * Covers: unit conversions, condition-code mapping, timezone-aware daily
+ * grouping, stale past-day bucket exclusion (the "Thursday problem"), day-name
+ * derivation from the local dateKey, hourly slicing, and error paths.
  */
-
-// We need to mock getConfig and global fetch before importing
-const mockApiKey = 'test-api-key';
 
 jest.mock('@/components/widgets/WeatherWidget', () => ({}), { virtual: true });
 
-// Save original env
 const originalEnv = process.env;
+const mockApiKey = 'test-owm-key';
+
+// Fixed "now": 2026-05-01 15:00:00 UTC (Friday 10 AM CDT)
+const MOCK_NOW = Date.UTC(2026, 4, 1, 15, 0, 0);
+
+// CDT = UTC-5 → tzOffsetSec = -18000
+const CDT_OFFSET = -18_000;
 
 beforeAll(() => {
   process.env = {
@@ -28,25 +29,37 @@ afterAll(() => {
   process.env = originalEnv;
 });
 
-// Helper: build a mock OpenWeather current response
-function mockCurrentResponse(overrides: {
-  temp?: number;
-  feels_like?: number;
-  humidity?: number;
-  windSpeed?: number;
-  weatherId?: number;
-  description?: string;
-  name?: string;
-} = {}) {
+beforeEach(() => {
+  jest.spyOn(Date, 'now').mockReturnValue(MOCK_NOW);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const SEC = (ms: number) => Math.floor(ms / 1000);
+
+function currentResponse(overrides: Partial<{
+  temp: number;
+  feelsLike: number;
+  humidity: number;
+  windSpeed: number;
+  weatherId: number;
+  description: string;
+  name: string;
+}> = {}) {
   return {
     main: {
-      temp: overrides.temp ?? 300, // 300K ≈ 80°F
-      feels_like: overrides.feels_like ?? 303,
+      temp: overrides.temp ?? 300,
+      feels_like: overrides.feelsLike ?? 300,
       humidity: overrides.humidity ?? 65,
     },
-    wind: {
-      speed: overrides.windSpeed ?? 5, // 5 m/s ≈ 11 mph
-    },
+    wind: { speed: overrides.windSpeed ?? 5 },
     weather: [{
       id: overrides.weatherId ?? 800,
       main: 'Clear',
@@ -54,15 +67,11 @@ function mockCurrentResponse(overrides: {
       icon: '01d',
     }],
     name: overrides.name ?? 'TestCity',
-    sys: {
-      sunrise: 1712480400, // arbitrary Unix timestamps
-      sunset:  1712527200,
-    },
+    sys: { sunrise: 1_700_000_000, sunset: 1_700_050_000 },
   };
 }
 
-// Helper: build a forecast list item
-function mockForecastItem(dt: number, temp: number, weatherId: number) {
+function forecastItem(dt: number, temp: number, weatherId = 800) {
   return {
     dt,
     main: { temp, temp_min: temp - 2, temp_max: temp + 2 },
@@ -70,233 +79,383 @@ function mockForecastItem(dt: number, temp: number, weatherId: number) {
   };
 }
 
-import { fetchCurrentWeather, fetchForecast, fetchWeatherData } from '../openweather';
+function forecastResponse(
+  items: ReturnType<typeof forecastItem>[],
+  tzOffsetSec = CDT_OFFSET,
+  cityName = 'TestCity',
+) {
+  return {
+    list: items,
+    city: { name: cityName, country: 'US', timezone: tzOffsetSec },
+  };
+}
 
-describe('OpenWeather integration', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+function mockFetch(body: object) {
+  return jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  } as never);
+}
+
+// ---------------------------------------------------------------------------
+// fetchCurrentWeather — unit conversions
+// ---------------------------------------------------------------------------
+
+describe('fetchCurrentWeather — unit conversions', () => {
+  it('converts 273.15 K (freezing) to exactly 32 °F', async () => {
+    mockFetch(currentResponse({ temp: 273.15, feelsLike: 273.15 }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.temperature).toBe(32);
+    expect(result.feelsLike).toBe(32);
   });
 
-  describe('fetchCurrentWeather (unit conversions + condition mapping)', () => {
-    it('converts Kelvin to Fahrenheit correctly', async () => {
-      // 273.15K = 32°F (freezing), 300K ≈ 80°F
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ temp: 273.15, feels_like: 273.15 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.temperature).toBe(32); // 273.15K = 32°F exactly
-      expect(result.feelsLike).toBe(32);
-    });
-
-    it('converts 0K to -460°F', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ temp: 0, feels_like: 0 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.temperature).toBe(-460); // 0K = -459.67°F, rounds to -460
-    });
-
-    it('converts 373.15K (boiling) to 212°F', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ temp: 373.15, feels_like: 373.15 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.temperature).toBe(212);
-    });
-
-    it('converts wind speed from m/s to mph', async () => {
-      // 10 m/s × 2.237 ≈ 22 mph
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ windSpeed: 10 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.windSpeed).toBe(22);
-    });
-
-    it('maps thunderstorm codes (200-299) to stormy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 211 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('stormy');
-    });
-
-    it('maps drizzle codes (300-399) to rainy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 301 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('rainy');
-    });
-
-    it('maps rain codes (500-599) to rainy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 502 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('rainy');
-    });
-
-    it('maps snow codes (600-699) to snowy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 601 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('snowy');
-    });
-
-    it('maps atmosphere codes (700-799) to cloudy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 741 })), // fog
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('cloudy');
-    });
-
-    it('maps clear (800) to sunny', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 800 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('sunny');
-    });
-
-    it('maps few/scattered clouds (801-802) to partly-cloudy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 802 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('partly-cloudy');
-    });
-
-    it('maps overcast clouds (803+) to cloudy', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ weatherId: 804 })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.condition).toBe('cloudy');
-    });
-
-    it('passes through humidity and description', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockCurrentResponse({ humidity: 85, description: 'light rain' })),
-      });
-
-      const result = await fetchCurrentWeather();
-      expect(result.humidity).toBe(85);
-      expect(result.description).toBe('light rain');
-    });
-
-    it('throws on API error response', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        text: () => Promise.resolve('City not found'),
-      });
-
-      await expect(fetchCurrentWeather()).rejects.toThrow('Failed to fetch current weather');
-    });
+  it('converts 373.15 K (boiling) to 212 °F', async () => {
+    mockFetch(currentResponse({ temp: 373.15, feelsLike: 373.15 }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.temperature).toBe(212);
   });
 
-  describe('fetchForecast (daily aggregation)', () => {
-    it('groups forecast items by day and computes high/low', async () => {
-      // Two items on the same day with different temps
-      const date1 = new Date('2026-03-15T06:00:00Z');
-      const date2 = new Date('2026-03-15T15:00:00Z');
+  it('rounds fractional Fahrenheit values', async () => {
+    // 295 K → (295 - 273.15) × 9/5 + 32 = 71.33°F → rounds to 71
+    mockFetch(currentResponse({ temp: 295 }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.temperature).toBe(71);
+  });
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          list: [
-            mockForecastItem(Math.floor(date1.getTime() / 1000), 280, 800), // 280K ≈ 44°F
-            mockForecastItem(Math.floor(date2.getTime() / 1000), 295, 800), // 295K ≈ 71°F
-          ],
-          city: { name: 'TestCity', country: 'US', timezone: 0 },
-        }),
-      });
+  it('converts 10 m/s wind to 22 mph', async () => {
+    mockFetch(currentResponse({ windSpeed: 10 }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.windSpeed).toBe(22);
+  });
 
-      const result = await fetchForecast();
-      expect(result.forecast.length).toBe(1);
-      expect(result.forecast[0]!.high).toBeGreaterThan(result.forecast[0]!.low);
-    });
+  it('converts 0 m/s wind to 0 mph', async () => {
+    mockFetch(currentResponse({ windSpeed: 0 }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.windSpeed).toBe(0);
+  });
+});
 
-    it('limits forecast to 7 days', async () => {
-      // Create 9 days of forecast data; implementation caps at 7
-      const items: ReturnType<typeof mockForecastItem>[] = [];
-      for (let d = 0; d < 9; d++) {
-        const date = new Date(`2026-03-${15 + d}T12:00:00Z`);
-        items.push(mockForecastItem(Math.floor(date.getTime() / 1000), 290, 800));
-      }
+// ---------------------------------------------------------------------------
+// fetchCurrentWeather — condition code mapping
+// ---------------------------------------------------------------------------
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          list: items,
-          city: { name: 'TestCity', country: 'US', timezone: 0 },
-        }),
-      });
+describe('fetchCurrentWeather — condition code mapping', () => {
+  const cases: [number, string, string][] = [
+    [200,  'stormy',        'thunderstorm (200)'],
+    [299,  'stormy',        'thunderstorm (299)'],
+    [300,  'rainy',         'drizzle (300)'],
+    [399,  'rainy',         'drizzle (399)'],
+    [500,  'rainy',         'rain (500)'],
+    [599,  'rainy',         'rain (599)'],
+    [600,  'snowy',         'snow (600)'],
+    [699,  'snowy',         'snow (699)'],
+    [700,  'cloudy',        'atmosphere/mist (700)'],
+    [741,  'cloudy',        'fog (741)'],
+    [799,  'cloudy',        'atmosphere (799)'],
+    [800,  'sunny',         'clear sky (800)'],
+    [801,  'partly-cloudy', 'few clouds (801)'],
+    [802,  'partly-cloudy', 'scattered clouds (802)'],
+    [803,  'cloudy',        'broken clouds (803)'],
+    [804,  'cloudy',        'overcast (804)'],
+  ];
 
-      const result = await fetchForecast();
-      expect(result.forecast.length).toBe(7);
-    });
+  it.each(cases)('code %i → "%s" (%s)', async (code, expected) => {
+    mockFetch(currentResponse({ weatherId: code }));
+    const { fetchCurrentWeather } = await import('../openweather');
+    const result = await fetchCurrentWeather();
+    expect(result.condition).toBe(expected);
+  });
+});
 
-    it('uses most common condition for the day', async () => {
-      const date = new Date('2026-03-15');
-      const baseTs = Math.floor(date.getTime() / 1000);
+// ---------------------------------------------------------------------------
+// fetchCurrentWeather — error paths
+// ---------------------------------------------------------------------------
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          list: [
-            mockForecastItem(baseTs, 290, 800),       // sunny
-            mockForecastItem(baseTs + 10800, 290, 500), // rainy
-            mockForecastItem(baseTs + 21600, 290, 500), // rainy
-            mockForecastItem(baseTs + 32400, 290, 500), // rainy
-          ],
-          city: { name: 'TestCity', country: 'US', timezone: 0 },
-        }),
-      });
+describe('fetchCurrentWeather — errors', () => {
+  it('throws on non-OK HTTP response', async () => {
+    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+      ok: false,
+      text: async () => 'City not found',
+    } as never);
 
-      const result = await fetchForecast();
-      // 3 rainy vs 1 sunny → rainy should win
-      expect(result.forecast[0]!.condition).toBe('rainy');
-    });
+    const { fetchCurrentWeather } = await import('../openweather');
+    await expect(fetchCurrentWeather()).rejects.toThrow('Failed to fetch current weather');
+  });
+});
 
-    it('includes location name from city data', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({
-          list: [mockForecastItem(Math.floor(Date.now() / 1000), 290, 800)],
-          city: { name: 'Springfield', country: 'US', timezone: 0 },
-        }),
-      });
+// ---------------------------------------------------------------------------
+// fetchForecast — timezone-aware daily grouping
+// ---------------------------------------------------------------------------
 
-      const result = await fetchForecast();
-      expect(result.locationName).toBe('Springfield, US');
-    });
+describe('fetchForecast — timezone-aware daily grouping', () => {
+  it('buckets a 3 AM UTC item into the PREVIOUS local day (CDT)', async () => {
+    // 3am UTC May 1 = 10pm CDT April 30 (Thursday) → dateKey "2026-04-30"
+    // Today (mocked) = 2026-05-01 in CDT, so April 30 is in the past and excluded.
+    // Separately, 6am UTC May 1 = 1am CDT May 1 → dateKey "2026-05-01" → included.
+    const thu3amUtc = SEC(Date.UTC(2026, 4, 1, 3, 0, 0));  // CDT: Thu Apr 30 10pm
+    const fri6amUtc = SEC(Date.UTC(2026, 4, 1, 6, 0, 0));  // CDT: Fri May 1  1am
+
+    mockFetch(forecastResponse([
+      forecastItem(thu3amUtc, 290),
+      forecastItem(fri6amUtc, 295),
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    // Thursday bucket is in the past → excluded; Friday is today → included
+    expect(result.forecast).toHaveLength(1);
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('skips daily buckets that fall before today at the location timezone', async () => {
+    // Build one item each for: Thu Apr 30, Fri May 1, Sat May 2 (all CDT).
+    // Thu is yesterday → must be excluded. Fri and Sat → included.
+    const thuItem = SEC(Date.UTC(2026, 3, 30, 12, 0, 0)); // Thu Apr 30 7am CDT
+    const friItem = SEC(Date.UTC(2026, 4, 1,  12, 0, 0)); // Fri May 1  7am CDT
+    const satItem = SEC(Date.UTC(2026, 4, 2,  12, 0, 0)); // Sat May 2  7am CDT
+
+    mockFetch(forecastResponse([
+      forecastItem(thuItem, 280),
+      forecastItem(friItem, 285),
+      forecastItem(satItem, 290),
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    const dayNames = result.forecast.map((d) => d.dayName);
+    expect(dayNames).not.toContain('Thu');
+    expect(dayNames).toContain('Fri');
+    expect(dayNames).toContain('Sat');
+  });
+
+  it('derives day name from the local dateKey, not the UTC timestamp', async () => {
+    // 2026-05-01 03:00 UTC = 2026-04-30 22:00 CDT (Thursday night).
+    // The dateKey for this item is "2026-04-30" (Thursday).
+    // HOWEVER today is May 1 (Friday) so Thursday is skipped.
+    // A mid-day Friday item (12pm UTC May 1 = 7am CDT May 1) → "Fri".
+    const friNoon = SEC(Date.UTC(2026, 4, 1, 12, 0, 0));
+
+    mockFetch(forecastResponse([forecastItem(friNoon, 290)]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('correctly labels a UTC-midnight item using the location timezone', async () => {
+    // With UTC offset = 0, local date == UTC date.
+    // 2026-05-01 noon UTC → dateKey "2026-05-01" → "Fri"
+    const noonUtc = SEC(Date.UTC(2026, 4, 1, 12, 0, 0));
+
+    mockFetch(forecastResponse([forecastItem(noonUtc, 290)], 0));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('limits the forecast to at most 7 days', async () => {
+    const items = Array.from({ length: 30 }, (_, i) =>
+      forecastItem(SEC(Date.UTC(2026, 4, 1 + i, 12, 0, 0)), 290)
+    );
+
+    mockFetch(forecastResponse(items));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast.length).toBeLessThanOrEqual(7);
+  });
+
+  it('uses the most common condition code for the day', async () => {
+    const base = SEC(Date.UTC(2026, 4, 1, 6, 0, 0)); // CDT: Fri 1am (today)
+
+    mockFetch(forecastResponse([
+      forecastItem(base,          290, 800), // sunny  ×1
+      forecastItem(base + 10800,  290, 500), // rainy  ×3
+      forecastItem(base + 21600,  290, 500),
+      forecastItem(base + 32400,  290, 500),
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast[0]?.condition).toBe('rainy');
+  });
+
+  it('reports the max as high and min as low for the day', async () => {
+    const base = SEC(Date.UTC(2026, 4, 1, 6, 0, 0));
+
+    mockFetch(forecastResponse([
+      forecastItem(base,         273.15, 800), // 32°F
+      forecastItem(base + 10800, 300,    800), // 80°F
+      forecastItem(base + 21600, 295,    800), // 71°F
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast[0]?.high).toBe(80);
+    expect(result.forecast[0]?.low).toBe(32);
+  });
+
+  it('includes the city name and country in locationName', async () => {
+    mockFetch(forecastResponse(
+      [forecastItem(SEC(Date.UTC(2026, 4, 1, 12, 0, 0)), 290)],
+      0,
+      'Springfield',
+    ));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.locationName).toBe('Springfield, US');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchForecast — day boundary precision
+// ---------------------------------------------------------------------------
+
+describe('fetchForecast — day boundary precision', () => {
+  it('item at exactly CDT midnight (05:00 UTC) goes into the new day', async () => {
+    // 2026-05-01 05:00:00 UTC = 2026-05-01 00:00:00 CDT → Friday bucket (today)
+    const cdtMidnight = SEC(Date.UTC(2026, 4, 1, 5, 0, 0));
+    mockFetch(forecastResponse([forecastItem(cdtMidnight, 290)]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+    expect(result.forecast).toHaveLength(1);
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('item 1 second before CDT midnight goes into the prior day and is excluded', async () => {
+    // 2026-05-01 04:59:59 UTC = 2026-04-30 23:59:59 CDT → Thursday bucket (past)
+    const justBeforeMidnight = SEC(Date.UTC(2026, 4, 1, 4, 59, 59));
+    const fridayNoon         = SEC(Date.UTC(2026, 4, 1, 12,  0,  0));
+
+    mockFetch(forecastResponse([
+      forecastItem(justBeforeMidnight, 400), // Thu — excluded
+      forecastItem(fridayNoon,         290), // Fri — included
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast).toHaveLength(1);
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+    // 400 K → 261 °F should NOT appear; 290 K → 62 °F should be high AND low
+    expect(result.forecast[0]?.high).toBe(62);
+    expect(result.forecast[0]?.low).toBe(62);
+  });
+
+  it('past-day temperatures do not pollute the current day high/low', async () => {
+    const thuItem = SEC(Date.UTC(2026, 3, 30, 12, 0, 0)); // Thu Apr 30 (past)
+    const friItem = SEC(Date.UTC(2026, 4,  1, 12, 0, 0)); // Fri May 1  (today)
+
+    mockFetch(forecastResponse([
+      forecastItem(thuItem, 320), // 320 K → 116 °F — excluded
+      forecastItem(friItem, 280), // 280 K →  44 °F — today only
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    const fri = result.forecast.find((d) => d.dayName === 'Fri');
+    expect(fri?.high).toBe(44); // not 116 from Thursday
+    expect(fri?.low).toBe(44);
+  });
+
+  it('items straddling midnight split cleanly into their respective day buckets', async () => {
+    // 04:59 UTC May 1 = 23:59 CDT Apr 30 (Thu) → excluded
+    // 05:01 UTC May 1 = 00:01 CDT May 1  (Fri) → Fri, rainy
+    // 06:00 UTC May 2 = 01:00 CDT May 2  (Sat) → Sat, partly-cloudy
+    const thuEnd   = SEC(Date.UTC(2026, 4, 1, 4, 59, 0));
+    const friStart = SEC(Date.UTC(2026, 4, 1, 5,  1, 0));
+    const satItem  = SEC(Date.UTC(2026, 4, 2, 6,  0, 0));
+
+    mockFetch(forecastResponse([
+      forecastItem(thuEnd,   283, 800), // ~50 °F  Thu — excluded
+      forecastItem(friStart, 293, 500), // ~68 °F  Fri — rainy
+      forecastItem(satItem,  298, 801), // ~77 °F  Sat — partly-cloudy
+    ]));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast).toHaveLength(2);
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+    expect(result.forecast[0]?.condition).toBe('rainy');
+    expect(result.forecast[1]?.dayName).toBe('Sat');
+    expect(result.forecast[1]?.condition).toBe('partly-cloudy');
+  });
+
+  it('a positive UTC offset (e.g. UTC+5:30 IST) rolls items forward into the next local day', async () => {
+    // IST = UTC+5:30 → tzOffsetSec = +19800
+    // 2026-05-01 00:00 UTC = 2026-05-01 05:30 IST → Friday bucket (today)
+    const utcMidnight = SEC(Date.UTC(2026, 4, 1, 0, 0, 0));
+
+    // Today in IST at MOCK_NOW (15:00 UTC) = 20:30 IST = still Fri
+    // todayKey with IST offset: (MOCK_NOW/1000 + 19800) → ~20:30 IST → "2026-05-01"
+    mockFetch(forecastResponse([forecastItem(utcMidnight, 305)], 19_800));
+    const { fetchForecast } = await import('../openweather');
+    const result = await fetchForecast();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchForecast — hourly slice
+// ---------------------------------------------------------------------------
+
+describe('fetchForecast — hourly slice', () => {
+  it('includes 3-hour intervals within [now − 3 h, now + 24 h]', async () => {
+    // tooOld: 4h before now → excluded
+    // justIn: 2h before now → included (active interval lookback = 3h)
+    // future24: exactly 24h after now → included
+    // tooFar: 25h after now → excluded
+    const tooOld  = SEC(MOCK_NOW - 4 * 3_600_000);
+    const justIn  = SEC(MOCK_NOW - 2 * 3_600_000);
+    const future24 = SEC(MOCK_NOW + 24 * 3_600_000);
+    const tooFar  = SEC(MOCK_NOW + 25 * 3_600_000);
+
+    const allItems = [tooOld, justIn, future24, tooFar].map((dt) =>
+      forecastItem(dt, 290)
+    );
+
+    mockFetch(forecastResponse(allItems));
+    const { fetchForecast } = await import('../openweather');
+
+    // fetchForecast doesn't expose hourly directly — use fetchWeatherData instead
+    const { fetchWeatherData } = await import('../openweather');
+
+    // Re-mock since fetchWeatherData makes two fetch calls
+    jest.restoreAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(MOCK_NOW);
+    jest.spyOn(global, 'fetch' as never)
+      .mockResolvedValueOnce({ ok: true, json: async () => currentResponse() } as never) // current
+      .mockResolvedValueOnce({ ok: true, json: async () => forecastResponse(allItems) } as never); // forecast
+
+    const result = await fetchWeatherData();
+    const hourlyTimes = result.hourly.map((h) => h.time.getTime() / 1000);
+
+    expect(hourlyTimes).not.toContain(tooOld);
+    expect(hourlyTimes).toContain(justIn);
+    expect(hourlyTimes).toContain(future24);
+    expect(hourlyTimes).not.toContain(tooFar);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchForecast — error paths
+// ---------------------------------------------------------------------------
+
+describe('fetchForecast — errors', () => {
+  it('throws on non-OK HTTP response', async () => {
+    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+      ok: false,
+      text: async () => 'Unauthorized',
+    } as never);
+
+    const { fetchForecast } = await import('../openweather');
+    await expect(fetchForecast()).rejects.toThrow('Failed to fetch forecast');
   });
 });

--- a/src/lib/integrations/__tests__/openweather.test.ts
+++ b/src/lib/integrations/__tests__/openweather.test.ts
@@ -6,6 +6,8 @@
  * derivation from the local dateKey, hourly slicing, and error paths.
  */
 
+export {};
+
 jest.mock('@/components/widgets/WeatherWidget', () => ({}), { virtual: true });
 
 const originalEnv = process.env;
@@ -435,7 +437,7 @@ describe('fetchForecast — hourly slice', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => forecastResponse(allItems) } as never); // forecast
 
     const result = await fetchWeatherData();
-    const hourlyTimes = result.hourly.map((h) => h.time.getTime() / 1000);
+    const hourlyTimes = result.hourly!.map((h) => h.time.getTime() / 1000);
 
     expect(hourlyTimes).not.toContain(tooOld);
     expect(hourlyTimes).toContain(justIn);

--- a/src/lib/integrations/__tests__/pirateweather.test.ts
+++ b/src/lib/integrations/__tests__/pirateweather.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for the Pirate Weather integration.
  *
- * Verifies the request URL plumbs lat/lon from the LocationParam (not just env)
- * and that day-of-week labels respect the response's IANA timezone rather than
- * UTC.
+ * Covers: URL construction, icon→condition mapping, unit conversions,
+ * timezone-aware day labels, hourly filtering + patching, period extraction,
+ * sunrise/sunset, minutely passthrough, and error paths.
  */
 
 export {}; // module marker so const declarations don't leak into global scope
@@ -12,6 +12,10 @@ jest.mock('@/components/widgets/WeatherWidget', () => ({}), { virtual: true });
 
 const originalEnv = process.env;
 const mockApiKey = 'test-pirate-key';
+
+// Fixed "now" so hourly-window tests are deterministic.
+// 2026-05-01 15:00 UTC = 10:00 AM CDT (Friday)
+const MOCK_NOW = Date.UTC(2026, 4, 1, 15, 0, 0);
 
 beforeAll(() => {
   process.env = {
@@ -27,110 +31,531 @@ afterAll(() => {
   process.env = originalEnv;
 });
 
+beforeEach(() => {
+  jest.spyOn(Date, 'now').mockReturnValue(MOCK_NOW);
+});
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
-function buildResponse(timezone = 'America/Chicago') {
-  // Use a Sunday-in-NY-but-still-Saturday-in-LA fixture so day labels expose
-  // any UTC vs local-TZ confusion.
-  const sundayUtcMidnight = Math.floor(Date.UTC(2026, 4, 3, 0, 0, 0) / 1000); // 2026-05-03 00:00 UTC = Sat 5pm in LA
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const SEC = (ms: number) => Math.floor(ms / 1000);
+
+function daily(dt: number, overrides: Partial<{
+  icon: string;
+  temperatureHigh: number;
+  temperatureLow: number;
+  precipProbability: number;
+}> = {}) {
   return {
-    latitude: 0,
-    longitude: 0,
-    timezone,
-    currently: {
-      time: sundayUtcMidnight,
-      icon: 'clear-day',
-      temperature: 70,
-      apparentTemperature: 70,
-      humidity: 0.5,
-      windSpeed: 5,
-      precipIntensity: 0,
-      precipProbability: 0,
-    },
-    minutely: { data: [] },
-    hourly: { data: [] },
-    daily: {
-      data: [
-        {
-          time: sundayUtcMidnight,
-          icon: 'clear-day',
-          temperatureHigh: 75,
-          temperatureLow: 60,
-          precipProbability: 0,
-          sunriseTime: sundayUtcMidnight + 6 * 3600,
-          sunsetTime: sundayUtcMidnight + 19 * 3600,
-        },
-      ],
-    },
+    time: dt,
+    icon: overrides.icon ?? 'clear-day',
+    temperatureHigh: overrides.temperatureHigh ?? 75,
+    temperatureLow: overrides.temperatureLow ?? 55,
+    precipProbability: overrides.precipProbability ?? 0,
+    sunriseTime: dt + 6 * 3600,
+    sunsetTime: dt + 19 * 3600,
   };
 }
 
-describe('pirateweather.fetchWeatherData', () => {
-  it('passes lat/lon from LocationParam to the request URL (env values are ignored when caller provides coords)', async () => {
-    const fetchSpy = jest
-      .spyOn(global, 'fetch' as never)
-      .mockResolvedValue({
-        ok: true,
-        json: async () => buildResponse(),
-      } as never);
+function hourly(dt: number, overrides: Partial<{
+  icon: string;
+  temperature: number;
+  precipProbability: number;
+  precipIntensity: number;
+}> = {}) {
+  return {
+    time: dt,
+    icon: overrides.icon ?? 'clear-day',
+    temperature: overrides.temperature ?? 68,
+    precipProbability: overrides.precipProbability ?? 0,
+    precipIntensity: overrides.precipIntensity ?? 0,
+  };
+}
 
+function buildResponse(overrides: Partial<{
+  timezone: string;
+  currentIcon: string;
+  currentTemp: number;
+  currentFeelsLike: number;
+  currentHumidity: number;
+  currentWindSpeed: number;
+  currentSummary: string;
+  currentPrecipIntensity: number;
+  dailyData: ReturnType<typeof daily>[];
+  hourlyData: ReturnType<typeof hourly>[];
+  minutelyData: { time: number; precipIntensity: number; precipProbability: number }[];
+}> = {}) {
+  const now = SEC(MOCK_NOW);
+  return {
+    latitude: 41.8781,
+    longitude: -87.6298,
+    timezone: overrides.timezone ?? 'America/Chicago',
+    currently: {
+      time: now,
+      icon: overrides.currentIcon ?? 'clear-day',
+      temperature: overrides.currentTemp ?? 70,
+      apparentTemperature: overrides.currentFeelsLike ?? 68,
+      humidity: overrides.currentHumidity ?? 0.65,
+      windSpeed: overrides.currentWindSpeed ?? 10,
+      precipIntensity: overrides.currentPrecipIntensity ?? 0,
+      precipProbability: 0,
+      summary: overrides.currentSummary,
+    },
+    minutely: overrides.minutelyData ? { data: overrides.minutelyData } : undefined,
+    hourly: { data: overrides.hourlyData ?? [] },
+    daily: { data: overrides.dailyData ?? [daily(now)] },
+  };
+}
+
+function mockFetch(body: object) {
+  return jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  } as never);
+}
+
+// ---------------------------------------------------------------------------
+// URL construction
+// ---------------------------------------------------------------------------
+
+describe('URL construction', () => {
+  it('uses lat/lon from LocationParam, ignoring env coordinates', async () => {
+    const spy = mockFetch(buildResponse());
     const { fetchWeatherData } = await import('../pirateweather');
     await fetchWeatherData({ lat: 40.7128, lon: -74.006 });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
-    expect(calledUrl).toContain('/40.7128,-74.006?');
-    expect(calledUrl).not.toContain('41.8781'); // env default not used
+    const url = spy.mock.calls[0]![0] as string;
+    expect(url).toContain('/40.7128,-74.006?');
+    expect(url).not.toContain('41.8781');
   });
 
-  it('falls back to env coordinates when no LocationParam is provided', async () => {
-    const fetchSpy = jest
-      .spyOn(global, 'fetch' as never)
-      .mockResolvedValue({
-        ok: true,
-        json: async () => buildResponse(),
-      } as never);
-
+  it('falls back to env coordinates when no LocationParam provided', async () => {
+    const spy = mockFetch(buildResponse());
     const { fetchWeatherData } = await import('../pirateweather');
     await fetchWeatherData();
 
-    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
-    expect(calledUrl).toContain('/41.8781,-87.6298?');
+    const url = spy.mock.calls[0]![0] as string;
+    expect(url).toContain('/41.8781,-87.6298?');
   });
 
-  it('uses the response timezone for day-of-week labels', async () => {
-    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
-      ok: true,
-      json: async () => buildResponse('America/Los_Angeles'),
-    } as never);
-
+  it('uses env coordinates but overrides display name for string location', async () => {
+    const spy = mockFetch(buildResponse());
     const { fetchWeatherData } = await import('../pirateweather');
-    const result = await fetchWeatherData({ lat: 34, lon: -118 });
+    const result = await fetchWeatherData('Springfield, IL');
 
-    // 2026-05-03 00:00 UTC is still 2026-05-02 (Saturday) in LA.
+    const url = spy.mock.calls[0]![0] as string;
+    expect(url).toContain('/41.8781,-87.6298?');   // env coords used
+    expect(result.location).toBe('Springfield, IL'); // string becomes display name
+  });
+
+  it('includes the API key in the URL', async () => {
+    const spy = mockFetch(buildResponse());
+    const { fetchWeatherData } = await import('../pirateweather');
+    await fetchWeatherData();
+
+    const url = spy.mock.calls[0]![0] as string;
+    expect(url).toContain(mockApiKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Icon → condition mapping
+// ---------------------------------------------------------------------------
+
+describe('mapIcon — icon string → WeatherCondition', () => {
+  const cases: [string, string][] = [
+    ['clear-day',           'sunny'],
+    ['clear-night',         'sunny'],
+    ['partly-cloudy-day',   'partly-cloudy'],
+    ['partly-cloudy-night', 'partly-cloudy'],
+    ['cloudy',              'cloudy'],
+    ['fog',                 'cloudy'],
+    ['wind',                'cloudy'],
+    ['rain',                'rainy'],
+    ['drizzle',             'rainy'],
+    ['snow',                'snowy'],
+    ['sleet',               'snowy'],
+    ['thunderstorm',        'stormy'],
+    ['unknown-icon',        'cloudy'], // default
+  ];
+
+  it.each(cases)('"%s" → "%s"', async (icon, expectedCondition) => {
+    mockFetch(buildResponse({ currentIcon: icon }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.condition).toBe(expectedCondition);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Current conditions
+// ---------------------------------------------------------------------------
+
+describe('current conditions', () => {
+  it('rounds temperature to nearest integer', async () => {
+    mockFetch(buildResponse({ currentTemp: 72.7, currentFeelsLike: 69.3 }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.temperature).toBe(73);
+    expect(result.current.feelsLike).toBe(69);
+  });
+
+  it('converts humidity from 0–1 to integer percent', async () => {
+    mockFetch(buildResponse({ currentHumidity: 0.78 }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.humidity).toBe(78);
+  });
+
+  it('rounds wind speed to nearest integer', async () => {
+    mockFetch(buildResponse({ currentWindSpeed: 7.6 }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.windSpeed).toBe(8);
+  });
+
+  it('uses summary as description when present', async () => {
+    mockFetch(buildResponse({ currentSummary: 'Light drizzle' }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.description).toBe('Light drizzle');
+  });
+
+  it('falls back to icon name (dashes → spaces) when summary is absent', async () => {
+    const response = buildResponse({ currentIcon: 'partly-cloudy-day' });
+    // Remove summary so the fallback triggers
+    (response.currently as { summary?: string }).summary = undefined;
+    mockFetch(response);
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.current.description).toBe('partly cloudy day');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7-day forecast
+// ---------------------------------------------------------------------------
+
+describe('7-day forecast', () => {
+  it('caps at 7 days even when API returns more', async () => {
+    const days = Array.from({ length: 10 }, (_, i) =>
+      daily(SEC(MOCK_NOW) + i * 86400)
+    );
+    mockFetch(buildResponse({ dailyData: days }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.forecast).toHaveLength(7);
+  });
+
+  it('labels each day using the response timezone, not UTC', async () => {
+    // 2026-05-03 00:00 UTC = Sat 7pm in Chicago (CDT, UTC-5) → still Sat
+    const saturdayUtcMidnight = SEC(Date.UTC(2026, 4, 3, 0, 0, 0));
+    mockFetch(buildResponse({
+      timezone: 'America/Chicago',
+      dailyData: [daily(saturdayUtcMidnight)],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
     expect(result.forecast[0]?.dayName).toBe('Sat');
   });
 
-  it('uses Eastern timezone for the same UTC moment', async () => {
-    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
-      ok: true,
-      json: async () => buildResponse('America/New_York'),
-    } as never);
-
+  it('uses LA timezone for the same UTC midnight (still Saturday in LA)', async () => {
+    const saturdayUtcMidnight = SEC(Date.UTC(2026, 4, 3, 0, 0, 0));
+    mockFetch(buildResponse({
+      timezone: 'America/Los_Angeles',
+      dailyData: [daily(saturdayUtcMidnight)],
+    }));
     const { fetchWeatherData } = await import('../pirateweather');
-    const result = await fetchWeatherData({ lat: 40, lon: -74 });
-
-    // 2026-05-03 00:00 UTC is 2026-05-02 8pm in NY (Saturday).
+    const result = await fetchWeatherData();
     expect(result.forecast[0]?.dayName).toBe('Sat');
   });
 
-  it('wraps network errors in a clear error message', async () => {
-    jest
-      .spyOn(global, 'fetch' as never)
-      .mockImplementation((() => Promise.reject(new Error('ECONNREFUSED'))) as never);
+  it('includes precipProbability as an integer percent', async () => {
+    mockFetch(buildResponse({
+      dailyData: [daily(SEC(MOCK_NOW), { precipProbability: 0.73 })],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.forecast[0]?.precipProbability).toBe(73);
+  });
 
+  it('maps forecast condition from the daily icon', async () => {
+    mockFetch(buildResponse({
+      dailyData: [daily(SEC(MOCK_NOW), { icon: 'rain' })],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+    expect(result.forecast[0]?.condition).toBe('rainy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7-day forecast — day boundaries
+// ---------------------------------------------------------------------------
+
+describe('7-day forecast — day boundaries', () => {
+  it('excludes a stale yesterday entry from daily.data[0]', async () => {
+    // Pirate Weather can return yesterday as daily.data[0] when serving a
+    // cached response generated before local midnight. That entry must be dropped.
+    //
+    // Thursday midnight CDT = 2026-04-30 00:00 CDT = 2026-04-30T05:00:00Z
+    const thuMidnightCdt = SEC(Date.UTC(2026, 3, 30, 5, 0, 0)); // Thu (past)
+    // Friday midnight CDT = 2026-05-01 00:00 CDT = 2026-05-01T05:00:00Z
+    const friMidnightCdt = SEC(Date.UTC(2026, 4,  1, 5, 0, 0)); // Fri (today)
+
+    mockFetch(buildResponse({
+      timezone: 'America/Chicago',
+      dailyData: [
+        daily(thuMidnightCdt), // yesterday — must be excluded
+        daily(friMidnightCdt), // today — must be first entry
+      ],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+    expect(result.forecast).toHaveLength(1);
+  });
+
+  it('past-day high/low do not appear in the forecast', async () => {
+    const thuMidnightCdt = SEC(Date.UTC(2026, 3, 30, 5, 0, 0));
+    const friMidnightCdt = SEC(Date.UTC(2026, 4,  1, 5, 0, 0));
+
+    mockFetch(buildResponse({
+      timezone: 'America/Chicago',
+      dailyData: [
+        daily(thuMidnightCdt, { temperatureHigh: 999, temperatureLow: -999 }),
+        daily(friMidnightCdt, { temperatureHigh: 75,  temperatureLow: 58  }),
+      ],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.forecast[0]?.high).toBe(75);
+    expect(result.forecast[0]?.low).toBe(58);
+  });
+
+  it('today is the first entry when the API data is current', async () => {
+    const friMidnightCdt = SEC(Date.UTC(2026, 4, 1, 5, 0, 0));
+
+    mockFetch(buildResponse({
+      timezone: 'America/Chicago',
+      dailyData: [daily(friMidnightCdt)],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('an EDT location (UTC-4) with 4am UTC midnight entry is correctly labeled', async () => {
+    // Eastern Daylight Time: midnight EDT = 04:00 UTC
+    const friMidnightEdt = SEC(Date.UTC(2026, 4, 1, 4, 0, 0)); // Fri 00:00 EDT
+
+    mockFetch(buildResponse({
+      timezone: 'America/New_York',
+      dailyData: [daily(friMidnightEdt)],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+
+  it('a UTC midnight entry in a UTC+5:30 timezone (IST) is correctly labeled as the local day', async () => {
+    // 2026-05-01 00:00 UTC = 2026-05-01 05:30 IST → Friday
+    const utcMidnight = SEC(Date.UTC(2026, 4, 1, 0, 0, 0));
+
+    mockFetch(buildResponse({
+      timezone: 'Asia/Kolkata',
+      dailyData: [daily(utcMidnight)],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    // 00:00 UTC = 05:30 IST on the same calendar day → still Friday
+    expect(result.forecast[0]?.dayName).toBe('Fri');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hourly forecast
+// ---------------------------------------------------------------------------
+
+describe('hourly forecast', () => {
+  it('only returns items within [now − 1 h, now + 12 h]', async () => {
+    const tooOld      = SEC(MOCK_NOW - 2 * 3_600_000);  // 2 h ago — excluded
+    const recentStart = SEC(MOCK_NOW - 30 * 60_000);     // 30 min ago — included
+    const current     = SEC(MOCK_NOW);
+    const future6h    = SEC(MOCK_NOW + 6 * 3_600_000);
+    const future12h   = SEC(MOCK_NOW + 12 * 3_600_000);  // boundary — included
+    const tooFar      = SEC(MOCK_NOW + 13 * 3_600_000);  // excluded
+
+    mockFetch(buildResponse({
+      hourlyData: [
+        hourly(tooOld),
+        hourly(recentStart),
+        hourly(current),
+        hourly(future6h),
+        hourly(future12h),
+        hourly(tooFar),
+      ],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    const times = result.hourly.map((h) => h.time.getTime());
+    expect(times).not.toContain(tooOld * 1000);
+    expect(times).toContain(recentStart * 1000);
+    expect(times).toContain(future12h * 1000);
+    expect(times).not.toContain(tooFar * 1000);
+  });
+
+  it('patches the currently-active hour with observed current conditions', async () => {
+    // An hourly slot that started 30 minutes ago is "active"
+    const activeSlot = SEC(MOCK_NOW - 30 * 60_000);
+
+    mockFetch(buildResponse({
+      currentIcon: 'rain',
+      currentTemp: 58,
+      currentPrecipIntensity: 0.05,
+      hourlyData: [
+        hourly(activeSlot, { icon: 'clear-day', temperature: 65 }),
+      ],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    const active = result.hourly.find((h) => h.time.getTime() === activeSlot * 1000);
+    expect(active?.condition).toBe('rainy');
+    expect(active?.temp).toBe(58);
+    expect(active?.precipIntensity).toBe(0.05);
+  });
+
+  it('does not patch future hourly slots', async () => {
+    const futureSlot = SEC(MOCK_NOW + 2 * 3_600_000);
+
+    mockFetch(buildResponse({
+      currentIcon: 'rain',
+      currentTemp: 58,
+      hourlyData: [hourly(futureSlot, { icon: 'clear-day', temperature: 72 })],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    const future = result.hourly.find((h) => h.time.getTime() === futureSlot * 1000);
+    expect(future?.condition).toBe('sunny');    // unchanged
+    expect(future?.temp).toBe(72);
+  });
+
+  it('includes precipProbability and precipIntensity on hourly entries', async () => {
+    const slot = SEC(MOCK_NOW + 3_600_000);
+    mockFetch(buildResponse({
+      hourlyData: [hourly(slot, { precipProbability: 0.4, precipIntensity: 0.02 })],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    const h = result.hourly[0];
+    expect(h?.precipProbability).toBe(40);
+    expect(h?.precipIntensity).toBe(0.02);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sunrise / sunset
+// ---------------------------------------------------------------------------
+
+describe('sunrise and sunset', () => {
+  it('exposes sunrise and sunset from daily[0]', async () => {
+    const base = SEC(MOCK_NOW);
+    const sunriseTs = base + 6 * 3600;
+    const sunsetTs  = base + 19 * 3600;
+
+    mockFetch(buildResponse({
+      dailyData: [{ ...daily(base), sunriseTime: sunriseTs, sunsetTime: sunsetTs }],
+    }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.sunrise?.getTime()).toBe(sunriseTs * 1000);
+    expect(result.sunset?.getTime()).toBe(sunsetTs * 1000);
+  });
+
+  it('returns undefined sunrise/sunset when daily data is empty', async () => {
+    const response = buildResponse({ dailyData: [] });
+    response.daily = { data: [] };
+    mockFetch(response);
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.sunrise).toBeUndefined();
+    expect(result.sunset).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minutely data
+// ---------------------------------------------------------------------------
+
+describe('minutely precipitation', () => {
+  it('passes minutely data through when the API includes it', async () => {
+    const minutelyData = [
+      { time: SEC(MOCK_NOW), precipIntensity: 0.1, precipProbability: 0.8 },
+      { time: SEC(MOCK_NOW) + 60, precipIntensity: 0.0, precipProbability: 0.1 },
+    ];
+    mockFetch(buildResponse({ minutelyData }));
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.minutely).toEqual(minutelyData);
+  });
+
+  it('returns undefined minutely when the API omits it', async () => {
+    mockFetch(buildResponse()); // no minutelyData in overrides → undefined
+    const { fetchWeatherData } = await import('../pirateweather');
+    const result = await fetchWeatherData();
+
+    expect(result.minutely).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+  it('throws when PIRATE_WEATHER_API_KEY is not set', async () => {
+    const savedKey = process.env.PIRATE_WEATHER_API_KEY;
+    delete process.env.PIRATE_WEATHER_API_KEY;
+
+    // Re-import so the module re-reads env
+    jest.resetModules();
+    const { fetchWeatherData } = await import('../pirateweather');
+    await expect(fetchWeatherData()).rejects.toThrow('PIRATE_WEATHER_API_KEY');
+
+    process.env.PIRATE_WEATHER_API_KEY = savedKey;
+  });
+
+  it('throws on non-OK HTTP response', async () => {
+    jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+      ok: false,
+      text: async () => 'Forbidden',
+    } as never);
+
+    jest.resetModules();
+    const { fetchWeatherData } = await import('../pirateweather');
+    await expect(fetchWeatherData()).rejects.toThrow('Failed to fetch Pirate Weather data');
+  });
+
+  it('wraps network errors with a descriptive message', async () => {
+    jest.spyOn(global, 'fetch' as never).mockRejectedValue(new Error('ECONNREFUSED'));
+    jest.resetModules();
     const { fetchWeatherData } = await import('../pirateweather');
     await expect(fetchWeatherData()).rejects.toThrow(/Pirate Weather network error: ECONNREFUSED/);
   });

--- a/src/lib/integrations/__tests__/pirateweather.test.ts
+++ b/src/lib/integrations/__tests__/pirateweather.test.ts
@@ -409,7 +409,7 @@ describe('hourly forecast', () => {
     const { fetchWeatherData } = await import('../pirateweather');
     const result = await fetchWeatherData();
 
-    const times = result.hourly.map((h) => h.time.getTime());
+    const times = result.hourly!.map((h) => h.time.getTime());
     expect(times).not.toContain(tooOld * 1000);
     expect(times).toContain(recentStart * 1000);
     expect(times).toContain(future12h * 1000);
@@ -431,7 +431,7 @@ describe('hourly forecast', () => {
     const { fetchWeatherData } = await import('../pirateweather');
     const result = await fetchWeatherData();
 
-    const active = result.hourly.find((h) => h.time.getTime() === activeSlot * 1000);
+    const active = result.hourly!.find((h) => h.time.getTime() === activeSlot * 1000);
     expect(active?.condition).toBe('rainy');
     expect(active?.temp).toBe(58);
     expect(active?.precipIntensity).toBe(0.05);
@@ -448,7 +448,7 @@ describe('hourly forecast', () => {
     const { fetchWeatherData } = await import('../pirateweather');
     const result = await fetchWeatherData();
 
-    const future = result.hourly.find((h) => h.time.getTime() === futureSlot * 1000);
+    const future = result.hourly!.find((h) => h.time.getTime() === futureSlot * 1000);
     expect(future?.condition).toBe('sunny');    // unchanged
     expect(future?.temp).toBe(72);
   });
@@ -461,7 +461,7 @@ describe('hourly forecast', () => {
     const { fetchWeatherData } = await import('../pirateweather');
     const result = await fetchWeatherData();
 
-    const h = result.hourly[0];
+    const h = result.hourly![0];
     expect(h?.precipProbability).toBe(40);
     expect(h?.precipIntensity).toBe(0.02);
   });
@@ -554,7 +554,9 @@ describe('error handling', () => {
   });
 
   it('wraps network errors with a descriptive message', async () => {
-    jest.spyOn(global, 'fetch' as never).mockRejectedValue(new Error('ECONNREFUSED'));
+    jest.spyOn(global, 'fetch' as never).mockImplementation(
+      (() => Promise.reject(new Error('ECONNREFUSED'))) as never
+    );
     jest.resetModules();
     const { fetchWeatherData } = await import('../pirateweather');
     await expect(fetchWeatherData()).rejects.toThrow(/Pirate Weather network error: ECONNREFUSED/);

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -188,7 +188,7 @@ export async function fetchWeatherData(location?: LocationParam): Promise<Weathe
   }
 
   const data: OpenMeteoResponse = await response.json();
-  const { current, hourly, daily } = data;
+  const { current, hourly, daily, timezone } = data;
 
   // ── Current conditions ────────────────────────────────────────────────────
   const currentWeather: CurrentWeather = {
@@ -208,22 +208,34 @@ export async function fetchWeatherData(location?: LocationParam): Promise<Weathe
   const sunset  = daily.sunset[0]  ? new Date(daily.sunset[0])  : undefined;
 
   // ── 7-day forecast ────────────────────────────────────────────────────────
-  const forecast: ForecastDay[] = daily.time.slice(0, 7).map((dateStr, i) => {
-    // YYYY-MM-DD in the location's TZ; parse as local-date to avoid the UTC
-    // shift bug.
-    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr);
-    const date = m
-      ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
-      : new Date(dateStr);
-    return {
-      date,
-      dayName: DAYS_SHORT[date.getDay()] ?? 'Day',
-      high: Math.round(daily.temperature_2m_max[i] ?? 0),
-      low: Math.round(daily.temperature_2m_min[i] ?? 0),
-      condition: mapWmoCode(daily.weather_code[i] ?? 0),
-      precipProbability: Math.round(daily.precipitation_probability_max?.[i] ?? 0),
-    };
-  });
+  // Today's local date at the forecast location — used to drop stale past-day
+  // entries that can appear when a cached response was generated yesterday.
+  // Open-Meteo's `daily.time` strings are already in the response timezone, so
+  // a YYYY-MM-DD comparison is sufficient. (See iann's PR #27 for the same
+  // issue addressed in the OWM and Pirate Weather paths.)
+  const todayLocalStr = new Intl.DateTimeFormat('en-CA', { timeZone: timezone })
+    .format(new Date());
+
+  const forecast: ForecastDay[] = daily.time
+    .map((dateStr, i) => ({ dateStr, i }))
+    .filter(({ dateStr }) => dateStr.slice(0, 10) >= todayLocalStr)
+    .slice(0, 7)
+    .map(({ dateStr, i }) => {
+      // YYYY-MM-DD in the location's TZ; parse as local-date to avoid the UTC
+      // shift bug.
+      const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr);
+      const date = m
+        ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+        : new Date(dateStr);
+      return {
+        date,
+        dayName: DAYS_SHORT[date.getDay()] ?? 'Day',
+        high: Math.round(daily.temperature_2m_max[i] ?? 0),
+        low: Math.round(daily.temperature_2m_min[i] ?? 0),
+        condition: mapWmoCode(daily.weather_code[i] ?? 0),
+        precipProbability: Math.round(daily.precipitation_probability_max?.[i] ?? 0),
+      };
+    });
 
   // ── Hourly: next 24 hours ─────────────────────────────────────────────────
   const nowMs = Date.now();

--- a/src/lib/integrations/openweather.ts
+++ b/src/lib/integrations/openweather.ts
@@ -209,6 +209,14 @@ async function fetchForecastRaw(location?: LocationParam): Promise<{
   // not UTC midnight (which can be as early as 7 PM in US time zones).
   const tzOffsetSec = data.city.timezone;
 
+  // Today's date key in location-local time — used to skip stale past-day buckets.
+  // OWM's 3-hour intervals start from the next UTC boundary, so when shifted to local
+  // time the very first interval can still belong to the previous local day (e.g. a
+  // 3 AM UTC Friday interval is 10 PM CDT Thursday). Without this guard the forecast
+  // would open with "Thu" when it is already Friday locally.
+  const nowLocalMs = (Math.floor(Date.now() / 1000) + tzOffsetSec) * 1000;
+  const todayKey = new Date(nowLocalMs).toISOString().split('T')[0]!;
+
   const dailyData = new Map<
     string,
     { date: Date; temps: number[]; conditions: number[] }
@@ -239,7 +247,9 @@ async function fetchForecastRaw(location?: LocationParam): Promise<{
   const forecast: ForecastDay[] = [];
   let count = 0;
 
-  for (const [, dayData] of dailyData) {
+  for (const [dateKey, dayData] of dailyData) {
+    // Skip any bucket that belongs to a past local day
+    if (dateKey < todayKey) continue;
     if (count >= 7) break;
 
     const high = Math.max(...dayData.temps);
@@ -258,9 +268,11 @@ async function fetchForecastRaw(location?: LocationParam): Promise<{
       }
     }
 
-    // Use location-local day of week (shift by timezone offset, then read UTC day)
-    const localShiftedDate = new Date(dayData.date.getTime() + tzOffsetSec * 1000);
-    const dayIndex = localShiftedDate.getUTCDay();
+    // Derive day-of-week directly from the local dateKey ("YYYY-MM-DD") so the
+    // label always matches the bucket's date, regardless of when the first
+    // 3-hour sample within that bucket happened to fall in UTC.
+    const [yr, mo, dy] = dateKey.split('-').map(Number);
+    const dayIndex = new Date(Date.UTC(yr!, mo! - 1, dy!)).getUTCDay();
     forecast.push({
       date: dayData.date,
       dayName: dayNames[dayIndex] || 'Day',

--- a/src/lib/integrations/pirateweather.ts
+++ b/src/lib/integrations/pirateweather.ts
@@ -191,17 +191,27 @@ export async function fetchWeatherData(location?: LocationParam): Promise<Weathe
     weekday: 'short',
     timeZone: timezone,
   });
-  const forecast: ForecastDay[] = daily.data.slice(0, 7).map((d) => {
-    const date = new Date(d.time * 1000);
-    return {
-      date,
-      dayName: dayNameFmt.format(date),
-      high: Math.round(d.temperatureHigh),
-      low: Math.round(d.temperatureLow),
-      condition: mapIcon(d.icon),
-      precipProbability: Math.round(d.precipProbability * 100),
-    };
-  });
+  // 'en-CA' gives YYYY-MM-DD, which is directly string-comparable.
+  const localDateFmt = new Intl.DateTimeFormat('en-CA', { timeZone: timezone });
+  // Today's local date at the forecast location — used to drop stale past-day
+  // entries that can appear when a cached response was generated yesterday
+  // (e.g. a Thursday entry visible on Friday morning until the cache expires).
+  const todayLocalStr = localDateFmt.format(new Date(Date.now()));
+
+  const forecast: ForecastDay[] = daily.data
+    .filter((d) => localDateFmt.format(new Date(d.time * 1000)) >= todayLocalStr)
+    .slice(0, 7)
+    .map((d) => {
+      const date = new Date(d.time * 1000);
+      return {
+        date,
+        dayName: dayNameFmt.format(date),
+        high: Math.round(d.temperatureHigh),
+        low: Math.round(d.temperatureLow),
+        condition: mapIcon(d.icon),
+        precipProbability: Math.round(d.precipProbability * 100),
+      };
+    });
 
   // ── Hourly: next 24 hours ─────────────────────────────────────────────────
   const nowMs = Date.now();


### PR DESCRIPTION
## Summary

Lands [@iann](https://github.com/iann)'s PR #27 fix locally with two additions:
1. Rebased onto current master (his branch was based on \`8acafb6\` — pre-v1.7.0 weather refactor).
2. Extended the past-day filter to **Open-Meteo** (the new v1.7.0 default), which had the same \`daily.time.slice(0, 7)\` pattern with no guard.

Original bug: forecast widget shows the previous local day (e.g. "Thu" on a Friday) when a cached weather response was generated before local midnight. Affects every provider, through three different mechanisms:

- **OpenWeatherMap**: 3-hour intervals start on non-zero UTC boundaries, so a 4 AM UTC interval shifted to CDT (−5 h) is 11 PM the previous local day. The first bucket lands on yesterday.
- **Pirate Weather**: Pre-aggregates daily entries server-side, but Redis (30-min) and Next \`fetch\` (\`revalidate: 1800\`) caches can serve a payload built before midnight. \`daily.data[0]\` still carries yesterday.
- **Open-Meteo**: Returns local-tz dates with \`timezone=auto\` so no shifting issue, but the same cache-staleness applies — \`daily.time[0]\` stays "yesterday" until the cache expires.

## Fixes

### \`openweather.ts\` (iann)
- Compute \`todayKey\` (YYYY-MM-DD) using the city's UTC offset, skip buckets where \`dateKey < todayKey\`.
- Derive day-of-week label directly from the bucket's \`dateKey\` string (\`Date.UTC(yr, mo-1, dy).getUTCDay()\`) instead of re-shifting the first 3-hour sample's UTC timestamp, which could disagree with the bucket.

### \`pirateweather.ts\` (iann)
- Use \`Intl.DateTimeFormat('en-CA', { timeZone })\` for stable \`YYYY-MM-DD\` comparison; filter \`daily.data\` before \`.slice(0, 7)\`.

### \`openmeteo.ts\` (this PR)
- Same \`Intl.DateTimeFormat('en-CA', { timeZone: response.timezone })\` pattern; filter \`daily.time\` before slicing. ~6 production lines.
- Test: stale response with \`[yesterday, today, tomorrow]\` → expects 2 days, today first, no yesterday data.

### \`WeatherWidget.tsx\` (iann)
- Client-side defense-in-depth: filter past-day entries before \`DayForecast\` renders, so a still-warm cache doesn't leak yesterday into the UI.
- Heading reads \`{visibleForecast.length}-Day Forecast\` so it always matches the actual rendered count.

## Tests

iann's 80 new test cases are preserved (midnight boundary inclusion, IST UTC+5:30, EDT 4 AM UTC, exact midnight vs 1-second-prior, OWM condition codes, PW icons). One new test added for Open-Meteo's past-day filter. Full \`npx jest\` passes (188 weather-suite tests / 952 total ignoring the pre-existing integration.test.ts that requires a real DB).

## Author attribution

iann's 5 commits are preserved with his authorship. The Open-Meteo extension is a separate commit on top.

## Test plan

- [ ] CI green (lint, type-check, jest, migration-replay, e2e-modality, build-only, test-install)
- [ ] Manual verification on the live deployment after merge: \`/api/weather\` first forecast entry should match today's local date, even immediately after a cache-warm at \`23:58\` local