### PR TITLE
feat(voice-api): scaffold /api/v1/voice with calendar/today endpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Voice API foundation (`/api/v1/voice/*`)**: New versioned, token-authenticated API surface for voice and home-automation integrations. First endpoint: `GET /api/v1/voice/calendar/today` returns today's events with a pre-formatted natural-language `spoken` field (`"Today you have Soccer Practice at 4 PM."`) so callers don't need their own templating. Reuses the existing `apiTokens` Bearer-token system; per-token rate-limited at 60 req/min. Documented in `docs/voice-api.md`. Phase 1 of the Alexa + HA distribution plan — additional intents (shopping/add, chore/complete, calendar/upcoming, etc.) coming in follow-ups.
+
 ## [1.7.2] – 2026-05-02
 
 > Same-day patch follow-up: forecast past-day filter across all weather providers + a developer-experience fix for `npx jest`.

--- a/docs/voice-api.md
+++ b/docs/voice-api.md
@@ -1,0 +1,91 @@
+# Voice API (`/api/v1/voice/*`)
+
+The Voice API is a versioned, token-authenticated surface designed for voice and home-automation integrations (Alexa skills, Home Assistant components, Google Assistant via HA, scripting hooks). It is intentionally separate from the internal session-cookie-authenticated routes the dashboard uses — the contract here is **stable** and external callers can rely on it.
+
+## Auth
+
+Every endpoint accepts:
+
+- `Authorization: Bearer <token>` — long-lived API token issued via `POST /api/auth/tokens` (parent-only). **Recommended for external integrations.**
+- A valid `prism_session` cookie — also works, useful for browser-based debugging.
+
+Tokens are SHA-256 hashed at rest and never re-displayed after creation.
+
+## Response shape
+
+Every endpoint returns:
+
+```json
+{
+  "ok": true,
+  "spoken": "Today you have Soccer Practice at 4 PM.",
+  "data": { "...endpoint-specific..." }
+}
+```
+
+- `ok` — boolean. `false` for errors.
+- `spoken` — natural-language string the caller speaks back to the user. Pre-formatted on the server so callers don't need templating.
+- `data` — optional structured payload. Present on success; omitted on error.
+
+Errors return the same shape with `ok: false`, an HTTP error status, and a user-friendly `spoken` apology (no stack traces or IDs).
+
+## Rate limiting
+
+Per-token, 60 requests per 60 seconds. Returns `429` with a `voice`-shaped error body when exceeded.
+
+## Versioning
+
+The path prefix `/api/v1/` is the contract version. Breaking changes ship under `/api/v2/` with `/api/v1/` continuing to function. New non-breaking endpoints can be added to `v1` freely.
+
+## Endpoints
+
+### `GET /api/v1/voice/calendar/today`
+
+Returns events whose `startTime` falls within today (server local time).
+
+**Response data**:
+
+```json
+{
+  "count": 1,
+  "events": [
+    {
+      "id": "uuid",
+      "title": "Soccer Practice",
+      "startTime": "2026-05-02T21:00:00.000Z",
+      "endTime": "2026-05-02T22:30:00.000Z",
+      "allDay": false,
+      "location": "Community Park"
+    }
+  ]
+}
+```
+
+**Spoken examples**:
+
+- `"You have no events today."`
+- `"Today you have Soccer Practice at 4 PM."`
+- `"Today you have Standup at 9 AM and Lunch at 12:30 PM."`
+- `"Today you have A at 8 AM, B at 10 AM, and C at 2 PM."` (Oxford comma)
+
+## Issuing a token
+
+```bash
+curl -X POST http://localhost:3000/api/auth/tokens \
+  -H "Cookie: prism_session=<your-parent-session>" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Alexa skill" }'
+```
+
+The response includes `token` — store it immediately, it is not retrievable later.
+
+## Roadmap
+
+The following endpoints are planned but not yet implemented (see `memory/alexa-voice-api-feature.md`):
+
+- `GET /api/v1/voice/calendar/upcoming` — next N events
+- `POST /api/v1/voice/shopping/add` — add item to a list
+- `POST /api/v1/voice/chore/complete` — mark a chore done by fuzzy name
+- `GET /api/v1/voice/tasks/today` — tasks due today
+- `POST /api/v1/voice/message/post` — post a family message
+- `GET /api/v1/voice/family` — family member names (for Alexa slot type sync)

