### PR TITLE
fix(visual-regression): mask Clock/Weather/Photo via data-widget attr

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -67,9 +67,9 @@ function getSeededParentName(): string {
 // screenshot (rendered as solid colored rectangles in the diff).
 function dynamicMasks(page: Page) {
   return [
-    page.locator('[role="region"]', { hasText: /^Clock$/ }),
-    page.locator('[role="region"]', { hasText: /^Weather$/ }),
-    page.locator('[role="region"]', { hasText: /^Photos?$/ }),
+    page.locator('[data-widget="Clock"]'),
+    page.locator('[data-widget="Weather"]'),
+    page.locator('[data-widget="Photo"]'),
   ];
 }
 

--- a/src/components/widgets/PhotoWidget.tsx
+++ b/src/components/widgets/PhotoWidget.tsx
@@ -24,6 +24,7 @@ export const PhotoWidget = React.memo(function PhotoWidget({ className }: PhotoW
 
   return (
     <WidgetContainer
+      widgetType="Photo"
       loading={loading}
       error={error}
       showHeader={false}

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -224,6 +224,7 @@ export const WeatherWidget = React.memo(function WeatherWidget({
 
   return (
     <WidgetContainer
+      widgetType="Weather"
       icon={<Cloud className="h-4 w-4" />}
       size="medium"
       loading={loading}

--- a/src/components/widgets/WidgetContainer.tsx
+++ b/src/components/widgets/WidgetContainer.tsx
@@ -118,6 +118,8 @@ export type WidgetSize = 'small' | 'medium' | 'large' | 'wide' | 'tall';
 export interface WidgetContainerProps {
   /** Widget title (shown in header) */
   title?: string;
+  /** Stable widget identifier for tests/analytics. Falls back to title. */
+  widgetType?: string;
   /** URL to navigate to when title is clicked */
   titleHref?: string;
   /** Icon to show before title */
@@ -186,6 +188,7 @@ export function WidgetContainer({
   size = 'medium',
   showHeader = true,
   widgetId,
+  widgetType,
   alignment: alignmentProp,
   className,
   onClick,
@@ -230,6 +233,7 @@ export function WidgetContainer({
         className
       )}
       onClick={onClick}
+      data-widget={widgetType ?? title}
       style={{
         // Grid rows: auto for header (if present), 1fr for content
         gridTemplateRows: showHeader && title ? 'auto 1fr' : '1fr',


### PR DESCRIPTION
## Summary

The visual regression mask selectors (`[role="region"]` with `hasText`) were matching zero elements because `WidgetContainer` renders a plain `Card` div without ARIA region roles. Live temps, clock values, and photo content were rendering into baselines instead of being blacked out.

- Add a stable `data-widget` attribute on `WidgetContainer`, defaulting to `title` and overridable via a new `widgetType` prop.
- Set `widgetType="Weather"` on `WeatherWidget` and `widgetType="Photo"` on `PhotoWidget` (both headerless, so no `title` to fall back on). Clock already has `title="Clock"`.
- Update spec masks to target `[data-widget="..."]`.

## Caveat

Existing baselines were captured with broken masks, so they'll diff against any new run. They need re-capture before this is stable enough for CI — a follow-up.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visually inspect a fresh capture to confirm Weather/Clock/Photo now render as solid rectangles