### PR TITLE
feat(caldav): Apple iCloud / CalDAV integration (alpha, read-only)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Added — Integrations
+- **CalDAV / Apple iCloud (alpha, read-only)**: Connect any CalDAV server — Apple iCloud (`https://caldav.icloud.com`), Nextcloud, Radicale, Baikal, Synology — from *Settings → Connected Accounts → CalDAV*. Username + app-specific password, encrypted at rest. Discovery picks calendars + Reminders lists; events sync into the same `events` table as Google/iCal, VTODO items into `tasks`. Two-way write (create / update / delete) is on the roadmap. Apple Reminders sync as tasks with the original priorities and due dates. New API surface: `POST /api/caldav/{test,discover,connect}`. Documented in `docs/features/CALENDAR.md`.
+
 ### Changed — Auth
 - **Sign-in toast fires for every blocked mutation**: When a signed-out viewer edits a field, ticks a chore, adds a shopping item, or otherwise attempts any `/api/*` mutation, the call returned 401 and the UI silently failed to update — no signal that auth was the cause. A global `window.fetch` interceptor in `AuthProvider` now catches mutation 401s and toasts "Sign in to make changes — Enter your PIN to save edits." Debounced 2.5s so a save burst fires one toast, not ten. Suppressed while the PIN modal is already open (so `requireAuth`'s own toast doesn't double up). Limited to `/api/*` paths and POST/PUT/PATCH/DELETE so third-party fetches and the initial session-check GET aren't affected. Mirrors the dashboard edit-button behavior we added in 1.8.1.
 

--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -33,7 +33,23 @@ iCloud doesn't speak OAuth or expose a public REST API, so Prism rides the same 
 
 From iCloud.com it's the same idea: *Calendar → ⓘ next to the calendar → Public Calendar → Copy Link*.
 
-Caveats: this is a one-way feed (changes you make in Prism don't push back to iCloud — there's no UI to "edit" these events because the feed is read-only), and the calendar has to be marked Public on iCloud's side. Apple Reminders, iCloud Photos, and other Apple services don't have an equivalent open path, so they aren't currently supported.
+Caveats: this is a one-way feed (changes you make in Prism don't push back to iCloud — there's no UI to "edit" these events because the feed is read-only), and the calendar has to be marked Public on iCloud's side.
+
+### Apple iCloud (CalDAV — private calendars + Reminders) — *alpha*
+
+For calendars you don't want to mark Public — or to sync **Reminders** as tasks — Prism supports iCloud over CalDAV. This is the same protocol the macOS/iOS Calendar app uses.
+
+1. Generate an app-specific password at [appleid.apple.com](https://appleid.apple.com) → *Sign-In and Security → App-Specific Passwords → Generate*.
+2. In Prism: *Settings → Connected Accounts → CalDAV → Connect CalDAV server*.
+3. Enter:
+   - **Server URL:** `https://caldav.icloud.com`
+   - **Username:** your iCloud email
+   - **Password:** the app-specific password from step 1 (not your Apple ID password)
+4. Click *Test Connection*, then *Find Calendars*, pick which calendars and Reminders lists to sync, and *Connect*.
+
+The same flow works for **Nextcloud** (`https://your-server/remote.php/dav`), **Radicale**, **Baikal** (`https://your-server/dav.php`), and **Synology Calendar** (`https://your-nas:5001/caldav/`).
+
+Caveats: this path is currently **read-only** — events and tasks pulled from CalDAV appear in the dashboard but can't be edited from Prism (two-way write is on the roadmap). App-specific passwords are stored encrypted in the Prism database and never leave your server. Apple Reminders sync into Prism's Tasks list with the same priorities and due dates the iOS app uses.
 
 ### Per-calendar customization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "dompurify": "^3.3.3",
         "drizzle-orm": "^0.38.2",
         "exifr": "^7.1.3",
+        "ical.js": "^2.2.1",
         "ioredis": "^5.4.1",
         "lucide-react": "^0.468.0",
         "maplibre-gl": "^5.23.0",
@@ -58,6 +59,7 @@
         "suncalc": "^1.9.0",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
+        "tsdav": "^2.1.8",
         "undici": "^6.25.0",
         "zod": "^3.24.1"
       },
@@ -8251,6 +8253,12 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
@@ -11404,6 +11412,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -15556,6 +15570,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -16947,6 +16970,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsdav": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.2.2.tgz",
+      "integrity": "sha512-/uC/RItcdYVxUj8b2gT4CorAkUmDFUuzhgS4XVT+OVzGRE80hH5ldubcWH13dHa2T9rNaXu6UIEWHlQ1UL7H1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "1.0.0",
+        "debug": "4.4.3",
+        "xml-js": "1.6.11"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -18571,6 +18608,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism",
-  "version": "1.8.0",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "dompurify": "^3.3.3",
     "drizzle-orm": "^0.38.2",
     "exifr": "^7.1.3",
+    "ical.js": "^2.2.1",
     "ioredis": "^5.4.1",
     "lucide-react": "^0.468.0",
     "maplibre-gl": "^5.23.0",
@@ -109,6 +110,7 @@
     "suncalc": "^1.9.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "tsdav": "^2.1.8",
     "undici": "^6.25.0",
     "zod": "^3.24.1"
   },