--- a/src/app/api/v1/voice/calendar/today/route.ts
+++ b/src/app/api/v1/voice/calendar/today/route.ts
@@ -1,0 +1,57 @@
+import { withAuth } from '@/lib/api/withAuth';
+import { voiceOk, voiceError } from '@/lib/api/voiceResponse';
+import { phraseEventList } from '@/lib/api/voicePhrases';
+import { db } from '@/lib/db/client';
+import { events } from '@/lib/db/schema';
+import { and, gte, lt, asc } from 'drizzle-orm';
+import { logError } from '@/lib/utils/logError';
+
+/**
+ * GET /api/v1/voice/calendar/today
+ *
+ * Returns today's events shaped for natural-language playback.
+ * Auth: any valid session OR API token. Rate-limited per caller.
+ */
+export async function GET() {
+  return withAuth(async () => {
+    try {
+      const now = new Date();
+      const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      const dayEnd = new Date(dayStart);
+      dayEnd.setDate(dayEnd.getDate() + 1);
+
+      const todayEvents = await db
+        .select({
+          id: events.id,
+          title: events.title,
+          startTime: events.startTime,
+          endTime: events.endTime,
+          allDay: events.allDay,
+          location: events.location,
+        })
+        .from(events)
+        .where(and(gte(events.startTime, dayStart), lt(events.startTime, dayEnd)))
+        .orderBy(asc(events.startTime));
+
+      const spoken = phraseEventList(todayEvents);
+
+      return voiceOk(spoken, {
+        count: todayEvents.length,
+        events: todayEvents.map((e) => ({
+          id: e.id,
+          title: e.title,
+          startTime: e.startTime.toISOString(),
+          endTime: e.endTime.toISOString(),
+          allDay: e.allDay,
+          location: e.location,
+        })),
+      });
+    } catch (error) {
+      logError('Voice API: calendar/today failed', error);
+      return voiceError('Sorry, I had trouble reading your calendar.', 500);
+    }
+  }, {
+    rateLimit: { feature: 'voice-api', limit: 60, windowSeconds: 60 },
+  });
+}
+

--- a/src/lib/api/__tests__/voicePhrases.test.ts
+++ b/src/lib/api/__tests__/voicePhrases.test.ts
@@ -1,0 +1,52 @@
+import { phraseEventList } from '../voicePhrases';
+
+const at = (h: number, m = 0) => {
+  const d = new Date('2026-01-01T00:00:00');
+  d.setHours(h, m);
+  return d;
+};
+
+describe('phraseEventList', () => {
+  it('says no events when list is empty', () => {
+    expect(phraseEventList([])).toBe('You have no events today.');
+  });
+
+  it('renders a single timed event', () => {
+    expect(phraseEventList([
+      { title: 'Soccer Practice', startTime: at(16), allDay: false },
+    ])).toBe('Today you have Soccer Practice at 4 PM.');
+  });
+
+  it('renders an all-day event without a time', () => {
+    expect(phraseEventList([
+      { title: 'Beach Day', startTime: at(0), allDay: true },
+    ])).toBe('Today you have Beach Day, all day.');
+  });
+
+  it('renders two events joined with "and"', () => {
+    expect(phraseEventList([
+      { title: 'Standup', startTime: at(9), allDay: false },
+      { title: 'Lunch', startTime: at(12, 30), allDay: false },
+    ])).toBe('Today you have Standup at 9 AM and Lunch at 12:30 PM.');
+  });
+
+  it('renders three or more events with Oxford comma', () => {
+    expect(phraseEventList([
+      { title: 'A', startTime: at(8), allDay: false },
+      { title: 'B', startTime: at(10), allDay: false },
+      { title: 'C', startTime: at(14), allDay: false },
+    ])).toBe('Today you have A at 8 AM, B at 10 AM, and C at 2 PM.');
+  });
+
+  it('omits zero minutes from the spoken time', () => {
+    expect(phraseEventList([
+      { title: 'Meeting', startTime: at(9, 0), allDay: false },
+    ])).toBe('Today you have Meeting at 9 AM.');
+  });
+
+  it('includes non-zero minutes', () => {
+    expect(phraseEventList([
+      { title: 'Meeting', startTime: at(9, 15), allDay: false },
+    ])).toBe('Today you have Meeting at 9:15 AM.');
+  });
+});

