### PR TITLE
chore(release): 1.8.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.2] – 2026-05-22
+
+> Adds an MCP server (`.mcp/`) that exposes Prism's REST API as Model Context Protocol tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write family data through natural-language chat.
+
 ### Added — Integrations
 - **MCP server for Prism (`.mcp/`)**: Self-contained Model Context Protocol server that exposes the Prism REST API as MCP tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write chores, tasks, events, shopping, messages, meals, goals, recipes, maintenance, points, weather, and family data directly from a chat window. Uses the existing API-token auth (Settings → Security → API Tokens) via env vars in the client config. Built on `@modelcontextprotocol/sdk` v1.29+ with stdio transport. Returns both legacy `content` text and modern `structuredContent` objects (2025-06-18 spec) so parsed-object-aware clients can skip a JSON parse step. Future remote/hosted variant would use Streamable HTTP + OAuth 2.1 per spec 2025-11-25 — current build is local-subprocess only. See [`.mcp/README.md`](../.mcp/README.md) for setup.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Bumps package.json 1.8.1 → 1.8.2 and migrates the Unreleased MCP entry into a [1.8.2] – 2026-05-22 section. The MCP server (`.mcp/`) shipped in #63 is the only feature change; #64's CHANGELOG anonymization isn't user-facing and doesn't warrant its own line.

## Highlights

- **MCP server (`.mcp/`)** — exposes Prism's REST API as MCP tools so Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, and VS Code Copilot Chat can read and write family data through chat. Bearer-token auth via env vars in the client's MCP config.