### PR TITLE
chore(release): version-sync check + release script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Prism version
       description: "Find this in Settings → About, or run: `docker exec prism-app sh -c 'cat package.json | grep version'`"
-      placeholder: "1.8.0"
+      placeholder: "e.g. 1.8.2"
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
 
       - run: npm run lint
 
+      - name: Version sync (package.json ↔ CHANGELOG)
+        run: bash scripts/check-version-sync.sh
+
   unit:
     name: Unit tests (jest)
     runs-on: ubuntu-latest

--- a/.mcp/package.json
+++ b/.mcp/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "smoke": "node smoke.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/.mcp/smoke.mjs
+++ b/.mcp/smoke.mjs
@@ -1,0 +1,78 @@
+// Smoke test for the Prism MCP server. Spawns dist/index.js over stdio,
+// sends an `initialize` + `tools/list` JSON-RPC pair, and asserts that
+// the expected family of tools is present. Run with:
+//   npm run smoke       (from .mcp/)
+// or directly:
+//   node smoke.mjs
+//
+// Uses a fake API token — only exercises the MCP wiring, not real API
+// calls (no tool invocations are sent). Verify end-to-end tool calls by
+// running the server through a real MCP client (Claude Desktop, etc.).
+
+import { spawn } from 'node:child_process';
+
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const child = spawn('node', [join(__dirname, 'dist/index.js')], {
+  env: {
+    ...process.env,
+    PRISM_BASE_URL: 'http://localhost:3000',
+    PRISM_API_TOKEN: 'smoke-fake-token',
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let buf = '';
+const messages = [];
+child.stdout.on('data', (chunk) => {
+  buf += chunk.toString();
+  let i;
+  while ((i = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, i).trim();
+    buf = buf.slice(i + 1);
+    if (line) messages.push(JSON.parse(line));
+  }
+});
+child.stderr.on('data', (chunk) => process.stderr.write(`[server] ${chunk}`));
+
+function send(msg) { child.stdin.write(JSON.stringify(msg) + '\n'); }
+function waitFor(id, timeout = 3000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = setInterval(() => {
+      const m = messages.find(m => m.id === id);
+      if (m) { clearInterval(tick); resolve(m); }
+      else if (Date.now() - start > timeout) { clearInterval(tick); reject(new Error(`timeout waiting for id ${id}`)); }
+    }, 25);
+  });
+}
+
+try {
+  send({
+    jsonrpc: '2.0', id: 1, method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0.0.0' } },
+  });
+  const init = await waitFor(1);
+  console.log(`✓ initialize OK — server: ${init.result?.serverInfo?.name} v${init.result?.serverInfo?.version}`);
+
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+  const list = await waitFor(2);
+  const tools = list.result?.tools ?? [];
+  console.log(`✓ tools/list OK — ${tools.length} tools`);
+
+  const expected = ['list_family', 'list_chores', 'add_shopping_item', 'complete_chore', 'get_weather', 'list_recipes'];
+  const missing = expected.filter(name => !tools.some(t => t.name === name));
+  if (missing.length) throw new Error(`missing expected tools: ${missing.join(', ')}`);
+  console.log(`✓ all expected tools present`);
+
+  console.log('\nSmoke test PASSED');
+  child.kill();
+  process.exit(0);
+} catch (err) {
+  console.error('SMOKE TEST FAILED:', err.message);
+  child.kill();
+  process.exit(1);
+}

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verifies that package.json's version field matches the most recent
+# versioned heading in docs/CHANGELOG.md (the "## [X.Y.Z] – ..." line that
+# sits below "## Unreleased"). Fails CI if they drift.
+#
+# Run manually:   bash scripts/check-version-sync.sh
+# Wired into CI:  .github/workflows/ci.yml (typecheck-lint job)
+#
+# Rationale for the check: every release lives in two files (package.json
+# bumps the source of truth, CHANGELOG records the user-facing notes). If
+# one is updated without the other, downstream surfaces drift — the GH
+# Pages docs site shows old release notes, or the dashboard reports an
+# old version. Single-pass check, no external deps beyond node.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION=$(node -p "require('./package.json').version")
+CHANGELOG_TOP=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' docs/CHANGELOG.md | head -1 \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+
+if [[ -z "$CHANGELOG_TOP" ]]; then
+  echo "ERROR: docs/CHANGELOG.md has no versioned section heading."
+  echo "       Expected a line matching '## [X.Y.Z] – ...' under '## Unreleased'."
+  exit 1
+fi
+
+if [[ "$CHANGELOG_TOP" != "$VERSION" ]]; then
+  echo "ERROR: version drift detected."
+  echo "  package.json:        $VERSION"
+  echo "  CHANGELOG.md (top):  $CHANGELOG_TOP"
+  echo ""
+  echo "Run 'bash scripts/release.sh <new-version>' to bump both in lockstep,"
+  echo "or update the lagging file by hand and re-run this check."
+  exit 1
+fi
+
+echo "✓ package.json ($VERSION) matches CHANGELOG.md top section"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# One-command release helper. Bumps package.json and migrates the current
+# "## Unreleased" CHANGELOG content under a new versioned section, then
+# runs the sync check so we never ship a half-released state.
+#
+# Usage:  bash scripts/release.sh <new-version>
+# e.g.   bash scripts/release.sh 1.8.3
+#
+# What this DOES:
+#   - Edits package.json's "version" field
+#   - Inserts a new "## [X.Y.Z] – YYYY-MM-DD" heading directly below
+#     "## Unreleased" in docs/CHANGELOG.md and moves the Unreleased
+#     entries underneath it (Unreleased itself becomes empty)
+#   - Runs scripts/check-version-sync.sh to confirm both files now agree
+#
+# What this DOES NOT:
+#   - Doesn't commit, branch, push, tag, or publish — those remain manual
+#     so the human (or AI) can review the diff first. The script prints
+#     the suggested next-step commands at the end.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <new-version>"
+  exit 1
+fi
+
+NEW_VERSION="$1"
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: version must be N.N.N (got: $NEW_VERSION)"
+  exit 1
+fi
+
+TODAY=$(date +%Y-%m-%d)
+
+# --- Pre-flight: validate Unreleased has content + version isn't taken
+# Both checks run BEFORE any file is mutated, so a failed pre-flight leaves
+# the working tree untouched.
+node - "$NEW_VERSION" <<'NODE'
+const fs = require('fs');
+const [version] = process.argv.slice(2);
+
+const p = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+if (p.version === version) {
+  console.error(`ERROR: package.json is already at ${version} — nothing to bump.`);
+  process.exit(1);
+}
+
+const lines = fs.readFileSync('docs/CHANGELOG.md', 'utf8').split('\n');
+const u = lines.findIndex(l => l.trim() === '## Unreleased');
+if (u < 0) {
+  console.error('ERROR: docs/CHANGELOG.md has no "## Unreleased" heading.');
+  process.exit(1);
+}
+const n = lines.findIndex((l, i) => i > u && /^## \[[0-9]/.test(l));
+if (n < 0) {
+  console.error('ERROR: docs/CHANGELOG.md has no existing versioned section to anchor against.');
+  process.exit(1);
+}
+const between = lines.slice(u + 1, n).filter(l => l.trim() !== '');
+if (between.length === 0) {
+  console.error('ERROR: "## Unreleased" section is empty — nothing to release.');
+  console.error('       Add release notes there before running this script.');
+  process.exit(1);
+}
+console.log(`✓ pre-flight: Unreleased has ${between.length} non-blank line(s), version ${version} is new`);
+NODE
+
+# --- Bump package.json ------------------------------------------------
+node -e "
+const fs = require('fs');
+const p = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+const previous = p.version;
+p.version = '$NEW_VERSION';
+fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');
+console.log('✓ package.json: ' + previous + ' → $NEW_VERSION');
+"
+
+# --- Migrate CHANGELOG Unreleased -> [NEW_VERSION] --------------------
+node - "$NEW_VERSION" "$TODAY" <<'NODE'
+const fs = require('fs');
+const [version, today] = process.argv.slice(2);
+
+const text = fs.readFileSync('docs/CHANGELOG.md', 'utf8');
+const lines = text.split('\n');
+
+const unreleasedIdx = lines.findIndex(l => l.trim() === '## Unreleased');
+if (unreleasedIdx < 0) {
+  console.error('ERROR: docs/CHANGELOG.md has no "## Unreleased" heading.');
+  process.exit(1);
+}
+
+const nextVersionIdx = lines.findIndex((l, i) =>
+  i > unreleasedIdx && /^## \[[0-9]/.test(l));
+if (nextVersionIdx < 0) {
+  console.error('ERROR: docs/CHANGELOG.md has no existing versioned section to anchor against.');
+  process.exit(1);
+}
+
+// Extract everything between "## Unreleased" and the next "## [", trimmed.
+const between = lines.slice(unreleasedIdx + 1, nextVersionIdx);
+let start = 0;
+while (start < between.length && between[start].trim() === '') start++;
+let end = between.length;
+while (end > start && between[end - 1].trim() === '') end--;
+const moved = between.slice(start, end);
+
+if (moved.length === 0) {
+  console.error('ERROR: "## Unreleased" section is empty — nothing to release.');
+  console.error('       Add release notes there before running this script.');
+  process.exit(1);
+}
+
+const newLines = [
+  ...lines.slice(0, unreleasedIdx + 1),
+  '',
+  `## [${version}] – ${today}`,
+  '',
+  ...moved,
+  '',
+  ...lines.slice(nextVersionIdx),
+];
+
+fs.writeFileSync('docs/CHANGELOG.md', newLines.join('\n'));
+console.log(`✓ CHANGELOG.md: moved ${moved.length} lines from Unreleased to [${version}] – ${today}`);
+NODE
+
+# --- Verify everything agrees ----------------------------------------
+bash scripts/check-version-sync.sh
+
+cat <<MSG
+
+Release prep complete. Suggested next steps:
+
+  git checkout -b chore/release-$NEW_VERSION
+  git add package.json docs/CHANGELOG.md
+  git commit -m "chore(release): $NEW_VERSION"
+  git push -u origin chore/release-$NEW_VERSION
+  gh pr create --base master --head chore/release-$NEW_VERSION \\
+       --title "chore(release): $NEW_VERSION"
+
+After the PR merges to master:
+
+  git checkout master && git pull
+  git tag -a v$NEW_VERSION -m "Release $NEW_VERSION"
+  git push origin v$NEW_VERSION
+  gh release create v$NEW_VERSION --title "$NEW_VERSION" \\
+       --notes-file <(awk '/^## \\[$NEW_VERSION\\]/{f=1;next} f&&/^## \\[/{exit} f' docs/CHANGELOG.md)
+
+MSG


### PR DESCRIPTION
Three-part mitigation for the recurring "version bumped in some places but not others" issue. Plus a bonus: a real MCP smoke test.

## Why this PR

Every release lives in two files (`package.json` is the source of truth; `docs/CHANGELOG.md` records the user-facing notes). Plus a sprinkle of hardcoded refs across docs and templates. When even one is forgotten, downstream surfaces drift — the GH Pages docs site shows old release notes, the bug-report template asks users about an old version, etc. Recent example: `docs/CHANGELOG.md` shipped at 1.8.2 while `.github/ISSUE_TEMPLATE/bug.yml` still placeholdered `1.8.0`.

## What's in here

### 1. Remove hardcoded version refs
- `.github/ISSUE_TEMPLATE/bug.yml` placeholder `"1.8.0"` → `"e.g. 1.8.2"` — generic, doesn't go stale.
- (`CLAUDE.md` is .gitignored so its hardcoded "Current version: 1.8.0" line was updated locally; not part of this commit.)

### 2. `scripts/check-version-sync.sh`
Fails when `package.json.version` doesn't match the top `## [X.Y.Z]` heading in `docs/CHANGELOG.md`. Wired into `ci.yml` so every PR catches drift before merge.

```
✓ package.json (1.8.2) matches CHANGELOG.md top section
```

### 3. `scripts/release.sh <new-version>`
One-command release prep:
- Bumps `package.json`
- Migrates the `## Unreleased` block under a new `## [X.Y.Z] – YYYY-MM-DD` heading
- Runs the sync check
- Pre-flight aborts cleanly if Unreleased is empty or the version is already taken — **no file is mutated** until both checks pass

Prints the suggested branch / commit / PR / tag / release commands at the end. Still manual to invoke each step so the human (or AI) can review the diff.

### Bonus: `.mcp/smoke.mjs` promoted to `npm run smoke`
Spawns `dist/index.js` over stdio, sends `initialize` + `tools/list`, asserts the expected tools are present. Was used to verify the MCP server during the cherry-pick; now lives as a proper script for future regressions.

```
✓ initialize OK — server: prism v1.0.0
✓ tools/list OK — 33 tools
✓ all expected tools present
Smoke test PASSED
```

## Test plan

- [x] `bash scripts/check-version-sync.sh` passes on current master
- [x] `bash scripts/release.sh 9.9.9` (dry-run) aborts cleanly because Unreleased is empty; working tree unchanged
- [x] `cd .mcp && npm run smoke` passes
- [ ] CI: new "Version sync" step in typecheck-lint job runs and passes