### PR TITLE
feat(photos): OneDrive folder auto-sync + cross-source dedup + priority (#57 Phase A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # Use the official Playwright container so Chromium is preinstalled.
+    # Previously the job downloaded Chromium from cdn.playwright.dev at
+    # job start, which began hanging indefinitely on GH-hosted runners
+    # around 2026-05-29 and killed the job at the timeout. Image must be
+    # kept in lockstep with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-jammy
+
     services:
       postgres:
         image: postgres:15-alpine
@@ -113,8 +121,6 @@ jobs:
           POSTGRES_USER: prism
           POSTGRES_PASSWORD: ci_test_password
           POSTGRES_DB: prism
-        ports:
-          - 5432:5432
         options: >-
           --health-cmd "pg_isready -U prism"
           --health-interval 10s
@@ -123,8 +129,6 @@ jobs:
 
       redis:
         image: redis:7-alpine
-        ports:
-          - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -132,8 +136,10 @@ jobs:
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql://prism:ci_test_password@localhost:5432/prism
-      REDIS_URL: redis://localhost:6379
+      # Inside container jobs services are reached by their alias on the
+      # docker network, not via localhost port forwards.
+      DATABASE_URL: postgresql://prism:ci_test_password@postgres:5432/prism
+      REDIS_URL: redis://redis:6379
       PORT: '3000'
       APP_URL: http://localhost:3000
       # Throwaway test-only values — the CI runner is ephemeral and never
@@ -156,13 +162,13 @@ jobs:
 
       - run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+      - name: Install psql (not bundled in Playwright image)
+        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client
 
       - name: Apply base schema
         env:
           PGPASSWORD: ci_test_password
-        run: psql -h localhost -U prism -d prism -v ON_ERROR_STOP=1 -f src/lib/db/init/02-schema.sql
+        run: psql -h postgres -U prism -d prism -v ON_ERROR_STOP=1 -f src/lib/db/init/02-schema.sql
 
       - name: Apply migrations
         run: node scripts/migrate.js
@@ -186,6 +192,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
+    # See e2e-modality for why we run inside the Playwright image.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-jammy
+
     services:
       postgres:
         image: postgres:15-alpine
@@ -193,8 +203,6 @@ jobs:
           POSTGRES_USER: prism
           POSTGRES_PASSWORD: ci_test_password
           POSTGRES_DB: prism
-        ports:
-          - 5432:5432
         options: >-
           --health-cmd "pg_isready -U prism"
           --health-interval 10s
@@ -203,8 +211,6 @@ jobs:
 
       redis:
         image: redis:7-alpine
-        ports:
-          - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -212,8 +218,8 @@ jobs:
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql://prism:ci_test_password@localhost:5432/prism
-      REDIS_URL: redis://localhost:6379
+      DATABASE_URL: postgresql://prism:ci_test_password@postgres:5432/prism
+      REDIS_URL: redis://redis:6379
       PORT: '3000'
       APP_URL: http://localhost:3000
       SESSION_SECRET: ci_test_session_secret_padding32
@@ -232,16 +238,13 @@ jobs:
 
       - run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
-
-      - name: Install redis-cli (reset.ts uses it when REDIS_URL is set)
-        run: sudo apt-get update && sudo apt-get install -y redis-tools
+      - name: Install psql + redis-cli (not bundled in Playwright image)
+        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client redis-tools
 
       - name: Apply base schema
         env:
           PGPASSWORD: ci_test_password
-        run: psql -h localhost -U prism -d prism -v ON_ERROR_STOP=1 -f src/lib/db/init/02-schema.sql
+        run: psql -h postgres -U prism -d prism -v ON_ERROR_STOP=1 -f src/lib/db/init/02-schema.sql
 
       - name: Apply migrations
         run: node scripts/migrate.js

--- a/docs/features/PHOTOS.md
+++ b/docs/features/PHOTOS.md
@@ -35,9 +35,33 @@ Connect Microsoft in *Settings → Connected Accounts → Microsoft*. Then in *S
 - **Orientation filter** — sync only landscape, portrait, or square photos (or all).
 - **Quality threshold** — minimum dimensions to sync (skips tiny thumbnails).
 
-The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved.
+The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved. **Auto-sync runs every 30 minutes** — drop a photo into the folder and it appears on the dashboard within the half hour, no manual trigger needed. (Hit the manual sync button in settings if you want it immediately.)
 
 You can have multiple OneDrive sources — useful if you want one folder for "family slideshow" and another for "wallpaper-only".
+
+#### Getting photos into the folder from your iPhone
+
+OneDrive backs up your whole camera roll to one big folder, but doesn't map iOS albums or favorites to a specific folder. So you populate the Prism folder one of three ways:
+
+1. **iOS Shortcut (recommended)** — a one-tap "Add to Prism" action on the Photos share sheet. Build it once:
+   - Open the **Shortcuts** app → **+** → name it "Add to Prism"
+   - Add action **Save File** (from the Documents category)
+   - Set the destination to your OneDrive Prism folder, turn **off** "Ask Where to Save"
+   - In the shortcut's settings (ⓘ), enable **Show in Share Sheet** and set "Accepted Types" to Images
+   - Now: in Photos, select any photos → Share → **Add to Prism**. They upload straight to the folder.
+2. **OneDrive app** — open OneDrive, select photos in your Camera Roll backup → **Copy to** → Prism folder.
+3. **From a computer** — drag files into the folder in the OneDrive web UI or synced desktop folder.
+
+> Prefer tagging on your phone with no Shortcut setup? The **iCloud Shared Album** source (coming in a follow-up) is built for exactly that — add a photo to a shared album from the iOS share sheet and it appears. See the roadmap.
+
+### Cross-source dedup + priority
+
+If you back up the same photos to **more than one** source (e.g. both OneDrive and iCloud), Prism shows each photo **once** rather than twice. When the same shot is found in multiple sources:
+
+- Photos are matched by **capture time + dimensions** (a cropped edit keeps the original timestamp but changes dimensions, so edits and originals both show — only true duplicates are collapsed).
+- The copy from your **preferred source wins**. Order your sources in *Settings → Photos* with the ▲▼ controls — top of the list = preferred. Reordering takes effect immediately; no re-sync needed.
+
+Example: rank OneDrive above iCloud, and any photo in both serves from OneDrive (e.g. your originals) while the iCloud copy (e.g. a web-optimized version) is suppressed from display.
 
 ---
 

--- a/drizzle/0012_photo_source_priority_dedup.sql
+++ b/drizzle/0012_photo_source_priority_dedup.sql
@@ -1,0 +1,25 @@
+-- 0012_photo_source_priority_dedup.sql
+--
+-- Cross-source photo dedup (issue #57). A user who backs up to BOTH
+-- OneDrive and iCloud will have the same photo pulled from two sources;
+-- we want to display it once, preferring whichever source they rank
+-- higher.
+--
+--   photo_sources.priority — lower = preferred. Read-time dedup keeps the
+--   lowest-priority-number copy when multiple sources carry the same shot.
+--
+--   photos.dedupe_key — `${takenAt-to-the-second}_${width}x${height}`.
+--   Identical key across sources ⇒ same photo. Null when EXIF capture
+--   time + dimensions are unavailable; those rows are never deduped.
+--
+-- Both adds are idempotent (IF NOT EXISTS), so a replay over an
+-- already-migrated DB is a no-op — see scripts/test-migration-replay.sh
+-- Scenario C.
+
+ALTER TABLE photo_sources
+  ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 100;
+
+ALTER TABLE photos
+  ADD COLUMN IF NOT EXISTS dedupe_key varchar(120);
+
+CREATE INDEX IF NOT EXISTS photos_dedupe_key_idx ON photos (dedupe_key);

--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -89,6 +89,7 @@ ALLOWLIST=(
   # Library docs the comments reference
   "date-fns.org"
   "rclone.org"
+  "playwright.dev"
   # Apple iCloud DAV endpoints (CalDAV calendars + CardDAV contacts)
   "caldav.icloud.com"
   "contacts.icloud.com"

--- a/src/app/api/photo-sources/[id]/route.ts
+++ b/src/app/api/photo-sources/[id]/route.ts
@@ -23,6 +23,11 @@ export async function PATCH(
     if (typeof body.name === 'string') updates.name = body.name;
     if (typeof body.enabled === 'boolean') updates.enabled = body.enabled;
     if (typeof body.onedriveFolderId === 'string') updates.onedriveFolderId = body.onedriveFolderId;
+    // Cross-source dedup priority (lower = preferred). Changing it takes
+    // effect immediately because dedup resolves at read time (#57).
+    if (typeof body.priority === 'number' && Number.isFinite(body.priority)) {
+      updates.priority = Math.trunc(body.priority);
+    }
 
     const [updated] = await db
       .update(photoSources)

--- a/src/app/api/photo-sources/route.ts
+++ b/src/app/api/photo-sources/route.ts
@@ -26,6 +26,7 @@ export async function GET() {
         id: photoSources.id,
         type: photoSources.type,
         name: photoSources.name,
+        priority: photoSources.priority,
         onedriveFolderId: photoSources.onedriveFolderId,
         enabled: photoSources.enabled,
         lastSynced: photoSources.lastSynced,
@@ -34,7 +35,10 @@ export async function GET() {
         photoCount: sql<number>`(SELECT count(*)::int FROM photos WHERE photos.source_id = photo_sources.id)`,
       })
       .from(photoSources)
-      .orderBy(photoSources.createdAt);
+      // Order by dedup priority (lower = preferred) so the settings list
+      // reads top-to-bottom as the preference order, then createdAt as a
+      // stable tiebreak.
+      .orderBy(photoSources.priority, photoSources.createdAt);
 
     return NextResponse.json({ sources });
   } catch (error) {

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -50,6 +50,30 @@ export async function GET(request: NextRequest) {
         conditions.push(like(photos.usage, `%${tag}%`));
       }
 
+      // Cross-source dedup (#57). A photo is suppressed if another photo
+      // with the same dedupe_key is carried by a source that "beats" it:
+      //   - strictly lower priority number (preferred source), OR
+      //   - equal priority + lower id (stable tiebreak so exactly one wins).
+      // Null-key photos (missing EXIF time/dims) are never suppressed.
+      // Scoping to a single sourceId (gallery "view this source") skips
+      // dedup so the user can still see every photo within one source.
+      if (!sourceId) {
+        conditions.push(sql`(
+          ${photos.dedupeKey} IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM ${photos} p2
+            JOIN ${photoSources} ps2 ON ps2.id = p2.source_id
+            JOIN ${photoSources} ps_self ON ps_self.id = ${photos.sourceId}
+            WHERE p2.dedupe_key = ${photos.dedupeKey}
+              AND p2.id <> ${photos.id}
+              AND (
+                ps2.priority < ps_self.priority
+                OR (ps2.priority = ps_self.priority AND p2.id < ${photos.id})
+              )
+          )
+        )`);
+      }
+
       const orderBy = sort === 'random' ? sql`RANDOM()` : desc(photos.takenAt);
 
       const query = db.select().from(photos).orderBy(orderBy).limit(limit).offset(offset);

--- a/src/app/settings/sections/PhotosSettingsSection.tsx
+++ b/src/app/settings/sections/PhotosSettingsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Plus, RefreshCw, Trash2, Cloud, HardDrive, Pin, X, FolderOpen, MapPin, ChevronRight, Image as ImageIcon } from 'lucide-react';
+import { Plus, RefreshCw, Trash2, Cloud, HardDrive, Pin, X, FolderOpen, MapPin, ChevronRight, ChevronUp, ChevronDown, Image as ImageIcon } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { cn } from '@/lib/utils';
@@ -15,8 +15,9 @@ import { toast } from '@/components/ui/use-toast';
 
 interface PhotoSource {
   id: string;
-  type: 'local' | 'onedrive' | 'immich';
+  type: 'local' | 'onedrive' | 'immich' | 'icloud_shared';
   name: string;
+  priority: number;
   onedriveFolderId: string | null;
   enabled: boolean;
   lastSynced: string | null;
@@ -219,6 +220,48 @@ export function PhotosSettingsSection() {
     }
   };
 
+  // Move a source up/down the dedup priority order. When the same photo
+  // exists in multiple sources, the one nearer the top of this list wins.
+  // We swap the two sources' priority values and persist both, then refetch.
+  const handleReorder = async (sourceId: string, direction: 'up' | 'down') => {
+    const idx = sources.findIndex((s) => s.id === sourceId);
+    if (idx < 0) return;
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= sources.length) return;
+
+    const a = sources[idx];
+    const b = sources[swapIdx];
+    if (!a || !b) return;
+    // If priorities are equal (e.g. legacy rows all at default 100),
+    // synthesize a gap so the swap is meaningful.
+    const aPrio = a.priority;
+    const bPrio = b.priority === aPrio ? aPrio + (direction === 'up' ? -1 : 1) : b.priority;
+
+    // Optimistic local reorder for snappy UI; refetch reconciles.
+    setSources((prev) => {
+      const next = [...prev];
+      [next[idx], next[swapIdx]] = [next[swapIdx]!, next[idx]!];
+      return next;
+    });
+
+    try {
+      await Promise.all([
+        fetch(`/api/photo-sources/${a.id}`, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ priority: bPrio }),
+        }),
+        fetch(`/api/photo-sources/${b.id}`, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ priority: aPrio }),
+        }),
+      ]);
+      await fetchSources();
+    } catch (err) {
+      console.error('Reorder error:', err);
+      await fetchSources();
+    }
+  };
+
   const { filters, setFilters } = useDisplayContextFilters();
   const { resolution, setResolution, screenSize } = useTargetResolution();
 
