### PR TITLE
feat(caldav): two-way write + providerConfig split

### DIFF
--- a/drizzle/0011_calendar_provider_config.sql
+++ b/drizzle/0011_calendar_provider_config.sql
@@ -1,0 +1,64 @@
+-- 0011_calendar_provider_config.sql
+--
+-- Adds `provider_config` JSONB to `calendar_sources`. Historically the
+-- `sync_errors` column was being overloaded to hold both:
+--   (a) error state — { needsReauth, lastError, timestamp }
+--   (b) connection config — { serverUrl, username, supportsEvents,
+--       supportsTasks, taskListId, contactBirthdaysEnabled }
+-- That worked but was semantically muddy: an error-handler that
+-- overwrote the column would lose connection config; a sync writer
+-- that updated config would smother any in-flight error state.
+--
+-- The migration:
+--   1. Add the new column.
+--   2. Copy the config-shaped keys out of sync_errors into provider_config
+--      for every existing CalDAV row.
+--   3. Strip those keys back out of sync_errors so the column carries
+--      only error state going forward.
+--
+-- Backward compat: reads that check `sync_errors->>'serverUrl'` etc.
+-- still work after the migration runs because the migration is the same
+-- transaction that updates application code to read from provider_config.
+-- (See PR feat/caldav-followups.)
+
+ALTER TABLE calendar_sources
+  ADD COLUMN IF NOT EXISTS provider_config jsonb;
+
+-- Copy CalDAV config out of sync_errors → provider_config.
+UPDATE calendar_sources
+SET provider_config = jsonb_build_object(
+  'serverUrl',                sync_errors->'serverUrl',
+  'username',                 sync_errors->'username',
+  'authMethod',               sync_errors->'authMethod',
+  'supportsEvents',           sync_errors->'supportsEvents',
+  'supportsTasks',            sync_errors->'supportsTasks',
+  'taskListId',               sync_errors->'taskListId',
+  'contactBirthdaysEnabled',  sync_errors->'contactBirthdaysEnabled'
+) - 'serverUrl' || jsonb_strip_nulls(
+  jsonb_build_object(
+    'serverUrl',                sync_errors->'serverUrl',
+    'username',                 sync_errors->'username',
+    'authMethod',               sync_errors->'authMethod',
+    'supportsEvents',           sync_errors->'supportsEvents',
+    'supportsTasks',            sync_errors->'supportsTasks',
+    'taskListId',               sync_errors->'taskListId',
+    'contactBirthdaysEnabled',  sync_errors->'contactBirthdaysEnabled'
+  )
+)
+WHERE provider = 'caldav'
+  AND sync_errors IS NOT NULL;
+
+-- Remove the migrated keys from sync_errors so the column carries only
+-- error state. (PostgreSQL doesn't have a multi-key jsonb subtraction,
+-- so chain `-` operators.)
+UPDATE calendar_sources
+SET sync_errors = sync_errors
+  - 'serverUrl'
+  - 'username'
+  - 'authMethod'
+  - 'supportsEvents'
+  - 'supportsTasks'
+  - 'taskListId'
+  - 'contactBirthdaysEnabled'
+WHERE provider = 'caldav'
+  AND sync_errors IS NOT NULL;

--- a/drizzle/0011_calendar_provider_config.sql
+++ b/drizzle/0011_calendar_provider_config.sql
@@ -12,29 +12,23 @@
 -- The migration:
 --   1. Add the new column.
 --   2. Copy the config-shaped keys out of sync_errors into provider_config
---      for every existing CalDAV row.
+--      for every existing CalDAV row that hasn't already been migrated.
 --   3. Strip those keys back out of sync_errors so the column carries
 --      only error state going forward.
 --
--- Backward compat: reads that check `sync_errors->>'serverUrl'` etc.
--- still work after the migration runs because the migration is the same
--- transaction that updates application code to read from provider_config.
--- (See PR feat/caldav-followups.)
+-- Idempotency: both UPDATEs guard against re-running over already-migrated
+-- rows. The first version of this migration (shipped briefly before this
+-- amendment) lacked the guards and, when applied twice in a row, blanked
+-- out provider_config because the second run pulled from an already-empty
+-- sync_errors. Fixed by gating on `provider_config IS NULL` and on the
+-- presence of at least one of the config keys in sync_errors.
 
 ALTER TABLE calendar_sources
   ADD COLUMN IF NOT EXISTS provider_config jsonb;
 
 -- Copy CalDAV config out of sync_errors → provider_config.
 UPDATE calendar_sources
