### PR TITLE
feat(auth): toast on every blocked mutation, not just dashboard edits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Changed — Auth
+- **Sign-in toast fires for every blocked mutation**: When a signed-out viewer edits a field, ticks a chore, adds a shopping item, or otherwise attempts any `/api/*` mutation, the call returned 401 and the UI silently failed to update — no signal that auth was the cause. A global `window.fetch` interceptor in `AuthProvider` now catches mutation 401s and toasts "Sign in to make changes — Enter your PIN to save edits." Debounced 2.5s so a save burst fires one toast, not ten. Suppressed while the PIN modal is already open (so `requireAuth`'s own toast doesn't double up). Limited to `/api/*` paths and POST/PUT/PATCH/DELETE so third-party fetches and the initial session-check GET aren't affected. Mirrors the dashboard edit-button behavior we added in 1.8.1.
+
 ### Changed — Weather
-- **Sun + moon info moved to the header row**: Sunrise time (with the lucide `Sunrise` icon, amber) and sunset time (with `Sunset`, orange) now sit alongside Feels Like / Humidity / Wind in the upper-right of the weather widget, joined by a small moon phase glyph. The redundant label strip under the daylight arc — sunrise / "Xh Ym" duration / sunset — is gone; the arc renders as pure visual now. The "Xh Ym" duration line in particular wasn't carrying its weight, and seeing sunrise/sunset times at the top alongside the temperature is faster to read than scanning down past the forecast.
+- **Sun + moon info now in the header row**: Sunrise (lucide `Sunrise` icon, amber) and sunset (`Sunset`, orange) times sit alongside Feels Like / Humidity / Wind in the upper-right of the weather widget. A moon-phase glyph + phase name (e.g. "Waning Gibbous") sits on its own line above the sun row.
+- **Daylight arc still carries its anchor strip**: sunrise / "Xh Ym" duration / sunset under the curve. (Briefly removed in favor of header-only; restored because the strip anchors the arc's edges and the duration reads well as context for the visualization.)
 
 ## [1.8.3] – 2026-05-22
 

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -130,6 +130,58 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => window.removeEventListener('prism:auth-expired', handleAuthExpired);
   }, []);
 
+  // Global "sign-in required" toast for mutation 401s.
+  //
+  // When a signed-out user edits a field, ticks a chore, adds a shopping
+  // item, etc., the underlying /api/* mutation returns 401. Without an
+  // interceptor, the UI just silently fails to update — confusing, since
+  // there's no signal that auth is the cause. We wrap window.fetch once
+  // here so every mutation response gets checked and a single toast fires
+  // the same way the dashboard edit-button click does.
+  //
+  // Constraints:
+  // - Only /api/* paths (don't interfere with third-party fetches like
+  //   Google Maps tiles, OneDrive image proxies, etc.).
+  // - Only mutation methods (POST/PUT/PATCH/DELETE). GETs to /api/* can
+  //   legitimately return 401 during the initial session check.
+  // - Debounced: a save burst (e.g. 10 chore updates) fires one toast,
+  //   not ten.
+  // - Suppressed while the PIN modal is open — requireAuth() already
+  //   toasted and is prompting; double-toast would be noise.
+  const showModalRef = useRef(false);
+  showModalRef.current = showModal;
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const originalFetch = window.fetch;
+    let lastToastAt = 0;
+    const DEBOUNCE_MS = 2500;
+
+    window.fetch = async (input, init) => {
+      const response = await originalFetch(input, init);
+      if (!response.ok && response.status === 401) {
+        const method = (init?.method ?? 'GET').toUpperCase();
+        const url = typeof input === 'string'
+          ? input
+          : input instanceof URL ? input.toString()
+          : (input as Request).url;
+        const isMutation = method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
+        const isApi = url.includes('/api/');
+        const now = Date.now();
+        if (isMutation && isApi && !showModalRef.current && now - lastToastAt > DEBOUNCE_MS) {
+          lastToastAt = now;
+          toast({
+            title: 'Sign in to make changes',
+            description: 'Enter your PIN to save edits.',
+            duration: 3000,
+          });
+        }
+      }
+      return response;
+    };
+
+    return () => { window.fetch = originalFetch; };
+  }, []);
+
   /**
    * Require authentication before proceeding
    * Returns the authenticated user or null if cancelled


### PR DESCRIPTION
Closes the gap where signed-out users editing a field, ticking a chore, or adding a shopping item got no feedback — the underlying `/api/*` call returned 401, the UI silently failed to update, no signal that auth was the cause.

Now `AuthProvider` wraps `window.fetch` once on mount and fires a single 'Sign in to make changes' toast whenever a mutation returns 401, mirroring the dashboard-edit-button behavior we added in 1.8.1.

## Scope

- **Methods**: POST / PUT / PATCH / DELETE only. GET / HEAD / OPTIONS pass through (initial session-check GET legitimately returns 401).
- **URLs**: `/api/*` only. Third-party fetches (Google Maps tiles, OneDrive image proxies, etc.) unaffected.
- **Debounce**: 2.5s between toasts. A save burst (e.g. 10 chore updates) fires one toast, not ten.
- **Suppression**: silent while the PIN modal is already showing — `requireAuth()`'s own toast already did the work.