### PR TITLE
chore(docs): hide alternatives + features-index from user-facing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Prism is a configurable family dashboard designed for large wall-mounted screens and handheld tablets. **Unlike Skylight, there's no $80/yr subscription. Unlike Dakboard, your data never leaves your house.** It connects to Google Calendar, Microsoft To Do, OneDrive, Apple iCloud (CalDAV), Kroger / Mariano's, and more, and surfaces the information your family actually needs in one place. Built for people who value privacy, hate subscriptions, and are comfortable with Docker.
 
-**Looking for a comparison?** See [Prism vs. Skylight, Dakboard, and MagicMirror²](https://sandydargoport.github.io/prism/alternatives/).
-
 **📖 Full documentation: <https://sandydargoport.github.io/prism/>**
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,6 @@ hide:
 **A free, open-source alternative to Skylight Calendar and Dakboard.** Touch-friendly shared display for your kitchen, hallway, or wall: calendar, chores, tasks, photos, weather, recipes, meal planning, shopping lists, and more — all under your roof, no subscription, no cloud.
 
 [Install Prism](getting-started/install.md){ .md-button .md-button--primary }
-[How does it compare?](alternatives.md){ .md-button }
 [View on GitHub](https://github.com/sandydargoport/prism){ .md-button }
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,9 +83,6 @@ extra:
 
 nav:
   - Home: index.md
-  - Compare:
-      - "vs. Skylight / Dakboard / MagicMirror²": alternatives.md
-      - "Features at a glance": features-index.md
   - Screenshots: screenshots.md
   - Get Started:
       - Install: getting-started/install.md
@@ -117,10 +114,17 @@ nav:
       - Changelog: CHANGELOG.md
   - Repo Traffic: traffic/index.html
 
-# Files present in docs/ but intentionally not in the rendered nav
-# (kept in-repo for engineering reference, not user docs).
+# Files present in docs/ but intentionally not in the rendered nav.
+# Two reasons something might be here:
+#   - Engineering reference (the *-review*, code-review-modalities, etc.)
+#   - SEO-only landing pages we want indexed by Google/LLM crawlers but
+#     not surfaced to users browsing the docs (alternatives, features-index).
+#     They stay in the build → sitemap.xml → are crawlable, but don't
+#     appear in the side nav.
 not_in_nav: |
   /arch-review-v4.md
   /calendar-cards-design.md
   /code-review-modalities.md
   /api-auth-levels.md
+  /alternatives.md
+  /features-index.md


### PR DESCRIPTION
Keeps the SEO value (pages still in sitemap.xml + crawlable) but pulls them out of nav, README, and homepage. User-facing surfaces are clean; search/LLM crawlers still index them.