### PR TITLE
feat(voice-api): require 'voice' token scope; reject session cookies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Prism are documented in this file.
 
 ### Added
 - **Voice API foundation (`/api/v1/voice/*`)**: New versioned, token-authenticated API surface for voice and home-automation integrations. First endpoint: `GET /api/v1/voice/calendar/today` returns today's events with a pre-formatted natural-language `spoken` field (`"Today you have Soccer Practice at 4 PM."`) so callers don't need their own templating. Reuses the existing `apiTokens` Bearer-token system; per-token rate-limited at 60 req/min. Documented in `docs/voice-api.md`. Phase 1 of the Alexa + HA distribution plan — additional intents (shopping/add, chore/complete, calendar/upcoming, etc.) coming in follow-ups.
+- **Voice token scope (`voice`)**: `withAuth` now supports a `tokenScope` option that rejects session-cookie callers and requires an API token whose scopes include either the named scope or `*`. The Voice API uses `tokenScope: 'voice'` so a leaked browser session cannot reach it, and Voice tokens issued with `scopes: ['voice']` are confined to `/api/v1/voice/*` (vs. the legacy `['*']` default which grants full account access). Token-creation validator now restricts scopes to the known set `['*', 'voice']`.
 
 ## [1.7.2] – 2026-05-02
 

--- a/docs/voice-api.md
+++ b/docs/voice-api.md
@@ -4,12 +4,25 @@ The Voice API is a versioned, token-authenticated surface designed for voice and
 
 ## Auth
 
-Every endpoint accepts:
+Every Voice API endpoint requires `Authorization: Bearer <token>` where the token's scopes include either `voice` or `*`. **Session cookies are rejected** — this is intentionally a machine-to-machine surface, so a stolen browser session can't reach voice endpoints.
 
-- `Authorization: Bearer <token>` — long-lived API token issued via `POST /api/auth/tokens` (parent-only). **Recommended for external integrations.**
-- A valid `prism_session` cookie — also works, useful for browser-based debugging.
+Tokens are issued via `POST /api/auth/tokens` (parent-only), SHA-256 hashed at rest, and never re-displayed after creation. The recommended scope for voice integrations is `['voice']` so a token leak cannot read or modify anything outside `/api/v1/voice/*`.
 
-Tokens are SHA-256 hashed at rest and never re-displayed after creation.
+```bash
+curl -X POST http://localhost:3000/api/auth/tokens \
+  -H "Cookie: prism_session=<your-parent-session>" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Alexa skill", "scopes": ["voice"] }'
+```
+
+The response includes `token` — store it immediately, it is not retrievable later.
+
+### Known scopes
+
+| Scope | Grants |
+|---|---|
+| `voice` | Read + write across `/api/v1/voice/*` only |
+| `*` | Full account access (legacy default; avoid for new tokens) |
 
 ## Response shape
 
@@ -68,16 +81,14 @@ Returns events whose `startTime` falls within today (server local time).
 - `"Today you have Standup at 9 AM and Lunch at 12:30 PM."`
 - `"Today you have A at 8 AM, B at 10 AM, and C at 2 PM."` (Oxford comma)
 
-## Issuing a token
+## Security model for write operations
 
-```bash
-curl -X POST http://localhost:3000/api/auth/tokens \
-  -H "Cookie: prism_session=<your-parent-session>" \
-  -H "Content-Type: application/json" \
-  -d '{ "name": "Alexa skill" }'
-```
+Voice cannot escalate privileges. Specifically:
 
-The response includes `token` — store it immediately, it is not retrievable later.
+- **Chore completions inherit the chore's `assignedTo`** as the completer — voice does not let one family member claim another's points.
+- **Ambiguous chore names require disambiguation.** If a fuzzy name match returns multiple chores assigned to different family members (e.g. both Emma and Sophie have "Feed the dog"), the endpoint returns `ok: false` with a `spoken` prompt asking for the assignee (*"Multiple chores match 'feed the dog' — which family member?"*) and `data.candidates: [...]`. The caller resends with `assignee` in the body. A single match completes immediately.
+- **Chores with `requiresApproval: true` create *pending* completions** when completed via voice, just like the in-app flow. The `spoken` response makes this explicit (e.g. *"Marked feed the dog complete. A parent will need to approve in the app."*).
+- **Approval is in-app only**, behind the Parent PIN. Voice has no way to approve a pending chore — there is no way to verify the speaker is a parent.
 
 ## Roadmap
 

--- a/src/app/api/v1/voice/calendar/today/route.ts
+++ b/src/app/api/v1/voice/calendar/today/route.ts
@@ -51,6 +51,7 @@ export async function GET() {
       return voiceError('Sorry, I had trouble reading your calendar.', 500);
     }
   }, {
+    tokenScope: 'voice',
     rateLimit: { feature: 'voice-api', limit: 60, windowSeconds: 60 },
   });
 }

--- a/src/lib/api/__tests__/withAuth.test.ts
+++ b/src/lib/api/__tests__/withAuth.test.ts
@@ -125,4 +125,49 @@ describe('withAuth', () => {
 
     expect(result).toBe(expected);
   });
