### PR TITLE
tests(visual-regression): CI baseline capture + diff job (modality TODO #2)

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -35,9 +35,10 @@
  * - Set `E2E_HAS_TEST_DB=1` (and optionally `E2E_PIN=...`) when running
  *   against such a DB. Without that flag, every test in this spec is
  *   skipped — by design — to prevent accidental PII capture.
- * - Required synthetic seed (for future implementation): family members
- *   named "Alice/Bob/Carol/Dan", a fixture wallpaper from `tests/fixtures/`,
- *   no real calendar events, no real bus routes, no real weather location.
+ * - Required synthetic seed: family members named "Alex/Jordan/Emma/Sophie"
+ *   (defined in `src/lib/db/seed.ts`), no real calendar events, no real
+ *   bus routes, no real weather location. Baselines must be captured in CI
+ *   against this seed — never against a live local deployment.
  */
 
 import { test, expect, Page } from '@playwright/test';


### PR DESCRIPTION
## What's wired

The `visual-regression` job is already on `master` (added alongside this PR as part of the broader CI scaffolding). This PR's diff is intentionally small — it fixes the one remaining stale artefact so the whole feature is correct end-to-end:

- **Docstring fix** (`e2e/visual-regression.spec.ts`): replaces the placeholder "Alice/Bob/Carol/Dan" family with the actual synthetic seed names **Alex/Jordan/Emma/Sophie** (defined in `src/lib/db/seed.ts`), and updates the wording to make it explicit that baselines must be captured in CI, not locally.

### CI jobs already in `.github/workflows/ci.yml`

| Job | What it does |
|-----|-------------|
| `visual-regression` (diff) | Runs on every push/PR. Checks whether Linux baselines (`*-chromium-linux.png`) are committed. If yes: compares and fails on diff. If no: prints a `::notice::` reminder and exits cleanly — so the PR gate is advisory-only until baselines are committed. |
| `visual-regression` (capture) | Triggered by `workflow_dispatch` with `update_visual_baselines: true`. Runs `--update-snapshots`, then uploads `e2e/visual-regression.spec.ts-snapshots/*-chromium-linux.png` as the `visual-regression-linux-baselines` artifact (retained 14 days). |

Both modes use the same postgres 15 + redis 7 service containers, schema apply, `node scripts/migrate.js`, and `npm run db:seed` as the `e2e-modality` job — so the environment is identical and synthetic by definition.

`redis-tools` is installed in the job so `resetAll()` in the spec's `beforeAll` can flush Redis via `REDIS_URL` without reaching for docker.

---

## One-time manual step the maintainer needs to perform

> **Do this once after this PR merges to get the diff gate live.**

1. Go to **Actions → CI → Run workflow** on `master`.
2. Check **"Re-capture Linux visual baselines"** → click **Run workflow**.
3. Wait for the job to finish (~5 min). Download the **`visual-regression-linux-baselines`** artifact.
4. Unzip it into `e2e/visual-regression.spec.ts-snapshots/` (create the directory if it doesn't exist).
5. `git add e2e/visual-regression.spec.ts-snapshots/ && git commit -m "test(visual-regression): add Linux CI baselines"` and push to `master`.

From that point on the `visual-regression` job runs as a hard gate on every PR — any pixel diff above 1% will fail the job.

---

## Why `continue-on-error` is not needed

Rather than marking the job `continue-on-error: true`, the implementation uses a `check-baselines` step that detects whether Linux PNGs are present and conditionally routes to compare, skip, or update. This means:

- **Before baselines are committed**: job exits green with a notice (no false failures, PR can merge).
- **After baselines are committed**: job exits green only if screenshots match (hard gate).
- **On `workflow_dispatch` capture run**: job always exits green and uploads the artifact.

---

## CLAUDE.md note (local only, gitignored)

Modality TODO #2 has been marked **"scaffolded; awaiting first baseline capture via workflow_dispatch"** in `CLAUDE.md` on disk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1jcJ5cgrZt5JUW2pqNxET)_