### PR TITLE
revert(seo): walk back competitive framing in user-facing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Prism
 
-**Self-hosted family dashboard — a free, open-source alternative to Skylight Calendar and Dakboard.** Touch-friendly shared display for your kitchen, hallway, or wall: calendar, chores, tasks, photos, weather, recipes, meal planning, shopping lists, and more — all in one place, all under your roof, no subscription.
+**A subscription-free, self-hosted family dashboard that integrates with the tools you already use without becoming yet another system of record.**
 
 [![License](https://img.shields.io/badge/license-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Test Install](https://github.com/sandydargoport/prism/actions/workflows/test-install.yml/badge.svg)](https://github.com/sandydargoport/prism/actions/workflows/test-install.yml)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/sandydargoport/prism/pkgs/container/prism)
 ![Platforms](https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-green)
 
-Prism is a configurable family dashboard designed for large wall-mounted screens and handheld tablets. **Unlike Skylight, there's no $80/yr subscription. Unlike Dakboard, your data never leaves your house.** It connects to Google Calendar, Microsoft To Do, OneDrive, Apple iCloud (CalDAV), Kroger / Mariano's, and more, and surfaces the information your family actually needs in one place. Built for people who value privacy, hate subscriptions, and are comfortable with Docker.
+Prism is a configurable family dashboard designed for large wall-mounted screens and handheld tablets. It connects to Google Calendar, Microsoft To Do, OneDrive, Apple iCloud (CalDAV), Kroger / Mariano's, and more, and surfaces the information your family actually needs in one place. Built for people who value privacy, hate subscriptions, and are comfortable with Docker.
 
 **📖 Full documentation: <https://sandydargoport.github.io/prism/>**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,16 @@ hide:
   - toc
 ---
 
-# Prism — self-hosted family dashboard
+# Prism
 
-**A free, open-source alternative to Skylight Calendar and Dakboard.** Touch-friendly shared display for your kitchen, hallway, or wall: calendar, chores, tasks, photos, weather, recipes, meal planning, shopping lists, and more — all under your roof, no subscription, no cloud.
+**A subscription-free, self-hosted family dashboard that integrates with the tools you already use without becoming yet another system of record.**
 
 [Install Prism](getting-started/install.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/sandydargoport/prism){ .md-button }
 
 ---
 
-Prism is a configurable family dashboard for large wall-mounted screens, tablets, and phones. **Unlike Skylight, there's no $80/yr subscription. Unlike Dakboard, your data never leaves your house.** It connects to Google Calendar, Apple iCloud (CalDAV), Microsoft To Do, OneDrive, OpenWeatherMap, Kroger / Mariano's, and more, and surfaces the information your family actually needs in one place. Built for people who value privacy, hate subscriptions, and are comfortable with Docker.
+Prism is a configurable family dashboard for large wall-mounted screens, tablets, and phones. It connects to Google Calendar, Apple iCloud (CalDAV), Microsoft To Do, OneDrive, OpenWeatherMap, Kroger / Mariano's, and more, and surfaces the information your family actually needs in one place. Built for people who value privacy, hate subscriptions, and are comfortable with Docker.
 
 ![Dashboard in dark mode](demos/dashboard-dark.png){ width="900" }
 

--- a/docs/traffic/index.html
+++ b/docs/traffic/index.html
@@ -61,6 +61,10 @@
   </div>
 
   <script>
+    function setStatus(msg) {
+      const el = document.getElementById('updated');
+      if (el) el.textContent = msg;
+    }
     async function main() {
       // history.json lives on the orphan `traffic-data` branch (see
       // .github/workflows/traffic.yml — the daily workflow can't push
@@ -69,10 +73,17 @@
       const TRAFFIC_DATA_URL = 'https://raw.githubusercontent.com/sandydargoport/prism/traffic-data/traffic/history.json';
       let res;
       try {
+        setStatus('Fetching traffic data…');
         res = await fetch(TRAFFIC_DATA_URL, { cache: 'no-store' });
-        if (!res.ok) throw new Error('remote fetch failed');
-      } catch {
-        res = await fetch('history.json');
+        if (!res.ok) throw new Error(`remote fetch ${res.status}`);
+      } catch (e) {
+        try {
+          setStatus('Remote fetch failed, trying local copy…');
+          res = await fetch('history.json');
+          if (!res.ok) throw new Error(`local fetch ${res.status}`);
+        } catch (e2) {
+          throw new Error(`Could not load history.json: ${e2.message || e2}`);
+        }
       }
       const data = await res.json();
 
@@ -218,7 +229,10 @@
         });
       }
     }
-    main().catch(e => { document.getElementById('updated').textContent = 'Failed to load history.json'; console.error(e); });
+    main().catch(e => {
+      setStatus(`Failed to load: ${e.message || e}`);
+      console.error('[traffic page]', e);
+    });
   </script>
 </body>
 </html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Prism — self-hosted family dashboard
-site_description: Free, open-source alternative to Skylight Calendar and Dakboard. Self-hosted, no subscription, no cloud. Calendar, chores, tasks, photos, weather — one display, one household.
+site_name: Prism
+site_description: A subscription-free, self-hosted family dashboard.
 site_url: https://sandydargoport.github.io/prism/
 repo_url: https://github.com/sandydargoport/prism
 repo_name: sandydargoport/prism

--- a/traffic/index.html
+++ b/traffic/index.html
@@ -61,6 +61,10 @@
   </div>
 
   <script>
+    function setStatus(msg) {
+      const el = document.getElementById('updated');
+      if (el) el.textContent = msg;
+    }
     async function main() {
       // history.json lives on the orphan `traffic-data` branch (see
       // .github/workflows/traffic.yml — the daily workflow can't push
@@ -69,10 +73,17 @@
       const TRAFFIC_DATA_URL = 'https://raw.githubusercontent.com/sandydargoport/prism/traffic-data/traffic/history.json';
       let res;
       try {
+        setStatus('Fetching traffic data…');
         res = await fetch(TRAFFIC_DATA_URL, { cache: 'no-store' });
-        if (!res.ok) throw new Error('remote fetch failed');
-      } catch {
-        res = await fetch('history.json');
+        if (!res.ok) throw new Error(`remote fetch ${res.status}`);
+      } catch (e) {
+        try {
+          setStatus('Remote fetch failed, trying local copy…');
+          res = await fetch('history.json');
+          if (!res.ok) throw new Error(`local fetch ${res.status}`);
+        } catch (e2) {
+          throw new Error(`Could not load history.json: ${e2.message || e2}`);
+        }
       }
       const data = await res.json();
 
@@ -218,7 +229,10 @@
         });
       }
     }
-    main().catch(e => { document.getElementById('updated').textContent = 'Failed to load history.json'; console.error(e); });
+    main().catch(e => {
+      setStatus(`Failed to load: ${e.message || e}`);
+      console.error('[traffic page]', e);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
Reverts README + homepage + mkdocs site_name to original tone. Keeps the SEO machinery (alternatives + features-index pages hidden from nav, topics, sitemap, OG tags). Also hardens traffic/index.html JS with explicit status updates so it can't silently hang on 'Loading…' anymore.