### PR TITLE
feat(traffic): add 14-day window-uniques + first-time referrers

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -57,14 +57,27 @@ jobs:
               'clones': {},
               'referrers': [],
               'referrer_history': {},
+              'window_uniques': {},
               'updated_at': None,
           })
           history.setdefault('referrer_history', {})
+          history.setdefault('window_uniques', {})
 
           # Merge views — keyed by YYYY-MM-DD, newer run wins
-          for day in load_api('/tmp/views.json').get('views', []):
+          views_api = load_api('/tmp/views.json')
+          for day in views_api.get('views', []):
               date = day['timestamp'][:10]
               history['views'][date] = {'count': day['count'], 'uniques': day['uniques']}
+
+          # Capture today's TOP-LEVEL uniques — GitHub's 14-day rolling
+          # deduplicated visitor count. Distinct from the per-day uniques
+          # above (which double-count a returning visitor across days).
+          # Stored keyed by the day the snapshot was taken so the viewer
+          # can chart the rolling-window value over time and show
+          # day-to-day deltas as "new this period."
+          today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+          if 'uniques' in views_api:
+              history['window_uniques'][today] = views_api['uniques']
 
           # Merge clones
           for day in load_api('/tmp/clones.json').get('clones', []):
@@ -81,7 +94,6 @@ jobs:
           if not isinstance(referrers_now, list):
               referrers_now = []
           history['referrers'] = referrers_now
-          today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
           if referrers_now:  # don't overwrite a good snapshot with [] from a 4xx
               history['referrer_history'][today] = referrers_now
 

--- a/docs/traffic/index.html
+++ b/docs/traffic/index.html
@@ -48,6 +48,14 @@
     </table>
   </div>
 