--- a/src/lib/api/voicePhrases.ts
+++ b/src/lib/api/voicePhrases.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure functions that turn structured data into natural-language strings
+ * for the Voice API's `spoken` field. Kept separate from route handlers so
+ * they can be unit-tested without HTTP/DB plumbing.
+ */
+
+type SpeakableEvent = {
+  title: string;
+  startTime: Date;
+  allDay: boolean;
+};
+
+export function phraseEventList(items: SpeakableEvent[]): string {
+  if (items.length === 0) return 'You have no events today.';
+
+  const parts = items.map((e) => {
+    if (e.allDay) return `${e.title}, all day`;
+    const time = e.startTime.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: e.startTime.getMinutes() === 0 ? undefined : '2-digit',
+    });
+    return `${e.title} at ${time}`;
+  });
+
+  if (parts.length === 1) return `Today you have ${parts[0]}.`;
+  if (parts.length === 2) return `Today you have ${parts[0]} and ${parts[1]}.`;
+
+  const last = parts.pop();
+  return `Today you have ${parts.join(', ')}, and ${last}.`;
+}

--- a/src/lib/api/voiceResponse.ts
+++ b/src/lib/api/voiceResponse.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Shape of every Voice API response. The `spoken` field is the natural-language
+ * string the caller (Alexa skill, HA component, etc.) speaks back to the user.
+ * Keeps caller code dumb — no client-side templating needed.
+ */
+export type VoiceResponse<T = unknown> = {
+  ok: boolean;
+  spoken: string;
+  data?: T;
+};
+
+export function voiceOk<T>(spoken: string, data?: T, status = 200): NextResponse {
+  const body: VoiceResponse<T> = data === undefined
+    ? { ok: true, spoken }
+    : { ok: true, spoken, data };
+  return NextResponse.json(body, { status });
+}
+
+export function voiceError(spoken: string, status = 400): NextResponse {
+  const body: VoiceResponse = { ok: false, spoken };
+  return NextResponse.json(body, { status });
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Alexa + Home Assistant integration plan ([memory plan file](memory/alexa-voice-api-feature.md)). Stands up the versioned voice-API namespace, the standard response shape, and one representative endpoint that exercises the auth + rate-limit + spoken-response pipeline end-to-end. Subsequent endpoints (shopping/add, chore/complete, calendar/upcoming, tasks/today, message/post, family) drop in cleanly on top of this scaffolding.

## What's added

- `GET /api/v1/voice/calendar/today` — today's events with a pre-formatted natural-language `spoken` field
- `src/lib/api/voiceResponse.ts` — `voiceOk` / `voiceError` helpers enforcing the shared `{ ok, spoken, data }` shape
- `src/lib/api/voicePhrases.ts` — `phraseEventList` (Oxford comma, all-day handling, smart minute formatting)
- 7 unit tests for the phrase builder
- `docs/voice-api.md` — auth, response shape, rate limits, versioning, planned endpoints, token issuance example
- CHANGELOG entry under `[Unreleased]`

## Reuses existing infrastructure (no new auth code)

- `apiTokens` table + `validateApiToken` (already shipped)
- `requireAuth` already accepts Bearer tokens with session-cookie fallback
- `withAuth` middleware handles auth + per-token rate limiting (60 req/min)

## Test plan

- [x] `npx jest src/lib/api/__tests__/voicePhrases.test.ts` — 7 passing
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: issue a token via `POST /api/auth/tokens`, then `curl -H "Authorization: Bearer <token>" http://localhost:3000/api/v1/voice/calendar/today`
- [ ] Confirm rate-limit returns 429 after 60 reqs in 60s