### PR TITLE
fix(traffic): drop duplicate windowUniques const declarations

### DIFF
--- a/docs/traffic/index.html
+++ b/docs/traffic/index.html
@@ -139,8 +139,7 @@
       //     hadn't seen in the prior 14 days (effectively "new" relative to
       //     the rolling window). Empty before window_uniques tracking
       //     starts capturing data, then fills in over time.
-      const windowUniques = data.window_uniques || {};
-      const windowDates = Object.keys(windowUniques).sort();
+      // windowUniques + windowDates already declared above (cumulative-est calc).
       const newThisPeriodSeries = viewDates.map(d => {
         if (!(d in windowUniques)) return null;
         const idx = windowDates.indexOf(d);

--- a/traffic/index.html
+++ b/traffic/index.html
@@ -139,8 +139,7 @@
       //     hadn't seen in the prior 14 days (effectively "new" relative to
       //     the rolling window). Empty before window_uniques tracking
       //     starts capturing data, then fills in over time.
-      const windowUniques = data.window_uniques || {};
-      const windowDates = Object.keys(windowUniques).sort();
+      // windowUniques + windowDates already declared above (cumulative-est calc).
       const newThisPeriodSeries = viewDates.map(d => {
         if (!(d in windowUniques)) return null;
         const idx = windowDates.indexOf(d);


### PR DESCRIPTION
Real cause of yesterday's 'Loading…' hang: SyntaxError from declaring the same const twice in main(). Browser refuses to execute the whole script. Confirmed via user's F12 console output. Single-line fix + sync to root copy.