+  <div class="chart-wrap" id="newReferrersWrap" style="display:none">
+    <div class="chart-title">First-Time Referrer Sources</div>
+    <table id="newReferrersTable">
+      <thead><tr><th>Source</th><th>First Seen</th><th>Views on First Day</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
   <script>
     async function main() {
       // history.json lives on the orphan `traffic-data` branch (see
@@ -76,7 +84,24 @@
       document.getElementById('totalClones').textContent  = totalClones.toLocaleString();
       document.getElementById('updated').textContent      = `Updated ${new Date(data.updated_at).toLocaleString()}`;
 
-      // Views chart
+      // Views chart — three datasets:
+      //   - Total Views (bar, blue): raw view count per day
+      //   - Unique Visitors (bar, green): GitHub's per-day unique count
+      //   - New This Period (line, amber): day-over-day increment in the
+      //     14-day rolling-window unique count. Positive = visitors GitHub
+      //     hadn't seen in the prior 14 days (effectively "new" relative to
+      //     the rolling window). Empty before window_uniques tracking
+      //     starts capturing data, then fills in over time.
+      const windowUniques = data.window_uniques || {};
+      const windowDates = Object.keys(windowUniques).sort();
+      const newThisPeriodSeries = viewDates.map(d => {
+        if (!(d in windowUniques)) return null;
+        const idx = windowDates.indexOf(d);
+        if (idx <= 0) return null;
+        const prev = windowUniques[windowDates[idx - 1]];
+        const cur  = windowUniques[d];
+        return Math.max(0, cur - prev);
+      });
       new Chart(document.getElementById('viewsChart'), {
         type: 'bar',
         data: {
@@ -95,6 +120,16 @@
               backgroundColor: '#2ea04388',
               borderColor: '#3fb950',
               borderWidth: 1,
+            },
+            {
+              type: 'line',
+              label: 'New This Period (14d window Δ)',
+              data: newThisPeriodSeries,
+              borderColor: '#d29922',
+              backgroundColor: '#d2992233',
+              tension: 0.3,
+              spanGaps: false,
+              pointRadius: 3,
             },
           ],
         },
@@ -117,6 +152,34 @@
       });
       if (!data.referrers?.length) {
         tbody.innerHTML = '<tr><td colspan="3" style="color:#8b949e">No referrer data yet</td></tr>';
+      }
+
+      // First-time referrers — walk referrer_history chronologically, track
+      // the set of ever-seen sources, and surface ones that newly appeared
+      // on each day. Useful for spotting fresh channels (HN, Reddit post,
+      // someone blogged about us, etc.) instead of just the rolling top-10.
+      const refHistory = data.referrer_history || {};
+      const refDates = Object.keys(refHistory).sort();
+      const seenSources = new Set();
+      const newSources = [];
+      for (const date of refDates) {
+        const todays = refHistory[date] || [];
+        for (const r of todays) {
+          if (!seenSources.has(r.referrer)) {
+            seenSources.add(r.referrer);
+            newSources.push({ referrer: r.referrer, firstSeen: date, count: r.count });
+          }
+        }
+      }
+      if (newSources.length > 0) {
+        document.getElementById('newReferrersWrap').style.display = '';
+        const ntbody = document.querySelector('#newReferrersTable tbody');
+        // Most recent first — that's the "what's new" reading order.
+        newSources.reverse().forEach(r => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${r.referrer}</td><td>${r.firstSeen}</td><td><span class="badge">${r.count}</span></td>`;
+          ntbody.appendChild(tr);
+        });
       }
     }
     main().catch(e => { document.getElementById('updated').textContent = 'Failed to load history.json'; console.error(e); });

--- a/docs/traffic/index.html
+++ b/docs/traffic/index.html
@@ -30,7 +30,11 @@
 
   <div class="stats">
     <div class="stat"><div class="stat-label">Total Views</div><div class="stat-value" id="totalViews">—</div></div>
-    <div class="stat"><div class="stat-label">Unique Visitors</div><div class="stat-value" id="totalUniques">—</div></div>
+    <div class="stat"><div class="stat-label">Visitor-Days</div><div class="stat-value" id="totalUniques">—</div></div>
+    <div class="stat" title="Estimate: sum of GitHub's 14-day rolling window uniques sampled at non-overlapping intervals. Approximates total unique visitors since tracking began. A visitor spanning two windows may double-count.">
+      <div class="stat-label">Est. Unique Visitors</div>
+      <div class="stat-value" id="cumUniqueEstimate">—</div>
+    </div>
     <div class="stat"><div class="stat-label">Days Tracked</div><div class="stat-value" id="daysTracked">—</div></div>
     <div class="stat"><div class="stat-label">Total Clones</div><div class="stat-value" id="totalClones">—</div></div>
   </div>
@@ -83,6 +87,38 @@
       document.getElementById('daysTracked').textContent  = viewDates.length;
       document.getElementById('totalClones').textContent  = totalClones.toLocaleString();
       document.getElementById('updated').textContent      = `Updated ${new Date(data.updated_at).toLocaleString()}`;
+
+      // Cumulative-unique estimate — the metric that actually uses our
+      // historical archive (the thing that differentiates us from
+      // GitHub's built-in Insights, which only shows last 14 days).
+      //
+      // Algorithm: walk window_uniques chronologically. Each entry is
+      // GitHub's 14-day rolling deduped count snapshotted on that day,
+      // so it represents uniques across that day's PRIOR 14 days. Pick
+      // anchor samples at non-overlapping 14-day intervals (anchor +14d,
+      // +28d, ...) and sum across the anchors. This approximates
+      // "unique visitors since tracking began." Imperfect — a visitor
+      // returning across a window boundary can double-count — but it's
+      // the only honest estimate we can compute without per-visitor IDs.
+      // Falls back to "—" until we have at least one window snapshot.
+      const windowUniques = data.window_uniques || {};
+      const windowDates = Object.keys(windowUniques).sort();
+      let cumEstimate = 0;
+      let lastAnchorIdx = -1;
+      for (let i = 0; i < windowDates.length; i++) {
+        if (lastAnchorIdx < 0) {
+          cumEstimate += windowUniques[windowDates[i]] || 0;
+          lastAnchorIdx = i;
+          continue;
+        }
+        const daysSinceAnchor = (new Date(windowDates[i]) - new Date(windowDates[lastAnchorIdx])) / 86400000;
+        if (daysSinceAnchor >= 14) {
+          cumEstimate += windowUniques[windowDates[i]] || 0;
+          lastAnchorIdx = i;
+        }
+      }
+      document.getElementById('cumUniqueEstimate').textContent =
+        windowDates.length > 0 ? `~${cumEstimate.toLocaleString()}` : '—';
 
       // Views chart — three datasets:
       //   - Total Views (bar, blue): raw view count per day

--- a/traffic/index.html
+++ b/traffic/index.html
@@ -48,6 +48,14 @@
     </table>
   </div>
 
+  <div class="chart-wrap" id="newReferrersWrap" style="display:none">
+    <div class="chart-title">First-Time Referrer Sources</div>
+    <table id="newReferrersTable">
+      <thead><tr><th>Source</th><th>First Seen</th><th>Views on First Day</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
   <script>
     async function main() {
       // history.json lives on the orphan `traffic-data` branch (see
@@ -76,7 +84,24 @@
       document.getElementById('totalClones').textContent  = totalClones.toLocaleString();
       document.getElementById('updated').textContent      = `Updated ${new Date(data.updated_at).toLocaleString()}`;
 
-      // Views chart
+      // Views chart — three datasets:
+      //   - Total Views (bar, blue): raw view count per day
+      //   - Unique Visitors (bar, green): GitHub's per-day unique count
+      //   - New This Period (line, amber): day-over-day increment in the
+      //     14-day rolling-window unique count. Positive = visitors GitHub
+      //     hadn't seen in the prior 14 days (effectively "new" relative to
+      //     the rolling window). Empty before window_uniques tracking
+      //     starts capturing data, then fills in over time.
+      const windowUniques = data.window_uniques || {};
+      const windowDates = Object.keys(windowUniques).sort();
+      const newThisPeriodSeries = viewDates.map(d => {
+        if (!(d in windowUniques)) return null;
+        const idx = windowDates.indexOf(d);
+        if (idx <= 0) return null;
+        const prev = windowUniques[windowDates[idx - 1]];
+        const cur  = windowUniques[d];
+        return Math.max(0, cur - prev);
+      });
       new Chart(document.getElementById('viewsChart'), {
         type: 'bar',
         data: {
@@ -95,6 +120,16 @@
               backgroundColor: '#2ea04388',
               borderColor: '#3fb950',
               borderWidth: 1,
+            },
+            {
+              type: 'line',
+              label: 'New This Period (14d window Δ)',
+              data: newThisPeriodSeries,
+              borderColor: '#d29922',
+              backgroundColor: '#d2992233',
+              tension: 0.3,
+              spanGaps: false,
+              pointRadius: 3,
             },
           ],
         },
@@ -117,6 +152,34 @@
       });
       if (!data.referrers?.length) {
         tbody.innerHTML = '<tr><td colspan="3" style="color:#8b949e">No referrer data yet</td></tr>';
+      }
+
+      // First-time referrers — walk referrer_history chronologically, track
+      // the set of ever-seen sources, and surface ones that newly appeared
+      // on each day. Useful for spotting fresh channels (HN, Reddit post,
+      // someone blogged about us, etc.) instead of just the rolling top-10.
+      const refHistory = data.referrer_history || {};
+      const refDates = Object.keys(refHistory).sort();
+      const seenSources = new Set();
+      const newSources = [];
+      for (const date of refDates) {
+        const todays = refHistory[date] || [];
+        for (const r of todays) {
+          if (!seenSources.has(r.referrer)) {
+            seenSources.add(r.referrer);
+            newSources.push({ referrer: r.referrer, firstSeen: date, count: r.count });
+          }
+        }
+      }
+      if (newSources.length > 0) {
+        document.getElementById('newReferrersWrap').style.display = '';
+        const ntbody = document.querySelector('#newReferrersTable tbody');
+        // Most recent first — that's the "what's new" reading order.
+        newSources.reverse().forEach(r => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${r.referrer}</td><td>${r.firstSeen}</td><td><span class="badge">${r.count}</span></td>`;
+          ntbody.appendChild(tr);
+        });
       }
     }
     main().catch(e => { document.getElementById('updated').textContent = 'Failed to load history.json'; console.error(e); });