-SET provider_config = jsonb_build_object(
-  'serverUrl',                sync_errors->'serverUrl',
-  'username',                 sync_errors->'username',
-  'authMethod',               sync_errors->'authMethod',
-  'supportsEvents',           sync_errors->'supportsEvents',
-  'supportsTasks',            sync_errors->'supportsTasks',
-  'taskListId',               sync_errors->'taskListId',
-  'contactBirthdaysEnabled',  sync_errors->'contactBirthdaysEnabled'
-) - 'serverUrl' || jsonb_strip_nulls(
+SET provider_config = jsonb_strip_nulls(
   jsonb_build_object(
     'serverUrl',                sync_errors->'serverUrl',
     'username',                 sync_errors->'username',
@@ -46,11 +40,18 @@ SET provider_config = jsonb_build_object(
   )
 )
 WHERE provider = 'caldav'
-  AND sync_errors IS NOT NULL;
+  AND provider_config IS NULL
+  AND sync_errors IS NOT NULL
+  AND (
+    sync_errors ? 'serverUrl' OR sync_errors ? 'username' OR
+    sync_errors ? 'supportsEvents' OR sync_errors ? 'supportsTasks' OR
+    sync_errors ? 'taskListId' OR sync_errors ? 'contactBirthdaysEnabled'
+  );
 
 -- Remove the migrated keys from sync_errors so the column carries only
 -- error state. (PostgreSQL doesn't have a multi-key jsonb subtraction,
--- so chain `-` operators.)
+-- so chain `-` operators.) Idempotent: stripping keys that are already
+-- absent is a no-op.
 UPDATE calendar_sources
 SET sync_errors = sync_errors
   - 'serverUrl'
@@ -61,4 +62,10 @@ SET sync_errors = sync_errors
   - 'taskListId'
   - 'contactBirthdaysEnabled'
 WHERE provider = 'caldav'
-  AND sync_errors IS NOT NULL;
+  AND sync_errors IS NOT NULL
+  AND (
+    sync_errors ? 'serverUrl' OR sync_errors ? 'username' OR
+    sync_errors ? 'authMethod' OR sync_errors ? 'supportsEvents' OR
+    sync_errors ? 'supportsTasks' OR sync_errors ? 'taskListId' OR
+    sync_errors ? 'contactBirthdaysEnabled'
+  );

--- a/scripts/smoke-caldav-write.mjs
+++ b/scripts/smoke-caldav-write.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Smoke test for CalDAV two-way write against a live iCloud calendar.
+// Runs inside the prism-app container (uses DATABASE_URL + ENCRYPTION_KEY from env).
+//
+// Drives tsdav directly (no Prism API layer) so we test the unknown:
+// iCal serialization + iCloud's CalDAV write protocol. The API wrapper
+// is a thin auth+arg-marshal layer on top of the same tsdav calls.
+//
+// Usage:  docker exec prism-app node /app/scripts/smoke-caldav-write.mjs <sourceId>
+
+import postgres from 'postgres';
+import { createDAVClient } from 'tsdav';
+import ICAL from 'ical.js';
+import { createDecipheriv } from 'node:crypto';
+
+const SOURCE_ID = process.argv[2];
+if (!SOURCE_ID) {
+  console.error('Usage: node smoke-caldav-write.mjs <sourceId>');
+  process.exit(1);
+}
+
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const ALGORITHM = 'aes-256-gcm';
+
+function decrypt(encoded) {
+  const key = Buffer.from(process.env.ENCRYPTION_KEY || process.env.PIN_ENCRYPTION_KEY, 'hex');
+  const data = Buffer.from(encoded, 'base64');
+  const iv = data.subarray(0, IV_LENGTH);
+  const authTag = data.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return decipher.update(ciphertext) + decipher.final('utf8');
+}
+
+function buildVEventICalString({ uid, title, startTime, endTime, description, location }) {
+  const vcalendar = new ICAL.Component(['vcalendar', [], []]);
+  vcalendar.updatePropertyWithValue('prodid', '-//Prism//CalDAV smoke//EN');
+  vcalendar.updatePropertyWithValue('version', '2.0');
+
+  const vevent = new ICAL.Component('vevent');
+  vevent.updatePropertyWithValue('uid', uid);
+  vevent.updatePropertyWithValue('summary', title);
+  if (description) vevent.updatePropertyWithValue('description', description);
+  if (location) vevent.updatePropertyWithValue('location', location);
+
+  const dtstamp = ICAL.Time.now();
+  dtstamp.zone = ICAL.Timezone.utcTimezone;
+  vevent.updatePropertyWithValue('dtstamp', dtstamp);
+
+  vevent.updatePropertyWithValue('dtstart', ICAL.Time.fromJSDate(startTime, true));
+  vevent.updatePropertyWithValue('dtend', ICAL.Time.fromJSDate(endTime, true));
+
+  vcalendar.addSubcomponent(vevent);
+  return vcalendar.toString();
+}
+
+const sql = postgres(process.env.DATABASE_URL);
+
+try {
+  const [src] = await sql`SELECT display_name, source_calendar_id, access_token, provider_config
+                          FROM calendar_sources WHERE id = ${SOURCE_ID}`;
+  if (!src) { console.error('Source not found'); process.exit(1); }
+
+  // postgres.js returns column names as-is (snake_case from the SELECT)
+  console.log(`[smoke] DEBUG keys: ${Object.keys(src).join(', ')}`);
+  console.log(`[smoke] Target calendar: ${src.display_name}`);
+  console.log(`[smoke] Calendar URL:    ${src.source_calendar_id}`);
+  console.log(`[smoke] provider_config: ${JSON.stringify(src.provider_config)}`);
+
+  const password = decrypt(src.access_token);
+  const cfg = src.provider_config || {};
+  const serverUrl = cfg.serverUrl || cfg.server_url;
+  const username = cfg.username;
+  console.log(`[smoke] User:            ${username}`);
+
+  const client = await createDAVClient({
+    serverUrl, credentials: { username, password },
+    authMethod: 'Basic', defaultAccountType: 'caldav',
+  });
+
+  const calendars = await client.fetchCalendars();
+  const calendar = calendars.find(c => c.url === src.source_calendar_id);
+  if (!calendar) { console.error('Calendar not found on server'); process.exit(1); }
+
+  const uid = `prism-smoke-${Date.now()}@prism.local`;
+  // 11pm tomorrow, 30 min
+  const start = new Date();
+  start.setDate(start.getDate() + 1);
+  start.setHours(23, 0, 0, 0);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+
+  console.log('\n[smoke] STEP 1: CREATE');
+  const createRes = await client.createCalendarObject({
+    calendar,
+    iCalString: buildVEventICalString({
+      uid, title: 'Prism CalDAV smoke test', startTime: start, endTime: end,
+      description: 'Created by scripts/smoke-caldav-write.mjs — safe to ignore',
+    }),
+    filename: `${uid}.ics`,
+  });
+  console.log(`[smoke]   status: ${createRes.status} ${createRes.statusText}`);
+  if (!createRes.ok) { console.error('[smoke] CREATE FAILED'); process.exit(1); }
+  const createdHref = createRes.headers.get('Location') || new URL(`${uid}.ics`, src.source_calendar_id).toString();
+  console.log(`[smoke]   href:   ${createdHref}`);
+
+  console.log('\n[smoke] STEP 2: READ-BACK to verify create');
+  await new Promise(r => setTimeout(r, 3000)); // iCloud eventual-consistency
+  let objs = await client.fetchCalendarObjects({ calendar });
+  const found = objs.find(o => o.url.includes(uid) || (o.data || '').includes(uid));
+  if (!found) { console.error('[smoke] CREATE READ-BACK FAILED — event not in calendar'); process.exit(1); }
+  console.log(`[smoke]   confirmed: found at ${found.url}`);
+  console.log(`[smoke]   etag:      ${found.etag}`);
+
+  console.log('\n[smoke] STEP 3: UPDATE title');
+  const updateRes = await client.updateCalendarObject({
+    calendarObject: {
+      url: found.url,
+      etag: found.etag,
+      data: buildVEventICalString({
+        uid, title: 'Prism CalDAV smoke test (UPDATED)', startTime: start, endTime: end,
+      }),
+    },
+  });
+  console.log(`[smoke]   status: ${updateRes.status} ${updateRes.statusText}`);
+  if (!updateRes.ok) { console.error('[smoke] UPDATE FAILED'); process.exit(1); }
+
+  console.log('\n[smoke] STEP 4: READ-BACK to verify update');
+  await new Promise(r => setTimeout(r, 3000));
+  objs = await client.fetchCalendarObjects({ calendar });
+  const updated = objs.find(o => o.url.includes(uid) || (o.data || '').includes(uid));
+  const updatedTitle = updated?.data?.match(/SUMMARY:(.+)/)?.[1]?.trim();
+  console.log(`[smoke]   title now: ${updatedTitle}`);
+  if (!updatedTitle?.includes('UPDATED')) {
+    console.error('[smoke] UPDATE READ-BACK FAILED');
+    console.error('[smoke]   raw vcard preview:', (updated?.data || '').slice(0, 400));
+    process.exit(1);
+  }
+
+  console.log('\n[smoke] STEP 5: DELETE');
+  const deleteRes = await client.deleteCalendarObject({
+    calendarObject: { url: updated.url, etag: updated.etag, data: '' },
+  });
+  console.log(`[smoke]   status: ${deleteRes.status} ${deleteRes.statusText}`);
+  if (!deleteRes.ok) { console.error('[smoke] DELETE FAILED'); process.exit(1); }
+
+  console.log('\n[smoke] STEP 6: READ-BACK to verify delete');
+  objs = await client.fetchCalendarObjects({ calendar });
+  const stillThere = objs.find(o => o.url.includes(uid));
+  if (stillThere) { console.error('[smoke] DELETE READ-BACK FAILED — event still on server'); process.exit(1); }
+  console.log('[smoke]   confirmed: event removed');
+
+  console.log('\n[smoke] ✅ ALL STEPS PASSED');
+} finally {
+  await sql.end();
+}

--- a/scripts/test-migration-replay.sh
+++ b/scripts/test-migration-replay.sh
@@ -11,6 +11,15 @@
 #                                    entry missing) on a fresh-install DB,
 #                                    and verifying the next migrate run
 #                                    recovers cleanly.
+#   C) Data preservation on replay — inserting realistic provider-shaped data
+#                                    into tables a DML migration touches, then
+#                                    forcing the migration to re-run (via
+#                                    __prism_migrations DELETE), and verifying
+#                                    the data round-trip is byte-identical.
+#                                    Scenario B catches "errors on replay" but
+#                                    can miss "succeeds but corrupts" — that
+#                                    bit 0011 (provider_config columns wiped
+#                                    to all-nulls on second run). C catches it.
 #
 # A "legacy install with only extensions" path does NOT exist in production —
 # every install that ever ran the app already has the original schema in
@@ -135,6 +144,69 @@ log "And replay still a no-op..."
 run_migrate
 
 log "Scenario B: PASS"
+
+# ----------------------------------------------------------------------------
+# Scenario C: data preservation on migration replay
+# ----------------------------------------------------------------------------
+# Insert one row per touched table BEFORE forcing a replay, then snapshot
+# the row's contents, replay, and diff. A migration that ALTER-only does
+# DDL trivially passes; a migration that does DML (e.g. JSONB key shuffles
+# like 0011) must hold the data invariant.
+#
+# Each added DML migration should append a row + snapshot pair here.
+# ----------------------------------------------------------------------------
+reset_pg
+log "=== Scenario C: data preservation on migration replay ==="
+start_pg
+
+log "Bring DB up to date..."
+run_migrate
+
+log "Seed a realistic CalDAV calendar_source row (touched by 0011)..."
+# Uses provider_config + a non-config sync_errors entry (lastError) to
+# mirror the production shape post-migration. If 0011 re-runs and
+# accidentally pulls from an empty sync_errors, it'd overwrite
+# provider_config with nulls and the diff at the end would fail.
+psql_exec "
+INSERT INTO calendar_sources (
+  provider, source_calendar_id, dashboard_calendar_name, display_name,
+  color, access_token, enabled, show_in_event_modal,
+  sync_errors, provider_config
+) VALUES (
+  'caldav',
+  'https://caldav.example.com/calendars/test/',
+  'Test',
+  'Test',
+  '#3B82F6',
+  'fake-encrypted',
+  true,
+  false,
+  '{\"lastError\": \"prior issue\", \"lastErrorAt\": \"2026-01-01T00:00:00Z\"}'::jsonb,
+  '{\"username\": \"test@example.com\", \"serverUrl\": \"https://caldav.example.com\", \"authMethod\": \"basic\", \"supportsEvents\": true, \"supportsTasks\": false}'::jsonb
+);
+"
+
+log "Snapshot provider_config + sync_errors before replay..."
+BEFORE=$(docker exec "$CONTAINER_NAME" psql -U prism -d prism -t -A -c \
+  "SELECT provider_config::text || '|' || sync_errors::text FROM calendar_sources WHERE display_name = 'Test'")
+
+log "Force a replay of every migration (clear tracking, intact schema + data)..."
+psql_exec "DELETE FROM public.__prism_migrations;"
+
+run_migrate
+
+log "Snapshot after replay + diff..."
+AFTER=$(docker exec "$CONTAINER_NAME" psql -U prism -d prism -t -A -c \
+  "SELECT provider_config::text || '|' || sync_errors::text FROM calendar_sources WHERE display_name = 'Test'")
+
+if [ "$BEFORE" != "$AFTER" ]; then
+  echo "ERROR: replay corrupted calendar_sources data" >&2
+  echo "  BEFORE: $BEFORE" >&2
+  echo "  AFTER:  $AFTER" >&2
+  exit 1
+fi
+
+log "Scenario C: PASS"
 
 # ----------------------------------------------------------------------------
 echo

--- a/src/app/api/caldav/connect/route.ts
+++ b/src/app/api/caldav/connect/route.ts
@@ -61,6 +61,9 @@ export async function POST(request: NextRequest) {
       // CardDAV sync only needs one anchor row to read credentials from,
       // and multiplying it across N calendars would mean N independent
       // sync attempts on the same address book.
+      //
+      // providerConfig is the new home for connection-shape data; syncErrors
+      // is reserved for error state. See migration 0011.
       const caldavConfig: Record<string, unknown> = {
         serverUrl,
         username,
@@ -81,7 +84,7 @@ export async function POST(request: NextRequest) {
           displayName: displayName,
           color: color || '#6366f1',
           accessToken: encryptedPassword,
-          syncErrors: caldavConfig,
+          providerConfig: caldavConfig,
           enabled: true,
           showInEventModal: false, // Read-only
         })

--- a/src/app/api/caldav/events/[sourceId]/route.ts
+++ b/src/app/api/caldav/events/[sourceId]/route.ts
@@ -1,0 +1,142 @@
+/**
+ * Two-way write to a CalDAV calendar.
+ *
+ * Scoped narrow on purpose: this PR ships the writeback path for review,
+ * but does NOT yet wire it into the main /api/events flow. The main events
+ * route will mirror the change locally, then call this endpoint when the
+ * event lives on a CalDAV source whose `providerConfig.writable === true`.
+ * That wiring is the next PR.
+ *
+ *   POST  /api/caldav/events/[sourceId]                 — create
+ *   PATCH /api/caldav/events/[sourceId]?href=…&etag=…   — update
+ *   DELETE /api/caldav/events/[sourceId]?href=…&etag=…  — delete
+ *
+ * Body shape (POST + PATCH): { uid, title, description?, location?,
+ * startTime, endTime, allDay? }. Dates are ISO 8601 strings.
+ *
+ * Requires `canModifySettings` for now — once integrated into /api/events,
+ * permissions will be inherited from that route.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { db } from '@/lib/db/client';
+import { calendarSources } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import {
+  pushCalDAVEventCreate,
+  pushCalDAVEventUpdate,
+  pushCalDAVEventDelete,
+} from '@/lib/services/calendar-sync';
+import { logError } from '@/lib/utils/logError';
+
+interface RouteCtx { params: Promise<{ sourceId: string }> }
+
+async function assertWritable(sourceId: string): Promise<true | NextResponse> {
+  const source = await db.query.calendarSources.findFirst({
+    where: eq(calendarSources.id, sourceId),
+  });
+  if (!source) return NextResponse.json({ error: 'Source not found' }, { status: 404 });
+  if (source.provider !== 'caldav') {
+    return NextResponse.json({ error: 'Not a CalDAV source' }, { status: 400 });
+  }
+  const cfg = (source.providerConfig as Record<string, unknown> | null) ?? {};
+  if (cfg.writable !== true) {
+    return NextResponse.json(
+      { error: 'CalDAV source is not flagged writable. Set providerConfig.writable=true to enable two-way write.' },
+      { status: 403 },
+    );
+  }
+  return true;
+}
+
+interface BodyShape {
+  uid: string;
+  title: string;
+  description?: string | null;
+  location?: string | null;
+  startTime: string;
+  endTime: string;
+  allDay?: boolean;
+}
+
+function parseBody(body: BodyShape) {
+  return {
+    uid: body.uid,
+    title: body.title,
+    description: body.description,
+    location: body.location,
+    startTime: new Date(body.startTime),
+    endTime: new Date(body.endTime),
+    allDay: body.allDay,
+  };
+}
+
+export async function POST(req: NextRequest, ctx: RouteCtx) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  const { sourceId } = await ctx.params;
+  const writable = await assertWritable(sourceId);
+  if (writable !== true) return writable;
+
+  try {
+    const body = (await req.json()) as BodyShape;
+    const result = await pushCalDAVEventCreate(sourceId, parseBody(body));
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: 502 });
+    return NextResponse.json({ href: result.href }, { status: 201 });
+  } catch (err) {
+    logError('CalDAV event create failed', err);
+    return NextResponse.json({ error: 'Create failed' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, ctx: RouteCtx) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  const { sourceId } = await ctx.params;
+  const writable = await assertWritable(sourceId);
+  if (writable !== true) return writable;
+
+  const href = req.nextUrl.searchParams.get('href');
+  const etag = req.nextUrl.searchParams.get('etag') ?? undefined;
+  if (!href) return NextResponse.json({ error: 'href required' }, { status: 400 });
+
+  try {
+    const body = (await req.json()) as BodyShape;
+    const result = await pushCalDAVEventUpdate(sourceId, href, etag, parseBody(body));
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: 502 });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logError('CalDAV event update failed', err);
+    return NextResponse.json({ error: 'Update failed' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, ctx: RouteCtx) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  const { sourceId } = await ctx.params;
+  const writable = await assertWritable(sourceId);
+  if (writable !== true) return writable;
+
+  const href = req.nextUrl.searchParams.get('href');
+  const etag = req.nextUrl.searchParams.get('etag') ?? undefined;
+  if (!href) return NextResponse.json({ error: 'href required' }, { status: 400 });
+
+  try {
+    const result = await pushCalDAVEventDelete(sourceId, href, etag);
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: 502 });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logError('CalDAV event delete failed', err);
+    return NextResponse.json({ error: 'Delete failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/calendars/route.ts
+++ b/src/app/api/calendars/route.ts
@@ -41,6 +41,7 @@ export async function GET() {
         groupId: calendarSources.groupId,
         lastSynced: calendarSources.lastSynced,
         syncErrors: calendarSources.syncErrors,
+        providerConfig: calendarSources.providerConfig,
         createdAt: calendarSources.createdAt,
         // User info
         userId: calendarSources.userId,
@@ -70,6 +71,7 @@ export async function GET() {
       groupColor: source.groupColor,
       lastSynced: source.lastSynced?.toISOString() || null,
       syncErrors: source.syncErrors,
+      providerConfig: source.providerConfig,
       createdAt: source.createdAt.toISOString(),
       // For family calendars, return a virtual "Family" user
       user: source.isFamily

--- a/src/app/api/task-lists/route.ts
+++ b/src/app/api/task-lists/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
           // Derived: which external system populated this list, if any.
           // 'caldav' when either:
           //   (a) at least one task in the list has a caldav-prefixed externalId, OR
-          //   (b) a calendar_source's syncErrors JSON has taskListId pointing here.
+          //   (b) a calendar_source's providerConfig has taskListId pointing here.
           // Checking (b) catches CalDAV-backed lists whose only tasks were
           // Apple's placeholder VTODOs (now filtered out by sync) — those
           // lists are empty but still legitimately CalDAV-sourced.
@@ -40,7 +40,7 @@ export async function GET() {
               WHEN EXISTS (
                 SELECT 1 FROM ${calendarSources}
                 WHERE ${calendarSources.provider} = 'caldav'
-                  AND ${calendarSources.syncErrors}->>'taskListId' = ${taskLists.id}::text
+                  AND ${calendarSources.providerConfig}->>'taskListId' = ${taskLists.id}::text
               ) THEN 'caldav'
               ELSE NULL
             END

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -347,11 +347,11 @@ export function CalendarView() {
             {isMobile ? null : (
               <>
                 <Button variant="outline" size="sm" onClick={goToToday} className="h-9">Today</Button>
-                <div className="flex items-center">
-                  <Button variant="ghost" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-9 w-9">
+                <div className="flex items-center gap-1">
+                  <Button variant="outline" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-9 w-9">
                     <ChevronLeft className="h-5 w-5" />
                   </Button>
-                  <Button variant="ghost" size="icon" onClick={goToNext} aria-label="Next" className="h-9 w-9">
+                  <Button variant="outline" size="icon" onClick={goToNext} aria-label="Next" className="h-9 w-9">
                     <ChevronRight className="h-5 w-5" />
                   </Button>
                 </div>

--- a/src/app/calendar/ViewOptionsMenu.tsx
+++ b/src/app/calendar/ViewOptionsMenu.tsx
@@ -142,15 +142,19 @@ export function ViewOptionsMenu({
     <Popover>
       <PopoverTrigger asChild>
         <Button
-          variant={nonDefaultCount > 0 ? 'secondary' : 'ghost'}
+          variant="outline"
           size="sm"
           aria-label="View options"
           title="View options"
           className={cn('gap-1.5 h-9', triggerClassName)}
         >
-          <Settings2 className={cn('h-4 w-4', nonDefaultCount > 0 && 'text-primary')} />
+          <Settings2 className="h-4 w-4" />
           <span className="hidden sm:inline">View</span>
           {nonDefaultCount > 0 && (
+            // Count circle is the ONLY visual indicator that filters are
+            // active — the button's outer fill stays the same regardless,
+            // so it sits uniformly alongside the View popover + Today
+            // button in the toolbar.
             <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
               {nonDefaultCount}
             </span>

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -298,7 +298,7 @@ export function CalendarsSection() {
                 // Calendar settings card otherwise.
                 .filter((cal) => {
                   if (cal.provider !== 'caldav') return true;
-                  const cfg = cal.syncErrors as { supportsEvents?: boolean } | null;
+                  const cfg = cal.providerConfig as { supportsEvents?: boolean } | null;
                   return cfg?.supportsEvents !== false;
                 })
                 .map((cal) => (

--- a/src/components/widgets/CalendarWidgetControls.tsx
+++ b/src/components/widgets/CalendarWidgetControls.tsx
@@ -98,10 +98,10 @@ export function CalendarWidgetControls({
           >
             Today
           </Button>
-          <Button variant="ghost" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-8 w-8">
+          <Button variant="outline" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-8 w-8">
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button variant="ghost" size="icon" onClick={goToNext} aria-label="Next" className="h-8 w-8">
+          <Button variant="outline" size="icon" onClick={goToNext} aria-label="Next" className="h-8 w-8">
             <ChevronRight className="h-4 w-4" />
           </Button>
         </>

--- a/src/components/widgets/WidgetContainer.tsx
+++ b/src/components/widgets/WidgetContainer.tsx
@@ -262,6 +262,13 @@ export function WidgetContainer({
           const popoverBgHsl = textIsLight ? '0 0% 8% / 0.95' : '0 0% 100% / 0.95';
           const accentBgHsl = textIsLight ? '0 0% 100% / 0.12' : '0 0% 0% / 0.08';
           const bgHsl = textIsLight ? '0 0% 0% / 0.4' : '0 0% 100% / 0.7';
+          // Calendar grid uses --muted for the hour column + past-hour
+          // shading + day-overflow popover, and --secondary in a handful
+          // of toolbar states. Both stayed at default theme luminance
+          // before this addition, which made the hour column / past
+          // cells invisible against the chosen text color.
+          const mutedBgHsl = textIsLight ? '0 0% 100% / 0.08' : '0 0% 0% / 0.06';
+          const secondaryBgHsl = textIsLight ? '0 0% 100% / 0.15' : '0 0% 0% / 0.1';
           return {
             color: overrideTextColor,
             // Text tokens — track the user's chosen color
@@ -269,12 +276,15 @@ export function WidgetContainer({
             '--card-foreground': fullHslVal,
             '--popover-foreground': fullHslVal,
             '--muted-foreground': mutedHslVal,
+            '--secondary-foreground': fullHslVal,
             '--seasonal-accent': fullHslVal,
             // Inner BG tokens — flip to opposite luminance so cards /
             // buttons / popovers stay visible against the chosen text color
             '--card': cardBgHsl,
             '--popover': popoverBgHsl,
             '--accent': accentBgHsl,
+            '--muted': mutedBgHsl,
+            '--secondary': secondaryBgHsl,
             '--background': bgHsl,
             // Border tokens — track text color but at the configured opacity
             '--input': borderHslVal,

--- a/src/components/widgets/WidgetContainer.tsx
+++ b/src/components/widgets/WidgetContainer.tsx
@@ -249,14 +249,34 @@ export function WidgetContainer({
           // Grid lines / borders use the dedicated gridLineOpacity control
           const borderOpacity = overrideGridLineOpacity < 1 ? overrideGridLineOpacity : 1;
           const borderHslVal = borderOpacity < 1 ? `${hsl} / ${borderOpacity}` : hsl;
+          // When the user picks a custom text color, the inner background
+          // tokens (bg-card, bg-background, bg-accent, bg-popover) used to
+          // stay at the default theme luminance — so picking white text
+          // turned every calendar card and "Today" / "Schedule" / arrow
+          // button into white-on-white. Flip the inner BG tokens to the
+          // opposite luminance so contrast holds for any chosen text color.
+          // Light text → dark inner BGs (10–25% opacity for layering);
+          // dark text → light inner BGs.
+          const textIsLight = isLightColor(overrideTextColor);
+          const cardBgHsl = textIsLight ? '0 0% 0% / 0.55' : '0 0% 100% / 0.85';
+          const popoverBgHsl = textIsLight ? '0 0% 8% / 0.95' : '0 0% 100% / 0.95';
+          const accentBgHsl = textIsLight ? '0 0% 100% / 0.12' : '0 0% 0% / 0.08';
+          const bgHsl = textIsLight ? '0 0% 0% / 0.4' : '0 0% 100% / 0.7';
           return {
             color: overrideTextColor,
-            // Override Tailwind CSS custom properties — text stays fully opaque
+            // Text tokens — track the user's chosen color
             '--foreground': fullHslVal,
             '--card-foreground': fullHslVal,
+            '--popover-foreground': fullHslVal,
             '--muted-foreground': mutedHslVal,
             '--seasonal-accent': fullHslVal,
-            // Border/grid lines use the opacity control so they can be faded on busy backgrounds
+            // Inner BG tokens — flip to opposite luminance so cards /
+            // buttons / popovers stay visible against the chosen text color
+            '--card': cardBgHsl,
+            '--popover': popoverBgHsl,
+            '--accent': accentBgHsl,
+            '--background': bgHsl,
+            // Border tokens — track text color but at the configured opacity
             '--input': borderHslVal,
             '--border': borderHslVal,
           } as React.CSSProperties;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -107,7 +107,17 @@ export const calendarSources = pgTable('calendar_sources', {
   icalUrl: text('ical_url'),
 
   lastSynced: timestamp('last_synced'),
+  // syncErrors carries actual error state ({ needsReauth, lastError, timestamp })
+  // for Google + similar OAuth flows. Historically also stored CalDAV
+  // connection config (server URL, username, supportsEvents/Tasks,
+  // taskListId, contactBirthdaysEnabled) which was semantically muddy.
+  // Migrated to providerConfig in v1.8.4. See feat/caldav-followups.
   syncErrors: jsonb('sync_errors'),
+  // Stable per-provider configuration: serverUrl + username for CalDAV,
+  // supportsEvents/supportsTasks/taskListId/contactBirthdaysEnabled flags,
+  // anything else that's "what this source is" rather than "what went
+  // wrong recently". Read at sync time; never mutated by error handlers.
+  providerConfig: jsonb('provider_config'),
 
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/src/lib/hooks/useCalendarEvents.ts
+++ b/src/lib/hooks/useCalendarEvents.ts
@@ -221,6 +221,7 @@ export function useCalendarSources() {
       groupColor: string | null;
       lastSynced: string | null;
       syncErrors: { needsReauth?: boolean; lastError?: string; timestamp?: string } | null;
+      providerConfig: Record<string, unknown> | null;
       user: { id: string; name: string; color: string } | null;
     }>
   >([]);

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -394,3 +394,154 @@ function isAllDay(vevent: ICAL.Component): boolean {
 function formatICalDate(date: Date): string {
   return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
 }
+
+/**
+ * Two-way write: create / update / delete events back to the CalDAV
+ * server. Wraps tsdav's createCalendarObject / updateCalendarObject /
+ * deleteCalendarObject. iCal serialization uses ical.js so we share
+ * the same parser/serializer the read path already pulls in.
+ *
+ * NOTE on scope: only single (non-recurring) VEVENTs are supported here.
+ * Recurrence + exceptions are intentionally deferred — they need
+ * EXDATE / RRULE-edits / split-occurrence semantics that don't fit a
+ * naive iCal roundtrip and would need a proper RRULE-aware UI on the
+ * Prism side first (issue #59).
+ */
+
+export interface CalDAVEventWrite {
+  uid: string;
+  title: string;
+  description?: string | null;
+  location?: string | null;
+  startTime: Date;
+  endTime: Date;
+  allDay?: boolean;
+}
+
+/** Serialize a single VEVENT into a complete VCALENDAR string. */
+function buildVEventICalString(ev: CalDAVEventWrite): string {
+  const vcalendar = new ICAL.Component(['vcalendar', [], []]);
+  vcalendar.updatePropertyWithValue('prodid', '-//Prism//CalDAV write//EN');
+  vcalendar.updatePropertyWithValue('version', '2.0');
+
+  const vevent = new ICAL.Component('vevent');
+  vevent.updatePropertyWithValue('uid', ev.uid);
+  vevent.updatePropertyWithValue('summary', ev.title);
+  if (ev.description) vevent.updatePropertyWithValue('description', ev.description);
+  if (ev.location) vevent.updatePropertyWithValue('location', ev.location);
+
+  const dtstamp = ICAL.Time.now();
+  dtstamp.zone = ICAL.Timezone.utcTimezone;
+  vevent.updatePropertyWithValue('dtstamp', dtstamp);
+
+  const start = ICAL.Time.fromJSDate(ev.startTime, !ev.allDay);
+  const end = ICAL.Time.fromJSDate(ev.endTime, !ev.allDay);
+  if (ev.allDay) {
+    start.isDate = true;
+    end.isDate = true;
+  }
+  vevent.updatePropertyWithValue('dtstart', start);
+  vevent.updatePropertyWithValue('dtend', end);
+
+  vcalendar.addSubcomponent(vevent);
+  return vcalendar.toString();
+}
+
+/**
+ * Push a new VEVENT to the given CalDAV calendar. Returns the href the
+ * server assigned so callers can store it for later update / delete.
+ */
+export async function createCalDAVEvent(
+  serverUrl: string,
+  username: string,
+  password: string,
+  calendarHref: string,
+  ev: CalDAVEventWrite,
+): Promise<{ href: string }> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const calendars = await client.fetchCalendars();
+  const calendar = calendars.find((c: DAVCalendar) => c.url === calendarHref);
+  if (!calendar) throw new Error(`Calendar not found: ${calendarHref}`);
+
+  const iCalString = buildVEventICalString(ev);
+  const filename = `${ev.uid}.ics`;
+  const response = await client.createCalendarObject({ calendar, iCalString, filename });
+
+  if (!response.ok) {
+    throw new Error(`CalDAV create failed: ${response.status} ${response.statusText}`);
+  }
+
+  // tsdav returns the raw fetch Response; the Location header carries the
+  // server-assigned href. Fall back to the constructed href if absent.
+  const loc = response.headers.get('Location') || response.headers.get('location');
+  const href = loc || new URL(filename, calendarHref).toString();
+  return { href };
+}
+
+/**
+ * Replace the VEVENT body for an existing CalDAV calendar object. The
+ * server identifies the target by its href (path on the calendar).
+ */
+export async function updateCalDAVEvent(
+  serverUrl: string,
+  username: string,
+  password: string,
+  calendarObjectHref: string,
+  etag: string | undefined,
+  ev: CalDAVEventWrite,
+): Promise<void> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const iCalString = buildVEventICalString(ev);
+  const response = await client.updateCalendarObject({
+    calendarObject: {
+      url: calendarObjectHref,
+      etag: etag ?? '',
+      data: iCalString,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`CalDAV update failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+/**
+ * Delete a CalDAV calendar object by href. ETag is optional but lets the
+ * server reject the delete if the object changed since the caller read it.
+ */
+export async function deleteCalDAVEvent(
+  serverUrl: string,
+  username: string,
+  password: string,
+  calendarObjectHref: string,
+  etag?: string,
+): Promise<void> {
+  const client = await createDAVClient({
+    serverUrl,
+    credentials: { username, password },
+    authMethod: 'Basic',
+    defaultAccountType: 'caldav',
+  });
+
+  const response = await client.deleteCalendarObject({
+    calendarObject: {
+      url: calendarObjectHref,
+      etag: etag ?? '',
+      data: '',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`CalDAV delete failed: ${response.status} ${response.statusText}`);
+  }
+}

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1001,3 +1001,95 @@ export async function syncAllCalDAVCalendars(
 
   return { total, errors: allErrors };
 }
+
+/**
+ * Two-way write helpers — push event mutations from Prism back to the
+ * remote CalDAV calendar. Each function loads the source's credentials
+ * (provider_config + accessToken), decrypts the password, and delegates
+ * to the low-level write functions in @/lib/integrations/caldav.
+ *
+ * These functions do NOT touch the local `events` table — the calling
+ * route is responsible for mirroring the change locally so the user
+ * sees their edit immediately. This split keeps the local + remote
+ * writes from drifting on partial failures (e.g. CalDAV server times
+ * out after we already wrote locally).
+ */
+
+async function loadCalDAVAuth(sourceId: string): Promise<{
+  serverUrl: string;
+  username: string;
+  password: string;
+  sourceCalendarId: string;
+} | { error: string }> {
+  const source = await db.query.calendarSources.findFirst({
+    where: eq(calendarSources.id, sourceId),
+  });
+  if (!source || source.provider !== 'caldav') {
+    return { error: 'Not a CalDAV source' };
+  }
+  if (!source.accessToken) return { error: 'No credentials available' };
+  const config = source.providerConfig as CalDAVConnectionConfig | null;
+  if (!config?.serverUrl || !config?.username) {
+    return { error: 'Missing CalDAV connection config' };
+  }
+  let password: string;
+  try {
+    password = decrypt(source.accessToken);
+  } catch {
+    return { error: 'Failed to decrypt credentials' };
+  }
+  return {
+    serverUrl: config.serverUrl,
+    username: config.username,
+    password,
+    sourceCalendarId: source.sourceCalendarId,
+  };
+}
+
+export async function pushCalDAVEventCreate(
+  sourceId: string,
+  ev: { uid: string; title: string; description?: string | null; location?: string | null; startTime: Date; endTime: Date; allDay?: boolean },
+): Promise<{ ok: true; href: string } | { ok: false; error: string }> {
+  const auth = await loadCalDAVAuth(sourceId);
+  if ('error' in auth) return { ok: false, error: auth.error };
+  try {
+    const { createCalDAVEvent } = await import('@/lib/integrations/caldav');
+    const { href } = await createCalDAVEvent(auth.serverUrl, auth.username, auth.password, auth.sourceCalendarId, ev);
+    return { ok: true, href };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function pushCalDAVEventUpdate(
+  sourceId: string,
+  calendarObjectHref: string,
+  etag: string | undefined,
+  ev: { uid: string; title: string; description?: string | null; location?: string | null; startTime: Date; endTime: Date; allDay?: boolean },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const auth = await loadCalDAVAuth(sourceId);
+  if ('error' in auth) return { ok: false, error: auth.error };
+  try {
+    const { updateCalDAVEvent } = await import('@/lib/integrations/caldav');
+    await updateCalDAVEvent(auth.serverUrl, auth.username, auth.password, calendarObjectHref, etag, ev);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function pushCalDAVEventDelete(
+  sourceId: string,
+  calendarObjectHref: string,
+  etag?: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const auth = await loadCalDAVAuth(sourceId);
+  if ('error' in auth) return { ok: false, error: auth.error };
+  try {
+    const { deleteCalDAVEvent } = await import('@/lib/integrations/caldav');
+    await deleteCalDAVEvent(auth.serverUrl, auth.username, auth.password, calendarObjectHref, etag);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -730,7 +730,7 @@ export async function syncCalDAVCalendarSource(
     return { synced: 0, errors: ['Failed to decrypt credentials — may need to reconnect'] };
   }
 
-  const config = source.syncErrors as CalDAVConnectionConfig | null;
+  const config = source.providerConfig as CalDAVConnectionConfig | null;
   if (!config?.serverUrl || !config?.username) {
     return { synced: 0, errors: ['Missing CalDAV connection config'] };
   }
@@ -850,7 +850,7 @@ export async function syncCalDAVTasks(
     return { synced: 0, errors: ['Failed to decrypt credentials'] };
   }
 
-  const config = source.syncErrors as CalDAVConnectionConfig | null;
+  const config = source.providerConfig as CalDAVConnectionConfig | null;
   if (!config?.serverUrl || !config?.username) {
     return { synced: 0, errors: ['Missing CalDAV connection config'] };
   }
@@ -906,7 +906,7 @@ export async function syncCalDAVTasks(
       if (newList) {
         taskListId = newList.id;
         await db.update(calendarSources)
-          .set({ syncErrors: { ...config, taskListId: newList.id } })
+          .set({ providerConfig: { ...config, taskListId: newList.id } })
           .where(eq(calendarSources.id, source.id));
       }
     }

--- a/src/lib/services/carddav-birthday-sync.ts
+++ b/src/lib/services/carddav-birthday-sync.ts
@@ -1,10 +1,10 @@
 /**
  * Pull birthdays out of CardDAV contacts and upsert into the birthdays
  * table. Credentials are reused from any existing CalDAV calendar_source
- * row whose syncErrors carries `contactBirthdaysEnabled: true` — the user
- * opts in by checking a box in the CalDAV connect dialog. One row's creds
- * are enough; we don't multi-tenant this. (If the user ever wants per-iCloud-
- * account isolation, this is the place to fan out.)
+ * row whose providerConfig carries `contactBirthdaysEnabled: true` — the
+ * user opts in by checking a box in the CalDAV connect dialog. One row's
+ * creds are enough; we don't multi-tenant this. (If the user ever wants
+ * per-iCloud-account isolation, this is the place to fan out.)
  */
 
 import { db } from '@/lib/db/client';
@@ -25,13 +25,13 @@ export async function syncCardDAVBirthdays(): Promise<SyncResult> {
   const enabledSource = await db.query.calendarSources.findFirst({
     where: and(
       eq(calendarSources.provider, 'caldav'),
-      sql`(${calendarSources.syncErrors}->>'contactBirthdaysEnabled')::boolean = true`,
+      sql`(${calendarSources.providerConfig}->>'contactBirthdaysEnabled')::boolean = true`,
     ),
   });
 
   if (!enabledSource) return result;
 
-  const cfg = (enabledSource.syncErrors as Record<string, unknown> | null) ?? {};
+  const cfg = (enabledSource.providerConfig as Record<string, unknown> | null) ?? {};
   const serverUrl = String(cfg.serverUrl || '');
   const username = String(cfg.username || '');
   if (!serverUrl || !username || !enabledSource.accessToken) {


### PR DESCRIPTION
## Summary

Both items from PR #46's \"What's NOT in this PR\" list:

1. **providerConfig column** — splits CalDAV connection config out of the muddy \`sync_errors\` JSONB into its own column. Migration 0011 moves keys + strips them from sync_errors. Eight read sites updated.
2. **Two-way write scaffolding** — new \`/api/caldav/events/[sourceId]\` endpoint with POST/PATCH/DELETE; service wrappers in calendar-sync.ts; low-level iCal serialization + tsdav calls in caldav.ts. Gated behind \`providerConfig.writable === true\` — off by default, no-op for existing connections until operator opts in.

## Filed as draft for review tomorrow

Two-way write is scoped narrow on purpose:

- **Single (non-recurring) VEVENT only.** Recurrence + exceptions need EXDATE / RRULE-edit / split-occurrence semantics and a RRULE-aware UI on the Prism side. Tracked separately on issue #59.
- **NOT wired into \`/api/events\` yet.** That's the next PR — it'll mirror local writes and call this endpoint when the source is CalDAV-writable. Splitting the wiring out keeps this review focused on the writeback contract.
- **No UI toggle to flip writable=true.** The admin sets it manually via SQL / providerConfig until the next PR adds a Connected Accounts switch.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Migration 0011 idempotent (ADD COLUMN IF NOT EXISTS + jsonb_strip_nulls)
- [ ] Manual smoke against a real CalDAV server: create / update / delete one VEVENT, confirm it appears on the source side
- [ ] Verify existing CalDAV sources still work after migration runs (read-side unchanged, providerConfig populated from old sync_errors values)