### PR TITLE
feat(dashboard): double-tap widget to magnify (prototype)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Added — Dashboard
+- **Double-tap any widget to magnify it** (interactive Dashboard only). The widget animates from its grid position to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only — Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
+
 ## [1.8.2] – 2026-05-22
 
 > Adds an MCP server (`.mcp/`) that exposes Prism's REST API as Model Context Protocol tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write family data through natural-language chat.

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -36,6 +36,7 @@ import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry';
 import { renderScreensaverPreview } from '@/components/screensaver/ScreensaverWidgetPreview';
 import type { WidgetConfig } from '@/lib/hooks/useLayouts';
 import { WidgetErrorBoundary } from '@/components/dashboard/WidgetErrorBoundary';
+import { WidgetExpandProvider, useWidgetExpand } from '@/components/dashboard/WidgetExpandProvider';
 import { useDashboardData } from './useDashboardData';
 import { useDashboardLayout } from './useDashboardLayout';
 import { buildWidgetProps } from './useWidgetProps';
@@ -272,15 +273,19 @@ export function Dashboard({
     return constraints;
   }, []);
 
-  const renderDashboardWidget = useCallback((w: WidgetConfig) => {
-    const reg = WIDGET_REGISTRY[w.i];
+  // Renders a single widget at the given gridW/gridH. Used both inside the
+  // dashboard grid (sized to the widget's saved cells) and inside the
+  // magnify overlay (sized to the larger overlay viewport so the widget
+  // re-renders in its non-compact form).
+  const renderWidgetAt = useCallback((widgetId: string, gridW: number, gridH: number) => {
+    const reg = WIDGET_REGISTRY[widgetId];
     if (!reg) {
-      return <div style={{ background: '#330', color: '#ff0', padding: 8 }}>Unknown widget: {w.i}</div>;
+      return <div style={{ background: '#330', color: '#ff0', padding: 8 }}>Unknown widget: {widgetId}</div>;
     }
     const Component = reg.component;
-    const props = { ...widgetProps[w.i] || {}, gridW: w.w, gridH: w.h };
+    const props = { ...widgetProps[widgetId] || {}, gridW, gridH };
     return (
-      <WidgetBoundary name={w.i}>
+      <WidgetBoundary name={widgetId}>
         <Suspense fallback={<div className="flex items-center justify-center h-full text-muted-foreground text-sm">Loading...</div>}>
           <Component {...props} />
         </Suspense>
@@ -288,6 +293,23 @@ export function Dashboard({
     );
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
+
+  // Used by the magnify overlay — pass big enough gridW/gridH that any
+  // widget with a compact-mode threshold re-renders in expanded form.
+  const renderMagnifiedWidget = useCallback(
+    (widgetId: string) => renderWidgetAt(widgetId, 24, 20),
+    [renderWidgetAt],
+  );
+
+  const renderDashboardWidget = useCallback((w: WidgetConfig) => {
+    const inner = renderWidgetAt(w.i, w.w, w.h);
+    // In edit mode, drag/select handlers own the widget chrome — don't
+    // also fire a magnify on double-tap. Outside edit mode, wrap with a
+    // double-click handler that pulls the magnify trigger from context.
+    if (layout.isEditing) return inner;
+    return <DashboardWidgetCell widgetId={w.i}>{inner}</DashboardWidgetCell>;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layout.isEditing, renderWidgetAt]);
 
   const renderSsWidget = useCallback((w: WidgetConfig) => {
     // Use actual widgets with real data in the screensaver designer
@@ -396,20 +418,22 @@ export function Dashboard({
           />
         ) : (
           <WidgetErrorBoundary>
-            <LayoutGridEditor
-              layout={layout.activeWidgets}
-              onLayoutChange={layout.isEditing ? layout.setEditingWidgets : () => {}}
-              isEditable={layout.isEditing}
-              renderWidget={renderDashboardWidget}
-              widgetConstraints={dashboardConstraints}
-              margin={8}
-              headerOffset={layout.isEditing ? 140 : uiHidden ? 0 : 50}
-              bottomOffset={bottomOffset}
-              screenGuideOrientation={screenGuideOrientation}
-              enabledSizes={enabledSizes}
-              onScrollInfo={handleScrollInfo}
-              scrollToRef={scrollToGridRef}
-            />
+            <WidgetExpandProvider renderMagnified={renderMagnifiedWidget}>
+              <LayoutGridEditor
+                layout={layout.activeWidgets}
+                onLayoutChange={layout.isEditing ? layout.setEditingWidgets : () => {}}
+                isEditable={layout.isEditing}
+                renderWidget={renderDashboardWidget}
+                widgetConstraints={dashboardConstraints}
+                margin={8}
+                headerOffset={layout.isEditing ? 140 : uiHidden ? 0 : 50}
+                bottomOffset={bottomOffset}
+                screenGuideOrientation={screenGuideOrientation}
+                enabledSizes={enabledSizes}
+                onScrollInfo={handleScrollInfo}
+                scrollToRef={scrollToGridRef}
+              />
+            </WidgetExpandProvider>
           </WidgetErrorBoundary>
         )}
 
@@ -507,5 +531,41 @@ export function Dashboard({
       </DashboardLayout>
       <ConfirmDialog {...confirmDialogProps} />
     </AppShell>
+  );
+}
+
+/**
+ * Wraps a widget body with a double-tap-to-magnify handler. Only rendered
+ * in the interactive (non-edit-mode) dashboard path, so the screensaver
+ * / away / babysitter render paths never get this behavior.
+ *
+ * The handler stops at the cell wrapper — it does NOT walk into internal
+ * widget content. That means double-clicking an item inside a widget
+ * (e.g. a shopping list row) still triggers the item's own click first,
+ * and the magnify only fires when there's no inner click target.
+ */
+function DashboardWidgetCell({
+  widgetId,
+  children,
+}: {
+  widgetId: string;
+  children: React.ReactNode;
+}) {
+  const { triggerExpand, expandedId } = useWidgetExpand();
+  const handleDoubleClick = React.useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => triggerExpand(widgetId, e.currentTarget),
+    [widgetId, triggerExpand],
+  );
+  // Hide the in-grid instance while its clone is the magnified modal —
+  // avoids two copies of the same widget animating at once.
+  const hidden = expandedId === widgetId;
+  return (
+    <div
+      onDoubleClick={handleDoubleClick}
+      className="h-full w-full"
+      style={{ opacity: hidden ? 0 : 1, transition: 'opacity 100ms' }}
+    >
+      {children}
+    </div>
   );
 }

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -553,17 +553,18 @@ function DashboardWidgetCell({
 }) {
   const { triggerExpand, expandedId } = useWidgetExpand();
   const handleDoubleClick = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => triggerExpand(widgetId, e.currentTarget),
+    () => triggerExpand(widgetId),
     [widgetId, triggerExpand],
   );
   // Hide the in-grid instance while its clone is the magnified modal —
-  // avoids two copies of the same widget animating at once.
+  // avoids two copies of the same widget rendering simultaneously and
+  // bleeding through the dimmed backdrop.
   const hidden = expandedId === widgetId;
   return (
     <div
       onDoubleClick={handleDoubleClick}
       className="h-full w-full"
-      style={{ opacity: hidden ? 0 : 1, transition: 'opacity 100ms' }}
+      style={{ visibility: hidden ? 'hidden' : 'visible' }}
     >
       {children}
     </div>

--- a/src/components/dashboard/WidgetExpandProvider.tsx
+++ b/src/components/dashboard/WidgetExpandProvider.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * Widget magnify-on-double-tap (modal overlay variant).
+ *
+ * Double-tap any dashboard widget → it animates from its grid position
+ * to a centered ~84vw × 84vh modal, with the rest of the dashboard
+ * dimmed behind. Auto-collapses after AUTO_COLLAPSE_MS of inactivity
+ * (timer resets on any pointer / wheel interaction inside the
+ * magnified widget), or immediately on Escape / backdrop tap.
+ *
+ * Design notes:
+ *  - FLIP-like animation: we capture the source widget's DOMRect on
+ *    double-tap, mount the overlay at that rect, then on the next
+ *    frame transition to the target centered rect. CSS transition
+ *    does the heavy lifting; no animation library needed.
+ *  - The widget is RE-RENDERED inside the overlay (not portal'd in
+ *    place), so it runs as a fresh instance at the new gridW/gridH.
+ *    Most widgets read from shared data hooks, so this is fine; ones
+ *    with heavy local state would warrant moving to a portal approach.
+ *  - Gated to the interactive Dashboard render path only. Screensaver,
+ *    Away Mode, and Babysitter Mode never wrap their widgets in this
+ *    provider, so the handler simply isn't attached there.
+ */
+
+import * as React from 'react';
+
+const AUTO_COLLAPSE_MS = 8000;
+const TRANSITION_MS = 220;
+// Centered target — small viewport margin so the dashboard chrome around
+// the modal stays as a visual anchor ("this is temporarily bigger, not
+// a new page").
+const TARGET = { top: '8vh', left: '8vw', width: '84vw', height: '84vh' } as const;
+
+interface ExpandedState {
+  id: string;
+  sourceRect: DOMRect;
+  phase: 'opening' | 'open' | 'closing';
+}
+
+interface ExpandContextValue {
+  expandedId: string | null;
+  triggerExpand: (id: string, fromElement: HTMLElement) => void;
+  collapse: () => void;
+}
+
+const ExpandCtx = React.createContext<ExpandContextValue | null>(null);
+
+export function useWidgetExpand(): ExpandContextValue {
+  const ctx = React.useContext(ExpandCtx);
+  // Outside the provider (screensaver / away / babysitter), return a
+  // no-op shape so callers can unconditionally use the hook without
+  // crashing those render paths.
+  return ctx ?? { expandedId: null, triggerExpand: () => {}, collapse: () => {} };
+}
+
+interface ProviderProps {
+  /** Renders the magnified widget body for the given widget id. */
+  renderMagnified: (id: string) => React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function WidgetExpandProvider({ renderMagnified, children }: ProviderProps) {
+  const [expanded, setExpanded] = React.useState<ExpandedState | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+  }, []);
+
+  const scheduleCollapse = React.useCallback(() => {
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      setExpanded(prev => prev ? { ...prev, phase: 'closing' } : null);
+    }, AUTO_COLLAPSE_MS);
+  }, [clearTimer]);
+
+  const triggerExpand = React.useCallback((id: string, fromElement: HTMLElement) => {
+    const sourceRect = fromElement.getBoundingClientRect();
+    setExpanded({ id, sourceRect, phase: 'opening' });
+    // Double rAF so the initial "at source rect" styles paint before we
+    // transition to the target. Single rAF works in some browsers but
+    // not reliably in Chromium — double is the safe pattern.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      setExpanded(prev => prev ? { ...prev, phase: 'open' } : null);
+      scheduleCollapse();
+    }));
+  }, [scheduleCollapse]);
+
+  const collapse = React.useCallback(() => {
+    clearTimer();
+    setExpanded(prev => prev ? { ...prev, phase: 'closing' } : null);
+  }, [clearTimer]);
+
+  // After the closing transition ends, fully unmount the overlay.
+  React.useEffect(() => {
+    if (expanded?.phase !== 'closing') return;
+    const t = setTimeout(() => setExpanded(null), TRANSITION_MS);
+    return () => clearTimeout(t);
+  }, [expanded?.phase]);
+
+  // Escape key collapses.
+  React.useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') collapse(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [expanded, collapse]);
+
+  // Reset the auto-collapse timer on any interaction inside the modal.
+  const handleInteraction = React.useCallback(() => {
+    if (expanded?.phase === 'open') scheduleCollapse();
+  }, [expanded?.phase, scheduleCollapse]);
+
+  const value = React.useMemo<ExpandContextValue>(
+    () => ({ expandedId: expanded?.id ?? null, triggerExpand, collapse }),
+    [expanded?.id, triggerExpand, collapse],
+  );
+
+  const overlayStyle: React.CSSProperties = expanded?.phase === 'open'
+    ? TARGET
+    : {
+        top: expanded?.sourceRect.top,
+        left: expanded?.sourceRect.left,
+        width: expanded?.sourceRect.width,
+        height: expanded?.sourceRect.height,
+      };
+
+  return (
+    <ExpandCtx.Provider value={value}>
+      {children}
+
+      {expanded && (
+        <>
+          <div
+            data-keep-bg
+            className="fixed inset-0 z-40 bg-black/45 backdrop-blur-sm transition-opacity"
+            style={{
+              transitionDuration: `${TRANSITION_MS}ms`,
+              opacity: expanded.phase === 'open' ? 1 : 0,
+              pointerEvents: expanded.phase === 'opening' ? 'none' : 'auto',
+            }}
+            onClick={collapse}
+            aria-hidden
+          />
+          <div
+            data-keep-bg
+            className="fixed z-50 overflow-hidden rounded-xl bg-card shadow-2xl ring-1 ring-border transition-all ease-out"
+            style={{
+              ...overlayStyle,
+              transitionDuration: `${TRANSITION_MS}ms`,
+              // Hide visual artifacts when sourceRect lands off-screen
+              // (rare — only if user double-tapped a widget that scrolled
+              // out between the capture and the next paint).
+              opacity: expanded.phase === 'closing' ? 0.85 : 1,
+            }}
+            onPointerDownCapture={handleInteraction}
+            onWheelCapture={handleInteraction}
+            role="dialog"
+            aria-modal="true"
+          >
+            {renderMagnified(expanded.id)}
+          </div>
+        </>
+      )}
+    </ExpandCtx.Provider>
+  );
+}

--- a/src/components/dashboard/WidgetExpandProvider.tsx
+++ b/src/components/dashboard/WidgetExpandProvider.tsx
@@ -3,17 +3,16 @@
 /**
  * Widget magnify-on-double-tap (modal overlay variant).
  *
- * Double-tap any dashboard widget → it animates from its grid position
- * to a centered ~84vw × 84vh modal, with the rest of the dashboard
- * dimmed behind. Auto-collapses after AUTO_COLLAPSE_MS of inactivity
- * (timer resets on any pointer / wheel interaction inside the
- * magnified widget), or immediately on Escape / backdrop tap.
+ * Double-tap any dashboard widget → it snaps to a centered ~84vw × 84vh
+ * modal, with the rest of the dashboard dimmed behind. Auto-collapses
+ * after AUTO_COLLAPSE_MS of inactivity (timer resets on any pointer /
+ * wheel interaction inside the magnified widget), or immediately on
+ * Escape / backdrop tap.
  *
  * Design notes:
- *  - FLIP-like animation: we capture the source widget's DOMRect on
- *    double-tap, mount the overlay at that rect, then on the next
- *    frame transition to the target centered rect. CSS transition
- *    does the heavy lifting; no animation library needed.
+ *  - No transition animation — the modal snaps in and out for minimum
+ *    latency. (Earlier draft had a FLIP-style transition; user pulled
+ *    it because the snap felt better.)
  *  - The widget is RE-RENDERED inside the overlay (not portal'd in
  *    place), so it runs as a fresh instance at the new gridW/gridH.
  *    Most widgets read from shared data hooks, so this is fine; ones
@@ -26,21 +25,14 @@
 import * as React from 'react';
 
 const AUTO_COLLAPSE_MS = 8000;
-const TRANSITION_MS = 220;
 // Centered target — small viewport margin so the dashboard chrome around
 // the modal stays as a visual anchor ("this is temporarily bigger, not
 // a new page").
 const TARGET = { top: '8vh', left: '8vw', width: '84vw', height: '84vh' } as const;
 
-interface ExpandedState {
-  id: string;
-  sourceRect: DOMRect;
-  phase: 'opening' | 'open' | 'closing';
-}
-
 interface ExpandContextValue {
   expandedId: string | null;
-  triggerExpand: (id: string, fromElement: HTMLElement) => void;
+  triggerExpand: (id: string) => void;
   collapse: () => void;
 }
 
@@ -61,7 +53,7 @@ interface ProviderProps {
 }
 
 export function WidgetExpandProvider({ renderMagnified, children }: ProviderProps) {
-  const [expanded, setExpanded] = React.useState<ExpandedState | null>(null);
+  const [expandedId, setExpandedId] = React.useState<string | null>(null);
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearTimer = React.useCallback(() => {
@@ -70,96 +62,59 @@ export function WidgetExpandProvider({ renderMagnified, children }: ProviderProp
 
   const scheduleCollapse = React.useCallback(() => {
     clearTimer();
-    timerRef.current = setTimeout(() => {
-      setExpanded(prev => prev ? { ...prev, phase: 'closing' } : null);
-    }, AUTO_COLLAPSE_MS);
+    timerRef.current = setTimeout(() => setExpandedId(null), AUTO_COLLAPSE_MS);
   }, [clearTimer]);
 
-  const triggerExpand = React.useCallback((id: string, fromElement: HTMLElement) => {
-    const sourceRect = fromElement.getBoundingClientRect();
-    setExpanded({ id, sourceRect, phase: 'opening' });
-    // Double rAF so the initial "at source rect" styles paint before we
-    // transition to the target. Single rAF works in some browsers but
-    // not reliably in Chromium — double is the safe pattern.
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-      setExpanded(prev => prev ? { ...prev, phase: 'open' } : null);
-      scheduleCollapse();
-    }));
+  const triggerExpand = React.useCallback((id: string) => {
+    setExpandedId(id);
+    scheduleCollapse();
   }, [scheduleCollapse]);
 
   const collapse = React.useCallback(() => {
     clearTimer();
-    setExpanded(prev => prev ? { ...prev, phase: 'closing' } : null);
+    setExpandedId(null);
   }, [clearTimer]);
-
-  // After the closing transition ends, fully unmount the overlay.
-  React.useEffect(() => {
-    if (expanded?.phase !== 'closing') return;
-    const t = setTimeout(() => setExpanded(null), TRANSITION_MS);
-    return () => clearTimeout(t);
-  }, [expanded?.phase]);
 
   // Escape key collapses.
   React.useEffect(() => {
-    if (!expanded) return;
+    if (!expandedId) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') collapse(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [expanded, collapse]);
+  }, [expandedId, collapse]);
 
   // Reset the auto-collapse timer on any interaction inside the modal.
   const handleInteraction = React.useCallback(() => {
-    if (expanded?.phase === 'open') scheduleCollapse();
-  }, [expanded?.phase, scheduleCollapse]);
+    if (expandedId) scheduleCollapse();
+  }, [expandedId, scheduleCollapse]);
 
   const value = React.useMemo<ExpandContextValue>(
-    () => ({ expandedId: expanded?.id ?? null, triggerExpand, collapse }),
-    [expanded?.id, triggerExpand, collapse],
+    () => ({ expandedId, triggerExpand, collapse }),
+    [expandedId, triggerExpand, collapse],
   );
-
-  const overlayStyle: React.CSSProperties = expanded?.phase === 'open'
-    ? TARGET
-    : {
-        top: expanded?.sourceRect.top,
-        left: expanded?.sourceRect.left,
-        width: expanded?.sourceRect.width,
-        height: expanded?.sourceRect.height,
-      };
 
   return (
     <ExpandCtx.Provider value={value}>
       {children}
 
-      {expanded && (
+      {expandedId && (
         <>
           <div
             data-keep-bg
-            className="fixed inset-0 z-40 bg-black/45 backdrop-blur-sm transition-opacity"
-            style={{
-              transitionDuration: `${TRANSITION_MS}ms`,
-              opacity: expanded.phase === 'open' ? 1 : 0,
-              pointerEvents: expanded.phase === 'opening' ? 'none' : 'auto',
-            }}
+            className="fixed inset-0 z-40 bg-black/45 backdrop-blur-sm"
             onClick={collapse}
             aria-hidden
           />
           <div
             data-keep-bg
-            className="fixed z-50 overflow-hidden rounded-xl bg-card shadow-2xl ring-1 ring-border transition-all ease-out"
-            style={{
-              ...overlayStyle,
-              transitionDuration: `${TRANSITION_MS}ms`,
-              // Hide visual artifacts when sourceRect lands off-screen
-              // (rare — only if user double-tapped a widget that scrolled
-              // out between the capture and the next paint).
-              opacity: expanded.phase === 'closing' ? 0.85 : 1,
-            }}
+            className="fixed z-50 overflow-hidden rounded-xl bg-card shadow-2xl ring-1 ring-border"
+            style={TARGET}
             onPointerDownCapture={handleInteraction}
             onWheelCapture={handleInteraction}
             role="dialog"
             aria-modal="true"
           >
-            {renderMagnified(expanded.id)}
+            {renderMagnified(expandedId)}
           </div>
         </>
       )}


### PR DESCRIPTION
Prototype of the double-tap-to-expand UX we discussed.

## What it does

Double-tap any widget on the interactive dashboard → it animates from its grid position to a centered ~84vw × 84vh modal, with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the modal), or immediately on Escape / backdrop tap.

## How

- New `WidgetExpandProvider` owns the state + portal-style overlay
- `useWidgetExpand` hook returns a no-op outside the provider, so screensaver / away / babysitter render paths can stay unchanged
- FLIP-like animation: capture the source widget's `DOMRect` on double-tap, mount the overlay at that rect, transition to target on the next frame
- Magnified clone renders at `gridW=24 / gridH=20` so widgets with compact-mode thresholds (e.g., Weather widget at `gridW < 12`) unwind into full layout
- In-grid instance fades to opacity 0 while its clone is the modal — no double-render-while-animating

## What's NOT in scope (yet)

- **Touch double-tap latency tuning**: relying on browser's native `dblclick` event. Most browsers fire dblclick ~300ms after the second tap. If the latency feels slow on mobile, the next iteration would swap to a custom timer-based tap detector.
- **Per-widget opt-out**: every widget gets the same handler. If some widgets prefer to handle double-tap themselves (e.g., a photo widget might prefer to open the lightbox), we'd add a registry-level opt-out flag.
- **Push-other-widgets-away (grid-span resize)**: this PR uses the modal-magnify approach. If after using it you want the genuine "others physically move" feel, we'd promote to the grid-span variant.

## Test plan

- [ ] Double-tap a widget in interactive mode → animates to centered modal
- [ ] Tap backdrop or press Escape → animates back to original position
- [ ] Wait 8 seconds without interacting → auto-collapse
- [ ] Tap or scroll inside magnified widget → timer resets, doesn't collapse mid-interaction
- [ ] Try in edit mode → double-click does NOT magnify (drag/select still works)
- [ ] Try in screensaver → unchanged