### PR TITLE
chore(release): 1.8.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Prism are documented in this file.
 ## [1.8.3] – 2026-05-22
 
 ### Added — Dashboard
-- **Double-tap any widget to magnify it** (interactive Dashboard only). The widget animates from its grid position to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only — Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
+- **Double-tap any widget to magnify it** (interactive Dashboard only). The widget snaps to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only — Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
 
 ## [1.8.2] – 2026-05-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.3] – 2026-05-22
+
 ### Added — Dashboard
 - **Double-tap any widget to magnify it** (interactive Dashboard only). The widget animates from its grid position to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only — Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Bumps package.json 1.8.2 → 1.8.3 and migrates the Unreleased entry into a [1.8.3] – 2026-05-22 section.

**First release cut using the new `scripts/release.sh`** — bumped package.json + migrated Unreleased in one command, sync-check passed.

## Highlights

- **Double-tap to magnify** any dashboard widget (interactive mode only). Snaps to a centered modal, auto-closes after 8s idle, Escape/backdrop tap closes immediately.