### PR TITLE
fix(seo): guard OG meta override against None page on 404 template

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,17 +9,23 @@
 
 {% block extrahead %}
   {{ super() }}
+  {# `page` is None on the auto-generated 404 template — guard every
+     page-scoped access so --strict doesn't blow up rendering 404.html.
+     Fall back to config.* values for those tags. #}
   {% set og_image_url = config.site_url ~ "assets/og-image.png" %}
+  {% set og_title = (page and page.title) or config.site_name %}
+  {% set og_desc  = (page and page.meta and page.meta.description) or config.site_description %}
+  {% set og_url   = (page and page.canonical_url) or config.site_url %}
   <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ page.title|default(config.site_name) }}">
-  <meta property="og:description" content="{{ page.meta.description|default(config.site_description) }}">
-  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_desc }}">
+  <meta property="og:url" content="{{ og_url }}">
   <meta property="og:image" content="{{ og_image_url }}">
   <meta property="og:image:width" content="1440">
   <meta property="og:image:height" content="900">
   <meta property="og:site_name" content="{{ config.site_name }}">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ page.title|default(config.site_name) }}">
-  <meta name="twitter:description" content="{{ page.meta.description|default(config.site_description) }}">
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ og_desc }}">
   <meta name="twitter:image" content="{{ og_image_url }}">
 {% endblock %}


### PR DESCRIPTION
PR #83 broke the docs build. The override's `page.meta.description` access blows up when `page` is None (on Material's auto-404 template). --strict rejected the build → site stayed on previous deploy → /alternatives/ + /features-index/ never went live. Adds falsy guards + config fallbacks.