+
+  describe('tokenScope', () => {
+    it('rejects session-cookie auth with 401', async () => {
+      // Session auth has no `scopes` field — that's how we detect it
+      mockRequireAuth.mockResolvedValue(parentAuth);
+      const handler = jest.fn();
+
+      const result = await withAuth(handler, { tokenScope: 'voice' });
+
+      expect(result).toBeInstanceOf(NextResponse);
+      expect((result as NextResponse).status).toBe(401);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('rejects API token without the required scope (403)', async () => {
+      mockRequireAuth.mockResolvedValue({ ...parentAuth, scopes: ['other'] });
+      const handler = jest.fn();
+
+      const result = await withAuth(handler, { tokenScope: 'voice' });
+
+      expect(result).toBeInstanceOf(NextResponse);
+      expect((result as NextResponse).status).toBe(403);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('accepts API token with the named scope', async () => {
+      const tokenAuth: AuthResult = { ...parentAuth, scopes: ['voice'] };
+      mockRequireAuth.mockResolvedValue(tokenAuth);
+      const handler = jest.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+
+      await withAuth(handler, { tokenScope: 'voice' });
+
+      expect(handler).toHaveBeenCalledWith(tokenAuth);
+    });
+
+    it('accepts API token with the wildcard scope', async () => {
+      const tokenAuth: AuthResult = { ...parentAuth, scopes: ['*'] };
+      mockRequireAuth.mockResolvedValue(tokenAuth);
+      const handler = jest.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+
+      await withAuth(handler, { tokenScope: 'voice' });
+
+      expect(handler).toHaveBeenCalledWith(tokenAuth);
+    });
+  });
 });

--- a/src/lib/api/withAuth.ts
+++ b/src/lib/api/withAuth.ts
@@ -12,6 +12,13 @@ export interface AuthResult {
 interface WithAuthOptions {
   /** Required permission (checked via requireRole for session auth; checked against token scopes for API tokens) */
   permission?: keyof RolePermissions;
+  /**
+   * Required token scope. When set, the request MUST be authenticated via an
+   * API token whose scopes include either `*` or the named scope. Session
+   * cookies are rejected. Use this for endpoints that are intentionally
+   * machine-to-machine only (e.g. the Voice API).
+   */
+  tokenScope?: string;
   /** Rate limit configuration */
   rateLimit?: {
     /** Feature name for rate limit key */
@@ -53,6 +60,22 @@ export async function withAuth<T>(
   // Check authentication
   const auth = await requireAuth();
   if (auth instanceof NextResponse) return auth;
+
+  // Check required token scope (rejects session-cookie callers)
+  if (options?.tokenScope) {
+    if (auth.scopes === undefined) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHORIZED', message: 'API token required for this endpoint' } },
+        { status: 401 }
+      );
+    }
+    if (!tokenHasScope(auth.scopes, options.tokenScope)) {
+      return NextResponse.json(
+        { error: { code: 'FORBIDDEN', message: `Token scope must include '${options.tokenScope}' or '*'` } },
+        { status: 403 }
+      );
+    }
+  }
 
   // Check permission if specified
   if (options?.permission) {

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -287,10 +287,20 @@ export const calendarNotesQuerySchema = z.object({
 
 // API TOKEN SCHEMAS
 
+/**
+ * Known token scopes. `*` grants full account access (the legacy default).
+ * `voice` is restricted to the `/api/v1/voice/*` namespace. New scopes
+ * should be added here AND enforced by `withAuth({ tokenScope: ... })`
+ * on the endpoints they cover.
+ */
+export const TOKEN_SCOPES = ['*', 'voice'] as const;
+export type TokenScope = (typeof TOKEN_SCOPES)[number];
+
 export const createApiTokenSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   scopes: z
-    .array(z.string().min(1).max(100))
+    .array(z.enum(TOKEN_SCOPES))
+    .min(1, 'At least one scope is required')
     .optional()
     .default(['*']),
 });


### PR DESCRIPTION
## Summary

Defense in depth before HACS publication. Two-part change:

### 1. `withAuth` gains a `tokenScope` option

When set, the request MUST be authenticated via a Bearer API token whose scopes include either the named scope or `*`. **Session cookies are rejected** — voice endpoints become intentionally machine-to-machine, so a stolen browser session cannot reach them. Tokens lacking the required scope get 403.

### 2. Token-creation validator locked to a known scope enum

`createApiTokenSchema` now restricts `scopes` to `['*', 'voice']`. New scopes must be added there **and** wired up by an endpoint via `tokenScope:` — otherwise issuing a bogus scope is meaningless. Also requires at least one scope.

### Side effect: voice endpoint now scoped

`GET /api/v1/voice/calendar/today` passes `tokenScope: 'voice'`. Existing `*` tokens still work; new voice integrations should be issued with `scopes: ['voice']` so a leak is confined to the voice surface.

### Bonus: chore-completion security model documented

`voice-api.md` now spells out the rules for the not-yet-built `chore/complete` endpoint, locking the design before code lands:

- Completions inherit the chore's `assignedTo` (no claiming someone else's points)
- `requiresApproval` chores create *pending* completions; voice cannot approve
- Approval stays in-app, behind the Parent PIN
- **Ambiguous names** (e.g. both Emma and Sophie have "Feed the dog") return a disambiguation prompt with `data.candidates`; caller resends with `assignee`

## Test plan

- [x] 4 new `tokenScope` cases added to `withAuth.test.ts` (53 total passing)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: issue a `voice`-scoped token, hit `/api/v1/voice/calendar/today` — works
- [ ] Manual: try the same endpoint with a session cookie — 401
- [ ] Manual: try with a token whose scopes are `['other']` — 403