@@ -363,6 +406,33 @@ export function PhotosSettingsSection() {
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0 ml-2">
+                      {/* Dedup priority reorder — only meaningful with 2+
+                          sources. Top of the list = preferred when the same
+                          photo appears in multiple sources. */}
+                      {sources.length > 1 && (
+                        <div className="flex flex-col mr-1">
+                          <button
+                            type="button"
+                            aria-label="Higher priority"
+                            title="Prefer this source for duplicate photos"
+                            disabled={sources[0]?.id === source.id}
+                            onClick={() => handleReorder(source.id, 'up')}
+                            className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-default leading-none"
+                          >
+                            <ChevronUp className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            aria-label="Lower priority"
+                            title="Prefer other sources for duplicate photos"
+                            disabled={sources[sources.length - 1]?.id === source.id}
+                            onClick={() => handleReorder(source.id, 'down')}
+                            className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-default leading-none"
+                          >
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      )}
                       {source.type === 'immich' && (
                         <Button
                           variant="ghost"

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -16,5 +16,8 @@ export async function register() {
     // redis client, node:crypto).
     const { startCalendarSyncCron } = await import('./lib/server/calendarSyncCron');
     startCalendarSyncCron();
+
+    const { startPhotoSyncCron } = await import('./lib/server/photoSyncCron');
+    startPhotoSyncCron();
   }
 }

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -466,6 +466,7 @@ CREATE TABLE IF NOT EXISTS public.photo_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     type character varying(20) NOT NULL,
     name character varying(255) NOT NULL,
+    priority integer DEFAULT 100 NOT NULL,
     onedrive_folder_id character varying(255),
     access_token text,
     refresh_token text,
@@ -504,7 +505,8 @@ CREATE TABLE IF NOT EXISTS public.photos (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     latitude numeric(9,6),
     longitude numeric(10,6),
-    is_external boolean DEFAULT false NOT NULL
+    is_external boolean DEFAULT false NOT NULL,
+    dedupe_key character varying(120)
 );
 
 
@@ -1533,6 +1535,13 @@ CREATE INDEX IF NOT EXISTS meals_week_of_idx ON public.meals USING btree (week_o
 --
 
 CREATE INDEX IF NOT EXISTS photos_favorite_idx ON public.photos USING btree (favorite);
+
+
+--
+-- Name: photos_dedupe_key_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS photos_dedupe_key_idx ON public.photos USING btree (dedupe_key);
 
 
 --

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1069,9 +1069,16 @@ export const photoSources = pgTable('photo_sources', {
   id: uuid('id').defaultRandom().primaryKey(),
 
   type: varchar('type', { length: 20 }).notNull()
-    .$type<'local' | 'onedrive' | 'immich'>(),
+    .$type<'local' | 'onedrive' | 'immich' | 'icloud_shared'>(),
 
   name: varchar('name', { length: 255 }).notNull(),
+
+  // Cross-source dedup priority. Lower = preferred. When the same photo
+  // (same dedupeKey) is pulled from multiple sources, the copy from the
+  // lowest-priority-number source is the one displayed; the others are
+  // suppressed at read time. Lets a user who backs up to BOTH OneDrive and
+  // iCloud pick which service's copy wins without re-syncing.
+  priority: integer('priority').default(100).notNull(),
 
   onedriveFolderId: varchar('onedrive_folder_id', { length: 255 }),
 
@@ -1136,12 +1143,21 @@ export const photos = pgTable('photos', {
   // record GPS metadata without downloading every photo.
   isExternal: boolean('is_external').default(false).notNull(),
 
+  // Cross-source dedup key: `${takenAt-to-the-second}_${width}x${height}`.
+  // Two photos with an identical key are treated as the same shot pulled
+  // from different sources (e.g. the same picture backed up to both
+  // OneDrive and iCloud). Null when the photo lacks EXIF capture time +
+  // dimensions — those are never deduped. Computed at sync time. Read-time
+  // dedup groups by this key and keeps the lowest source.priority copy.
+  dedupeKey: varchar('dedupe_key', { length: 120 }),
+
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
   sourceIdIdx: index('photos_source_id_idx').on(table.sourceId),
   takenAtIdx: index('photos_taken_at_idx').on(table.takenAt),
   favoriteIdx: index('photos_favorite_idx').on(table.favorite),
   usageIdx: index('photos_usage_idx').on(table.usage),
+  dedupeKeyIdx: index('photos_dedupe_key_idx').on(table.dedupeKey),
 }));
 
 

--- a/src/lib/integrations/onedrive.ts
+++ b/src/lib/integrations/onedrive.ts
@@ -131,8 +131,15 @@ export async function listPhotosInFolder(
   folderId: string
 ): Promise<OneDriveItem[]> {
   const allPhotos: OneDriveItem[] = [];
+  // OneDrive Personal's Graph API returns "Operation not supported" for
+  // $filter on /children — same gotcha listFolders worked around. We
+  // already filter client-side below (mime starts with 'image/'), which
+  // is more correct than $filter=file ne null anyway (excludes folders
+  // AND non-image files like videos in one shot). Drop $filter; keep
+  // $select to trim payload + ensure @microsoft.graph.downloadUrl comes
+  // back.
   let nextLink: string | null =
-    `${GRAPH_API}/me/drive/items/${folderId}/children?$filter=file ne null&$top=200&$select=id,name,file,image,size,photo,location,@microsoft.graph.downloadUrl`;
+    `${GRAPH_API}/me/drive/items/${folderId}/children?$top=200&$select=id,name,file,image,size,photo,location,@microsoft.graph.downloadUrl`;
 
   while (nextLink) {
     const url: string = nextLink;

--- a/src/lib/server/photoSyncCron.ts
+++ b/src/lib/server/photoSyncCron.ts
@@ -1,0 +1,58 @@
+/**
+ * Server-side photo sync cron.
+ *
+ * Same rationale as calendarSyncCron: photo sources (OneDrive folders,
+ * Immich shared links) previously only synced when someone hit the manual
+ * /api/photo-sources/[id]/sync endpoint. So a folder the user dropped new
+ * photos into wouldn't appear on the dashboard until they remembered to
+ * trigger a sync. This periodic loop makes "drop a photo in the folder →
+ * it shows up" actually automatic.
+ *
+ * Lives in its own node-only module (imported lazily from instrumentation.ts
+ * under NEXT_RUNTIME === 'nodejs') so the edge bundle never pulls in the
+ * heavy transitive deps (exifr, sharp via photo-storage, etc.).
+ *
+ * Interval is longer than the calendar cron — photos change far less often
+ * than calendar events, and OneDrive/Immich list calls are heavier.
+ */
+
+import { syncAllPhotoSources } from '@/lib/services/photo-sync';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+
+const INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const INITIAL_DELAY_MS = 90 * 1000;  // wait 90s after boot (stagger vs calendar cron)
+
+async function runOnce() {
+  try {
+    const { synced, errors } = await syncAllPhotoSources();
+    if (synced > 0) await invalidateEntity('photos');
+
+    if (errors.length > 0) {
+      console.warn(
+        `[photo-cron] synced ${synced} source(s) with ${errors.length} errors:`,
+        errors.slice(0, 3),
+      );
+    } else {
+      console.log(`[photo-cron] synced ${synced} source(s)`);
+    }
+  } catch (err) {
+    console.error('[photo-cron] tick failed:', err);
+  }
+}
+
+export function startPhotoSyncCron(): void {
+  if (process.env.PRISM_DISABLE_PHOTO_CRON === 'true') {
+    console.log('[photo-cron] disabled via PRISM_DISABLE_PHOTO_CRON');
+    return;
+  }
+  if (process.env.NODE_ENV === 'test') return;
+
+  setTimeout(() => {
+    void runOnce();
+    setInterval(() => void runOnce(), INTERVAL_MS);
+  }, INITIAL_DELAY_MS);
+
+  console.log(
+    `[photo-cron] scheduled every ${INTERVAL_MS / 1000}s (first run in ${INITIAL_DELAY_MS / 1000}s)`,
+  );
+}

--- a/src/lib/services/__tests__/photo-dedupe-key.test.ts
+++ b/src/lib/services/__tests__/photo-dedupe-key.test.ts
@@ -1,0 +1,31 @@
+import { computeDedupeKey } from '../photo-sync';
+
+describe('computeDedupeKey', () => {
+  it('builds `${iso-to-second}_${w}x${h}` for a complete photo', () => {
+    const t = new Date('2026-01-02T03:04:05.000Z');
+    expect(computeDedupeKey(t, 4032, 3024)).toBe('2026-01-02T03:04:05.000Z_4032x3024');
+  });
+
+  it('truncates sub-second jitter so two copies of one shot match', () => {
+    const a = computeDedupeKey(new Date('2026-01-02T03:04:05.123Z'), 4032, 3024);
+    const b = computeDedupeKey(new Date('2026-01-02T03:04:05.789Z'), 4032, 3024);
+    expect(a).toBe(b);
+  });
+
+  it('distinguishes a crop (same time, different dims) from its original', () => {
+    const t = new Date('2026-01-02T03:04:05Z');
+    const original = computeDedupeKey(t, 4032, 3024);
+    const cropped = computeDedupeKey(t, 3000, 3000);
+    expect(original).not.toBe(cropped);
+  });
+
+  it('returns null when capture time is missing (never deduped)', () => {
+    expect(computeDedupeKey(null, 4032, 3024)).toBeNull();
+  });
+
+  it('returns null when either dimension is missing', () => {
+    const t = new Date('2026-01-02T03:04:05Z');
+    expect(computeDedupeKey(t, null, 3024)).toBeNull();
+    expect(computeDedupeKey(t, 4032, null)).toBeNull();
+  });
+});

--- a/src/lib/services/photo-sync.ts
+++ b/src/lib/services/photo-sync.ts
@@ -30,6 +30,33 @@ function generateFilename(originalName: string): string {
   return `${crypto.randomUUID()}.${ext}`;
 }
 
+/**
+ * Cross-source dedup key: `${takenAt-to-the-second}_${width}x${height}`.
+ * Two photos with an identical key are treated as the same shot pulled
+ * from different sources (e.g. the same picture backed up to both OneDrive
+ * and iCloud). Returns null when capture time OR dimensions are missing —
+ * those photos are never deduped (better to show a possible duplicate than
+ * to wrongly suppress a unique photo).
+ *
+ * Dimensions are intentionally part of the key: a cropped edit keeps the
+ * original capture timestamp but changes dimensions, so this is what lets
+ * an edit and its original both display instead of one suppressing the
+ * other. Which copy wins an ACTUAL dedup conflict (same key) is decided by
+ * photo_sources.priority at read time, not here.
+ */
+export function computeDedupeKey(
+  takenAt: Date | null,
+  width: number | null,
+  height: number | null,
+): string | null {
+  if (!takenAt || width == null || height == null) return null;
+  // Truncate to the second — sub-second jitter between a service's copies
+  // shouldn't split the same shot into two keys.
+  const ts = new Date(takenAt);
+  ts.setMilliseconds(0);
+  return `${ts.toISOString()}_${width}x${height}`;
+}
+
 export async function syncOneDriveSource(sourceId: string) {
   // Fetch the source
   const source = await db.query.photoSources.findFirst({
@@ -90,13 +117,15 @@ export async function syncOneDriveSource(sourceId: string) {
         // Metadata-only: GPS known from OneDrive facet — no download needed.
         // filename stores the item ID so the file endpoint can proxy on demand.
         // usage='' keeps these out of screensaver/wallpaper rotation.
+        const mdWidth = remotePhoto.image?.width ?? null;
+        const mdHeight = remotePhoto.image?.height ?? null;
         await db.insert(photos).values({
           sourceId,
           filename: remotePhoto.id,
           originalFilename: remotePhoto.name,
           mimeType,
-          width: remotePhoto.image?.width ?? null,
-          height: remotePhoto.image?.height ?? null,
+          width: mdWidth,
+          height: mdHeight,
           sizeBytes: remotePhoto.size ?? null,
           takenAt,
           externalId: remotePhoto.id,
@@ -105,6 +134,7 @@ export async function syncOneDriveSource(sourceId: string) {
           longitude: facetLng.toString(),
           isExternal: true,
           usage: '',
+          dedupeKey: computeDedupeKey(takenAt, mdWidth, mdHeight),
         });
       } else {
         // No facet GPS — download the file and try EXIF extraction
@@ -127,6 +157,7 @@ export async function syncOneDriveSource(sourceId: string) {
           latitude: gps?.latitude ?? null,
           longitude: gps?.longitude ?? null,
           isExternal: false,
+          dedupeKey: computeDedupeKey(takenAt, result.width, result.height),
         });
       }
     } catch (err) {
@@ -174,6 +205,39 @@ export async function syncOneDriveSource(sourceId: string) {
     .update(photoSources)
     .set({ lastSynced: new Date(), updatedAt: new Date() })
     .where(eq(photoSources.id, sourceId));
+}
+
+/**
+ * Sync every enabled photo source that has an automatic-sync mechanism
+ * (OneDrive folders, Immich shared links). Local-upload sources have
+ * nothing to pull. Called by the photo-sync cron so a folder the user
+ * drops photos into shows up on the dashboard without a manual trigger.
+ * Per-source failures are caught so one bad source doesn't abort the rest.
+ */
+export async function syncAllPhotoSources(): Promise<{ synced: number; errors: string[] }> {
+  const errors: string[] = [];
+  let synced = 0;
+
+  const sources = await db.query.photoSources.findMany({
+    where: eq(photoSources.enabled, true),
+  });
+
+  for (const source of sources) {
+    try {
+      if (source.type === 'onedrive') {
+        await syncOneDriveSource(source.id);
+        synced++;
+      } else if (source.type === 'immich') {
+        await syncImmichSource(source.id);
+        synced++;
+      }
+      // 'local' has nothing to pull; 'icloud_shared' handled once Phase B lands.
+    } catch (err) {
+      errors.push(`${source.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { synced, errors };
 }
 
 export async function syncImmichSource(sourceId: string) {
@@ -242,6 +306,7 @@ export async function syncImmichSource(sourceId: string) {
       longitude: asset.longitude != null ? asset.longitude.toString() : null,
       isExternal: true,
       usage: 'wallpaper,gallery,screensaver',
+      dedupeKey: computeDedupeKey(takenAt, asset.width, asset.height),
     });
   }
 


### PR DESCRIPTION
## Phase A of #57 — pluggable photo sources

The OneDrive *folder* source already existed (`syncOneDriveSource` pulls a designated folder). This PR makes it low-friction and adds the cross-source dedup machinery.

### What's in this PR

- **Auto-sync cron** (`photoSyncCron.ts`, every 30 min) — sources previously only synced on manual trigger. Now a folder you drop photos into appears automatically. Behind `PRISM_DISABLE_PHOTO_CRON`.
- **Cross-source dedup** — same photo in multiple sources displays once. Matched by `takenAt-to-second + dimensions`, resolved at read time so priority changes apply instantly.
- **Source priority** — `photo_sources.priority` (lower = preferred), ▲▼ reorder in Settings → Photos. Preferred source's copy wins any dedup conflict.
- **Schema** (migration 0012, three-file): `photo_sources.priority`, `photos.dedupe_key`. Idempotent; passes replay incl. Scenario C.
- **Docs**: auto-sync, iOS Shortcut recipe, dedup/priority behavior.

### Test plan
- [x] tsc clean, jest 1145 pass + 5 new dedupe-key tests
- [x] migration replay all scenarios incl. C
- [x] dedup SQL verified on synthetic data
- [x] next build compiles
- [ ] Manual UI check: ▲▼ reorder in Settings → Photos (deployed locally)

### Not in this PR
- Phase B: iCloud Shared Album source
- #52 Consolidated Integrations sweep