### PR TITLE
chore(test): gate integration suite on E2E_HAS_TEST_DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
       - run: npm ci
 
       # Integration tests (src/lib/db/__tests__/integration.test.ts) require
-      # a real Postgres + seeded schema — they belong in a separate job, not
-      # the pure unit run.
-      - run: npm test -- --ci --testPathIgnorePatterns="integration\\.test\\.ts$"
+      # a real Postgres + seeded schema. They self-skip when E2E_HAS_TEST_DB
+      # is not '1' (this job doesn't set it), so a plain jest run is enough.
+      - run: npm test -- --ci
 
   migration-replay:
     name: Migration replay (modality TODO #3)

--- a/src/lib/db/__tests__/integration.test.ts
+++ b/src/lib/db/__tests__/integration.test.ts
@@ -22,7 +22,16 @@ const describeIf = HAS_TEST_DB ? describe : describe.skip;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-const db = getTestDb();
+// Only initialize when E2E_HAS_TEST_DB is set — getTestDb() reads .env for
+// DB_PASSWORD at module load and throws in environments (like CI's plain
+// unit-tests job) where there's no .env file. The definite-assignment `!`
+// is safe because lifecycle hooks below only fire when at least one test
+// in this file runs, and `describeIf` skips every suite when HAS_TEST_DB
+// is false.
+let db!: ReturnType<typeof getTestDb>;
+if (HAS_TEST_DB) {
+  db = getTestDb();
+}
 
 async function truncateTables(): Promise<void> {
   // Order matters due to FK constraints: dependents first

--- a/src/lib/db/__tests__/integration.test.ts
+++ b/src/lib/db/__tests__/integration.test.ts
@@ -4,15 +4,21 @@
  * Integration tests against the real prism_test PostgreSQL database.
  * No DB query mocks — all queries hit the actual database.
  *
- * Prerequisites:
- *   - Docker container prism-db running on host port 5433
- *   - prism_test database created and schema applied
+ * Gated on `E2E_HAS_TEST_DB=1` — without it the suite is skipped (not failed)
+ * so `npx jest` runs cleanly on a dev machine that doesn't expose Postgres.
+ * CI's e2e-modality job sets the flag and provides a real `prism_test` DB.
+ *
+ * Prerequisites (when running with E2E_HAS_TEST_DB=1):
+ *   - Postgres reachable at localhost:5433 with the `prism_test` database
  *   - DB_PASSWORD in .env (or as env var)
  */
 
 import { eq } from 'drizzle-orm';
 import { getTestDb, closeTestDb } from './testDb';
 import * as schema from '../schema';
+
+const HAS_TEST_DB = process.env.E2E_HAS_TEST_DB === '1';
+const describeIf = HAS_TEST_DB ? describe : describe.skip;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -39,7 +45,7 @@ afterAll(async () => {
 
 // ─── Events CRUD ──────────────────────────────────────────────────────────────
 
-describe('Events CRUD', () => {
+describeIf('Events CRUD', () => {
   it('inserts an event and reads it back with all fields matching', async () => {
     const startTime = new Date('2026-06-01T09:00:00Z');
     const endTime = new Date('2026-06-01T10:00:00Z');
@@ -115,7 +121,7 @@ describe('Events CRUD', () => {
 
 // ─── Chore completion flow ────────────────────────────────────────────────────
 
-describe('Chore completion flow', () => {
+describeIf('Chore completion flow', () => {
   it('creates a user and chore, inserts a completion, verifies it, then deletes it', async () => {
     // Create a family member
     const [user] = await db.insert(schema.users).values({
@@ -211,7 +217,7 @@ describe('Chore completion flow', () => {
 
 // ─── Auth: login + session lifecycle ─────────────────────────────────────────
 
-describe('Auth: session lifecycle', () => {
+describeIf('Auth: session lifecycle', () => {
   /**
    * Check if Redis is reachable from the test runner (outside Docker).
    * Redis is typically only exposed inside the Docker network, so if


### PR DESCRIPTION
## Summary

Local \`npx jest\` was failing 8/8 in \`src/lib/db/__tests__/integration.test.ts\` because the suite hits a real Postgres at \`localhost:5433/prism_test\`, which isn't available on most dev machines. The current docker-compose doesn't expose prism-db on 5433 anyway (5433 is panache-db).

Top-level describes now use \`describeIf = HAS_TEST_DB ? describe : describe.skip\` so the suite self-skips when \`E2E_HAS_TEST_DB !== '1'\`. CI's unit-tests job doesn't set the flag (no real DB available), so it skips automatically. The old \`--testPathIgnorePatterns\` flag is now redundant and removed.

Result: \`npx jest\` runs clean locally (952 pass, 8 skipped, 0 fail) for the first time. CI behavior unchanged.

## Test plan

- [ ] CI green (jest, type-check, lint, migration-replay, e2e-modality)
- [ ] Local: \`npx jest src/lib/db/__tests__/integration.test.ts\` reports "8 skipped" instead of failing
- [ ] When run with \`E2E_HAS_TEST_DB=1\` against a real \`prism_test\` DB, the suite executes as before