### PR TITLE
fix(docs): features-index linked to nonexistent CHORES.md

### DIFF
--- a/docs/features-index.md
+++ b/docs/features-index.md
@@ -14,7 +14,7 @@ A unified family calendar that reads from Google Calendar, Apple iCloud (CalDAV)
 
 Recurring chore tracking with per-child assignments, completion approval by a parent, and points earned per chore. Includes a redemption flow (kids spend points on goals). The whole "weekly allowance / responsibility" pattern, built-in.
 
-→ Full docs: [Chores](features/CHORES.md) · [Goals](features/GOALS.md)
+→ Full docs: [Goals & Chores](features/GOALS.md)
 
 ## Tasks
 


### PR DESCRIPTION
PR #83 added features-index.md with a broken link to features/CHORES.md (doesn't exist — Chores docs live inside GOALS.md). mkdocs --strict caught it. Re-link to GOALS.md.