--- a/traffic/index.html
+++ b/traffic/index.html
@@ -30,7 +30,11 @@
 
   <div class="stats">
     <div class="stat"><div class="stat-label">Total Views</div><div class="stat-value" id="totalViews">—</div></div>
-    <div class="stat"><div class="stat-label">Unique Visitors</div><div class="stat-value" id="totalUniques">—</div></div>
+    <div class="stat"><div class="stat-label">Visitor-Days</div><div class="stat-value" id="totalUniques">—</div></div>
+    <div class="stat" title="Estimate: sum of GitHub's 14-day rolling window uniques sampled at non-overlapping intervals. Approximates total unique visitors since tracking began. A visitor spanning two windows may double-count.">
+      <div class="stat-label">Est. Unique Visitors</div>
+      <div class="stat-value" id="cumUniqueEstimate">—</div>
+    </div>
     <div class="stat"><div class="stat-label">Days Tracked</div><div class="stat-value" id="daysTracked">—</div></div>
     <div class="stat"><div class="stat-label">Total Clones</div><div class="stat-value" id="totalClones">—</div></div>
   </div>
@@ -83,6 +87,38 @@
       document.getElementById('daysTracked').textContent  = viewDates.length;
       document.getElementById('totalClones').textContent  = totalClones.toLocaleString();
       document.getElementById('updated').textContent      = `Updated ${new Date(data.updated_at).toLocaleString()}`;