--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -89,6 +89,10 @@ ALLOWLIST=(
   # Library docs the comments reference
   "date-fns.org"
   "rclone.org"
+  # Apple iCloud DAV endpoints (CalDAV calendars + CardDAV contacts)
+  "caldav.icloud.com"
+  "contacts.icloud.com"
+  "appleid.apple.com"
   # Common public-suffix anchors that show up via vendor doc URLs
   "google.com"
   "microsoft.com"

--- a/src/app/api/birthdays/sync/route.ts
+++ b/src/app/api/birthdays/sync/route.ts
@@ -14,9 +14,10 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { db } from '@/lib/db/client';
-import { birthdays, calendarSources } from '@/lib/db/schema';
-import { eq, and, sql } from 'drizzle-orm';
+import { calendarSources } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
 import { logError } from '@/lib/utils/logError';
+import { upsertBirthday } from '@/lib/services/birthday-merge';
 import {
   fetchCalendarEvents,
   refreshAccessToken,
@@ -250,25 +251,20 @@ export async function POST() {
       const calSource = calendarSourceLabel[event.id] || 'google';
       rows.push({ name: parsed.name, birthDate, eventType: parsed.eventType, googleCalendarSource: calSource });
     }
-    // Upsert each row individually for better error tracking
+    // upsertBirthday handles the prefix-aware merge so that a calendar
+    // event titled "Julia's birthday" (which the regex strips down to
+    // "Julia") collapses onto an iCloud contact with FN "Julia O'Brien"
+    // when both share a birth month/day, instead of becoming a separate
+    // row. See src/lib/services/birthday-merge.ts.
     let synced = 0;
     for (const row of rows) {
       try {
-        await db
-          .insert(birthdays)
-          .values({
-            name: row.name,
-            birthDate: row.birthDate,
-            eventType: row.eventType,
-            googleCalendarSource: row.googleCalendarSource,
-          })
-          .onConflictDoUpdate({
-            target: [birthdays.name, birthdays.eventType],
-            set: {
-              birthDate: row.birthDate,
-              googleCalendarSource: row.googleCalendarSource,
-            },
-          });
+        await upsertBirthday({
+          name: row.name,
+          birthDate: row.birthDate,
+          eventType: row.eventType as 'birthday' | 'anniversary' | 'milestone',
+          source: row.googleCalendarSource,
+        });
         synced++;
       } catch (err) {
         console.error('[BirthdaySync] Failed to upsert:', row.name, row.eventType, err);

--- a/src/app/api/birthdays/sync/route.ts
+++ b/src/app/api/birthdays/sync/route.ts
@@ -252,8 +252,8 @@ export async function POST() {
       rows.push({ name: parsed.name, birthDate, eventType: parsed.eventType, googleCalendarSource: calSource });
     }
     // upsertBirthday handles the prefix-aware merge so that a calendar
-    // event titled "Julia's birthday" (which the regex strips down to
-    // "Julia") collapses onto an iCloud contact with FN "Julia O'Brien"
+    // event titled "Alex's birthday" (which the regex strips down to
+    // "Alex") collapses onto an iCloud contact with FN "Alex Doe"
     // when both share a birth month/day, instead of becoming a separate
     // row. See src/lib/services/birthday-merge.ts.
     let synced = 0;

--- a/src/app/api/caldav/connect/route.ts
+++ b/src/app/api/caldav/connect/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import type { AuthResult } from '@/lib/auth';
+import { db } from '@/lib/db/client';
+import { calendarSources } from '@/lib/db/schema';
+import { encrypt } from '@/lib/utils/crypto';
+import { invalidateCache } from '@/lib/cache/redis';
+import { logActivity } from '@/lib/services/auditLog';
+import { testCalDAVConnection } from '@/lib/integrations/caldav';
+
+/**
+ * POST /api/caldav/connect
+ * Connect selected CalDAV calendars as calendar sources.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const { serverUrl, username, password, calendars } = await request.json();
+
+    if (!serverUrl || !username || !password || !Array.isArray(calendars) || calendars.length === 0) {
+      return NextResponse.json(
+        { error: 'Server URL, credentials, and at least one calendar are required' },
+        { status: 400 }
+      );
+    }
+
+    // Verify connection before storing
+    const test = await testCalDAVConnection(serverUrl, username, password);
+    if (!test.success) {
+      return NextResponse.json(
+        { error: test.error || 'Connection failed' },
+        { status: 400 }
+      );
+    }
+
+    const encryptedPassword = encrypt(password);
+    const caldavConfig = {
+      serverUrl,
+      username,
+      authMethod: 'basic',
+    };
+
+    const created: string[] = [];
+
+    for (const cal of calendars) {
+      const { href, displayName, color } = cal as { href: string; displayName: string; color?: string };
+
+      const [source] = await db
+        .insert(calendarSources)
+        .values({
+          provider: 'caldav',
+          sourceCalendarId: href,
+          dashboardCalendarName: displayName,
+          displayName: displayName,
+          color: color || '#6366f1',
+          accessToken: encryptedPassword,
+          syncErrors: caldavConfig,
+          enabled: true,
+          showInEventModal: false, // Read-only
+        })
+        .returning();
+
+      if (source) created.push(source.id);
+    }
+
+    await invalidateCache('calendar-sources:*');
+    await invalidateCache('calendar-groups:*');
+    await invalidateCache('events:*');
+
+    logActivity({
+      userId: (auth as AuthResult).userId,
+      action: 'create',
+      entityType: 'integration',
+      entityId: 'caldav',
+      summary: `Connected ${created.length} CalDAV calendar(s) from ${serverUrl}`,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: `Connected ${created.length} calendar(s)`,
+      sourceIds: created,
+    }, { status: 201 });
+  } catch (error) {
+    console.error('CalDAV connect error:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect CalDAV calendars' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/caldav/connect/route.ts
+++ b/src/app/api/caldav/connect/route.ts
@@ -8,6 +8,7 @@ import { invalidateCache } from '@/lib/cache/redis';
 import { logActivity } from '@/lib/services/auditLog';
 import { testCalDAVConnection } from '@/lib/integrations/caldav';
 import { syncCalDAVCalendarSource, syncCalDAVTasks } from '@/lib/services/calendar-sync';
+import { syncCardDAVBirthdays } from '@/lib/services/carddav-birthday-sync';
 
 /**
  * POST /api/caldav/connect
@@ -21,7 +22,7 @@ export async function POST(request: NextRequest) {
   if (forbidden) return forbidden;
 
   try {
-    const { serverUrl, username, password, calendars } = await request.json();
+    const { serverUrl, username, password, calendars, syncContactBirthdays } = await request.json();
 
     if (!serverUrl || !username || !password || !Array.isArray(calendars) || calendars.length === 0) {
       return NextResponse.json(
@@ -43,7 +44,8 @@ export async function POST(request: NextRequest) {
 
     const created: string[] = [];
 
-    for (const cal of calendars) {
+    for (let i = 0; i < calendars.length; i++) {
+      const cal = calendars[i];
       const { href, displayName, color, supportsEvents, supportsTasks } = cal as {
         href: string;
         displayName: string;
@@ -55,13 +57,20 @@ export async function POST(request: NextRequest) {
       // Store supports flags inline with the CalDAV connection config so
       // sync + UI can route this source correctly. Default both to true when
       // discovery didn't tell us — old behavior of "sync both" preserved.
-      const caldavConfig = {
+      // Anchor contactBirthdaysEnabled on the first inserted row only — the
+      // CardDAV sync only needs one anchor row to read credentials from,
+      // and multiplying it across N calendars would mean N independent
+      // sync attempts on the same address book.
+      const caldavConfig: Record<string, unknown> = {
         serverUrl,
         username,
         authMethod: 'basic',
         supportsEvents: supportsEvents !== false,
         supportsTasks: supportsTasks !== false,
       };
+      if (i === 0 && syncContactBirthdays) {
+        caldavConfig.contactBirthdaysEnabled = true;
+      }
 
       const [source] = await db
         .insert(calendarSources)
@@ -106,6 +115,16 @@ export async function POST(request: NextRequest) {
           console.error(`Initial CalDAV sync failed for source ${sourceId}:`,
             err instanceof Error ? err.message : err);
         }
+      }
+      if (syncContactBirthdays) {
+        try {
+          const r = await syncCardDAVBirthdays();
+          if (r.errors.length) console.error('Initial CardDAV birthday sync errors:', r.errors);
+        } catch (err) {
+          console.error('Initial CardDAV birthday sync failed:',
+            err instanceof Error ? err.message : err);
+        }
+        await invalidateCache('birthdays:*').catch(() => {});
       }
       // Invalidate event/task caches AFTER sync completes so the dashboard
       // picks up the new rows on its next poll.

--- a/src/app/api/caldav/connect/route.ts
+++ b/src/app/api/caldav/connect/route.ts
@@ -7,6 +7,7 @@ import { encrypt } from '@/lib/utils/crypto';
 import { invalidateCache } from '@/lib/cache/redis';
 import { logActivity } from '@/lib/services/auditLog';
 import { testCalDAVConnection } from '@/lib/integrations/caldav';
+import { syncCalDAVCalendarSource, syncCalDAVTasks } from '@/lib/services/calendar-sync';
 
 /**
  * POST /api/caldav/connect
@@ -80,9 +81,29 @@ export async function POST(request: NextRequest) {
       summary: `Connected ${created.length} CalDAV calendar(s) from ${serverUrl}`,
     });
 
+    // Fire-and-forget initial sync so the user sees events / tasks within
+    // seconds of connecting instead of waiting up to 10 minutes for the
+    // periodic cron. Errors logged server-side; the response returns 201
+    // immediately regardless.
+    (async () => {
+      for (const sourceId of created) {
+        try {
+          await syncCalDAVCalendarSource(sourceId);
+          await syncCalDAVTasks(sourceId);
+        } catch (err) {
+          console.error(`Initial CalDAV sync failed for source ${sourceId}:`,
+            err instanceof Error ? err.message : err);
+        }
+      }
+      // Invalidate event/task caches AFTER sync completes so the dashboard
+      // picks up the new rows on its next poll.
+      await invalidateCache('events:*').catch(() => {});
+      await invalidateCache('tasks:*').catch(() => {});
+    })();
+
     return NextResponse.json({
       success: true,
-      message: `Connected ${created.length} calendar(s)`,
+      message: `Connected ${created.length} calendar(s) — syncing in background`,
       sourceIds: created,
     }, { status: 201 });
   } catch (error) {

--- a/src/app/api/caldav/connect/route.ts
+++ b/src/app/api/caldav/connect/route.ts
@@ -40,16 +40,28 @@ export async function POST(request: NextRequest) {
     }
 
     const encryptedPassword = encrypt(password);
-    const caldavConfig = {
-      serverUrl,
-      username,
-      authMethod: 'basic',
-    };
 
     const created: string[] = [];
 
     for (const cal of calendars) {
-      const { href, displayName, color } = cal as { href: string; displayName: string; color?: string };
+      const { href, displayName, color, supportsEvents, supportsTasks } = cal as {
+        href: string;
+        displayName: string;
+        color?: string;
+        supportsEvents?: boolean;
+        supportsTasks?: boolean;
+      };
+
+      // Store supports flags inline with the CalDAV connection config so
+      // sync + UI can route this source correctly. Default both to true when
+      // discovery didn't tell us — old behavior of "sync both" preserved.
+      const caldavConfig = {
+        serverUrl,
+        username,
+        authMethod: 'basic',
+        supportsEvents: supportsEvents !== false,
+        supportsTasks: supportsTasks !== false,
+      };
 
       const [source] = await db
         .insert(calendarSources)

--- a/src/app/api/caldav/discover/route.ts
+++ b/src/app/api/caldav/discover/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { discoverCalendars } from '@/lib/integrations/caldav';
+
+/**
+ * POST /api/caldav/discover
+ * Discover available calendars on a CalDAV server.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const { serverUrl, username, password } = await request.json();
+
+    if (!serverUrl || !username || !password) {
+      return NextResponse.json(
+        { error: 'Server URL, username, and password are required' },
+        { status: 400 }
+      );
+    }
+
+    const calendars = await discoverCalendars(serverUrl, username, password);
+    return NextResponse.json({ calendars });
+  } catch (error) {
+    console.error('CalDAV discover error:', error);
+    return NextResponse.json(
+      { error: 'Failed to discover calendars' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/caldav/sync-birthdays/route.ts
+++ b/src/app/api/caldav/sync-birthdays/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { syncCardDAVBirthdays } from '@/lib/services/carddav-birthday-sync';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { logError } from '@/lib/utils/logError';
+
+/**
+ * POST /api/caldav/sync-birthdays
+ * Manually re-run CardDAV birthday sync. Reads creds from whichever
+ * CalDAV source row was flagged with contactBirthdaysEnabled at connect
+ * time. Returns 200 with { synced, errors } regardless of whether any
+ * rows changed, or 400 if no contact-enabled source is configured.
+ */
+export async function POST() {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const result = await syncCardDAVBirthdays();
+    if (result.synced > 0) await invalidateEntity('birthdays');
+    return NextResponse.json(result);
+  } catch (err) {
+    logError('CardDAV birthday sync failed', err);
+    return NextResponse.json(
+      { error: 'Sync failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/caldav/test/route.ts
+++ b/src/app/api/caldav/test/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { testCalDAVConnection } from '@/lib/integrations/caldav';
+
+/**
+ * POST /api/caldav/test
+ * Test connectivity to a CalDAV server.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const { serverUrl, username, password } = await request.json();
+
+    if (!serverUrl || !username || !password) {
+      return NextResponse.json(
+        { error: 'Server URL, username, and password are required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await testCalDAVConnection(serverUrl, username, password);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('CalDAV test error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Connection test failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/calendar-groups/route.ts
+++ b/src/app/api/calendar-groups/route.ts
@@ -32,7 +32,20 @@ export async function GET() {
           userId: calendarGroups.userId,
           sortOrder: calendarGroups.sortOrder,
           userSortOrder: users.sortOrder,
-          sourceCount: sql<number>`(SELECT count(*)::int FROM calendar_sources WHERE calendar_sources.group_id = ${calendarGroups.id})`,
+          // Count only sources that actually carry events — CalDAV reminder
+          // lists (supportsEvents=false) are hidden from the Calendar UI so
+          // including them here would make the badge show "3 sources" while
+          // the user can only see 2. The IS DISTINCT FROM 'false' check
+          // treats missing/null flags as truthy for backward compatibility
+          // with non-CalDAV providers and legacy rows.
+          sourceCount: sql<number>`(
+            SELECT count(*)::int FROM calendar_sources
+            WHERE calendar_sources.group_id = ${calendarGroups.id}
+              AND (
+                calendar_sources.provider != 'caldav'
+                OR (calendar_sources.sync_errors->>'supportsEvents') IS DISTINCT FROM 'false'
+              )
+          )`,
           userName: users.name,
           userColor: users.color,
         })

--- a/src/app/api/calendars/sync/route.ts
+++ b/src/app/api/calendars/sync/route.ts
@@ -18,6 +18,8 @@ import {
   syncGoogleCalendarSource,
   syncAllIcalCalendars,
   syncIcalCalendarSource,
+  syncAllCalDAVCalendars,
+  syncCalDAVCalendarSource,
 } from '@/lib/services/calendar-sync';
 
 /**
@@ -75,17 +77,20 @@ export async function POST(request: NextRequest) {
       }
       const syncResult = source.provider === 'ical'
         ? await syncIcalCalendarSource(body.calendarId, options)
-        : await syncGoogleCalendarSource(body.calendarId, options);
+        : source.provider === 'caldav'
+          ? await syncCalDAVCalendarSource(body.calendarId, options)
+          : await syncGoogleCalendarSource(body.calendarId, options);
       result = { synced: syncResult.synced, errors: syncResult.errors };
     } else {
       // Sync all calendars across all supported providers
-      const [google, ical] = await Promise.all([
+      const [google, ical, caldav] = await Promise.all([
         syncAllGoogleCalendars(options),
         syncAllIcalCalendars(options),
+        syncAllCalDAVCalendars(options),
       ]);
       result = {
-        total: google.total + ical.total,
-        errors: [...google.errors, ...ical.errors],
+        total: google.total + ical.total + caldav.total,
+        errors: [...google.errors, ...ical.errors, ...caldav.errors],
       };
     }
 

--- a/src/app/api/integrations/status/route.ts
+++ b/src/app/api/integrations/status/route.ts
@@ -57,10 +57,16 @@ export async function GET() {
       .from(photoSources)
       .where(eq(photoSources.type, 'onedrive'));
 
-    // Gmail: check api_credentials with service='gmail-bus'
+    // Gmail: check api_credentials with service='gmail-bus'. We deliberately
+    // don't surface expiresAt here. Gmail access tokens have a 1-hour TTL but
+    // bus-tracking-sync.ts auto-refreshes them on the next sync tick via the
+    // stored refresh token, so a "past expires_at" is not a user-actionable
+    // problem. When the refresh truly fails (TokenRevokedError), the sync
+    // path deletes the credential row outright — at which point this query
+    // returns null and `connected: false` flips the UI to "Connect Gmail".
     const gmailCred = await db.query.apiCredentials.findFirst({
       where: (c, { eq: eqFn }) => eqFn(c.service, 'gmail-bus'),
-      columns: { expiresAt: true, updatedAt: true },
+      columns: { id: true },
     });
 
     return NextResponse.json({
@@ -82,7 +88,6 @@ export async function GET() {
       },
       gmail: {
         connected: !!gmailCred,
-        expiresAt: gmailCred?.expiresAt?.toISOString() || null,
       },
     });
   } catch (error) {

--- a/src/app/api/task-lists/route.ts
+++ b/src/app/api/task-lists/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
-import { taskLists, tasks } from '@/lib/db/schema';
+import { taskLists, tasks, calendarSources } from '@/lib/db/schema';
 import { eq, asc, sql } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { getCached } from '@/lib/cache/redis';
@@ -24,15 +24,26 @@ export async function GET() {
           createdAt: taskLists.createdAt,
           updatedAt: taskLists.updatedAt,
           // Derived: which external system populated this list, if any.
-          // 'caldav' when at least one task in the list has a caldav-prefixed
-          // externalId; null for purely Prism-internal lists. Lets the
-          // settings UI badge "From: Apple iCloud" on auto-created lists
-          // without requiring a join client-side.
+          // 'caldav' when either:
+          //   (a) at least one task in the list has a caldav-prefixed externalId, OR
+          //   (b) a calendar_source's syncErrors JSON has taskListId pointing here.
+          // Checking (b) catches CalDAV-backed lists whose only tasks were
+          // Apple's placeholder VTODOs (now filtered out by sync) — those
+          // lists are empty but still legitimately CalDAV-sourced.
           linkedProvider: sql<string | null>`(
-            SELECT 'caldav' FROM ${tasks}
-            WHERE ${tasks.listId} = ${taskLists.id}
-              AND ${tasks.externalId} LIKE 'caldav:%'
-            LIMIT 1
+            CASE
+              WHEN EXISTS (
+                SELECT 1 FROM ${tasks}
+                WHERE ${tasks.listId} = ${taskLists.id}
+                  AND ${tasks.externalId} LIKE 'caldav:%'
+              ) THEN 'caldav'
+              WHEN EXISTS (
+                SELECT 1 FROM ${calendarSources}
+                WHERE ${calendarSources.provider} = 'caldav'
+                  AND ${calendarSources.syncErrors}->>'taskListId' = ${taskLists.id}::text
+              ) THEN 'caldav'
+              ELSE NULL
+            END
           )`,
         })
         .from(taskLists)

--- a/src/app/api/task-lists/route.ts
+++ b/src/app/api/task-lists/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
-import { taskLists } from '@/lib/db/schema';
-import { eq, asc } from 'drizzle-orm';
+import { taskLists, tasks } from '@/lib/db/schema';
+import { eq, asc, sql } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { getCached } from '@/lib/cache/redis';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
@@ -15,7 +15,26 @@ export async function GET() {
     const lists = await getCached(
       'task-lists:all',
       async () => db
-        .select()
+        .select({
+          id: taskLists.id,
+          name: taskLists.name,
+          color: taskLists.color,
+          sortOrder: taskLists.sortOrder,
+          createdBy: taskLists.createdBy,
+          createdAt: taskLists.createdAt,
+          updatedAt: taskLists.updatedAt,
+          // Derived: which external system populated this list, if any.
+          // 'caldav' when at least one task in the list has a caldav-prefixed
+          // externalId; null for purely Prism-internal lists. Lets the
+          // settings UI badge "From: Apple iCloud" on auto-created lists
+          // without requiring a join client-side.
+          linkedProvider: sql<string | null>`(
+            SELECT 'caldav' FROM ${tasks}
+            WHERE ${tasks.listId} = ${taskLists.id}
+              AND ${tasks.externalId} LIKE 'caldav:%'
+            LIMIT 1
+          )`,
+        })
         .from(taskLists)
         .orderBy(asc(taskLists.sortOrder), asc(taskLists.name)),
       300

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,36 @@
 import { DashboardClient } from './DashboardClient';
+import { db } from '@/lib/db/client';
 
 export const metadata = {
   title: 'Dashboard',
   description: 'Your family dashboard - view calendars, tasks, weather, and more.',
 };
 
-export default function HomePage() {
+// Named dashboards at /d/[slug] wrap their content in a zoom container driven
+// by `layouts.fontScale`. The default dashboard at `/` was missing the same
+// wrapper, so the Display Settings slider had no effect on the main
+// dashboard — fix is to fetch the default layout's fontScale here and apply
+// the same zoom wrapper.
+export default async function HomePage() {
+  let fontScale = 100;
+  try {
+    const layout = await db.query.layouts.findFirst({
+      where: (l, { eq: eqFn }) => eqFn(l.isDefault, true),
+      columns: { fontScale: true },
+    });
+    fontScale = layout?.fontScale ?? 100;
+  } catch {
+    // DB unavailable — keep default scale.
+  }
+
   return (
     <main className="min-h-screen bg-background">
-      {/* Server-rendered content for fast LCP — replaced by client dashboard on hydration */}
       <div id="ssr-placeholder" className="h-screen flex items-center justify-center" aria-hidden="true">
         <h1 className="text-4xl font-bold text-muted-foreground/20">Prism</h1>
       </div>
-      <DashboardClient />
+      <div style={fontScale !== 100 ? { zoom: fontScale / 100 } : undefined}>
+        <DashboardClient />
+      </div>
     </main>
   );
 }

--- a/src/app/settings/SettingsPinGate.tsx
+++ b/src/app/settings/SettingsPinGate.tsx
@@ -188,16 +188,16 @@ function SettingsPinPrompt({
       onClick={onDismiss}
     >
       <div
-        className="bg-card rounded-2xl p-6 max-w-sm w-full mx-4 shadow-lg"
+        className="bg-card rounded-2xl p-3 max-w-[20rem] w-full mx-4 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between mb-5 pb-4 border-b border-border">
+        <div className="flex items-center justify-between mb-2 pb-2 border-b border-border">
           <div>
-            <h2 className="text-lg font-semibold">Parent PIN Required</h2>
-            <p className="text-sm text-muted-foreground mt-0.5">Select a parent to continue</p>
+            <h2 className="text-base font-semibold leading-tight">Parent PIN Required</h2>
+            <p className="text-xs text-muted-foreground">Select a parent to continue</p>
           </div>
-          <Button variant="ghost" size="icon" onClick={onDismiss}>
+          <Button variant="ghost" size="icon" onClick={onDismiss} className="h-7 w-7">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -216,47 +216,47 @@ function SettingsPinPrompt({
             )}>
               {/* Avatar section — invisible placeholder when no parent yet */}
               {!selectedParent ? (
-                <div className="flex flex-col items-center mx-auto mb-4 invisible" aria-hidden>
-                  <div className="h-16 w-16 rounded-full mb-1" />
-                  <span className="font-medium">name</span>
-                  <span className="text-xs">subtitle</span>
+                <div className="flex flex-col items-center mx-auto mb-1.5 invisible" aria-hidden>
+                  <div className="h-12 w-12 rounded-full" />
+                  <span className="text-sm font-medium">name</span>
+                  <span className="text-[10px]">subtitle</span>
                 </div>
               ) : parents.length > 1 ? (
                 <button
                   onClick={() => { setSelectedParent(null); setPin([]); setError(null); }}
-                  className="group flex flex-col items-center mx-auto mb-4"
+                  className="group flex flex-col items-center mx-auto mb-1.5"
                 >
                   <UserAvatar
                     name={selectedParent.name}
                     color={selectedParent.color}
                     imageUrl={selectedParent.avatarUrl}
                     size="lg"
-                    className="h-16 w-16 mb-1 group-hover:ring-2 ring-primary transition-all"
+                    className="h-12 w-12 group-hover:ring-2 ring-primary transition-all"
                   />
-                  <span className="font-medium">{selectedParent.name}</span>
-                  <span className="text-xs text-muted-foreground">Tap to switch</span>
+                  <span className="text-sm font-medium mt-0.5">{selectedParent.name}</span>
+                  <span className="text-[10px] text-muted-foreground">Tap to switch</span>
                 </button>
               ) : (
-                <div className="flex flex-col items-center mx-auto mb-4">
+                <div className="flex flex-col items-center mx-auto mb-1.5">
                   <UserAvatar
                     name={selectedParent.name}
                     color={selectedParent.color}
                     imageUrl={selectedParent.avatarUrl}
                     size="lg"
-                    className="h-16 w-16 mb-1 ring-2 ring-primary"
+                    className="h-12 w-12 ring-2 ring-primary"
                   />
-                  <span className="font-medium">{selectedParent.name}</span>
-                  <span className="text-xs text-muted-foreground">Enter your PIN</span>
+                  <span className="text-sm font-medium mt-0.5">{selectedParent.name}</span>
+                  <span className="text-[10px] text-muted-foreground">Enter your PIN</span>
                 </div>
               )}
 
               {/* PIN dots */}
-              <div className={cn('flex gap-3 justify-center mb-4', isShaking && 'animate-shake')}>
+              <div className={cn('flex gap-1.5 justify-center mb-1', isShaking && 'animate-shake')}>
                 {Array.from({ length: pinLength }, (_, i) => (
                   <div
                     key={i}
                     className={cn(
-                      'w-3 h-3 rounded-full transition-all duration-150',
+                      'w-2.5 h-2.5 rounded-full transition-all duration-150',
                       i < pin.length
                         ? error ? 'bg-destructive scale-110' : 'bg-primary scale-110'
                         : 'bg-muted border-2 border-border'
@@ -266,12 +266,12 @@ function SettingsPinPrompt({
               </div>
 
               {/* Error message */}
-              <div className="h-6 mb-3 flex items-center justify-center">
-                {error && <p className="text-sm text-destructive">{error}</p>}
+              <div className="h-4 flex items-center justify-center">
+                {error && <p className="text-xs text-destructive">{error}</p>}
               </div>
 
               {/* Number pad */}
-              <div className="grid grid-cols-3 gap-3 max-w-[280px] mx-auto">
+              <div className="grid grid-cols-3 gap-1.5 max-w-[200px] mx-auto">
                 {['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', 'del'].map((key, idx) => {
                   if (key === '') return <div key={idx} />;
                   if (key === 'del') {
@@ -281,9 +281,9 @@ function SettingsPinPrompt({
                         onClick={handleBackspace}
                         disabled={isVerifying}
                         className={cn(
-                          'w-16 h-16 rounded-full mx-auto flex items-center justify-center',
+                          'w-12 h-12 rounded-full mx-auto flex items-center justify-center',
                           'bg-muted hover:bg-muted/80 active:bg-accent active:scale-95',
-                          'transition-all duration-100 text-muted-foreground text-sm',
+                          'transition-all duration-100 text-muted-foreground text-xs',
                           isVerifying && 'opacity-50'
                         )}
                       >
@@ -297,10 +297,10 @@ function SettingsPinPrompt({
                       onClick={() => handleKeyPress(key)}
                       disabled={isVerifying}
                       className={cn(
-                        'w-16 h-16 rounded-full mx-auto flex items-center justify-center',
+                        'w-12 h-12 rounded-full mx-auto flex items-center justify-center',
                         'bg-secondary hover:bg-secondary/80',
                         'active:bg-primary active:text-primary-foreground active:scale-95',
-                        'transition-all duration-100 text-lg font-semibold',
+                        'transition-all duration-100 text-base font-semibold',
                         isVerifying && 'opacity-50'
                       )}
                     >
@@ -311,8 +311,8 @@ function SettingsPinPrompt({
               </div>
 
               {/* Loading */}
-              <div className="h-6 mt-3 flex items-center justify-center">
-                {isVerifying && <p className="text-sm text-muted-foreground">Verifying...</p>}
+              <div className="h-4 mt-1.5 flex items-center justify-center">
+                {isVerifying && <p className="text-xs text-muted-foreground">Verifying...</p>}
               </div>
             </div>
 
@@ -321,13 +321,13 @@ function SettingsPinPrompt({
               '[grid-area:1/1] flex flex-col justify-center text-center transition-opacity duration-150',
               selectedParent && 'opacity-0 pointer-events-none'
             )}>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-1.5">
                 {parents.map((parent) => (
                   <button
                     key={parent.id}
                     onClick={() => setSelectedParent(parent)}
                     className={cn(
-                      'flex flex-col items-center p-3 rounded-xl',
+                      'flex flex-col items-center p-1.5 rounded-xl',
                       'hover:bg-accent/50 active:bg-accent transition-colors',
                       'touch-action-manipulation'
                     )}
@@ -337,9 +337,9 @@ function SettingsPinPrompt({
                       color={parent.color}
                       imageUrl={parent.avatarUrl}
                       size="lg"
-                      className="h-14 w-14 mb-2"
+                      className="h-12 w-12 mb-1"
                     />
-                    <span className="text-sm font-medium">{parent.name}</span>
+                    <span className="text-xs font-medium">{parent.name}</span>
                   </button>
                 ))}
               </div>

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useState } from 'react';
+import { CheckCircle2, AlertCircle, Loader2, Server } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+interface DiscoveredCalendar {
+  href: string;
+  displayName: string;
+  color: string | null;
+  description: string | null;
+}
+
+export function CalDAVConnectDialog({
+  open,
+  onOpenChange,
+  onConnected,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConnected?: () => void;
+}) {
+  const [step, setStep] = useState<'credentials' | 'calendars' | 'done'>('credentials');
+  const [serverUrl, setServerUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const [calendars, setCalendars] = useState<DiscoveredCalendar[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [connecting, setConnecting] = useState(false);
+  const [connectedCount, setConnectedCount] = useState(0);
+
+  const reset = () => {
+    setStep('credentials');
+    setServerUrl('');
+    setUsername('');
+    setPassword('');
+    setTesting(false);
+    setTestResult(null);
+    setDiscovering(false);
+    setCalendars([]);
+    setSelected(new Set());
+    setConnecting(false);
+    setConnectedCount(0);
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await fetch('/api/caldav/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ serverUrl, username, password }),
+      });
+      const data = await res.json();
+      setTestResult(data);
+    } catch {
+      setTestResult({ success: false, error: 'Request failed' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleDiscover = async () => {
+    setDiscovering(true);
+    try {
+      const res = await fetch('/api/caldav/discover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ serverUrl, username, password }),
+      });
+      const data = await res.json();
+      if (data.calendars) {
+        setCalendars(data.calendars);
+        setSelected(new Set(data.calendars.map((c: DiscoveredCalendar) => c.href)));
+        setStep('calendars');
+      }
+    } catch {
+      setTestResult({ success: false, error: 'Failed to discover calendars' });
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      const selectedCalendars = calendars.filter(c => selected.has(c.href));
+      const res = await fetch('/api/caldav/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          serverUrl,
+          username,
+          password,
+          calendars: selectedCalendars,
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setConnectedCount(data.sourceIds?.length || selectedCalendars.length);
+        setStep('done');
+        onConnected?.();
+      }
+    } catch {
+      // Error handling
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const toggleCalendar = (href: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(href)) next.delete(href);
+      else next.add(href);
+      return next;
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) reset(); onOpenChange(o); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Server className="h-5 w-5" />
+            {step === 'credentials' && 'Connect CalDAV Server'}
+            {step === 'calendars' && 'Select Calendars'}
+            {step === 'done' && 'Connected!'}
+          </DialogTitle>
+          <DialogDescription>
+            {step === 'credentials' && 'Works with Apple iCloud, Nextcloud, Radicale, Baikal, Synology, and other CalDAV servers.'}
+            {step === 'calendars' && 'Choose which calendars to sync with Prism.'}
+            {step === 'done' && `${connectedCount} calendar(s) connected and syncing.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'credentials' && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="caldav-url">Server URL</Label>
+              <Input
+                id="caldav-url"
+                value={serverUrl}
+                onChange={e => setServerUrl(e.target.value)}
+                placeholder="https://cloud.example.com/remote.php/dav"
+              />
+              <div className="text-xs text-muted-foreground space-y-0.5">
+                <p><strong>Apple iCloud:</strong> https://caldav.icloud.com (use your iCloud email + an app-specific password from appleid.apple.com)</p>
+                <p><strong>Nextcloud:</strong> https://your-server/remote.php/dav</p>
+                <p><strong>Radicale:</strong> https://your-server/</p>
+                <p><strong>Baikal:</strong> https://your-server/dav.php</p>
+                <p><strong>Synology:</strong> https://your-nas:5001/caldav/</p>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="caldav-user">Username</Label>
+              <Input
+                id="caldav-user"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+                placeholder="username"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="caldav-pass">Password or App Token</Label>
+              <Input
+                id="caldav-pass"
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder="password or app-specific token"
+              />
+            </div>
+
+            {testResult && (
+              <div className={cn(
+                'flex items-center gap-2 p-3 rounded-lg text-sm',
+                testResult.success
+                  ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400'
+                  : 'bg-destructive/10 text-destructive'
+              )}>
+                {testResult.success ? <CheckCircle2 className="h-4 w-4 shrink-0" /> : <AlertCircle className="h-4 w-4 shrink-0" />}
+                {testResult.success ? 'Connection successful!' : testResult.error}
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={handleTest} disabled={!serverUrl || !username || !password || testing}>
+                {testing ? <><Loader2 className="h-4 w-4 mr-1 animate-spin" />Testing...</> : 'Test Connection'}
+              </Button>
+              <Button
+                onClick={handleDiscover}
+                disabled={!testResult?.success || discovering}
+              >
+                {discovering ? <><Loader2 className="h-4 w-4 mr-1 animate-spin" />Discovering...</> : 'Find Calendars'}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {step === 'calendars' && (
+          <div className="space-y-4">
+            <div className="space-y-2 max-h-64 overflow-auto">
+              {calendars.map(cal => (
+                <label
+                  key={cal.href}
+                  className="flex items-center gap-3 p-2 rounded-lg border border-border hover:bg-accent cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(cal.href)}
+                    onChange={() => toggleCalendar(cal.href)}
+                    className="rounded"
+                  />
+                  <div
+                    className="w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: cal.color || '#6366f1' }}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{cal.displayName}</p>
+                    {cal.description && <p className="text-xs text-muted-foreground truncate">{cal.description}</p>}
+                  </div>
+                </label>
+              ))}
+              {calendars.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No calendars found on this server.</p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setStep('credentials')}>Back</Button>
+              <Button onClick={handleConnect} disabled={selected.size === 0 || connecting}>
+                {connecting ? <><Loader2 className="h-4 w-4 mr-1 animate-spin" />Connecting...</> : `Connect ${selected.size} Calendar${selected.size !== 1 ? 's' : ''}`}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {step === 'done' && (
+          <DialogFooter>
+            <Button onClick={() => { reset(); onOpenChange(false); }}>Done</Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -20,6 +20,8 @@ interface DiscoveredCalendar {
   displayName: string;
   color: string | null;
   description: string | null;
+  supportsEvents: boolean;
+  supportsTasks: boolean;
 }
 
 export function CalDAVConnectDialog({

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -42,6 +42,7 @@ export function CalDAVConnectDialog({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [connecting, setConnecting] = useState(false);
   const [connectedCount, setConnectedCount] = useState(0);
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const reset = () => {
     setStep('credentials');
@@ -98,6 +99,7 @@ export function CalDAVConnectDialog({
 
   const handleConnect = async () => {
     setConnecting(true);
+    setConnectError(null);
     try {
       const selectedCalendars = calendars.filter(c => selected.has(c.href));
       const res = await fetch('/api/caldav/connect', {
@@ -110,14 +112,19 @@ export function CalDAVConnectDialog({
           calendars: selectedCalendars,
         }),
       });
-      const data = await res.json();
-      if (data.success) {
+      // Try to parse JSON either way — the API returns { error } on failure.
+      let data: { success?: boolean; sourceIds?: string[]; error?: string } = {};
+      try { data = await res.json(); } catch { /* non-JSON response */ }
+
+      if (res.ok && data.success) {
         setConnectedCount(data.sourceIds?.length || selectedCalendars.length);
         setStep('done');
         onConnected?.();
+      } else {
+        setConnectError(data.error || `Connect failed (HTTP ${res.status})`);
       }
-    } catch {
-      // Error handling
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : 'Network error');
     } finally {
       setConnecting(false);
     }
@@ -255,6 +262,13 @@ export function CalDAVConnectDialog({
                 <p className="text-sm text-muted-foreground text-center py-4">No calendars found on this server.</p>
               )}
             </div>
+
+            {connectError && (
+              <div className="flex items-start gap-2 p-3 rounded-lg text-sm bg-destructive/10 text-destructive">
+                <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                <div className="flex-1">{connectError}</div>
+              </div>
+            )}
 
             <DialogFooter>
               <Button variant="outline" onClick={() => setStep('credentials')}>Back</Button>

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -45,6 +45,7 @@ export function CalDAVConnectDialog({
   const [connecting, setConnecting] = useState(false);
   const [connectedCount, setConnectedCount] = useState(0);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [syncContactBirthdays, setSyncContactBirthdays] = useState(false);
 
   const reset = () => {
     setStep('credentials');
@@ -58,6 +59,7 @@ export function CalDAVConnectDialog({
     setSelected(new Set());
     setConnecting(false);
     setConnectedCount(0);
+    setSyncContactBirthdays(false);
   };
 
   const handleTest = async () => {
@@ -112,6 +114,7 @@ export function CalDAVConnectDialog({
           username,
           password,
           calendars: selectedCalendars,
+          syncContactBirthdays,
         }),
       });
       // Try to parse JSON either way — the API returns { error } on failure.
@@ -264,6 +267,21 @@ export function CalDAVConnectDialog({
                 <p className="text-sm text-muted-foreground text-center py-4">No calendars found on this server.</p>
               )}
             </div>
+
+            <label className="flex items-start gap-3 p-3 rounded-lg border border-border hover:bg-accent cursor-pointer">
+              <input
+                type="checkbox"
+                checked={syncContactBirthdays}
+                onChange={e => setSyncContactBirthdays(e.target.checked)}
+                className="mt-0.5 rounded"
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">Also import birthdays from contacts</p>
+                <p className="text-xs text-muted-foreground">
+                  Pulls BDAY fields from your address book via CardDAV (using the same login) and adds them to the birthdays widget. Reminders and notes are not supported by Apple over CalDAV — this is birthdays only.
+                </p>
+              </div>
+            </label>
 
             {connectError && (
               <div className="flex items-start gap-2 p-3 rounded-lg text-sm bg-destructive/10 text-destructive">

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -157,14 +157,23 @@ export function CalDAVConnectDialog({
                 id="caldav-url"
                 value={serverUrl}
                 onChange={e => setServerUrl(e.target.value)}
-                placeholder="https://cloud.example.com/remote.php/dav"
+                placeholder="https://caldav.icloud.com"
               />
               <div className="text-xs text-muted-foreground space-y-0.5">
-                <p><strong>Apple iCloud:</strong> https://caldav.icloud.com (use your iCloud email + an app-specific password from appleid.apple.com)</p>
-                <p><strong>Nextcloud:</strong> https://your-server/remote.php/dav</p>
-                <p><strong>Radicale:</strong> https://your-server/</p>
-                <p><strong>Baikal:</strong> https://your-server/dav.php</p>
-                <p><strong>Synology:</strong> https://your-nas:5001/caldav/</p>
+                <p className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setServerUrl('https://caldav.icloud.com')}
+                    className="text-primary hover:underline font-medium"
+                  >
+                    Use Apple iCloud
+                  </button>
+                </p>
+                <p><strong>Apple iCloud:</strong> <code>https://caldav.icloud.com</code> — username is your Apple ID email; password is a 16-char app-specific password from <a href="https://appleid.apple.com" target="_blank" rel="noreferrer" className="text-primary hover:underline">appleid.apple.com</a> (Sign-In and Security → App-Specific Passwords), <em>not</em> your real Apple ID password.</p>
+                <p><strong>Nextcloud:</strong> <code>https://your-server/remote.php/dav</code></p>
+                <p><strong>Radicale:</strong> <code>https://your-server/</code></p>
+                <p><strong>Baikal:</strong> <code>https://your-server/dav.php</code></p>
+                <p><strong>Synology:</strong> <code>https://your-nas:5001/caldav/</code></p>
               </div>
             </div>
             <div className="space-y-2">
@@ -173,18 +182,23 @@ export function CalDAVConnectDialog({
                 id="caldav-user"
                 value={username}
                 onChange={e => setUsername(e.target.value)}
-                placeholder="username"
+                placeholder="you@icloud.com"
+                autoComplete="username"
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="caldav-pass">Password or App Token</Label>
+              <Label htmlFor="caldav-pass">Password</Label>
               <Input
                 id="caldav-pass"
                 type="password"
                 value={password}
                 onChange={e => setPassword(e.target.value)}
-                placeholder="password or app-specific token"
+                placeholder="xxxx-xxxx-xxxx-xxxx for iCloud"
+                autoComplete="current-password"
               />
+              <p className="text-xs text-muted-foreground">
+                For Apple iCloud: paste the 16-character app-specific password including the hyphens. Other providers: your normal account password (or whatever app-token they require).
+              </p>
             </div>
 
             {testResult && (

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -291,7 +291,17 @@ export function CalendarsSection() {
                   </Button>
                 </div>
               )}
-              {localCalendars.map((cal) => (
+              {localCalendars
+                // Hide CalDAV sources that don't support VEVENT — they're
+                // task-only (Apple Reminders lists, etc.) and surface in
+                // Task Lists settings instead. They'd just be noise in the
+                // Calendar settings card otherwise.
+                .filter((cal) => {
+                  if (cal.provider !== 'caldav') return true;
+                  const cfg = cal.syncErrors as { supportsEvents?: boolean } | null;
+                  return cfg?.supportsEvents !== false;
+                })
+                .map((cal) => (
                 <div
                   key={cal.id}
                   className={cn(

--- a/src/app/settings/sections/ConnectedAccountsSection.tsx
+++ b/src/app/settings/sections/ConnectedAccountsSection.tsx
@@ -31,7 +31,6 @@ interface IntegrationStatus {
   };
   gmail: {
     connected: boolean;
-    expiresAt: string | null;
   };
 }
 
@@ -414,12 +413,6 @@ export function ConnectedAccountsSection() {
         <CardContent>
           {status?.gmail.connected ? (
             <div className="space-y-3">
-              {status.gmail.expiresAt && new Date(status.gmail.expiresAt) < new Date() && (
-                <div className="flex items-center gap-3 p-3 rounded-md border border-orange-500/50 bg-orange-50 dark:bg-orange-950/30">
-                  <AlertTriangle className="h-5 w-5 text-orange-500 shrink-0" />
-                  <p className="text-sm text-orange-700 dark:text-orange-400">Token expired — reconnect to resume bus tracking.</p>
-                </div>
-              )}
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={handleConnectGmail}>
                   <RefreshCw className="h-4 w-4 mr-2" />

--- a/src/app/settings/sections/ConnectedAccountsSection.tsx
+++ b/src/app/settings/sections/ConnectedAccountsSection.tsx
@@ -5,11 +5,12 @@ import { useSearchParams } from 'next/navigation';
 import { toast } from '@/components/ui/use-toast';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
-import { AlertTriangle, RefreshCw, Mail, HardDrive, Globe, Wand2 } from 'lucide-react';
+import { AlertTriangle, RefreshCw, Mail, HardDrive, Globe, Wand2, Server } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
+import { CalDAVConnectDialog } from '@/app/settings/components/CalDAVConnectDialog';
 
 interface IntegrationStatus {
   google: {
@@ -55,6 +56,7 @@ export function ConnectedAccountsSection() {
   const [status, setStatus] = useState<IntegrationStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [disconnecting, setDisconnecting] = useState<string | null>(null);
+  const [caldavDialogOpen, setCaldavDialogOpen] = useState(false);
 
   const fetchStatus = async () => {
     try {
@@ -442,6 +444,37 @@ export function ConnectedAccountsSection() {
           )}
         </CardContent>
       </Card>
+
+      {/* CalDAV Card (Apple iCloud, Nextcloud, Radicale, Baikal, Synology) */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Server className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <CardTitle className="text-lg">CalDAV</CardTitle>
+                <CardDescription>Apple iCloud, Nextcloud, Radicale, Baikal, Synology &middot; Calendars + Reminders</CardDescription>
+              </div>
+            </div>
+            <Badge variant="outline" className="border-amber-500 text-amber-600">Alpha</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-3">
+            Connect via username + app-specific password. Read-only sync of events and tasks. Two-way write support is planned.
+          </p>
+          <Button onClick={() => setCaldavDialogOpen(true)} variant="outline" className="w-full justify-start">
+            <Server className="h-4 w-4 mr-3" />
+            Connect CalDAV server
+          </Button>
+        </CardContent>
+      </Card>
+
+      <CalDAVConnectDialog
+        open={caldavDialogOpen}
+        onOpenChange={setCaldavDialogOpen}
+        onConnected={fetchStatus}
+      />
 
       <ConfirmDialog {...confirmDialogProps} />
     </div>

--- a/src/app/settings/sections/TaskIntegrationsSection.tsx
+++ b/src/app/settings/sections/TaskIntegrationsSection.tsx
@@ -311,6 +311,13 @@ export function TaskIntegrationsSection() {
               >
                 Change
               </Button>
+            ) : (list as { linkedProvider?: string }).linkedProvider === 'caldav' ? (
+              // CalDAV-backed lists are already sourced from the CalDAV
+              // calendar_source — the "From Apple iCloud" badge under the
+              // name says so. Hide the Connect button (it would just dump
+              // the user into a provider picker that doesn't include
+              // CalDAV / Apple as a target).
+              null
             ) : (
               <Button
                 variant="outline"

--- a/src/app/settings/sections/TaskIntegrationsSection.tsx
+++ b/src/app/settings/sections/TaskIntegrationsSection.tsx
@@ -387,26 +387,7 @@ export function TaskIntegrationsSection() {
             window.location.href = `/api/auth/google-tasks?taskListId=${integration.connectingEntityId}`;
           }
         }}
-        disabledProviders={[
-          {
-            icon: (
-              <svg className="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="#E44332">
-                <path d="M21 7.5L12 2 3 7.5v9l9 5.5 9-5.5v-9zM12 4l7 4.3v7.4l-7 4.3-7-4.3V8.3L12 4z" />
-              </svg>
-            ),
-            name: 'Todoist',
-            label: 'Coming soon',
-          },
-          {
-            icon: (
-              <svg className="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-              </svg>
-            ),
-            name: 'Apple Reminders',
-            label: 'Coming soon',
-          },
-        ]}
+        disabledProviders={[]}
       />
 
       {/* External List Selection Modal */}

--- a/src/app/settings/sections/integrations/components.tsx
+++ b/src/app/settings/sections/integrations/components.tsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
   Link2,
   ExternalLink,
+  Cloud,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -508,6 +509,19 @@ export function EntityListCard<T extends { id: string; name: string }>({
                             </svg>
                           )}
                           <span>Synced with: {connectedSource.externalListName || config?.providers[connectedSource.provider]?.name || 'External'}</span>
+                        </div>
+                      )}
+                      {/* CalDAV-backed entities don't have a task_source row
+                          (the CalDAV calendar_source owns the credentials),
+                          so they wouldn't otherwise show a "synced with"
+                          label. Fall back to entity.linkedProvider so the
+                          user can see "this list is auto-populated from
+                          Apple iCloud" without needing to wire CalDAV into
+                          task_sources. */}
+                      {!connectedSource && (entity as T & { linkedProvider?: string }).linkedProvider === 'caldav' && (
+                        <div className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+                          <Cloud className="h-3 w-3" />
+                          <span>From Apple iCloud (read-only)</span>
                         </div>
                       )}
                     </div>

--- a/src/app/settings/sections/integrations/constants.tsx
+++ b/src/app/settings/sections/integrations/constants.tsx
@@ -53,15 +53,6 @@ export const TASK_CONFIG: IntegrationConfig = {
   providers: {
     microsoft_todo: { name: 'Microsoft To-Do', icon: MS_TODO_ICON, color: '#0078D4' },
     google_tasks: { name: 'Google Tasks', icon: GOOGLE_TASKS_ICON, color: '#4285F4' },
-    todoist: {
-      name: 'Todoist',
-      icon: (
-        <svg className="h-5 w-5" viewBox="0 0 24 24" fill="#E44332">
-          <path d="M21 7.5L12 2 3 7.5v9l9 5.5 9-5.5v-9zM12 4l7 4.3v7.4l-7 4.3-7-4.3V8.3L12 4z" />
-        </svg>
-      ),
-      color: '#E44332',
-    },
   },
   errorMessages: {
     ...SHARED_ERROR_MESSAGES,

--- a/src/components/auth/QuickPinModal.tsx
+++ b/src/components/auth/QuickPinModal.tsx
@@ -205,19 +205,20 @@ export function QuickPinModal({
       onClick={() => onOpenChange(false)}
     >
       <div
-        className="bg-card rounded-2xl p-4 max-w-sm w-full mx-4 shadow-lg"
+        className="bg-card rounded-2xl p-3 max-w-[20rem] w-full mx-4 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between mb-3 pb-3 border-b border-border">
+        <div className="flex items-center justify-between mb-2 pb-2 border-b border-border">
           <div>
-            <h2 className="text-lg font-semibold">{title}</h2>
-            <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+            <h2 className="text-base font-semibold leading-tight">{title}</h2>
+            <p className="text-xs text-muted-foreground">{description}</p>
           </div>
           <Button
             variant="ghost"
             size="icon"
             onClick={() => onOpenChange(false)}
+            className="h-7 w-7"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -233,47 +234,47 @@ export function QuickPinModal({
           )}>
             {/* Avatar section — invisible placeholder when no member yet, so height is stable */}
             {!selectedMember ? (
-              <div className="flex flex-col items-center mx-auto mb-2 invisible" aria-hidden>
-                <div className="h-16 w-16 rounded-full mb-1" />
-                <span className="font-medium">name</span>
-                <span className="text-xs">subtitle</span>
+              <div className="flex flex-col items-center mx-auto mb-1.5 invisible" aria-hidden>
+                <div className="h-12 w-12 rounded-full" />
+                <span className="text-sm font-medium">name</span>
+                <span className="text-[10px]">subtitle</span>
               </div>
             ) : lockToMember ? (
-              <div className="flex flex-col items-center mx-auto mb-2">
+              <div className="flex flex-col items-center mx-auto mb-1.5">
                 <UserAvatar
                   name={selectedMember.name}
                   color={selectedMember.color}
                   imageUrl={selectedMember.avatarUrl}
                   size="lg"
-                  className="h-16 w-16 mb-1 ring-2 ring-primary"
+                  className="h-12 w-12 ring-2 ring-primary"
                 />
-                <span className="font-medium">{selectedMember.name}</span>
-                <span className="text-xs text-muted-foreground">Enter your PIN</span>
+                <span className="text-sm font-medium mt-0.5">{selectedMember.name}</span>
+                <span className="text-[10px] text-muted-foreground">Enter your PIN</span>
               </div>
             ) : (
               <button
                 onClick={() => { setSelectedMember(null); setPin([]); setError(null); }}
-                className="group flex flex-col items-center mx-auto mb-2"
+                className="group flex flex-col items-center mx-auto mb-1.5"
               >
                 <UserAvatar
                   name={selectedMember.name}
                   color={selectedMember.color}
                   imageUrl={selectedMember.avatarUrl}
                   size="lg"
-                  className="h-16 w-16 mb-1 group-hover:ring-2 ring-primary transition-all"
+                  className="h-12 w-12 group-hover:ring-2 ring-primary transition-all"
                 />
-                <span className="font-medium">{selectedMember.name}</span>
-                <span className="text-xs text-muted-foreground">Tap to switch</span>
+                <span className="text-sm font-medium mt-0.5">{selectedMember.name}</span>
+                <span className="text-[10px] text-muted-foreground">Tap to switch</span>
               </button>
             )}
 
             {/* PIN dots */}
-            <div className={cn('flex gap-2 justify-center mb-2', isShaking && 'animate-shake')}>
+            <div className={cn('flex gap-1.5 justify-center mb-1', isShaking && 'animate-shake')}>
               {Array.from({ length: pinLength }, (_, i) => (
                 <div
                   key={i}
                   className={cn(
-                    'w-3 h-3 rounded-full transition-all duration-150',
+                    'w-2.5 h-2.5 rounded-full transition-all duration-150',
                     i < pin.length
                       ? error ? 'bg-destructive scale-110' : 'bg-primary scale-110'
                       : 'bg-muted border-2 border-border'
@@ -283,12 +284,12 @@ export function QuickPinModal({
             </div>
 
             {/* Error message */}
-            <div className="h-5 mb-1 flex items-center justify-center">
-              {error && <p className="text-sm text-destructive">{error}</p>}
+            <div className="h-4 flex items-center justify-center">
+              {error && <p className="text-xs text-destructive">{error}</p>}
             </div>
 
             {/* Number pad */}
-            <div className="grid grid-cols-3 gap-2 max-w-[260px] mx-auto">
+            <div className="grid grid-cols-3 gap-1.5 max-w-[200px] mx-auto">
               {['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', 'del'].map((key, idx) => {
                 if (key === '') return <div key={idx} />;
                 if (key === 'del') {
@@ -298,9 +299,9 @@ export function QuickPinModal({
                       onClick={handleBackspace}
                       disabled={isVerifying}
                       className={cn(
-                        'w-16 h-16 rounded-full mx-auto flex items-center justify-center',
+                        'w-12 h-12 rounded-full mx-auto flex items-center justify-center',
                         'bg-muted hover:bg-muted/80 active:bg-accent active:scale-95',
-                        'transition-all duration-100 text-muted-foreground text-sm',
+                        'transition-all duration-100 text-muted-foreground text-xs',
                         isVerifying && 'opacity-50'
                       )}
                     >
@@ -314,10 +315,10 @@ export function QuickPinModal({
                     onClick={() => handleKeyPress(key)}
                     disabled={isVerifying}
                     className={cn(
-                      'w-16 h-16 rounded-full mx-auto flex items-center justify-center',
+                      'w-12 h-12 rounded-full mx-auto flex items-center justify-center',
                       'bg-secondary hover:bg-secondary/80',
                       'active:bg-primary active:text-primary-foreground active:scale-95',
-                      'transition-all duration-100 text-lg font-semibold',
+                      'transition-all duration-100 text-base font-semibold',
                       isVerifying && 'opacity-50'
                     )}
                   >
@@ -328,8 +329,8 @@ export function QuickPinModal({
             </div>
 
             {/* Loading */}
-            <div className="h-6 mt-3 flex items-center justify-center">
-              {isVerifying && <p className="text-sm text-muted-foreground">Verifying...</p>}
+            <div className="h-4 mt-1.5 flex items-center justify-center">
+              {isVerifying && <p className="text-xs text-muted-foreground">Verifying...</p>}
             </div>
           </div>
 
@@ -343,13 +344,13 @@ export function QuickPinModal({
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-2 gap-1.5">
                 {members.map((member) => (
                   <button
                     key={member.id || member.loginIndex}
                     onClick={() => setSelectedMember(member)}
                     className={cn(
-                      'flex flex-col items-center p-2 rounded-xl',
+                      'flex flex-col items-center p-1.5 rounded-xl',
                       'hover:bg-accent/50 active:bg-accent transition-colors',
                       'touch-action-manipulation'
                     )}
@@ -359,9 +360,9 @@ export function QuickPinModal({
                       color={member.color}
                       imageUrl={member.avatarUrl}
                       size="lg"
-                      className="h-14 w-14 mb-2"
+                      className="h-12 w-12 mb-1"
                     />
-                    <span className="text-sm font-medium">{member.name}</span>
+                    <span className="text-xs font-medium">{member.name}</span>
                   </button>
                 ))}
               </div>

--- a/src/components/auth/QuickPinModal.tsx
+++ b/src/components/auth/QuickPinModal.tsx
@@ -205,11 +205,11 @@ export function QuickPinModal({
       onClick={() => onOpenChange(false)}
     >
       <div
-        className="bg-card rounded-2xl p-6 max-w-sm w-full mx-4 shadow-lg"
+        className="bg-card rounded-2xl p-4 max-w-sm w-full mx-4 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between mb-5 pb-4 border-b border-border">
+        <div className="flex items-center justify-between mb-3 pb-3 border-b border-border">
           <div>
             <h2 className="text-lg font-semibold">{title}</h2>
             <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
@@ -233,13 +233,13 @@ export function QuickPinModal({
           )}>
             {/* Avatar section — invisible placeholder when no member yet, so height is stable */}
             {!selectedMember ? (
-              <div className="flex flex-col items-center mx-auto mb-4 invisible" aria-hidden>
+              <div className="flex flex-col items-center mx-auto mb-2 invisible" aria-hidden>
                 <div className="h-16 w-16 rounded-full mb-1" />
                 <span className="font-medium">name</span>
                 <span className="text-xs">subtitle</span>
               </div>
             ) : lockToMember ? (
-              <div className="flex flex-col items-center mx-auto mb-4">
+              <div className="flex flex-col items-center mx-auto mb-2">
                 <UserAvatar
                   name={selectedMember.name}
                   color={selectedMember.color}
@@ -253,7 +253,7 @@ export function QuickPinModal({
             ) : (
               <button
                 onClick={() => { setSelectedMember(null); setPin([]); setError(null); }}
-                className="group flex flex-col items-center mx-auto mb-4"
+                className="group flex flex-col items-center mx-auto mb-2"
               >
                 <UserAvatar
                   name={selectedMember.name}
@@ -268,7 +268,7 @@ export function QuickPinModal({
             )}
 
             {/* PIN dots */}
-            <div className={cn('flex gap-3 justify-center mb-4', isShaking && 'animate-shake')}>
+            <div className={cn('flex gap-2 justify-center mb-2', isShaking && 'animate-shake')}>
               {Array.from({ length: pinLength }, (_, i) => (
                 <div
                   key={i}
@@ -283,12 +283,12 @@ export function QuickPinModal({
             </div>
 
             {/* Error message */}
-            <div className="h-6 mb-3 flex items-center justify-center">
+            <div className="h-5 mb-1 flex items-center justify-center">
               {error && <p className="text-sm text-destructive">{error}</p>}
             </div>
 
             {/* Number pad */}
-            <div className="grid grid-cols-3 gap-3 max-w-[280px] mx-auto">
+            <div className="grid grid-cols-3 gap-2 max-w-[260px] mx-auto">
               {['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', 'del'].map((key, idx) => {
                 if (key === '') return <div key={idx} />;
                 if (key === 'del') {
@@ -343,13 +343,13 @@ export function QuickPinModal({
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-2">
                 {members.map((member) => (
                   <button
                     key={member.id || member.loginIndex}
                     onClick={() => setSelectedMember(member)}
                     className={cn(
-                      'flex flex-col items-center p-3 rounded-xl',
+                      'flex flex-col items-center p-2 rounded-xl',
                       'hover:bg-accent/50 active:bg-accent transition-colors',
                       'touch-action-manipulation'
                     )}

--- a/src/components/dashboard/useDashboardLayout.ts
+++ b/src/components/dashboard/useDashboardLayout.ts
@@ -128,16 +128,42 @@ export function useDashboardLayout(layouts: LayoutsData, slug?: string) {
     }
   }, [activeLayout, editingWidgets, ssLayout, layouts]);
 
-  const handleSaveAs = useCallback(async (defaultName?: string) => {
-    const name = window.prompt('Layout name:', defaultName || 'New Layout');
-    if (!name) return;
-    await layouts.saveLayout({
-      name,
-      widgets: editingWidgets,
-      isDefault: true,
-      screensaverWidgets: ssLayout,
-      orientation: activeLayout?.orientation || 'landscape',
-    });
+  // Save-As supports two modes:
+  //   - { id }: overwrite an existing dashboard. Preserves the target's
+  //     name, slug, and isDefault — only widgets + screensaver are swapped.
+  //     The dialog shows a confirm step before this fires.
+  //   - { name }: create a new dashboard with the given name. Same behavior
+  //     as the previous prompt() flow, just driven by a real dialog input.
+  // Legacy callers passing a bare string (e.g. the Apply Community Layout
+  // path) still get the new-dashboard branch via the string overload.
+  const handleSaveAs = useCallback(async (
+    opts?: string | { id: string } | { name: string },
+  ) => {
+    if (!opts) return;
+    if (typeof opts === 'string') opts = { name: opts };
+
+    if ('id' in opts) {
+      const target = layouts.allLayouts.find(l => l.id === opts.id);
+      if (!target) return;
+      await layouts.saveLayout({
+        id: target.id,
+        name: target.name,
+        widgets: editingWidgets,
+        isDefault: target.isDefault,
+        screensaverWidgets: ssLayout,
+        orientation: target.orientation || 'landscape',
+      });
+    } else {
+      const name = opts.name.trim();
+      if (!name) return;
+      await layouts.saveLayout({
+        name,
+        widgets: editingWidgets,
+        isDefault: false,
+        screensaverWidgets: ssLayout,
+        orientation: activeLayout?.orientation || 'landscape',
+      });
+    }
     setIsEditing(false);
   }, [editingWidgets, ssLayout, activeLayout, layouts]);
 

--- a/src/components/dashboard/useDashboardLayout.ts
+++ b/src/components/dashboard/useDashboardLayout.ts
@@ -20,6 +20,7 @@ interface LayoutsData {
   saveLayout: (data: Partial<Layout> & { name: string; widgets: WidgetConfig[] }) => Promise<unknown>;
   deleteLayout: (id: string) => Promise<void>;
   allLayouts: Layout[];
+  loading: boolean;
 }
 
 export function useDashboardLayout(layouts: LayoutsData, slug?: string) {
@@ -77,9 +78,18 @@ export function useDashboardLayout(layouts: LayoutsData, slug?: string) {
     }
   }, [activeLayout, activeUser]);
 
+  // While layouts are still fetching, render NOTHING rather than falling
+  // back to DEFAULT_TEMPLATE — for any established user whose saved layout
+  // doesn't exactly match the template, that fallback shows a stale set of
+  // widgets for a fraction of a second before swapping to the real one, and
+  // the swap reads as "Prism flashed a different dashboard at me." A blank
+  // frame for the same fraction-second is less disorienting than a wrong
+  // one. We only fall back to DEFAULT_TEMPLATE once loading completes AND
+  // no saved layout exists (genuine first-run / blank-slate install).
   const activeWidgets = isEditing
     ? editingWidgets
-    : activeLayout?.widgets ?? DEFAULT_TEMPLATE.widgets;
+    : activeLayout?.widgets
+      ?? (layouts.loading ? [] : DEFAULT_TEMPLATE.widgets);
 
   const handleEditStart = useCallback(() => {
     // Auth gate: only logged-in parents can edit. Signed-out users get a

--- a/src/components/layout/CoordinateEditor.tsx
+++ b/src/components/layout/CoordinateEditor.tsx
@@ -28,22 +28,32 @@ export function CoordinateEditor({ widgets, onWidgetsChange, mode, onFocusedWidg
     ? SCREENSAVER_WIDGETS.map(w => w.id)
     : ALL_WIDGET_TYPES;
 
-  // Split into visible and hidden
+  // Split into visible and hidden, both sorted alphabetically by label so
+  // the "Add widget" picker and the "currently visible" table follow the
+  // same ordering. Previously `visibleIds` followed WIDGET_REGISTRY's
+  // insertion order, which put newer widgets (Birthdays, Bus Tracker) at
+  // arbitrary positions that didn't match the alpha-sorted hidden list.
+  const byLabel = (a: string, b: string) => {
+    const aLabel = WIDGET_REGISTRY[a]?.label || a;
+    const bLabel = WIDGET_REGISTRY[b]?.label || b;
+    return aLabel.localeCompare(bLabel);
+  };
+
   const visibleIds = useMemo(() =>
-    allWidgetIds.filter(id => {
-      const w = widgets.find(w => w.i === id);
-      return w && w.visible !== false;
-    }),
+    allWidgetIds
+      .filter(id => {
+        const w = widgets.find(w => w.i === id);
+        return w && w.visible !== false;
+      })
+      .sort(byLabel),
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   [allWidgetIds, widgets]);
 
   const hiddenIds = useMemo(() =>
     allWidgetIds
       .filter(id => !visibleIds.includes(id))
-      .sort((a, b) => {
-        const aLabel = WIDGET_REGISTRY[a]?.label || a;
-        const bLabel = WIDGET_REGISTRY[b]?.label || b;
-        return aLabel.localeCompare(bLabel);
-      }),
+      .sort(byLabel),
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   [allWidgetIds, visibleIds]);
 
   // Close add dropdown on outside click

--- a/src/components/layout/LayoutEditor.tsx
+++ b/src/components/layout/LayoutEditor.tsx
@@ -7,7 +7,7 @@ import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { useScreenSafeZones } from '@/lib/hooks/useScreenSafeZones';
 import { LayoutEditorShareDialog } from './LayoutEditorShareDialog';
 import { LayoutEditorImportDialog } from './LayoutEditorImportExport';
-import { CreateDashboardDialog } from './LayoutEditorDashboardManager';
+import { CreateDashboardDialog, SaveAsDialog } from './LayoutEditorDashboardManager';
 import { RenameDashboardDialog } from './LayoutEditorRenameDashboard';
 import { LayoutEditorMeasureBar } from './LayoutEditorMeasureBar';
 import { LayoutEditorToolbarLeft } from './LayoutEditorToolbarLeft';
@@ -187,7 +187,7 @@ export function LayoutEditor({
             onToggleMeasureMode={toggleMeasureMode}
             onToggleScreensaverEdit={onToggleScreensaverEdit}
             onSave={state.handleSave}
-            onSaveAs={() => { onSaveAs?.(); setActivePopover(null); }}
+            onSaveAs={() => { state.setShowSaveAsDialog(true); setActivePopover(null); }}
             onReset={onReset}
             onScreensaverReset={onScreensaverReset}
             onCancel={onCancel}
@@ -204,6 +204,15 @@ export function LayoutEditor({
         open={state.showCreateDialog}
         onClose={() => state.setShowCreateDialog(false)}
         onCreate={(name, startFrom) => { onCreateDashboard?.(name, startFrom); state.setShowCreateDialog(false); }}
+      />
+
+      <SaveAsDialog
+        open={state.showSaveAsDialog}
+        onClose={() => state.setShowSaveAsDialog(false)}
+        allDashboards={allDashboards}
+        currentDashboardId={currentDashboardId}
+        onOverwrite={(id) => onSaveAs?.({ id })}
+        onCreateNew={(name) => onSaveAs?.({ name })}
       />
 
       <RenameDashboardDialog

--- a/src/components/layout/LayoutEditorDashboardManager.tsx
+++ b/src/components/layout/LayoutEditorDashboardManager.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { PopoverButton } from './LayoutEditorPopover';
 import { CheckIcon } from './LayoutEditorIcons';
 import type { DashboardInfo } from './LayoutEditorTypes';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 const moreItemClass = 'w-full text-left px-3 py-1.5 text-sm hover:bg-accent transition-colors';
 
@@ -38,6 +39,128 @@ export function DashboardDropdown({ layoutName, isActive, onToggle, allDashboard
         <button onClick={onCreateOpen} className={`${moreItemClass} text-primary`}>+ New Dashboard...</button>
       </div>
     </PopoverButton>
+  );
+}
+
+/**
+ * Save-As picker. Lets the user save the current edit session either as a
+ * new dashboard (name input) OR by overwriting one of the existing
+ * dashboards (button row, confirm-on-click). Overwriting preserves the
+ * target's name, slug, and isDefault — it's the layout content (widgets +
+ * screensaver) that gets swapped.
+ */
+export function SaveAsDialog({
+  open,
+  onClose,
+  allDashboards,
+  currentDashboardId,
+  onOverwrite,
+  onCreateNew,
+}: {
+  open: boolean;
+  onClose: () => void;
+  allDashboards: DashboardInfo[];
+  currentDashboardId?: string;
+  onOverwrite: (id: string) => void;
+  onCreateNew: (name: string) => void;
+}) {
+  const [newName, setNewName] = useState('');
+  const [confirmTarget, setConfirmTarget] = useState<DashboardInfo | null>(null);
+
+  if (!open) return null;
+
+  const handleCreateNew = () => {
+    if (!newName.trim()) return;
+    onCreateNew(newName.trim());
+    setNewName('');
+    onClose();
+  };
+
+  const handleOverwriteClick = (d: DashboardInfo) => {
+    setConfirmTarget(d);
+  };
+
+  const handleConfirmOverwrite = () => {
+    if (!confirmTarget) return;
+    onOverwrite(confirmTarget.id);
+    setConfirmTarget(null);
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" onClick={onClose}>
+        <div className="bg-popover border border-border rounded-lg shadow-xl p-4 max-w-sm w-full mx-4 space-y-3" onClick={e => e.stopPropagation()}>
+          <div className="text-sm font-medium">Save As</div>
+
+          {/* Overwrite existing */}
+          {allDashboards.length > 0 && (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Overwrite an existing dashboard</div>
+              <div className="space-y-1 max-h-[30vh] overflow-auto">
+                {allDashboards.map(d => (
+                  <button
+                    key={d.id}
+                    onClick={() => handleOverwriteClick(d)}
+                    className="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-accent transition-colors flex items-center gap-2"
+                  >
+                    <span className="flex-1 truncate">{d.name}</span>
+                    {d.id === currentDashboardId && (
+                      <span className="text-[10px] text-muted-foreground">current</span>
+                    )}
+                    {d.isDefault && d.id !== currentDashboardId && (
+                      <span className="text-[10px] text-muted-foreground">default</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* New dashboard */}
+          <div className="border-t border-border pt-3">
+            <label className="text-xs text-muted-foreground block mb-1">Save as a new dashboard</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newName}
+                onChange={e => setNewName(e.target.value)}
+                placeholder="New dashboard name"
+                className="flex-1 px-2 py-1.5 text-sm bg-muted border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                maxLength={100}
+                onKeyDown={e => { if (e.key === 'Enter') handleCreateNew(); }}
+              />
+              <button
+                onClick={handleCreateNew}
+                disabled={!newName.trim()}
+                className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                Create
+              </button>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm rounded-md bg-muted hover:bg-accent transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={!!confirmTarget}
+        title={`Overwrite "${confirmTarget?.name ?? ''}"?`}
+        description={`This will replace the saved widgets and screensaver for "${confirmTarget?.name ?? ''}" with the current edit session. The dashboard's name, slug, and default flag are preserved.`}
+        confirmLabel="Overwrite"
+        variant="destructive"
+        onConfirm={handleConfirmOverwrite}
+        onCancel={() => setConfirmTarget(null)}
+      />
+    </>
   );
 }
 

--- a/src/components/layout/LayoutEditorTypes.ts
+++ b/src/components/layout/LayoutEditorTypes.ts
@@ -19,7 +19,7 @@ export interface LayoutEditorProps {
   widgets: WidgetConfig[];
   onWidgetsChange: (widgets: WidgetConfig[]) => void;
   onSave: (name?: string) => void | Promise<void>;
-  onSaveAs: (defaultName?: string) => void;
+  onSaveAs: (opts?: string | { id: string } | { name: string }) => void;
   onReset: () => void;
   onCancel: () => void;
   onDeleteLayout?: (id: string) => void;

--- a/src/components/layout/grid/CssGridDisplay.tsx
+++ b/src/components/layout/grid/CssGridDisplay.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { WidgetBgOverrideProvider } from '@/components/widgets/WidgetContainer';
-import { getWidgetStyle, getTextColorClass } from './gridWidgetStyles';
+import { getWidgetStyle, getWidgetContentStyle, getTextColorClass } from './gridWidgetStyles';
 import { useSquareCells } from './useSquareCells';
 import { GRID_COLS } from '@/lib/constants/grid';
 import type { CssGridDisplayProps } from './gridEditorTypes';
@@ -60,6 +60,7 @@ export function CssGridDisplay({
       >
         {visibleWidgets.map(w => {
           const widgetStyle = getWidgetStyle(w);
+          const contentStyle = getWidgetContentStyle(w);
           const textClass = getTextColorClass(w);
           const hasCustomBg = !!w.backgroundColor;
 
@@ -75,7 +76,7 @@ export function CssGridDisplay({
               }}
             >
               <WidgetBgOverrideProvider value={{ hasCustomBg, textColor: w.textColor, textOpacity: w.textOpacity, gridLineOpacity: w.gridLineOpacity, cellBackgroundColor: w.cellBackgroundColor, cellBackgroundOpacity: w.cellBackgroundOpacity }}>
-                <div className="h-full w-full overflow-hidden">
+                <div className="h-full w-full overflow-hidden" style={contentStyle}>
                   {renderWidget(w)}
                 </div>
               </WidgetBgOverrideProvider>

--- a/src/components/layout/grid/CssGridEditor.tsx
+++ b/src/components/layout/grid/CssGridEditor.tsx
@@ -14,7 +14,7 @@ import {
   type Modifier,
 } from '@dnd-kit/core';
 import { WidgetBgOverrideProvider } from '@/components/widgets/WidgetContainer';
-import { getWidgetStyle, getTextColorClass } from './gridWidgetStyles';
+import { getWidgetStyle, getWidgetContentStyle, getTextColorClass } from './gridWidgetStyles';
 import type { EditorTheme } from './gridEditorTypes';
 import type { WidgetConfig } from '@/lib/hooks/useLayouts';
 
@@ -264,6 +264,7 @@ function DragOverlayContent({
   renderWidget: (widget: WidgetConfig) => React.ReactNode;
 }) {
   const widgetStyle = getWidgetStyle(widget);
+  const contentStyle = getWidgetContentStyle(widget);
   const textClass = getTextColorClass(widget);
 
   return (
@@ -277,7 +278,7 @@ function DragOverlayContent({
       className={`rounded-lg border-2 border-primary shadow-lg ${textClass}`}
     >
       <WidgetBgOverrideProvider value={{ hasCustomBg: !!widget.backgroundColor, textColor: widget.textColor, textOpacity: widget.textOpacity, gridLineOpacity: widget.gridLineOpacity, cellBackgroundColor: widget.cellBackgroundColor, cellBackgroundOpacity: widget.cellBackgroundOpacity }}>
-        <div className="h-full w-full overflow-hidden" style={{ pointerEvents: 'none' }}>
+        <div className="h-full w-full overflow-hidden" style={{ pointerEvents: 'none', ...contentStyle }}>
           {renderWidget(widget)}
         </div>
       </WidgetBgOverrideProvider>
@@ -319,6 +320,7 @@ function DraggableWidget({
   });
 
   const widgetStyle = getWidgetStyle(widget);
+  const contentStyle = getWidgetContentStyle(widget);
   const textClass = getTextColorClass(widget, '');
   const hasCustomBg = !!widget.backgroundColor;
 
@@ -362,7 +364,7 @@ function DraggableWidget({
       <WidgetBgOverrideProvider value={{ hasCustomBg, textColor: widget.textColor, textOpacity: widget.textOpacity, gridLineOpacity: widget.gridLineOpacity, cellBackgroundColor: widget.cellBackgroundColor, cellBackgroundOpacity: widget.cellBackgroundOpacity }}>
         <div
           className={`h-full w-full overflow-hidden ${textClass}`}
-          style={{ pointerEvents: 'none' }}
+          style={{ pointerEvents: 'none', ...contentStyle }}
         >
           {renderWidget(widget)}
         </div>

--- a/src/components/layout/grid/gridWidgetStyles.ts
+++ b/src/components/layout/grid/gridWidgetStyles.ts
@@ -3,8 +3,17 @@ import { hexToRgba, isLightColor } from '@/lib/utils/color';
 import type { WidgetConfig } from '@/lib/hooks/useLayouts';
 
 /**
- * Compute inline CSSProperties for a widget's background, outline, and text color.
- * Used by both CssGridDisplay and the editor.
+ * Compute inline CSSProperties for a widget's background, outline, and text
+ * color. Used by both CssGridDisplay and the editor.
+ *
+ * NOTE: `textScale` (zoom) is intentionally NOT included here anymore — it
+ * lives in `getWidgetContentStyle` so it can be applied on the inner content
+ * wrapper, NOT the grid-cell wrapper. Applying `zoom` to a CSS grid cell
+ * sporadically fails to propagate into the rendered subtree on the
+ * dashboard render path (visible bug: dashboard weather widget ignored
+ * its textScale even though the screensaver's identical code path
+ * honored it). Moving the zoom inward isolates it from the grid layout
+ * algorithm and makes scaling deterministic across both views.
  */
 export function getWidgetStyle(w: WidgetConfig): CSSProperties | undefined {
   if (!w.backgroundColor && !w.outlineColor && !w.textColor) return undefined;
@@ -37,13 +46,20 @@ export function getWidgetStyle(w: WidgetConfig): CSSProperties | undefined {
       : w.textColor;
   }
 
-  if (w.textScale && w.textScale !== 1) {
-    // Use zoom instead of fontSize because Tailwind text classes use rem (root-relative),
-    // which ignores parent em/font-size. Zoom scales everything proportionally.
-    (style as Record<string, unknown>).zoom = w.textScale;
-  }
-
   return style;
+}
+
+/**
+ * Style applied to the INSIDE wrapper of a widget cell (not the grid
+ * cell itself). Currently just `zoom: textScale` — see getWidgetStyle for
+ * the reason this is separated out.
+ */
+export function getWidgetContentStyle(w: WidgetConfig): CSSProperties | undefined {
+  if (!w.textScale || w.textScale === 1) return undefined;
+  // Tailwind text classes use rem (root-relative), which ignores parent
+  // em/font-size — `zoom` scales everything (rem text, SVG dimensions,
+  // layout boxes) proportionally without changing the cell's grid slot.
+  return { zoom: w.textScale } as CSSProperties;
 }
 
 /**

--- a/src/components/layout/useLayoutEditorState.ts
+++ b/src/components/layout/useLayoutEditorState.ts
@@ -49,6 +49,7 @@ export function useLayoutEditorState({
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showSaveAsDialog, setShowSaveAsDialog] = useState(false);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const [saveFeedback, setSaveFeedback] = useState('');
@@ -155,6 +156,7 @@ export function useLayoutEditorState({
     showImportDialog, setShowImportDialog,
     showShareDialog, setShowShareDialog,
     showCreateDialog, setShowCreateDialog,
+    showSaveAsDialog, setShowSaveAsDialog,
     showRenameDialog, setShowRenameDialog,
     renameValue, setRenameValue,
     saveFeedback,

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -302,11 +302,14 @@ export const WeatherWidget = React.memo(function WeatherWidget({
   const resolvedDays = forecastDays ?? Math.min(7, Math.max(1, weatherData.forecast.length));
 
   // Pre-filter to today-or-future so the label count matches what renders.
+  // Provider stores forecast.date as UTC-midnight of the location's calendar
+  // day (see openmeteo.ts comment), so read via getUTC* to compare against
+  // the viewer's local-today calendar string.
   const now = new Date();
   const todayLocalStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const visibleForecast = weatherData.forecast.slice(0, resolvedDays).filter((day) => {
     const d = new Date(day.date);
-    const s = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const s = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
     return s >= todayLocalStr;
   });
 
@@ -507,8 +510,10 @@ function DayHeader({
   return (
     <div className="flex flex-col mt-1">
       {days.map((day, i) => {
+        // Provider anchors forecast.date at UTC midnight of the location's
+        // calendar day; getUTC* avoids TZ slippage between server + viewer.
         const d = new Date(day.date);
-        const dayLocalStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        const dayLocalStr = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
         const isToday = dayLocalStr === todayLocalStr;
         const label = isToday ? 'TODAY' : day.dayName.toUpperCase();
 

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -558,7 +558,7 @@ function DayHeader({
               <span className="text-[11px] text-muted-foreground tabular-nums w-7 text-right flex-shrink-0">
                 {fmt(day.low)}°
               </span>
-              <div className="flex-1 relative h-4 rounded-full bg-muted-foreground/25 ring-1 ring-inset ring-muted-foreground/15 overflow-hidden min-w-0">
+              <div className="flex-1 relative h-4 rounded-full bg-black/10 dark:bg-white/15 ring-1 ring-inset ring-black/10 dark:ring-white/15 overflow-hidden min-w-0">
                 <div
                   className="absolute top-0 bottom-0 rounded-full"
                   style={{

--- a/src/components/widgets/widgetRegistry.ts
+++ b/src/components/widgets/widgetRegistry.ts
@@ -44,7 +44,7 @@ export const WIDGET_REGISTRY: Record<string, WidgetRegistryEntry> = {
     label: 'Clock',
     icon: 'Clock',
     minW: 8,
-    minH: 8,
+    minH: 4,
     defaultW: 12,
     defaultH: 12,
   },

--- a/src/lib/hooks/useTaskLists.ts
+++ b/src/lib/hooks/useTaskLists.ts
@@ -10,6 +10,8 @@ export interface TaskList {
   createdBy?: string | null;
   createdAt: string;
   updatedAt: string;
+  /** When set, this list is auto-populated by an external provider sync. */
+  linkedProvider?: 'caldav' | null;
 }
 
 interface CreateTaskListInput {

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -1,0 +1,345 @@
+/**
+ * CalDAV calendar integration for Prism.
+ *
+ * Supports Nextcloud, Radicale, Baikal, Synology, and any standard CalDAV server.
+ * Uses tsdav for protocol handling and ical.js for event parsing.
+ */
+
+import { createDAVClient, type DAVCalendar, type DAVObject } from 'tsdav';
+import ICAL from 'ical.js';
+
+export interface CalDAVCalendar {
+  href: string;
+  displayName: string;
+  color: string | null;
+  description: string | null;
+  ctag: string | null;
+  supportsEvents: boolean;
+  supportsTasks: boolean;
+}
+
+export interface CalDAVEvent {
+  uid: string;
+  title: string;
+  description: string | null;
+  location: string | null;
+  startTime: Date;
+  endTime: Date;
+  allDay: boolean;
+  color: string | null;
+  recurring: boolean;
+  recurrenceRule: string | null;
+}
+
+export interface CalDAVTask {
+  uid: string;
+  title: string;
+  description: string | null;
+  dueDate: Date | null;
+  completed: boolean;
+  completedAt: Date | null;
+  priority: 'high' | 'medium' | 'low' | null;
+  categories: string[];
+}
+
+export interface CalDAVConnectionConfig {
+  serverUrl: string;
+  username: string;
+  authMethod: 'basic';
+}
+
+/**
+ * Test connectivity to a CalDAV server.
+ */
+export async function testCalDAVConnection(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const client = await createDAVClient({
+      serverUrl,
+      credentials: { username, password },
+      authMethod: 'Basic',
+      defaultAccountType: 'caldav',
+    });
+
+    // Try to fetch calendars — if this works, the connection is good
+    await client.fetchCalendars();
+
+    return { success: true };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes('401') || msg.includes('Unauthorized')) {
+      return { success: false, error: 'Authentication failed. Check username and password.' };
+    }
+    if (msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND')) {
+      return { success: false, error: 'Could not connect to server. Check the URL.' };
+    }
+    return { success: false, error: `Connection failed: ${msg}` };
+  }
+}
+
+/**
+ * Discover available calendars on a CalDAV server.
+ */
+export async function discoverCalendars(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<CalDAVCalendar[]> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const calendars = await client.fetchCalendars();
+
+  return calendars
+    .filter((cal: DAVCalendar) => {
+      // Include calendars that support VEVENT or VTODO
+      const components = cal.components as string[] | undefined;
+      if (components && !components.includes('VEVENT') && !components.includes('VTODO')) return false;
+      return true;
+    })
+    .map((cal: DAVCalendar) => {
+      const components = cal.components as string[] | undefined;
+      return {
+        href: cal.url,
+        displayName: String(cal.displayName || 'Unnamed Calendar'),
+        color: String((cal as Record<string, unknown>).calendarColor || '') || null,
+        description: cal.description ? String(cal.description) : null,
+        ctag: (cal as Record<string, unknown>).ctag ? String((cal as Record<string, unknown>).ctag) : null,
+        supportsEvents: !components || components.includes('VEVENT'),
+        supportsTasks: !!components && components.includes('VTODO'),
+      };
+    });
+}
+
+/**
+ * Fetch events from a CalDAV calendar within a time range.
+ */
+export async function fetchCalDAVEvents(
+  serverUrl: string,
+  username: string,
+  password: string,
+  calendarHref: string,
+  timeMin: Date,
+  timeMax: Date,
+): Promise<CalDAVEvent[]> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const calendars = await client.fetchCalendars();
+  const calendar = calendars.find((c: DAVCalendar) => c.url === calendarHref);
+
+  if (!calendar) {
+    throw new Error(`Calendar not found: ${calendarHref}`);
+  }
+
+  const objects = await client.fetchCalendarObjects({
+    calendar,
+    timeRange: {
+      start: formatICalDate(timeMin),
+      end: formatICalDate(timeMax),
+    },
+  });
+
+  const events: CalDAVEvent[] = [];
+
+  for (const obj of objects) {
+    try {
+      const parsed = parseICalObject(obj, timeMin, timeMax);
+      events.push(...parsed);
+    } catch (error) {
+      console.error('Failed to parse CalDAV event:', error instanceof Error ? error.message : error);
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Parse a single iCalendar object into one or more events.
+ * Handles recurring events by expanding instances within the time range.
+ */
+function parseICalObject(
+  obj: DAVObject,
+  rangeStart: Date,
+  rangeEnd: Date,
+): CalDAVEvent[] {
+  const data = obj.data;
+  if (!data) return [];
+
+  const jcal = ICAL.parse(data);
+  const comp = new ICAL.Component(jcal);
+  const vevents = comp.getAllSubcomponents('vevent');
+  const events: CalDAVEvent[] = [];
+
+  for (const vevent of vevents) {
+    const event = new ICAL.Event(vevent);
+
+    if (!event.summary) continue;
+
+    const isRecurring = event.isRecurrenceException() || !!vevent.getFirstPropertyValue('rrule');
+
+    if (isRecurring && !event.isRecurrenceException()) {
+      // Expand recurring event instances within the range
+      try {
+        const iterator = event.iterator();
+        let next = iterator.next();
+        let count = 0;
+        const maxInstances = 100;
+
+        while (next && count < maxInstances) {
+          const occurrence = event.getOccurrenceDetails(next);
+          const start = occurrence.startDate.toJSDate();
+          const end = occurrence.endDate.toJSDate();
+
+          if (start > rangeEnd) break;
+          if (end >= rangeStart) {
+            events.push({
+              uid: `${event.uid}_${start.toISOString()}`,
+              title: event.summary,
+              description: event.description || null,
+              location: event.location || null,
+              startTime: start,
+              endTime: end,
+              allDay: isAllDay(vevent),
+              color: null,
+              recurring: true,
+              recurrenceRule: vevent.getFirstPropertyValue('rrule')?.toString() || null,
+            });
+          }
+
+          next = iterator.next();
+          count++;
+        }
+      } catch {
+        // If recurrence expansion fails, add the base event
+        events.push(makeEvent(event, vevent));
+      }
+    } else {
+      events.push(makeEvent(event, vevent));
+    }
+  }
+
+  return events;
+}
+
+function makeEvent(event: ICAL.Event, vevent: ICAL.Component): CalDAVEvent {
+  return {
+    uid: event.uid,
+    title: event.summary,
+    description: event.description || null,
+    location: event.location || null,
+    startTime: event.startDate.toJSDate(),
+    endTime: event.endDate.toJSDate(),
+    allDay: isAllDay(vevent),
+    color: null,
+    recurring: false,
+    recurrenceRule: null,
+  };
+}
+
+/**
+ * Fetch tasks (VTODO) from a CalDAV calendar.
+ */
+export async function fetchCalDAVTasks(
+  serverUrl: string,
+  username: string,
+  password: string,
+  calendarHref: string,
+): Promise<CalDAVTask[]> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const calendars = await client.fetchCalendars();
+  const calendar = calendars.find((c: DAVCalendar) => c.url === calendarHref);
+
+  if (!calendar) {
+    throw new Error(`Calendar not found: ${calendarHref}`);
+  }
+
+  // Fetch all objects (tsdav doesn't filter by component type in time range for VTODOs)
+  const objects = await client.fetchCalendarObjects({ calendar });
+
+  const tasks: CalDAVTask[] = [];
+
+  for (const obj of objects) {
+    try {
+      const parsed = parseVTodoObject(obj);
+      if (parsed) tasks.push(parsed);
+    } catch (error) {
+      console.error('Failed to parse CalDAV task:', error instanceof Error ? error.message : error);
+    }
+  }
+
+  return tasks;
+}
+
+/**
+ * Parse a VTODO iCalendar object into a task.
+ */
+function parseVTodoObject(obj: DAVObject): CalDAVTask | null {
+  const data = obj.data;
+  if (!data) return null;
+
+  const jcal = ICAL.parse(data);
+  const comp = new ICAL.Component(jcal);
+  const vtodo = comp.getFirstSubcomponent('vtodo');
+
+  if (!vtodo) return null;
+
+  const summary = vtodo.getFirstPropertyValue('summary');
+  if (!summary) return null;
+
+  const description = vtodo.getFirstPropertyValue('description');
+  const due = vtodo.getFirstPropertyValue('due');
+  const completed = vtodo.getFirstPropertyValue('completed');
+  const status = vtodo.getFirstPropertyValue('status');
+  const priority = vtodo.getFirstPropertyValue('priority');
+  const categories = vtodo.getFirstPropertyValue('categories');
+  const uid = vtodo.getFirstPropertyValue('uid');
+
+  // Map iCal priority (1-9) to Prism priority
+  let prismPriority: 'high' | 'medium' | 'low' | null = null;
+  if (priority) {
+    const p = Number(priority);
+    if (p >= 1 && p <= 3) prismPriority = 'high';
+    else if (p >= 4 && p <= 6) prismPriority = 'medium';
+    else if (p >= 7 && p <= 9) prismPriority = 'low';
+  }
+
+  return {
+    uid: String(uid || `vtodo-${Date.now()}`),
+    title: String(summary),
+    description: description ? String(description) : null,
+    dueDate: due ? (due instanceof ICAL.Time ? due.toJSDate() : new Date(String(due))) : null,
+    completed: status === 'COMPLETED' || !!completed,
+    completedAt: completed ? (completed instanceof ICAL.Time ? completed.toJSDate() : new Date(String(completed))) : null,
+    priority: prismPriority,
+    categories: categories ? (Array.isArray(categories) ? categories.map(String) : [String(categories)]) : [],
+  };
+}
+
+function isAllDay(vevent: ICAL.Component): boolean {
+  const dtstart = vevent.getFirstProperty('dtstart');
+  if (!dtstart) return false;
+  const type = dtstart.getParameter('value');
+  return type === 'date' || type === 'DATE';
+}
+
+function formatICalDate(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+}

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -46,6 +46,14 @@ export interface CalDAVConnectionConfig {
   serverUrl: string;
   username: string;
   authMethod: 'basic';
+  /** True when the source calendar advertises VEVENT support. Persisted at
+   *  connect time so sync + UI can route this source correctly (a Reminders
+   *  list won't appear in the Calendar UI, an event-only calendar won't
+   *  spawn a task list). Undefined on legacy rows from before this field
+   *  was stored — treat as "true" for backward compatibility. */
+  supportsEvents?: boolean;
+  /** True when the source calendar advertises VTODO support. */
+  supportsTasks?: boolean;
 }
 
 /**

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -109,13 +109,29 @@ export async function discoverCalendars(
       return {
         href: cal.url,
         displayName: String(cal.displayName || 'Unnamed Calendar'),
-        color: String((cal as Record<string, unknown>).calendarColor || '') || null,
+        color: normalizeCalDAVColor((cal as Record<string, unknown>).calendarColor),
         description: cal.description ? String(cal.description) : null,
         ctag: (cal as Record<string, unknown>).ctag ? String((cal as Record<string, unknown>).ctag) : null,
         supportsEvents: !components || components.includes('VEVENT'),
         supportsTasks: !!components && components.includes('VTODO'),
       };
     });
+}
+
+/**
+ * Coerce a CalDAV-reported color string to the #RRGGBB form our schema
+ * stores (varchar(7)). Apple iCloud returns colors as `#RRGGBBAA` with an
+ * alpha channel appended — that's 9 chars and overflows the column. Strip
+ * the alpha when present, accept #RRGGBB and #RGB as-is, drop anything
+ * that doesn't parse so callers can fall back to their default color.
+ */
+function normalizeCalDAVColor(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const s = raw.trim();
+  if (/^#[0-9a-fA-F]{8}$/.test(s)) return s.slice(0, 7); // #RRGGBBAA → #RRGGBB
+  if (/^#[0-9a-fA-F]{6}$/.test(s)) return s;
+  if (/^#[0-9a-fA-F]{3}$/.test(s)) return s;
+  return null;
 }
 
 /**

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -54,6 +54,10 @@ export interface CalDAVConnectionConfig {
   supportsEvents?: boolean;
   /** True when the source calendar advertises VTODO support. */
   supportsTasks?: boolean;
+  /** Durable mapping from this CalDAV source to a Prism task_lists row.
+   *  Written on first task-list creation so subsequent syncs reuse the
+   *  same list instead of creating orphans every tick. */
+  taskListId?: string;
 }
 
 /**

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -159,11 +159,14 @@ export async function fetchCalDAVEvents(
     throw new Error(`Calendar not found: ${calendarHref}`);
   }
 
+  // tsdav's timeRange expects standard ISO8601 (with hyphens + colons);
+  // formatICalDate strips those for basic-format iCal DTSTART use only,
+  // so pass toISOString() directly here.
   const objects = await client.fetchCalendarObjects({
     calendar,
     timeRange: {
-      start: formatICalDate(timeMin),
-      end: formatICalDate(timeMax),
+      start: timeMin.toISOString(),
+      end: timeMax.toISOString(),
     },
   });
 

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -290,19 +290,39 @@ export async function fetchCalDAVTasks(
     throw new Error(`Calendar not found: ${calendarHref}`);
   }
 
-  // Fetch all objects (tsdav doesn't filter by component type in time range for VTODOs)
-  const objects = await client.fetchCalendarObjects({ calendar });
+  // Fetch all objects (tsdav doesn't filter by component type in time range for VTODOs).
+  // Apple iCloud requires an explicit VTODO comp-filter to return reminders —
+  // without it the response is empty even for Reminders-list calendars.
+  const objects = await client.fetchCalendarObjects({
+    calendar,
+    filters: [{
+      'comp-filter': {
+        _attributes: { name: 'VCALENDAR' },
+        'comp-filter': {
+          _attributes: { name: 'VTODO' },
+        },
+      },
+    }],
+  });
+
+  console.log(`[caldav-tasks] ${calendarHref}: fetched ${objects.length} object(s)`);
 
   const tasks: CalDAVTask[] = [];
+  let parsedCount = 0;
 
   for (const obj of objects) {
     try {
       const parsed = parseVTodoObject(obj);
-      if (parsed) tasks.push(parsed);
+      if (parsed) {
+        tasks.push(parsed);
+        parsedCount++;
+      }
     } catch (error) {
       console.error('Failed to parse CalDAV task:', error instanceof Error ? error.message : error);
     }
   }
+
+  console.log(`[caldav-tasks] ${calendarHref}: parsed ${parsedCount} VTODO(s) into tasks`);
 
   return tasks;
 }

--- a/src/lib/integrations/carddav.ts
+++ b/src/lib/integrations/carddav.ts
@@ -1,0 +1,119 @@
+/**
+ * CardDAV contacts integration — birthday-only.
+ *
+ * Reuses tsdav (already pulled in for CalDAV). Apple iCloud serves CardDAV
+ * from a different hostname than CalDAV (contacts.icloud.com vs.
+ * caldav.icloud.com); we swap automatically. For Nextcloud, Baikal, etc.
+ * the same DAV root handles both protocols and the URL passes through.
+ */
+
+import { createDAVClient, type DAVCollection } from 'tsdav';
+import ICAL from 'ical.js';
+
+export interface ContactBirthday {
+  /** Full display name from FN or N. Used as the dedupe key. */
+  name: string;
+  /** ISO YYYY-MM-DD. Year is `1904` when the vCard omitted it. */
+  birthDate: string;
+}
+
+/**
+ * Coerce a CalDAV server URL into the matching CardDAV root for the same
+ * provider. Apple is the only common case that splits the two; everything
+ * else passes through unchanged.
+ */
+export function deriveCardDAVUrl(serverUrl: string): string {
+  return serverUrl.replace(/caldav\.icloud\.com/i, 'contacts.icloud.com');
+}
+
+/**
+ * Fetch all birthdays (BDAY field) from every contact across every address
+ * book on a CardDAV server. Returns one entry per (name, birthDate) pair —
+ * contacts without a BDAY are skipped silently.
+ */
+export async function fetchCardDAVBirthdays(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<ContactBirthday[]> {
+  const client = await createDAVClient({
+    serverUrl: deriveCardDAVUrl(serverUrl),
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'carddav',
+  });
+
+  const addressBooks = await client.fetchAddressBooks();
+  const results: ContactBirthday[] = [];
+
+  for (const book of addressBooks) {
+    try {
+      const vcards = await client.fetchVCards({ addressBook: book as DAVCollection });
+      for (const obj of vcards) {
+        const parsed = parseVCardBirthday(obj.data);
+        if (parsed) results.push(parsed);
+      }
+    } catch (err) {
+      console.error(
+        `[carddav] failed to fetch from ${book.url}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Extract a (name, birthDate) tuple from a single vCard, or null if the
+ * card has no BDAY or no usable name. BDAY in vCard 3.0/4.0 commonly looks
+ * like `1990-05-15`, `19900515`, or `--05-15` (year omitted).
+ */
+function parseVCardBirthday(data: string | undefined): ContactBirthday | null {
+  if (!data) return null;
+
+  try {
+    const jcard = ICAL.parse(data);
+    const comp = new ICAL.Component(jcard);
+    const fn = comp.getFirstPropertyValue('fn');
+    const bday = comp.getFirstPropertyValue('bday');
+    if (!fn || !bday) return null;
+
+    const name = String(fn).trim();
+    if (!name) return null;
+
+    const birthDate = normalizeBday(String(bday));
+    if (!birthDate) return null;
+
+    return { name, birthDate };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Coerce the many BDAY shapes vCard allows into ISO `YYYY-MM-DD`. When the
+ * year is missing we substitute 1904 — the same sentinel the Google birthday
+ * sync writes, so the birthdays table can treat both sources uniformly.
+ */
+function normalizeBday(raw: string): string | null {
+  const s = raw.trim();
+
+  // YYYY-MM-DD (vCard 4.0 + ical.js normalized form)
+  let m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+
+  // YYYYMMDD (vCard 3.0 basic)
+  m = s.match(/^(\d{4})(\d{2})(\d{2})$/);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+
+  // --MMDD or --MM-DD (year omitted, common for "I don't track year")
+  m = s.match(/^--(\d{2})-?(\d{2})$/);
+  if (m) return `1904-${m[1]}-${m[2]}`;
+
+  // ISO datetime — strip the time portion
+  m = s.match(/^(\d{4})-(\d{2})-(\d{2})T/);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+
+  return null;
+}

--- a/src/lib/integrations/carddav.ts
+++ b/src/lib/integrations/carddav.ts
@@ -99,21 +99,40 @@ function parseVCardBirthday(data: string | undefined): ContactBirthday | null {
 function normalizeBday(raw: string): string | null {
   const s = raw.trim();
 
+  let year: string | null = null;
+  let month: string | null = null;
+  let day: string | null = null;
+
   // YYYY-MM-DD (vCard 4.0 + ical.js normalized form)
   let m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  if (m) { year = m[1]!; month = m[2]!; day = m[3]!; }
 
   // YYYYMMDD (vCard 3.0 basic)
-  m = s.match(/^(\d{4})(\d{2})(\d{2})$/);
-  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  if (!year) {
+    m = s.match(/^(\d{4})(\d{2})(\d{2})$/);
+    if (m) { year = m[1]!; month = m[2]!; day = m[3]!; }
+  }
 
-  // --MMDD or --MM-DD (year omitted, common for "I don't track year")
-  m = s.match(/^--(\d{2})-?(\d{2})$/);
-  if (m) return `1904-${m[1]}-${m[2]}`;
+  // --MMDD or --MM-DD (vCard 4.0 explicit year-omitted form)
+  if (!year) {
+    m = s.match(/^--(\d{2})-?(\d{2})$/);
+    if (m) { year = '1904'; month = m[1]!; day = m[2]!; }
+  }
 
   // ISO datetime — strip the time portion
-  m = s.match(/^(\d{4})-(\d{2})-(\d{2})T/);
-  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  if (!year) {
+    m = s.match(/^(\d{4})-(\d{2})-(\d{2})T/);
+    if (m) { year = m[1]!; month = m[2]!; day = m[3]!; }
+  }
 
-  return null;
+  if (!year || !month || !day) return null;
+
+  // Apple iCloud Contacts stores "no birth year given" as the literal year
+  // 1604 in CardDAV vCards — a long-standing iOS idiosyncrasy rather than a
+  // standard. Map it back to our year-omitted sentinel (1904) so the
+  // birthdays widget treats it the same as Google Contacts' year-less rows
+  // (no age displayed) instead of rendering "age 421".
+  if (year === '1604') year = '1904';
+
+  return `${year}-${month}-${day}`;
 }

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -271,15 +271,19 @@ export async function fetchWeatherData(
     .filter(({ dateStr }) => dateStr.slice(0, 10) >= todayLocalStr)
     .slice(0, 7)
     .map(({ dateStr, i }) => {
-      // YYYY-MM-DD in the location's TZ; parse as local-date to avoid the UTC
-      // shift bug.
+      // YYYY-MM-DD in the location's TZ. Anchor at UTC midnight so the
+      // JSON round-trip preserves the calendar day: ISO string of a UTC-
+      // midnight Date is "YYYY-MM-DDT00:00:00.000Z", which the client can
+      // read back via getUTC* without TZ slippage. Computing dayName from
+      // getUTCDay() keeps the day-of-week label consistent regardless of
+      // the container's TZ (Docker = UTC; family viewer = Central).
       const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr);
       const date = m
-        ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+        ? new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
         : new Date(dateStr);
       return {
         date,
-        dayName: DAYS_SHORT[date.getDay()] ?? 'Day',
+        dayName: DAYS_SHORT[date.getUTCDay()] ?? 'Day',
         high: Math.round(daily.temperature_2m_max[i] ?? 0),
         low: Math.round(daily.temperature_2m_min[i] ?? 0),
         condition: mapWmoCode(daily.weather_code[i] ?? 0),

--- a/src/lib/server/calendarSyncCron.ts
+++ b/src/lib/server/calendarSyncCron.ts
@@ -12,7 +12,7 @@
  * extended quiet periods, events silently went stale.
  */
 
-import { syncAllGoogleCalendars, syncAllIcalCalendars } from '@/lib/services/calendar-sync';
+import { syncAllGoogleCalendars, syncAllIcalCalendars, syncAllCalDAVCalendars } from '@/lib/services/calendar-sync';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 
 const INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
@@ -20,22 +20,26 @@ const INITIAL_DELAY_MS = 60 * 1000;  // wait 1 min after boot
 
 async function runOnce() {
   try {
-    const [google, ical] = await Promise.all([
+    const [google, ical, caldav] = await Promise.all([
       syncAllGoogleCalendars(),
       syncAllIcalCalendars(),
+      syncAllCalDAVCalendars(),
     ]);
-    const total = google.total + ical.total;
-    const errors = [...google.errors, ...ical.errors];
+    const total = google.total + ical.total + caldav.total;
+    const errors = [...google.errors, ...ical.errors, ...caldav.errors];
 
     await invalidateEntity('events');
+    // CalDAV sources also sync VTODO into the tasks table; invalidate that
+    // cache too so the Tasks page picks up new / updated reminders.
+    await invalidateEntity('tasks');
 
     if (errors.length > 0) {
       console.warn(
-        `[calendar-cron] synced ${total} events with ${errors.length} errors:`,
+        `[calendar-cron] synced ${total} events/tasks with ${errors.length} errors:`,
         errors.slice(0, 3),
       );
     } else {
-      console.log(`[calendar-cron] synced ${total} events`);
+      console.log(`[calendar-cron] synced ${total} events/tasks`);
     }
   } catch (err) {
     // Never let a transient sync failure crash the cron loop.

--- a/src/lib/server/calendarSyncCron.ts
+++ b/src/lib/server/calendarSyncCron.ts
@@ -13,6 +13,7 @@
  */
 
 import { syncAllGoogleCalendars, syncAllIcalCalendars, syncAllCalDAVCalendars } from '@/lib/services/calendar-sync';
+import { syncCardDAVBirthdays } from '@/lib/services/carddav-birthday-sync';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 
 const INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
@@ -20,18 +21,20 @@ const INITIAL_DELAY_MS = 60 * 1000;  // wait 1 min after boot
 
 async function runOnce() {
   try {
-    const [google, ical, caldav] = await Promise.all([
+    const [google, ical, caldav, carddav] = await Promise.all([
       syncAllGoogleCalendars(),
       syncAllIcalCalendars(),
       syncAllCalDAVCalendars(),
+      syncCardDAVBirthdays(),
     ]);
-    const total = google.total + ical.total + caldav.total;
-    const errors = [...google.errors, ...ical.errors, ...caldav.errors];
+    const total = google.total + ical.total + caldav.total + carddav.synced;
+    const errors = [...google.errors, ...ical.errors, ...caldav.errors, ...carddav.errors];
 
     await invalidateEntity('events');
     // CalDAV sources also sync VTODO into the tasks table; invalidate that
     // cache too so the Tasks page picks up new / updated reminders.
     await invalidateEntity('tasks');
+    if (carddav.synced > 0) await invalidateEntity('birthdays');
 
     if (errors.length > 0) {
       console.warn(

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -1,0 +1,119 @@
+/**
+ * Cross-source birthday dedup. Same person commonly arrives twice — once
+ * from a Google Calendar event titled "Julia's birthday" (regex-parsed,
+ * carries just the first name) and once from a vCard with FN "Julia O'Brien"
+ * (CardDAV sync, carries the full name). The (name, eventType) unique index
+ * doesn't catch these because the names differ.
+ *
+ * The heuristic that doesn't false-positive across distinct people:
+ *   - same birth month + day
+ *   - one name is a TOKEN-PREFIX of the other (e.g. "Julia" ⊂ "Julia O'Brien"
+ *     but "Lara Katz" ⊄ "Lara Tal" — different people who happen to share
+ *     a January 15 birthday)
+ *
+ * When that holds, we keep the longer name and prefer the non-1904 year
+ * (1904 is the year-omitted sentinel from CardDAV / Google Contacts).
+ *
+ * Sharing first name + birthday but with two distinct last names is
+ * (deliberately) NOT auto-merged — that's the false-positive case.
+ */
+
+import { db } from '@/lib/db/client';
+import { birthdays } from '@/lib/db/schema';
+import { and, eq, sql } from 'drizzle-orm';
+
+interface UpsertOpts {
+  name: string;
+  birthDate: string;       // YYYY-MM-DD
+  eventType?: 'birthday' | 'anniversary' | 'milestone';
+  source: string;          // e.g. 'birthdays', 'friends_family', 'caldav_contacts'
+}
+
+/** Strip punctuation, collapse whitespace, lowercase. */
+function normalize(s: string): string {
+  return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Token-prefix: "julia" is prefix of "julia obrien", "lara katz" is NOT prefix of "lara tal". */
+function isTokenPrefix(short: string, long: string): boolean {
+  const a = normalize(short).split(' ');
+  const b = normalize(long).split(' ');
+  if (a.length > b.length) return false;
+  return a.every((tok, i) => tok === b[i]);
+}
+
+function parseYear(birthDate: string): number {
+  return parseInt(birthDate.split('-')[0]!, 10);
+}
+
+/**
+ * Insert a birthday, but merge with any existing prefix-match candidate
+ * sharing the same month/day. Returns the action taken so callers can
+ * count synced vs deduped rows.
+ */
+export async function upsertBirthday(opts: UpsertOpts): Promise<'inserted' | 'updated' | 'skipped'> {
+  const { name, birthDate, source } = opts;
+  const eventType = opts.eventType ?? 'birthday';
+  const [yearStr, mo, dy] = birthDate.split('-');
+  if (!mo || !dy || !yearStr) return 'skipped';
+  const newYear = parseInt(yearStr, 10);
+
+  const candidates = await db.query.birthdays.findMany({
+    where: and(
+      eq(birthdays.eventType, eventType),
+      sql`EXTRACT(MONTH FROM ${birthdays.birthDate}) = ${parseInt(mo, 10)}`,
+      sql`EXTRACT(DAY FROM ${birthdays.birthDate}) = ${parseInt(dy, 10)}`,
+    ),
+  });
+
+  for (const existing of candidates) {
+    // Exact match: standard upsert behavior — refresh fields, keep id.
+    if (normalize(existing.name) === normalize(name)) {
+      await db.update(birthdays).set({
+        birthDate,
+        googleCalendarSource: source,
+      }).where(eq(birthdays.id, existing.id));
+      return 'updated';
+    }
+
+    // Existing is the shorter prefix → promote it to the longer name.
+    if (isTokenPrefix(existing.name, name)) {
+      const existingYear = parseYear(existing.birthDate);
+      const keepYear = existingYear !== 1904 ? existingYear : newYear;
+      await db.update(birthdays).set({
+        name,
+        birthDate: `${keepYear}-${mo}-${dy}`,
+        googleCalendarSource: source,
+      }).where(eq(birthdays.id, existing.id));
+      return 'updated';
+    }
+
+    // New is the shorter prefix → keep existing, optionally improve its year.
+    if (isTokenPrefix(name, existing.name)) {
+      const existingYear = parseYear(existing.birthDate);
+      if (existingYear === 1904 && newYear !== 1904) {
+        await db.update(birthdays).set({
+          birthDate: `${newYear}-${mo}-${dy}`,
+        }).where(eq(birthdays.id, existing.id));
+        return 'updated';
+      }
+      return 'skipped';
+    }
+
+    // Same first name but neither name is a prefix of the other — different
+    // people. Continue to the next candidate.
+  }
+
+  // No prefix-match. Use the existing (name, eventType) unique index
+  // for the standard upsert path.
+  await db.insert(birthdays).values({
+    name,
+    birthDate,
+    eventType,
+    googleCalendarSource: source,
+  }).onConflictDoUpdate({
+    target: [birthdays.name, birthdays.eventType],
+    set: { birthDate, googleCalendarSource: source },
+  });
+  return 'inserted';
+}

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -1,15 +1,15 @@
 /**
  * Cross-source birthday dedup. Same person commonly arrives twice — once
- * from a Google Calendar event titled "Julia's birthday" (regex-parsed,
- * carries just the first name) and once from a vCard with FN "Julia O'Brien"
+ * from a Google Calendar event titled "Alex's birthday" (regex-parsed,
+ * carries just the first name) and once from a vCard with FN "Alex Doe"
  * (CardDAV sync, carries the full name). The (name, eventType) unique index
  * doesn't catch these because the names differ.
  *
  * The heuristic that doesn't false-positive across distinct people:
  *   - same birth month + day
- *   - one name is a TOKEN-PREFIX of the other (e.g. "Julia" ⊂ "Julia O'Brien"
- *     but "Lara Katz" ⊄ "Lara Tal" — different people who happen to share
- *     a January 15 birthday)
+ *   - one name is a TOKEN-PREFIX of the other (e.g. "Alex" ⊂ "Alex Doe"
+ *     but "Jordan Doe" ⊄ "Jordan Smith" — two distinct contacts who
+ *     happen to share a birth day)
  *
  * When that holds, we keep the longer name and prefer the non-1904 year
  * (1904 is the year-omitted sentinel from CardDAV / Google Contacts).
@@ -34,7 +34,7 @@ function normalize(s: string): string {
   return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
 }
 
-/** Token-prefix: "julia" is prefix of "julia obrien", "lara katz" is NOT prefix of "lara tal". */
+/** Token-prefix: "alex" is prefix of "alex doe", "jordan doe" is NOT prefix of "jordan smith". */
 function isTokenPrefix(short: string, long: string): boolean {
   const a = normalize(short).split(' ');
   const b = normalize(long).split(' ');

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -868,15 +868,25 @@ export async function syncCalDAVTasks(
       source.sourceCalendarId,
     );
 
-    // Each CalDAV source maps to one Prism task list. Find the list_id
-    // already in use by any existing task for this source (self-heals
-    // sources synced before this code path existed); otherwise create a
-    // new task_list named after the calendar.
-    const existingTaskForSource = await db.query.tasks.findFirst({
-      where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
-      columns: { listId: true },
-    });
-    let taskListId = existingTaskForSource?.listId ?? null;
+    // Each CalDAV source maps to one Prism task list. Lookup order:
+    //   1. config.taskListId — durable mapping written back into syncErrors
+    //      JSON on first create. Survives task purges; one source = one list.
+    //   2. existing task row's listId — back-compat for sources synced
+    //      before (1) existed.
+    //   3. create a fresh task_list, then persist its id into config so
+    //      future ticks hit branch (1) instead of creating more dupes.
+    //
+    // Before (1) existed, every cron tick that swept stale tasks lost the
+    // source→list link and synthesized a new task_list, accumulating one
+    // orphan list per source per tick.
+    let taskListId: string | null = config.taskListId ?? null;
+    if (!taskListId) {
+      const existingTaskForSource = await db.query.tasks.findFirst({
+        where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+        columns: { listId: true },
+      });
+      taskListId = existingTaskForSource?.listId ?? null;
+    }
     if (!taskListId) {
       const [newList] = await db
         .insert(taskLists)
@@ -885,7 +895,13 @@ export async function syncCalDAVTasks(
           color: source.color || '#6366f1',
         })
         .returning();
-      if (newList) taskListId = newList.id;
+      if (newList) {
+        taskListId = newList.id;
+        // Persist the mapping so the next tick takes branch (1).
+        await db.update(calendarSources)
+          .set({ syncErrors: { ...config, taskListId: newList.id } })
+          .where(eq(calendarSources.id, source.id));
+      }
     }
 
     // Back-fill list_id on any pre-existing tasks for this source that

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/db/client';
-import { calendarSources, events, tasks } from '@/lib/db/schema';
+import { calendarSources, events, tasks, taskLists } from '@/lib/db/schema';
 import { eq, and, gte, lte, sql } from 'drizzle-orm';
 import {
   fetchCalDAVEvents,
@@ -856,6 +856,37 @@ export async function syncCalDAVTasks(
       source.sourceCalendarId,
     );
 
+    // Each CalDAV source maps to one Prism task list. Find the list_id
+    // already in use by any existing task for this source (self-heals
+    // sources synced before this code path existed); otherwise create a
+    // new task_list named after the calendar.
+    const existingTaskForSource = await db.query.tasks.findFirst({
+      where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+      columns: { listId: true },
+    });
+    let taskListId = existingTaskForSource?.listId ?? null;
+    if (!taskListId) {
+      const [newList] = await db
+        .insert(taskLists)
+        .values({
+          name: source.displayName || 'CalDAV Reminders',
+          color: source.color || '#6366f1',
+        })
+        .returning();
+      if (newList) taskListId = newList.id;
+    }
+
+    // Back-fill list_id on any pre-existing tasks for this source that
+    // were inserted before the task-list wiring landed.
+    if (taskListId) {
+      await db.update(tasks)
+        .set({ listId: taskListId })
+        .where(and(
+          sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+          sql`${tasks.listId} IS NULL`,
+        ));
+    }
+
     for (const task of caldavTasks) {
       const externalId = `caldav:${source.id}:${task.uid}`;
 
@@ -871,6 +902,7 @@ export async function syncCalDAVTasks(
         completedAt: task.completedAt,
         priority: (task.priority || 'medium') as 'high' | 'medium' | 'low',
         category: task.categories[0] || null,
+        listId: taskListId,
         externalId,
         externalUpdatedAt: new Date(),
         lastSynced: new Date(),

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db/client';
 import { calendarSources, events, tasks, taskLists } from '@/lib/db/schema';
-import { eq, and, gte, lte, sql } from 'drizzle-orm';
+import { eq, and, gte, lte, sql, inArray } from 'drizzle-orm';
 import {
   fetchCalDAVEvents,
   fetchCalDAVTasks,
@@ -887,8 +887,22 @@ export async function syncCalDAVTasks(
         ));
     }
 
+    // Apple iCloud injects metadata VTODOs into reminder lists whose data
+    // has migrated to the CloudKit-only Reminders system. Those don't
+    // represent real tasks — they're nag messages telling the user where
+    // their data went. Skip them so Prism doesn't show them as real tasks.
+    const APPLE_PLACEHOLDER_TITLES = new Set([
+      'Where are my reminders?',
+      'The creator of this list has upgraded these reminders.',
+    ]);
+
+    const seenExternalIds = new Set<string>();
+
     for (const task of caldavTasks) {
+      if (APPLE_PLACEHOLDER_TITLES.has(task.title.trim())) continue;
+
       const externalId = `caldav:${source.id}:${task.uid}`;
+      seenExternalIds.add(externalId);
 
       const existing = await db.query.tasks.findFirst({
         where: eq(tasks.externalId, externalId),
@@ -916,6 +930,18 @@ export async function syncCalDAVTasks(
       }
 
       synced++;
+    }
+
+    // Mirror upstream deletions: any caldav-prefixed task for this source
+    // that wasn't in the fetch round-trips out of Prism too. Also catches
+    // existing placeholder rows that pre-date the title filter above.
+    const allLocal = await db.query.tasks.findMany({
+      where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+      columns: { id: true, externalId: true },
+    });
+    const stale = allLocal.filter(t => t.externalId && !seenExternalIds.has(t.externalId));
+    if (stale.length > 0) {
+      await db.delete(tasks).where(inArray(tasks.id, stale.map(t => t.id)));
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,6 +1,11 @@
 import { db } from '@/lib/db/client';
-import { calendarSources, events } from '@/lib/db/schema';
+import { calendarSources, events, tasks } from '@/lib/db/schema';
 import { eq, and, gte, lte, sql } from 'drizzle-orm';
+import {
+  fetchCalDAVEvents,
+  fetchCalDAVTasks,
+  type CalDAVConnectionConfig,
+} from '@/lib/integrations/caldav';
 import {
   fetchCalendarEvents,
   fetchCalendarList,
@@ -687,4 +692,232 @@ export async function getCalendarSourcesWithStatus() {
       },
     },
   });
+}
+
+// ─── CalDAV sync ───────────────────────────────────────────────────────────
+//
+// Read-only sync from any CalDAV server (Apple iCloud, Nextcloud, Radicale,
+// Baikal, Synology). Two-way write (createCalendarObject) isn't wired up yet
+// — that lives in a follow-up branch. Events from CalDAV land in the same
+// `events` table as Google + iCal; VTODO items land in `tasks`.
+
+/**
+ * Sync events from a single CalDAV calendar source.
+ */
+export async function syncCalDAVCalendarSource(
+  sourceId: string,
+  options: { timeMin?: Date; timeMax?: Date } = {}
+): Promise<{ synced: number; errors: string[] }> {
+  const errors: string[] = [];
+  let synced = 0;
+
+  const source = await db.query.calendarSources.findFirst({
+    where: eq(calendarSources.id, sourceId),
+  });
+
+  if (!source || source.provider !== 'caldav') {
+    return { synced: 0, errors: ['Not a CalDAV source'] };
+  }
+
+  if (!source.accessToken) {
+    return { synced: 0, errors: ['No credentials available'] };
+  }
+
+  let password: string;
+  try {
+    password = decrypt(source.accessToken);
+  } catch {
+    return { synced: 0, errors: ['Failed to decrypt credentials — may need to reconnect'] };
+  }
+
+  const config = source.syncErrors as CalDAVConnectionConfig | null;
+  if (!config?.serverUrl || !config?.username) {
+    return { synced: 0, errors: ['Missing CalDAV connection config'] };
+  }
+
+  const timeMin = options.timeMin || new Date(Date.now() - DEFAULT_TIME_MIN_MS);
+  const timeMax = options.timeMax || new Date(Date.now() + DEFAULT_TIME_MAX_MS);
+
+  try {
+    const caldavEvents = await fetchCalDAVEvents(
+      config.serverUrl,
+      config.username,
+      password,
+      source.sourceCalendarId,
+      timeMin,
+      timeMax,
+    );
+
+    for (const event of caldavEvents) {
+      const existing = await db.query.events.findFirst({
+        where: and(
+          eq(events.calendarSourceId, sourceId),
+          eq(events.externalEventId, event.uid),
+        ),
+      });
+
+      const eventData = {
+        title: event.title,
+        description: event.description,
+        location: event.location,
+        startTime: event.startTime,
+        endTime: event.endTime,
+        allDay: event.allDay,
+        color: event.color || source.color,
+        recurring: event.recurring,
+        recurrenceRule: event.recurrenceRule,
+        calendarSourceId: sourceId,
+        externalEventId: event.uid,
+        updatedAt: new Date(),
+      };
+
+      if (existing) {
+        await db.update(events).set(eventData).where(eq(events.id, existing.id));
+      } else {
+        await db.insert(events).values(eventData);
+      }
+
+      synced++;
+    }
+
+    // Drop events that no longer exist upstream (within the sync window only —
+    // matches the behavior of the Google + iCal paths in this file).
+    const upstreamUids = new Set(caldavEvents.map((e) => e.uid));
+    const localEvents = await db.query.events.findMany({
+      where: and(
+        eq(events.calendarSourceId, sourceId),
+        gte(events.startTime, timeMin),
+        lte(events.startTime, timeMax),
+      ),
+    });
+
+    for (const local of localEvents) {
+      if (local.externalEventId && !upstreamUids.has(local.externalEventId)) {
+        await db.delete(events).where(eq(events.id, local.id));
+      }
+    }
+
+    await db
+      .update(calendarSources)
+      .set({ lastSynced: new Date(), syncErrors: config })
+      .where(eq(calendarSources.id, sourceId));
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    errors.push(`CalDAV sync failed: ${msg}`);
+
+    await db
+      .update(calendarSources)
+      .set({
+        syncErrors: { ...config, lastError: msg, lastErrorAt: new Date().toISOString() },
+      })
+      .where(eq(calendarSources.id, sourceId));
+  }
+
+  return { synced, errors };
+}
+
+/**
+ * Sync tasks (VTODO) from a CalDAV calendar source into Prism tasks.
+ */
+export async function syncCalDAVTasks(
+  sourceId: string,
+): Promise<{ synced: number; errors: string[] }> {
+  const errors: string[] = [];
+  let synced = 0;
+
+  const source = await db.query.calendarSources.findFirst({
+    where: eq(calendarSources.id, sourceId),
+  });
+
+  if (!source || source.provider !== 'caldav') {
+    return { synced: 0, errors: ['Not a CalDAV source'] };
+  }
+  if (!source.accessToken) {
+    return { synced: 0, errors: ['No credentials available'] };
+  }
+
+  let password: string;
+  try {
+    password = decrypt(source.accessToken);
+  } catch {
+    return { synced: 0, errors: ['Failed to decrypt credentials'] };
+  }
+
+  const config = source.syncErrors as CalDAVConnectionConfig | null;
+  if (!config?.serverUrl || !config?.username) {
+    return { synced: 0, errors: ['Missing CalDAV connection config'] };
+  }
+
+  try {
+    const caldavTasks = await fetchCalDAVTasks(
+      config.serverUrl,
+      config.username,
+      password,
+      source.sourceCalendarId,
+    );
+
+    for (const task of caldavTasks) {
+      const externalId = `caldav:${source.id}:${task.uid}`;
+
+      const existing = await db.query.tasks.findFirst({
+        where: eq(tasks.externalId, externalId),
+      });
+
+      const taskData = {
+        title: task.title,
+        description: task.description,
+        dueDate: task.dueDate || null,
+        completed: task.completed,
+        completedAt: task.completedAt,
+        priority: (task.priority || 'medium') as 'high' | 'medium' | 'low',
+        category: task.categories[0] || null,
+        externalId,
+        externalUpdatedAt: new Date(),
+        lastSynced: new Date(),
+        updatedAt: new Date(),
+      };
+
+      if (existing) {
+        await db.update(tasks).set(taskData).where(eq(tasks.id, existing.id));
+      } else {
+        await db.insert(tasks).values(taskData);
+      }
+
+      synced++;
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    errors.push(`CalDAV task sync failed: ${msg}`);
+  }
+
+  return { synced, errors };
+}
+
+/**
+ * Sync all enabled CalDAV calendar sources (events + tasks).
+ */
+export async function syncAllCalDAVCalendars(
+  options: { timeMin?: Date; timeMax?: Date } = {}
+): Promise<{ total: number; errors: string[] }> {
+  const allErrors: string[] = [];
+  let total = 0;
+
+  const sources = await db.query.calendarSources.findMany({
+    where: and(
+      eq(calendarSources.provider, 'caldav'),
+      eq(calendarSources.enabled, true),
+    ),
+  });
+
+  for (const source of sources) {
+    const eventResult = await syncCalDAVCalendarSource(source.id, options);
+    total += eventResult.synced;
+    allErrors.push(...eventResult.errors);
+
+    const taskResult = await syncCalDAVTasks(source.id);
+    total += taskResult.synced;
+    allErrors.push(...taskResult.errors);
+  }
+
+  return { total, errors: allErrors };
 }

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -868,53 +868,6 @@ export async function syncCalDAVTasks(
       source.sourceCalendarId,
     );
 
-    // Each CalDAV source maps to one Prism task list. Lookup order:
-    //   1. config.taskListId — durable mapping written back into syncErrors
-    //      JSON on first create. Survives task purges; one source = one list.
-    //   2. existing task row's listId — back-compat for sources synced
-    //      before (1) existed.
-    //   3. create a fresh task_list, then persist its id into config so
-    //      future ticks hit branch (1) instead of creating more dupes.
-    //
-    // Before (1) existed, every cron tick that swept stale tasks lost the
-    // source→list link and synthesized a new task_list, accumulating one
-    // orphan list per source per tick.
-    let taskListId: string | null = config.taskListId ?? null;
-    if (!taskListId) {
-      const existingTaskForSource = await db.query.tasks.findFirst({
-        where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
-        columns: { listId: true },
-      });
-      taskListId = existingTaskForSource?.listId ?? null;
-    }
-    if (!taskListId) {
-      const [newList] = await db
-        .insert(taskLists)
-        .values({
-          name: source.displayName || 'CalDAV Reminders',
-          color: source.color || '#6366f1',
-        })
-        .returning();
-      if (newList) {
-        taskListId = newList.id;
-        // Persist the mapping so the next tick takes branch (1).
-        await db.update(calendarSources)
-          .set({ syncErrors: { ...config, taskListId: newList.id } })
-          .where(eq(calendarSources.id, source.id));
-      }
-    }
-
-    // Back-fill list_id on any pre-existing tasks for this source that
-    // were inserted before the task-list wiring landed.
-    if (taskListId) {
-      await db.update(tasks)
-        .set({ listId: taskListId })
-        .where(and(
-          sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
-          sql`${tasks.listId} IS NULL`,
-        ));
-    }
-
     // Apple iCloud injects metadata VTODOs into reminder lists whose data
     // has migrated to the CloudKit-only Reminders system. Those don't
     // represent real tasks — they're nag messages telling the user where
@@ -924,11 +877,52 @@ export async function syncCalDAVTasks(
       'The creator of this list has upgraded these reminders.',
     ]);
 
+    const realTasks = caldavTasks.filter(
+      t => !APPLE_PLACEHOLDER_TITLES.has(t.title.trim())
+    );
+
+    // Lazy task-list creation: if a CalDAV source returns only Apple's
+    // placeholder VTODOs (the common case for modern iCloud Reminders, whose
+    // real data lives in CloudKit and isn't reachable over CalDAV), don't
+    // pollute Settings with an empty task_list that the user can't populate.
+    // Only materialize a Prism task_list once we actually have real content
+    // to put in it, or once we already created one on a prior sync.
+    let taskListId: string | null = config.taskListId ?? null;
+    if (!taskListId && realTasks.length > 0) {
+      const existingTaskForSource = await db.query.tasks.findFirst({
+        where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+        columns: { listId: true },
+      });
+      taskListId = existingTaskForSource?.listId ?? null;
+    }
+    if (!taskListId && realTasks.length > 0) {
+      const [newList] = await db
+        .insert(taskLists)
+        .values({
+          name: source.displayName || 'CalDAV Reminders',
+          color: source.color || '#6366f1',
+        })
+        .returning();
+      if (newList) {
+        taskListId = newList.id;
+        await db.update(calendarSources)
+          .set({ syncErrors: { ...config, taskListId: newList.id } })
+          .where(eq(calendarSources.id, source.id));
+      }
+    }
+
+    if (taskListId) {
+      await db.update(tasks)
+        .set({ listId: taskListId })
+        .where(and(
+          sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
+          sql`${tasks.listId} IS NULL`,
+        ));
+    }
+
     const seenExternalIds = new Set<string>();
 
-    for (const task of caldavTasks) {
-      if (APPLE_PLACEHOLDER_TITLES.has(task.title.trim())) continue;
-
+    for (const task of realTasks) {
       const externalId = `caldav:${source.id}:${task.uid}`;
       seenExternalIds.add(externalId);
 

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -735,6 +735,13 @@ export async function syncCalDAVCalendarSource(
     return { synced: 0, errors: ['Missing CalDAV connection config'] };
   }
 
+  // Skip event sync for sources whose discovery flagged them as VTODO-only.
+  // (undefined === legacy row from before flags were stored, so default to
+  // running the sync — back-compatible.)
+  if (config.supportsEvents === false) {
+    return { synced: 0, errors: [] };
+  }
+
   const timeMin = options.timeMin || new Date(Date.now() - DEFAULT_TIME_MIN_MS);
   const timeMax = options.timeMax || new Date(Date.now() + DEFAULT_TIME_MAX_MS);
 
@@ -846,6 +853,11 @@ export async function syncCalDAVTasks(
   const config = source.syncErrors as CalDAVConnectionConfig | null;
   if (!config?.serverUrl || !config?.username) {
     return { synced: 0, errors: ['Missing CalDAV connection config'] };
+  }
+
+  // Skip task sync for sources whose discovery flagged them as VEVENT-only.
+  if (config.supportsTasks === false) {
+    return { synced: 0, errors: [] };
   }
 
   try {

--- a/src/lib/services/carddav-birthday-sync.ts
+++ b/src/lib/services/carddav-birthday-sync.ts
@@ -1,0 +1,86 @@
+/**
+ * Pull birthdays out of CardDAV contacts and upsert into the birthdays
+ * table. Credentials are reused from any existing CalDAV calendar_source
+ * row whose syncErrors carries `contactBirthdaysEnabled: true` — the user
+ * opts in by checking a box in the CalDAV connect dialog. One row's creds
+ * are enough; we don't multi-tenant this. (If the user ever wants per-iCloud-
+ * account isolation, this is the place to fan out.)
+ */
+
+import { db } from '@/lib/db/client';
+import { birthdays, calendarSources } from '@/lib/db/schema';
+import { and, eq, sql } from 'drizzle-orm';
+import { decrypt } from '@/lib/utils/crypto';
+import { fetchCardDAVBirthdays } from '@/lib/integrations/carddav';
+
+interface SyncResult {
+  synced: number;
+  errors: string[];
+}
+
+export async function syncCardDAVBirthdays(): Promise<SyncResult> {
+  const result: SyncResult = { synced: 0, errors: [] };
+
+  const enabledSource = await db.query.calendarSources.findFirst({
+    where: and(
+      eq(calendarSources.provider, 'caldav'),
+      sql`(${calendarSources.syncErrors}->>'contactBirthdaysEnabled')::boolean = true`,
+    ),
+  });
+
+  if (!enabledSource) return result;
+
+  const cfg = (enabledSource.syncErrors as Record<string, unknown> | null) ?? {};
+  const serverUrl = String(cfg.serverUrl || '');
+  const username = String(cfg.username || '');
+  if (!serverUrl || !username || !enabledSource.accessToken) {
+    result.errors.push('CardDAV sync: source row missing credentials');
+    return result;
+  }
+
+  let password: string;
+  try {
+    password = decrypt(enabledSource.accessToken);
+  } catch (err) {
+    result.errors.push(`CardDAV sync: failed to decrypt password — ${err instanceof Error ? err.message : err}`);
+    return result;
+  }
+
+  let contacts;
+  try {
+    contacts = await fetchCardDAVBirthdays(serverUrl, username, password);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.errors.push(`CardDAV fetch failed: ${msg}`);
+    return result;
+  }
+
+  // Upsert each (name, birthdate) pair. The unique index on
+  // (name, eventType) means a duplicate from Google + CardDAV converges
+  // onto one row — the CardDAV value wins on conflict, which matches the
+  // user's mental model of "iCloud is my source of truth for contacts."
+  for (const c of contacts) {
+    try {
+      await db
+        .insert(birthdays)
+        .values({
+          name: c.name,
+          birthDate: c.birthDate,
+          eventType: 'birthday',
+          googleCalendarSource: 'caldav_contacts',
+        })
+        .onConflictDoUpdate({
+          target: [birthdays.name, birthdays.eventType],
+          set: {
+            birthDate: c.birthDate,
+            googleCalendarSource: 'caldav_contacts',
+          },
+        });
+      result.synced++;
+    } catch (err) {
+      result.errors.push(`Upsert failed for "${c.name}": ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/services/carddav-birthday-sync.ts
+++ b/src/lib/services/carddav-birthday-sync.ts
@@ -58,7 +58,7 @@ export async function syncCardDAVBirthdays(): Promise<SyncResult> {
 
   // upsertBirthday handles three cases per contact:
   //   - exact name match → refresh fields
-  //   - prefix match (e.g. existing "Julia" with our new "Julia O'Brien" or
+  //   - prefix match (e.g. existing "Alex" with our new "Alex Doe" or
   //     vice versa, same month/day) → merge, keeping the longer name and the
   //     non-1904 year. Avoids the cross-source dupes we used to accumulate
   //     when Google Calendar carried a first name and CardDAV the full name.

--- a/src/lib/services/carddav-birthday-sync.ts
+++ b/src/lib/services/carddav-birthday-sync.ts
@@ -8,10 +8,11 @@
  */
 
 import { db } from '@/lib/db/client';
-import { birthdays, calendarSources } from '@/lib/db/schema';
+import { calendarSources } from '@/lib/db/schema';
 import { and, eq, sql } from 'drizzle-orm';
 import { decrypt } from '@/lib/utils/crypto';
 import { fetchCardDAVBirthdays } from '@/lib/integrations/carddav';
+import { upsertBirthday } from './birthday-merge';
 
 interface SyncResult {
   synced: number;
@@ -55,27 +56,21 @@ export async function syncCardDAVBirthdays(): Promise<SyncResult> {
     return result;
   }
 
-  // Upsert each (name, birthdate) pair. The unique index on
-  // (name, eventType) means a duplicate from Google + CardDAV converges
-  // onto one row — the CardDAV value wins on conflict, which matches the
-  // user's mental model of "iCloud is my source of truth for contacts."
+  // upsertBirthday handles three cases per contact:
+  //   - exact name match → refresh fields
+  //   - prefix match (e.g. existing "Julia" with our new "Julia O'Brien" or
+  //     vice versa, same month/day) → merge, keeping the longer name and the
+  //     non-1904 year. Avoids the cross-source dupes we used to accumulate
+  //     when Google Calendar carried a first name and CardDAV the full name.
+  //   - no match → insert new
   for (const c of contacts) {
     try {
-      await db
-        .insert(birthdays)
-        .values({
-          name: c.name,
-          birthDate: c.birthDate,
-          eventType: 'birthday',
-          googleCalendarSource: 'caldav_contacts',
-        })
-        .onConflictDoUpdate({
-          target: [birthdays.name, birthdays.eventType],
-          set: {
-            birthDate: c.birthDate,
-            googleCalendarSource: 'caldav_contacts',
-          },
-        });
+      await upsertBirthday({
+        name: c.name,
+        birthDate: c.birthDate,
+        eventType: 'birthday',
+        source: 'caldav_contacts',
+      });
       result.synced++;
     } catch (err) {
       result.errors.push(`Upsert failed for "${c.name}": ${err instanceof Error ? err.message : err}`);


### PR DESCRIPTION
## Summary
- Adds read-only CalDAV sync for Apple iCloud, Nextcloud, Radicale, Baikal, Synology
- New UI: *Settings → Connected Accounts → CalDAV* opens a multi-step connect dialog
- New API: `POST /api/caldav/{test,discover,connect}`
- Events sync into `events`, Reminders/VTODO sync into `tasks`
- Marked **Alpha** — needs validation against a real iCloud account before promoting

## Why draft
I don't have an iCloud-paid account handy to verify against `caldav.icloud.com`. Posting to issue #45 asking for a tester. If basic event + Reminders sync works for them, I'll cut a follow-up PR to add two-way write (`createCalendarObject` / `updateCalendarObject` / `deleteCalendarObject` — all already in tsdav) and graduate this from alpha.

## What's in scope here
- `src/lib/integrations/caldav.ts` — tsdav + ical.js wrapper, exports `testCalDAVConnection`, `discoverCalendars`, `fetchCalDAVEvents`, `fetchCalDAVTasks`
- `src/app/api/caldav/{test,discover,connect}/route.ts` — protected by `requireRole('canModifySettings')`, credentials encrypted via existing `crypto.encrypt`
- `src/app/settings/components/CalDAVConnectDialog.tsx` — credentials → discovery → confirmation flow
- `src/app/settings/sections/ConnectedAccountsSection.tsx` — new CalDAV card with Alpha badge
- `src/lib/services/calendar-sync.ts` — `syncCalDAVCalendarSource`, `syncCalDAVTasks`, `syncAllCalDAVCalendars`
- `src/app/api/calendars/sync/route.ts` — dispatches CalDAV sources alongside Google + iCal
- `docs/features/CALENDAR.md` — adds an iCloud-via-CalDAV section next to the existing webcal subscription path
- Dependencies: `tsdav@^2.1.8`, `ical.js@^2.2.1`

## What's *not* in scope (follow-ups)
- Two-way write — Prism cannot create / edit / delete CalDAV events yet
- Disconnect button + per-source management UI in Connected Accounts (the underlying calendar source UI already covers this, just not surfaced here)
- VTODO sync currently only inserts/updates — it doesn't delete tasks removed upstream (events do)
- The `syncErrors` jsonb column is being overloaded to hold CalDAV connection config — works, semantically muddy. A dedicated `providerConfig` column is the right fix once this graduates from alpha.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — only pre-existing warnings, none from CalDAV files
- [x] `npx jest` — 1139/1139 tests pass
- [ ] **Manual test against Apple iCloud** — blocked on tester (issue #45)
- [ ] **Manual test against Nextcloud / Radicale** — anyone with a server is welcome to try

## Security notes
- Passwords stored encrypted in `calendarSources.accessToken` using existing `lib/utils/crypto` helpers
- `requireRole(auth, 'canModifySettings')` on all three new API routes
- App-specific passwords (not the user's Apple ID password) — the dialog copy guides users to generate one at appleid.apple.com