+
+      // Cumulative-unique estimate — the metric that actually uses our
+      // historical archive (the thing that differentiates us from
+      // GitHub's built-in Insights, which only shows last 14 days).
+      //
+      // Algorithm: walk window_uniques chronologically. Each entry is
+      // GitHub's 14-day rolling deduped count snapshotted on that day,
+      // so it represents uniques across that day's PRIOR 14 days. Pick
+      // anchor samples at non-overlapping 14-day intervals (anchor +14d,
+      // +28d, ...) and sum across the anchors. This approximates
+      // "unique visitors since tracking began." Imperfect — a visitor
+      // returning across a window boundary can double-count — but it's
+      // the only honest estimate we can compute without per-visitor IDs.
+      // Falls back to "—" until we have at least one window snapshot.
+      const windowUniques = data.window_uniques || {};
+      const windowDates = Object.keys(windowUniques).sort();
+      let cumEstimate = 0;
+      let lastAnchorIdx = -1;
+      for (let i = 0; i < windowDates.length; i++) {
+        if (lastAnchorIdx < 0) {
+          cumEstimate += windowUniques[windowDates[i]] || 0;
+          lastAnchorIdx = i;
+          continue;
+        }
+        const daysSinceAnchor = (new Date(windowDates[i]) - new Date(windowDates[lastAnchorIdx])) / 86400000;
+        if (daysSinceAnchor >= 14) {
+          cumEstimate += windowUniques[windowDates[i]] || 0;
+          lastAnchorIdx = i;
+        }
+      }
+      document.getElementById('cumUniqueEstimate').textContent =
+        windowDates.length > 0 ? `~${cumEstimate.toLocaleString()}` : '—';
 
       // Views chart — three datasets:
       //   - Total Views (bar, blue): raw view count per day


### PR DESCRIPTION
Adds a 3rd dataset on the daily chart (14-day rolling window uniques, day-over-day delta as 'new this period') and a 'First-Time Referrer Sources' table that surfaces fresh channels. See commit message for honest-limitations note.