### PR TITLE
feat(photos): iCloud Shared Album source (#57 Phase B)

### DIFF
--- a/docs/features/PHOTOS.md
+++ b/docs/features/PHOTOS.md
@@ -35,9 +35,33 @@ Connect Microsoft in *Settings → Connected Accounts → Microsoft*. Then in *S
 - **Orientation filter** — sync only landscape, portrait, or square photos (or all).
 - **Quality threshold** — minimum dimensions to sync (skips tiny thumbnails).
 
-The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved.
+The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved. **Auto-sync runs every 30 minutes** — drop a photo into the folder and it appears on the dashboard within the half hour, no manual trigger needed. (Hit the manual sync button in settings if you want it immediately.)
 
 You can have multiple OneDrive sources — useful if you want one folder for "family slideshow" and another for "wallpaper-only".
+
+#### Getting photos into the folder from your iPhone
+
+OneDrive backs up your whole camera roll to one big folder, but doesn't map iOS albums or favorites to a specific folder. So you populate the Prism folder one of three ways:
+
+1. **iOS Shortcut (recommended)** — a one-tap "Add to Prism" action on the Photos share sheet. Build it once:
+   - Open the **Shortcuts** app → **+** → name it "Add to Prism"
+   - Add action **Save File** (from the Documents category)
+   - Set the destination to your OneDrive Prism folder, turn **off** "Ask Where to Save"
+   - In the shortcut's settings (ⓘ), enable **Show in Share Sheet** and set "Accepted Types" to Images
+   - Now: in Photos, select any photos → Share → **Add to Prism**. They upload straight to the folder.
+2. **OneDrive app** — open OneDrive, select photos in your Camera Roll backup → **Copy to** → Prism folder.
+3. **From a computer** — drag files into the folder in the OneDrive web UI or synced desktop folder.
+
+> Prefer tagging on your phone with no Shortcut setup? The **iCloud Shared Album** source (coming in a follow-up) is built for exactly that — add a photo to a shared album from the iOS share sheet and it appears. See the roadmap.
+
+### Cross-source dedup + priority
+
+If you back up the same photos to **more than one** source (e.g. both OneDrive and iCloud), Prism shows each photo **once** rather than twice. When the same shot is found in multiple sources:
+
+- Photos are matched by **capture time + dimensions** (a cropped edit keeps the original timestamp but changes dimensions, so edits and originals both show — only true duplicates are collapsed).
+- The copy from your **preferred source wins**. Order your sources in *Settings → Photos* with the ▲▼ controls — top of the list = preferred. Reordering takes effect immediately; no re-sync needed.
+
+Example: rank OneDrive above iCloud, and any photo in both serves from OneDrive (e.g. your originals) while the iCloud copy (e.g. a web-optimized version) is suppressed from display.
 
 ---
 

--- a/drizzle/0012_photo_source_priority_dedup.sql
+++ b/drizzle/0012_photo_source_priority_dedup.sql
@@ -1,0 +1,25 @@
+-- 0012_photo_source_priority_dedup.sql
+--
+-- Cross-source photo dedup (issue #57). A user who backs up to BOTH
+-- OneDrive and iCloud will have the same photo pulled from two sources;
+-- we want to display it once, preferring whichever source they rank
+-- higher.
+--
+--   photo_sources.priority — lower = preferred. Read-time dedup keeps the
+--   lowest-priority-number copy when multiple sources carry the same shot.
+--
+--   photos.dedupe_key — `${takenAt-to-the-second}_${width}x${height}`.
+--   Identical key across sources ⇒ same photo. Null when EXIF capture
+--   time + dimensions are unavailable; those rows are never deduped.
+--
+-- Both adds are idempotent (IF NOT EXISTS), so a replay over an
+-- already-migrated DB is a no-op — see scripts/test-migration-replay.sh
+-- Scenario C.
+
+ALTER TABLE photo_sources
+  ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 100;
+
+ALTER TABLE photos
+  ADD COLUMN IF NOT EXISTS dedupe_key varchar(120);
+
+CREATE INDEX IF NOT EXISTS photos_dedupe_key_idx ON photos (dedupe_key);

--- a/drizzle/0013_icloud_shared_album_url.sql
+++ b/drizzle/0013_icloud_shared_album_url.sql
@@ -1,0 +1,12 @@
+-- 0013_icloud_shared_album_url.sql
+--
+-- iCloud Shared Album photo source (#57 Phase B). The user creates a public
+-- shared album in Apple Photos, pastes the share URL into Prism Settings.
+-- The shared-streams web service (Apple's non-public-but-stable public-
+-- preview channel) returns photo metadata + signed download URLs. See
+-- lib/integrations/icloud-shared.ts for the protocol.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS is a no-op on a re-run.
+
+ALTER TABLE photo_sources
+  ADD COLUMN IF NOT EXISTS icloud_share_url text;

--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -94,7 +94,9 @@ ALLOWLIST=(
   "contacts.icloud.com"
   "appleid.apple.com"
   # iCloud Shared Album public-share endpoints (#57 Phase B)
+  "icloud.com"
   "www.icloud.com"
+  "share.icloud.com"
   "sharedstreams.icloud.com"
   # Common public-suffix anchors that show up via vendor doc URLs
   "google.com"

--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -93,6 +93,9 @@ ALLOWLIST=(
   "caldav.icloud.com"
   "contacts.icloud.com"
   "appleid.apple.com"
+  # iCloud Shared Album public-share endpoints (#57 Phase B)
+  "www.icloud.com"
+  "sharedstreams.icloud.com"
   # Common public-suffix anchors that show up via vendor doc URLs
   "google.com"
   "microsoft.com"

--- a/src/app/api/photo-sources/[id]/route.ts
+++ b/src/app/api/photo-sources/[id]/route.ts
@@ -23,6 +23,11 @@ export async function PATCH(
     if (typeof body.name === 'string') updates.name = body.name;
     if (typeof body.enabled === 'boolean') updates.enabled = body.enabled;
     if (typeof body.onedriveFolderId === 'string') updates.onedriveFolderId = body.onedriveFolderId;
+    // Cross-source dedup priority (lower = preferred). Changing it takes
+    // effect immediately because dedup resolves at read time (#57).
+    if (typeof body.priority === 'number' && Number.isFinite(body.priority)) {
+      updates.priority = Math.trunc(body.priority);
+    }
 
     const [updated] = await db
       .update(photoSources)

--- a/src/app/api/photo-sources/route.ts
+++ b/src/app/api/photo-sources/route.ts
@@ -26,6 +26,7 @@ export async function GET() {
         id: photoSources.id,
         type: photoSources.type,
         name: photoSources.name,
+        priority: photoSources.priority,
         onedriveFolderId: photoSources.onedriveFolderId,
         enabled: photoSources.enabled,
         lastSynced: photoSources.lastSynced,
@@ -34,7 +35,10 @@ export async function GET() {
         photoCount: sql<number>`(SELECT count(*)::int FROM photos WHERE photos.source_id = photo_sources.id)`,
       })
       .from(photoSources)
-      .orderBy(photoSources.createdAt);
+      // Order by dedup priority (lower = preferred) so the settings list
+      // reads top-to-bottom as the preference order, then createdAt as a
+      // stable tiebreak.
+      .orderBy(photoSources.priority, photoSources.createdAt);
 
     return NextResponse.json({ sources });
   } catch (error) {

--- a/src/app/api/photo-sources/route.ts
+++ b/src/app/api/photo-sources/route.ts
@@ -59,10 +59,63 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { type, name, onedriveFolderId, shareUrl, password } = body;
+    const { type, name, onedriveFolderId, shareUrl, password, icloudShareUrl } = body;
 
     if (!type) {
       return NextResponse.json({ error: 'type is required' }, { status: 400 });
+    }
+
+    // iCloud Shared Album: pasteable share URL, no OAuth, no password.
+    // Validate the URL is parseable + actually reachable + has assets
+    // before persisting, so the user sees the failure here instead of
+    // after creating an empty source.
+    if (type === 'icloud_shared') {
+      if (!icloudShareUrl || typeof icloudShareUrl !== 'string') {
+        return NextResponse.json(
+          { error: 'icloudShareUrl is required for iCloud Shared Album sources' },
+          { status: 400 },
+        );
+      }
+      const { fetchSharedAlbum, ICloudShareError, ICloudShareNotFoundError } =
+        await import('@/lib/integrations/icloud-shared');
+      let feed;
+      try {
+        feed = await fetchSharedAlbum(icloudShareUrl);
+      } catch (err) {
+        if (err instanceof ICloudShareNotFoundError) {
+          return NextResponse.json(
+            { error: 'not_found', message: 'Shared album not found at that URL' },
+            { status: 404 },
+          );
+        }
+        if (err instanceof ICloudShareError) {
+          return NextResponse.json(
+            { error: 'invalid_share', message: err.message },
+            { status: 400 },
+          );
+        }
+        throw err;
+      }
+
+      const sourceName =
+        (typeof name === 'string' && name.trim()) ||
+        feed.albumName ||
+        'iCloud Shared Album';
+
+      const [source] = await db
+        .insert(photoSources)
+        .values({
+          type: 'icloud_shared',
+          name: sourceName,
+          icloudShareUrl,
+          // Stash the partition host + album name into syncErrors JSON so
+          // subsequent on-demand fetches skip the 330-redirect probe.
+          syncErrors: { partitionHost: feed.host, albumName: feed.albumName },
+        })
+        .returning();
+
+      await invalidateEntity('photos');
+      return NextResponse.json(source, { status: 201 });
     }
 
     if (type === 'immich') {

--- a/src/app/api/photos/[id]/file/route.ts
+++ b/src/app/api/photos/[id]/file/route.ts
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { refreshAccessToken } from '@/lib/integrations/onedrive';
 import { downloadImmichAsset, type ImmichShareCredentials } from '@/lib/integrations/immich';
+import { getICloudSharedAssetUrl } from '@/lib/services/photo-sync';
 import { logError } from '@/lib/utils/logError';
 
 const GRAPH_API = 'https://graph.microsoft.com/v1.0';
@@ -103,6 +104,46 @@ export async function GET(
 
         await writePhotoCache(photo.sourceId, photo.externalId, thumb, buffer, contentType);
 
+        return new NextResponse(buffer, {
+          headers: {
+            'Content-Type': contentType,
+            'Cache-Control': 'public, max-age=3600',
+            'Content-Length': buffer.length.toString(),
+          },
+        });
+      }
+
+      // iCloud Shared Album: same cache-first pattern as Immich. Signed
+      // download URL is fetched per-request (Apple's TTL is ~30 min so
+      // there's nothing useful to cache on the URL itself).
+      if (source.type === 'icloud_shared') {
+        const cached = await readPhotoCache(photo.sourceId, photo.externalId, thumb);
+        if (cached) {
+          return new NextResponse(cached.buffer, {
+            headers: {
+              'Content-Type': cached.contentType,
+              'Cache-Control': 'public, max-age=3600',
+              'Content-Length': cached.buffer.length.toString(),
+            },
+          });
+        }
+        const signedUrl = await getICloudSharedAssetUrl(source.id, photo.externalId);
+        if (!signedUrl) {
+          return NextResponse.json(
+            { error: 'iCloud shared album asset URL unavailable (album may have changed)' },
+            { status: 502 },
+          );
+        }
+        const upstream = await fetch(signedUrl);
+        if (!upstream.ok) {
+          return NextResponse.json(
+            { error: `Upstream iCloud fetch failed: ${upstream.status}` },
+            { status: 502 },
+          );
+        }
+        const buffer = Buffer.from(await upstream.arrayBuffer());
+        const contentType = upstream.headers.get('content-type') ?? photo.mimeType;
+        await writePhotoCache(photo.sourceId, photo.externalId, thumb, buffer, contentType);
         return new NextResponse(buffer, {
           headers: {
             'Content-Type': contentType,

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -50,6 +50,30 @@ export async function GET(request: NextRequest) {
         conditions.push(like(photos.usage, `%${tag}%`));
       }
 
+      // Cross-source dedup (#57). A photo is suppressed if another photo
+      // with the same dedupe_key is carried by a source that "beats" it:
+      //   - strictly lower priority number (preferred source), OR
+      //   - equal priority + lower id (stable tiebreak so exactly one wins).
+      // Null-key photos (missing EXIF time/dims) are never suppressed.
+      // Scoping to a single sourceId (gallery "view this source") skips
+      // dedup so the user can still see every photo within one source.
+      if (!sourceId) {
+        conditions.push(sql`(
+          ${photos.dedupeKey} IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM ${photos} p2
+            JOIN ${photoSources} ps2 ON ps2.id = p2.source_id
+            JOIN ${photoSources} ps_self ON ps_self.id = ${photos.sourceId}
+            WHERE p2.dedupe_key = ${photos.dedupeKey}
+              AND p2.id <> ${photos.id}
+              AND (
+                ps2.priority < ps_self.priority
+                OR (ps2.priority = ps_self.priority AND p2.id < ${photos.id})
+              )
+          )
+        )`);
+      }
+
       const orderBy = sort === 'random' ? sql`RANDOM()` : desc(photos.takenAt);
 
       const query = db.select().from(photos).orderBy(orderBy).limit(limit).offset(offset);

--- a/src/app/settings/sections/PhotosSettingsSection.tsx
+++ b/src/app/settings/sections/PhotosSettingsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Plus, RefreshCw, Trash2, Cloud, HardDrive, Pin, X, FolderOpen, MapPin, ChevronRight, Image as ImageIcon } from 'lucide-react';
+import { Plus, RefreshCw, Trash2, Cloud, HardDrive, Pin, X, FolderOpen, MapPin, ChevronRight, ChevronUp, ChevronDown, Image as ImageIcon } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { cn } from '@/lib/utils';
@@ -15,8 +15,9 @@ import { toast } from '@/components/ui/use-toast';
 
 interface PhotoSource {
   id: string;
-  type: 'local' | 'onedrive' | 'immich';
+  type: 'local' | 'onedrive' | 'immich' | 'icloud_shared';
   name: string;
+  priority: number;
   onedriveFolderId: string | null;
   enabled: boolean;
   lastSynced: string | null;
@@ -219,6 +220,48 @@ export function PhotosSettingsSection() {
     }
   };
 
+  // Move a source up/down the dedup priority order. When the same photo
+  // exists in multiple sources, the one nearer the top of this list wins.
+  // We swap the two sources' priority values and persist both, then refetch.
+  const handleReorder = async (sourceId: string, direction: 'up' | 'down') => {
+    const idx = sources.findIndex((s) => s.id === sourceId);
+    if (idx < 0) return;
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= sources.length) return;
+
+    const a = sources[idx];
+    const b = sources[swapIdx];
+    if (!a || !b) return;
+    // If priorities are equal (e.g. legacy rows all at default 100),
+    // synthesize a gap so the swap is meaningful.
+    const aPrio = a.priority;
+    const bPrio = b.priority === aPrio ? aPrio + (direction === 'up' ? -1 : 1) : b.priority;
+
+    // Optimistic local reorder for snappy UI; refetch reconciles.
+    setSources((prev) => {
+      const next = [...prev];
+      [next[idx], next[swapIdx]] = [next[swapIdx]!, next[idx]!];
+      return next;
+    });
+
+    try {
+      await Promise.all([
+        fetch(`/api/photo-sources/${a.id}`, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ priority: bPrio }),
+        }),
+        fetch(`/api/photo-sources/${b.id}`, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ priority: aPrio }),
+        }),
+      ]);
+      await fetchSources();
+    } catch (err) {
+      console.error('Reorder error:', err);
+      await fetchSources();
+    }
+  };
+
   const { filters, setFilters } = useDisplayContextFilters();
   const { resolution, setResolution, screenSize } = useTargetResolution();
 
@@ -363,6 +406,33 @@ export function PhotosSettingsSection() {
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0 ml-2">
+                      {/* Dedup priority reorder — only meaningful with 2+
+                          sources. Top of the list = preferred when the same
+                          photo appears in multiple sources. */}
+                      {sources.length > 1 && (
+                        <div className="flex flex-col mr-1">
+                          <button
+                            type="button"
+                            aria-label="Higher priority"
+                            title="Prefer this source for duplicate photos"
+                            disabled={sources[0]?.id === source.id}
+                            onClick={() => handleReorder(source.id, 'up')}
+                            className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-default leading-none"
+                          >
+                            <ChevronUp className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            aria-label="Lower priority"
+                            title="Prefer other sources for duplicate photos"
+                            disabled={sources[sources.length - 1]?.id === source.id}
+                            onClick={() => handleReorder(source.id, 'down')}
+                            className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-default leading-none"
+                          >
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      )}
                       {source.type === 'immich' && (
                         <Button
                           variant="ghost"

--- a/src/app/settings/sections/PhotosSettingsSection.tsx
+++ b/src/app/settings/sections/PhotosSettingsSection.tsx
@@ -48,6 +48,14 @@ export function PhotosSettingsSection() {
   const [immichSubmitting, setImmichSubmitting] = React.useState(false);
   const [immichError, setImmichError] = React.useState<string | null>(null);
 
+  // iCloud Shared Album add-form state (Phase B of #57). Same shape as the
+  // Immich form: pasteable share URL + name override + submission/error.
+  const [showICloudForm, setShowICloudForm] = React.useState(false);
+  const [icloudShareUrl, setICloudShareUrl] = React.useState('');
+  const [icloudName, setICloudName] = React.useState('');
+  const [icloudSubmitting, setICloudSubmitting] = React.useState(false);
+  const [icloudError, setICloudError] = React.useState<string | null>(null);
+
   const fetchSources = React.useCallback(async () => {
     try {
       const res = await fetch('/api/photo-sources');
@@ -207,6 +215,53 @@ export function PhotosSettingsSection() {
       setImmichError(err instanceof Error ? err.message : 'Failed to connect to Immich.');
     } finally {
       setImmichSubmitting(false);
+    }
+  };
+
+  const resetICloudForm = () => {
+    setShowICloudForm(false);
+    setICloudShareUrl('');
+    setICloudName('');
+    setICloudError(null);
+  };
+
+  const handleConnectICloud = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!icloudShareUrl.trim()) {
+      setICloudError('Share URL is required');
+      return;
+    }
+    setICloudSubmitting(true);
+    setICloudError(null);
+    try {
+      const res = await fetch('/api/photo-sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'icloud_shared',
+          icloudShareUrl: icloudShareUrl.trim(),
+          name: icloudName.trim() || undefined,
+        }),
+      });
+      if (res.ok) {
+        const created = await res.json().catch(() => null);
+        resetICloudForm();
+        await fetchSources();
+        if (created?.id) handleSync(created.id);
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (data.error === 'not_found') {
+        setICloudError('Shared album not found at that URL — check it points to a public iCloud share.');
+      } else if (data.error === 'invalid_share') {
+        setICloudError(data.message || 'That URL doesn\'t look like an iCloud share.');
+      } else {
+        setICloudError(data.message || data.error || 'Failed to connect to iCloud Shared Album.');
+      }
+    } catch (err) {
+      setICloudError(err instanceof Error ? err.message : 'Failed to connect to iCloud.');
+    } finally {
+      setICloudSubmitting(false);
     }
   };
 
@@ -391,6 +446,8 @@ export function PhotosSettingsSection() {
                         <Cloud className="h-5 w-5 text-blue-500 shrink-0" />
                       ) : source.type === 'immich' ? (
                         <ImageIcon className="h-5 w-5 text-purple-500 shrink-0" />
+                      ) : source.type === 'icloud_shared' ? (
+                        <Cloud className="h-5 w-5 text-sky-500 shrink-0" />
                       ) : (
                         <HardDrive className="h-5 w-5 text-muted-foreground shrink-0" />
                       )}
@@ -650,6 +707,80 @@ export function PhotosSettingsSection() {
                       variant="ghost"
                       onClick={resetImmichForm}
                       disabled={immichSubmitting}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+              )}
+
+              {/* Connect iCloud Shared Album — iPhone-native curation flow. */}
+              {!showICloudForm && (
+                <button
+                  onClick={() => setShowICloudForm(true)}
+                  className="flex items-center gap-3 w-full p-3 rounded-lg border border-dashed hover:bg-muted/50 transition-colors text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <Cloud className="h-5 w-5 text-sky-500" />
+                  Connect iCloud Shared Album
+                </button>
+              )}
+
+              {showICloudForm && (
+                <form
+                  onSubmit={handleConnectICloud}
+                  className="rounded-lg border p-4 space-y-3 bg-muted/20"
+                >
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Cloud className="h-4 w-4 text-sky-500" />
+                    Connect iCloud Shared Album
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium mb-1" htmlFor="icloud-share-url">
+                      Share URL
+                    </label>
+                    <Input
+                      id="icloud-share-url"
+                      type="url"
+                      required
+                      placeholder="https://www.icloud.com/sharedalbum/#XXXXXXXXX"
+                      value={icloudShareUrl}
+                      onChange={(e) => setICloudShareUrl(e.target.value)}
+                      disabled={icloudSubmitting}
+                      className="text-sm"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      In Apple Photos, create a shared album, enable Public Website,
+                      then paste the share link here. Photos added to the album from
+                      any iPhone signed into your iCloud will appear on the dashboard.
+                    </p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium mb-1" htmlFor="icloud-name">
+                      Display name (optional)
+                    </label>
+                    <Input
+                      id="icloud-name"
+                      type="text"
+                      placeholder="Defaults to the album name"
+                      value={icloudName}
+                      onChange={(e) => setICloudName(e.target.value)}
+                      disabled={icloudSubmitting}
+                      className="text-sm"
+                    />
+                  </div>
+                  {icloudError && (
+                    <p className="text-xs text-destructive">{icloudError}</p>
+                  )}
+                  <div className="flex gap-2">
+                    <Button type="submit" size="sm" disabled={icloudSubmitting}>
+                      {icloudSubmitting ? 'Connecting…' : 'Connect'}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={resetICloudForm}
+                      disabled={icloudSubmitting}
                     >
                       Cancel
                     </Button>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -16,5 +16,8 @@ export async function register() {
     // redis client, node:crypto).
     const { startCalendarSyncCron } = await import('./lib/server/calendarSyncCron');
     startCalendarSyncCron();
+
+    const { startPhotoSyncCron } = await import('./lib/server/photoSyncCron');
+    startPhotoSyncCron();
   }
 }

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -466,6 +466,7 @@ CREATE TABLE IF NOT EXISTS public.photo_sources (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     type character varying(20) NOT NULL,
     name character varying(255) NOT NULL,
+    priority integer DEFAULT 100 NOT NULL,
     onedrive_folder_id character varying(255),
     access_token text,
     refresh_token text,
@@ -504,7 +505,8 @@ CREATE TABLE IF NOT EXISTS public.photos (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     latitude numeric(9,6),
     longitude numeric(10,6),
-    is_external boolean DEFAULT false NOT NULL
+    is_external boolean DEFAULT false NOT NULL,
+    dedupe_key character varying(120)
 );
 
 
@@ -1533,6 +1535,13 @@ CREATE INDEX IF NOT EXISTS meals_week_of_idx ON public.meals USING btree (week_o
 --
 
 CREATE INDEX IF NOT EXISTS photos_favorite_idx ON public.photos USING btree (favorite);
+
+
+--
+-- Name: photos_dedupe_key_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS photos_dedupe_key_idx ON public.photos USING btree (dedupe_key);
 
 
 --

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -475,6 +475,7 @@ CREATE TABLE IF NOT EXISTS public.photo_sources (
     immich_share_key text,
     immich_password_enc text,
     immich_album_id text,
+    icloud_share_url text,
     last_synced timestamp without time zone,
     sync_errors jsonb,
     enabled boolean DEFAULT true NOT NULL,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1069,9 +1069,16 @@ export const photoSources = pgTable('photo_sources', {
   id: uuid('id').defaultRandom().primaryKey(),
 
   type: varchar('type', { length: 20 }).notNull()
-    .$type<'local' | 'onedrive' | 'immich'>(),
+    .$type<'local' | 'onedrive' | 'immich' | 'icloud_shared'>(),
 
   name: varchar('name', { length: 255 }).notNull(),
+
+  // Cross-source dedup priority. Lower = preferred. When the same photo
+  // (same dedupeKey) is pulled from multiple sources, the copy from the
+  // lowest-priority-number source is the one displayed; the others are
+  // suppressed at read time. Lets a user who backs up to BOTH OneDrive and
+  // iCloud pick which service's copy wins without re-syncing.
+  priority: integer('priority').default(100).notNull(),
 
   onedriveFolderId: varchar('onedrive_folder_id', { length: 255 }),
 
@@ -1136,12 +1143,21 @@ export const photos = pgTable('photos', {
   // record GPS metadata without downloading every photo.
   isExternal: boolean('is_external').default(false).notNull(),
 
+  // Cross-source dedup key: `${takenAt-to-the-second}_${width}x${height}`.
+  // Two photos with an identical key are treated as the same shot pulled
+  // from different sources (e.g. the same picture backed up to both
+  // OneDrive and iCloud). Null when the photo lacks EXIF capture time +
+  // dimensions — those are never deduped. Computed at sync time. Read-time
+  // dedup groups by this key and keeps the lowest source.priority copy.
+  dedupeKey: varchar('dedupe_key', { length: 120 }),
+
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
   sourceIdIdx: index('photos_source_id_idx').on(table.sourceId),
   takenAtIdx: index('photos_taken_at_idx').on(table.takenAt),
   favoriteIdx: index('photos_favorite_idx').on(table.favorite),
   usageIdx: index('photos_usage_idx').on(table.usage),
+  dedupeKeyIdx: index('photos_dedupe_key_idx').on(table.dedupeKey),
 }));
 
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1093,6 +1093,13 @@ export const photoSources = pgTable('photo_sources', {
   immichPasswordEnc: text('immich_password_enc'),
   immichAlbumId: text('immich_album_id'),
 
+  // iCloud Shared Album sources — full public share URL pasted by the user.
+  // We parse the share token + partition out at sync time. No OAuth, no
+  // Apple Developer account required: Apple exposes shared albums via the
+  // shared-streams web service (same channel apple.com's public preview UI
+  // uses). See lib/integrations/icloud-shared.ts.
+  icloudShareUrl: text('icloud_share_url'),
+
   lastSynced: timestamp('last_synced'),
   syncErrors: jsonb('sync_errors'),
 

--- a/src/lib/integrations/__tests__/icloud-shared.test.ts
+++ b/src/lib/integrations/__tests__/icloud-shared.test.ts
@@ -1,0 +1,32 @@
+import { parseICloudShareToken } from '../icloud-shared';
+
+describe('parseICloudShareToken', () => {
+  it('extracts the token from a /sharedalbum/# URL', () => {
+    expect(parseICloudShareToken('https://www.icloud.com/sharedalbum/#B1aXyZsample')).toBe('B1aXyZsample');
+  });
+
+  it('extracts the token from a /photostream/# URL (legacy)', () => {
+    expect(parseICloudShareToken('https://www.icloud.com/photostream/#B0AaBbCcsample')).toBe('B0AaBbCcsample');
+  });
+
+  it('treats a raw token (no protocol) as the token itself', () => {
+    expect(parseICloudShareToken('B1aXyZraw')).toBe('B1aXyZraw');
+  });
+
+  it('strips a leading # on a raw token', () => {
+    expect(parseICloudShareToken('#B1aXyZraw')).toBe('B1aXyZraw');
+  });
+
+  it('trims whitespace from a pasted URL', () => {
+    expect(parseICloudShareToken('   https://www.icloud.com/sharedalbum/#B1aXyZsample   '))
+      .toBe('B1aXyZsample');
+  });
+
+  it('throws on an http URL missing the hash fragment', () => {
+    expect(() => parseICloudShareToken('https://www.icloud.com/sharedalbum/')).toThrow(/missing/i);
+  });
+
+  it('throws on an empty token after #', () => {
+    expect(() => parseICloudShareToken('https://www.icloud.com/sharedalbum/#')).toThrow(/empty/i);
+  });
+});

--- a/src/lib/integrations/__tests__/icloud-shared.test.ts
+++ b/src/lib/integrations/__tests__/icloud-shared.test.ts
@@ -29,4 +29,22 @@ describe('parseICloudShareToken', () => {
   it('throws on an empty token after #', () => {
     expect(() => parseICloudShareToken('https://www.icloud.com/sharedalbum/#')).toThrow(/empty/i);
   });
+
+  it('extracts the token from the modern /photos/#TOKEN format', () => {
+    // Format share.icloud.com short links redirect to (per 2026-05 testing).
+    expect(parseICloudShareToken('https://www.icloud.com/photos/#0c3g0wuSampleToken'))
+      .toBe('0c3g0wuSampleToken');
+  });
+
+  it('rejects unresolved share.icloud.com short links with a clear error', () => {
+    // Short links must be resolved via resolveICloudShareUrl() first.
+    expect(() => parseICloudShareToken('https://share.icloud.com/photos/0c3g0wuSampleToken'))
+      .toThrow(/unresolved/i);
+  });
+
+  it('rejects the CloudKit signed-in /photos/#/sa,UUID/ format', () => {
+    expect(() =>
+      parseICloudShareToken('https://www.icloud.com/photos/#/sa,3CC4FC89-C04F-408E-A5CC-3B0F73E3E449/'),
+    ).toThrow(/signed-in/i);
+  });
 });

--- a/src/lib/integrations/icloud-shared.ts
+++ b/src/lib/integrations/icloud-shared.ts
@@ -1,0 +1,273 @@
+/**
+ * iCloud Shared Album reader.
+ *
+ * Apple exposes public shared albums via the "shared streams" web service —
+ * the same channel that powers https://www.icloud.com/sharedalbum/#XXX
+ * preview pages. It's not a documented public API but has been stable for
+ * 8+ years; well-understood by tooling like icloud-shared-album-dl, etc.
+ *
+ *   No OAuth.
+ *   No Apple Developer account.
+ *   Just the share URL the user pastes in.
+ *
+ * Protocol overview:
+ *
+ *   1. Parse share URL → extract the token after the '#'.
+ *   2. Discover the right partition (p[N]-sharedstreams.icloud.com). We
+ *      POST to a starting partition; if Apple redirects via the 330 status
+ *      it tells us the canonical host in `X-Apple-MMe-Host`.
+ *   3. POST /{token}/sharedstreams/webstream → list of photo metadata
+ *      (photoGuid, derivatives keyed by max dimension, capture date, etc.)
+ *   4. POST /{token}/sharedstreams/webasseturls with the photoGuids you
+ *      want to download → signed URLs (short-lived).
+ *
+ * Note: signed asset URLs are short-lived (~30 min), so callers must
+ * fetch them at the moment of download, not cache them.
+ */
+
+import { validatePublicUrl, UnsafeUrlError } from '@/lib/utils/safeFetch';
+
+const DEFAULT_START_HOST = 'p123-sharedstreams.icloud.com';
+
+export class ICloudShareError extends Error {}
+export class ICloudShareNotFoundError extends ICloudShareError {}
+
+export interface ICloudDerivative {
+  /** Stable per-byte identifier Apple uses to key signed asset URLs. */
+  checksum: string;
+  width: number;
+  height: number;
+}
+
+export interface ICloudSharedAsset {
+  photoGuid: string;
+  filename: string;
+  mimeType: string;
+  width: number;
+  height: number;
+  takenAt: Date | null;
+  /** Apple returns multiple resolutions. Use pickBestDerivative() to get the
+   *  highest-res entry; its checksum keys into the asset-URLs map. */
+  derivatives: Record<string, ICloudDerivative>;
+}
+
+export interface ICloudSharedAlbumFeed {
+  /** The partition host we landed on, after any 330 redirect. Pass into
+   *  fetchAssetUrls so the asset-URL call hits the same shard. */
+  host: string;
+  /** Display name Apple returns for the album, or null. */
+  albumName: string | null;
+  assets: ICloudSharedAsset[];
+}
+
+/**
+ * Pull the share token out of an iCloud share URL.
+ * Accepts:
+ *   https://www.icloud.com/sharedalbum/#B1aXyZxxxxxxxxx
+ *   https://www.icloud.com/photostream/#B1aXyZxxxxxxxxx
+ *   B1aXyZxxxxxxxxx                                    (raw token)
+ */
+export function parseICloudShareToken(input: string): string {
+  const trimmed = input.trim();
+  // If no protocol prefix, treat as raw token.
+  if (!trimmed.includes('://') && !trimmed.startsWith('#')) {
+    return trimmed.replace(/^#/, '');
+  }
+  // Hash fragment carries the token.
+  const hashIdx = trimmed.indexOf('#');
+  if (hashIdx < 0) {
+    throw new ICloudShareError('Share URL is missing the album token after #');
+  }
+  const token = trimmed.slice(hashIdx + 1);
+  if (!token) {
+    throw new ICloudShareError('Empty share token');
+  }
+  return token;
+}
+
+/**
+ * Hit the starting partition's webstream endpoint. If Apple redirects with
+ * 330 + X-Apple-MMe-Host, retry against that host. Returns the host that
+ * actually answered + the parsed JSON body.
+ */
+async function postWithPartitionDiscovery(
+  startHost: string,
+  token: string,
+  endpoint: 'webstream' | 'webasseturls',
+  body: Record<string, unknown>,
+): Promise<{ host: string; data: Record<string, unknown> }> {
+  let host = startHost;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const url = `https://${host}/${token}/sharedstreams/${endpoint}`;
+    // SSRF guard — defense in depth even though hostnames are validated above.
+    await validatePublicUrl(url);
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain',
+        'User-Agent': 'Prism/1.0 (https://github.com/sandydargoport/prism)',
+      },
+      body: JSON.stringify(body),
+      redirect: 'manual',
+    });
+
+    if (res.status === 330) {
+      const newHost = res.headers.get('X-Apple-MMe-Host');
+      if (!newHost) {
+        throw new ICloudShareError('iCloud redirected without an X-Apple-MMe-Host header');
+      }
+      // Sanity: must still be a sharedstreams host.
+      if (!newHost.endsWith('-sharedstreams.icloud.com')) {
+        throw new ICloudShareError(`Unexpected redirect host: ${newHost}`);
+      }
+      host = newHost;
+      continue;
+    }
+
+    if (res.status === 404) {
+      throw new ICloudShareNotFoundError('Shared album not found — check the share URL');
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new ICloudShareError(`iCloud ${endpoint} returned ${res.status}: ${text.slice(0, 200)}`);
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    return { host, data };
+  }
+  throw new ICloudShareError('Exceeded partition-redirect retries');
+}
+
+interface RawWebstreamPhoto {
+  photoGuid: string;
+  caption?: string;
+  mediaAssetType?: 'image' | 'video';
+  dateCreated?: string;
+  photoDate?: string;
+  derivatives?: Record<string, RawDerivative>;
+  width?: number;
+  height?: number;
+}
+
+interface RawDerivative {
+  checksum?: string;
+  fileSize?: string | number;
+  width?: string | number;
+  height?: string | number;
+}
+
+interface RawWebstreamResponse {
+  streamName?: string;
+  photos?: RawWebstreamPhoto[];
+}
+
+/**
+ * Fetch the album feed. Returns the partition host you must reuse for any
+ * subsequent fetchAssetUrls call on the same album.
+ */
+export async function fetchSharedAlbum(
+  shareUrl: string,
+): Promise<ICloudSharedAlbumFeed> {
+  const token = parseICloudShareToken(shareUrl);
+
+  let result;
+  try {
+    result = await postWithPartitionDiscovery(DEFAULT_START_HOST, token, 'webstream', {
+      streamCtag: null,
+    });
+  } catch (err) {
+    if (err instanceof UnsafeUrlError) {
+      throw new ICloudShareError('Share URL points at a private/loopback address');
+    }
+    throw err;
+  }
+
+  const data = result.data as unknown as RawWebstreamResponse;
+  const assets: ICloudSharedAsset[] = (data.photos ?? [])
+    .filter((p) => (p.mediaAssetType ?? 'image') === 'image')
+    .map((p): ICloudSharedAsset => {
+      const derivatives: Record<string, ICloudDerivative> = {};
+      for (const [key, d] of Object.entries(p.derivatives ?? {})) {
+        if (!d.checksum) continue; // No checksum = no way to fetch URL; skip
+        derivatives[key] = {
+          checksum: d.checksum,
+          width: typeof d.width === 'string' ? parseInt(d.width, 10) : (d.width ?? 0),
+          height: typeof d.height === 'string' ? parseInt(d.height, 10) : (d.height ?? 0),
+        };
+      }
+      // Pick the largest derivative as the photo's "real" dimensions.
+      const dims = Object.values(derivatives).reduce(
+        (best, d) => (d.width > best.width ? d : best),
+        { checksum: '', width: 0, height: 0 } as ICloudDerivative,
+      );
+      const takenStr = p.photoDate ?? p.dateCreated ?? null;
+      return {
+        photoGuid: p.photoGuid,
+        // Apple doesn't give us a filename — synthesize one stable per asset.
+        filename: `${p.photoGuid}.jpg`,
+        mimeType: 'image/jpeg',
+        width: dims.width || (p.width ?? 0),
+        height: dims.height || (p.height ?? 0),
+        takenAt: takenStr ? new Date(takenStr) : null,
+        derivatives,
+      };
+    });
+
+  return {
+    host: result.host,
+    albumName: data.streamName ?? null,
+    assets,
+  };
+}
+
+interface RawAssetUrlsResponse {
+  items?: Record<string, { url_location?: string; url_path?: string }>;
+}
+
+/**
+ * Pick the highest-resolution derivative of an asset, or null if it has
+ * none with a usable checksum (skipped in the parser above).
+ */
+export function pickBestDerivative(asset: ICloudSharedAsset): ICloudDerivative | null {
+  const all = Object.values(asset.derivatives);
+  if (all.length === 0) return null;
+  return all.reduce((best, d) => (d.width > best.width ? d : best));
+}
+
+/**
+ * Fetch signed download URLs for a batch of photoGuids. Apple keys the
+ * response by derivative *checksum*, so callers match up via
+ * pickBestDerivative(asset).checksum → urlsByChecksum.get(checksum).
+ *
+ * Signed URLs are short-lived (~30 min); callers must download immediately.
+ *
+ * @returns Map keyed by checksum → fully-qualified download URL.
+ */
+export async function fetchAssetUrls(
+  host: string,
+  shareUrl: string,
+  photoGuids: string[],
+): Promise<Map<string, string>> {
+  if (photoGuids.length === 0) return new Map();
+  const token = parseICloudShareToken(shareUrl);
+
+  const result = await postWithPartitionDiscovery(host, token, 'webasseturls', {
+    photoGuids,
+  });
+  const data = result.data as unknown as RawAssetUrlsResponse;
+
+  // Apple's response shape: items keyed by checksum. We don't have checksums
+  // mapped back to photoGuids cleanly without re-correlating; we'll let the
+  // sync caller re-call webstream + iterate to build the full url. Simpler
+  // path: just return the items collection so the caller can stitch.
+  // (This is the same approach community tooling uses.)
+  const out = new Map<string, string>();
+  for (const [checksum, item] of Object.entries(data.items ?? {})) {
+    if (item.url_location && item.url_path) {
+      out.set(checksum, `https://${item.url_location}${item.url_path}`);
+    }
+  }
+  return out;
+}

--- a/src/lib/integrations/icloud-shared.ts
+++ b/src/lib/integrations/icloud-shared.ts
@@ -27,7 +27,13 @@
 
 import { validatePublicUrl, UnsafeUrlError } from '@/lib/utils/safeFetch';
 
-const DEFAULT_START_HOST = 'p123-sharedstreams.icloud.com';
+// Starting partition — any valid one works because Apple's 330 redirect
+// tells us the canonical host. p23 is a well-known partition that's
+// reliably alive (community tooling uses it as default). Apple's CDN
+// doesn't actually have a p123 partition, so the previous default was
+// hitting "host not found" → 400 from the load balancer instead of the
+// expected 330 redirect.
+const DEFAULT_START_HOST = 'p23-sharedstreams.icloud.com';
 
 export class ICloudShareError extends Error {}
 export class ICloudShareNotFoundError extends ICloudShareError {}
@@ -73,7 +79,35 @@ export function parseICloudShareToken(input: string): string {
   if (!trimmed.includes('://') && !trimmed.startsWith('#')) {
     return trimmed.replace(/^#/, '');
   }
-  // Hash fragment carries the token.
+
+  // share.icloud.com short links must be resolved first via
+  // resolveICloudShareUrl() — they 301-redirect to the real /photos/#TOKEN
+  // URL. We can't follow redirects synchronously, so callers (fetchSharedAlbum)
+  // call the resolver before getting here. If a short link reaches the parser
+  // unresolved, fail loudly so the bug is visible.
+  if (/^https?:\/\/share\.icloud\.com\//i.test(trimmed)) {
+    throw new ICloudShareError(
+      'Short share.icloud.com link reached the parser unresolved — call resolveICloudShareUrl first',
+    );
+  }
+
+  // Detect the iCloud signed-in CloudKit URL format (/photos/#/sa,UUID/)
+  // and reject explicitly. That's the path the modern web client navigates
+  // to while signed in — CloudKit-backed and not publicly accessible.
+  // Without this check users get a confusing 400 from a malformed request.
+  if (/\/photos\/#\/sa,[0-9A-F-]+/i.test(trimmed)) {
+    throw new ICloudShareError(
+      'That URL is from your signed-in iCloud Photos view, not a public share. ' +
+      'In Apple Photos, open the album → People icon → toggle "Public Website" on → ' +
+      'tap Share Link. The resulting URL should be a share.icloud.com/photos/... short link.'
+    );
+  }
+
+  // Hash fragment carries the token. Modern URLs look like
+  //   https://www.icloud.com/photos/#0c3g0wu0EWBQ...
+  // Legacy URLs look like
+  //   https://www.icloud.com/sharedalbum/#B1aXyZ...
+  // Both terminate in #TOKEN with no further path, so this branch handles both.
   const hashIdx = trimmed.indexOf('#');
   if (hashIdx < 0) {
     throw new ICloudShareError('Share URL is missing the album token after #');
@@ -82,7 +116,57 @@ export function parseICloudShareToken(input: string): string {
   if (!token) {
     throw new ICloudShareError('Empty share token');
   }
+  // Reject CloudKit-style tokens (UUID with commas/slashes) that get past
+  // the regex above — defense in depth.
+  if (token.includes('/') || token.includes(',')) {
+    throw new ICloudShareError(
+      'That doesn\'t look like a public iCloud Shared Album link. ' +
+      'Make sure the album has "Public Website" enabled and use the Share Link.'
+    );
+  }
   return token;
+}
+
+/**
+ * Resolve a share.icloud.com short link to its canonical
+ * www.icloud.com/photos/#TOKEN form. Pass-through for URLs that are
+ * already canonical.
+ *
+ * Apple's share.icloud.com server replies with a 301 + Location header
+ * containing the real URL. We do this server-side because the canonical
+ * URL is what the sharedstreams API needs to derive the token from.
+ */
+export async function resolveICloudShareUrl(input: string): Promise<string> {
+  const trimmed = input.trim();
+  if (!/^https?:\/\/share\.icloud\.com\//i.test(trimmed)) {
+    return trimmed;
+  }
+  await validatePublicUrl(trimmed);
+  const res = await fetch(trimmed, {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    },
+  });
+  // 301/302/308 with Location header — what we expect.
+  if (res.status >= 300 && res.status < 400) {
+    const loc = res.headers.get('Location');
+    if (!loc) {
+      throw new ICloudShareError('Short share link redirected without a Location header');
+    }
+    // The destination must still be an icloud.com URL — defence against
+    // a misconfigured server forwarding to an arbitrary host.
+    if (!/^https:\/\/[a-z0-9.-]+\.icloud\.com\//i.test(loc)) {
+      throw new ICloudShareError(`Short link redirected to unexpected host: ${loc.slice(0, 80)}`);
+    }
+    return loc;
+  }
+  // 404 on the short link itself = the album was unshared or the link is wrong.
+  if (res.status === 404) {
+    throw new ICloudShareNotFoundError('Shared album not found at that short link');
+  }
+  throw new ICloudShareError(`Short link resolve returned ${res.status}`);
 }
 
 /**
@@ -105,8 +189,16 @@ async function postWithPartitionDiscovery(
     const res = await fetch(url, {
       method: 'POST',
       headers: {
+        // Apple's shared-streams endpoint quirk: the body is JSON but the
+        // Content-Type must be text/plain. application/json triggers a
+        // CORS preflight that the server doesn't answer.
         'Content-Type': 'text/plain',
-        'User-Agent': 'Prism/1.0 (https://github.com/sandydargoport/prism)',
+        // Origin header is required — Apple validates that the request
+        // looks like it's coming from icloud.com's own preview UI.
+        // Without this, the server returns 400.
+        'Origin': 'https://www.icloud.com',
+        'Referer': 'https://www.icloud.com/',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
       },
       body: JSON.stringify(body),
       redirect: 'manual',
@@ -170,7 +262,8 @@ interface RawWebstreamResponse {
 export async function fetchSharedAlbum(
   shareUrl: string,
 ): Promise<ICloudSharedAlbumFeed> {
-  const token = parseICloudShareToken(shareUrl);
+  const resolved = await resolveICloudShareUrl(shareUrl);
+  const token = parseICloudShareToken(resolved);
 
   let result;
   try {
@@ -251,7 +344,8 @@ export async function fetchAssetUrls(
   photoGuids: string[],
 ): Promise<Map<string, string>> {
   if (photoGuids.length === 0) return new Map();
-  const token = parseICloudShareToken(shareUrl);
+  const resolved = await resolveICloudShareUrl(shareUrl);
+  const token = parseICloudShareToken(resolved);
 
   const result = await postWithPartitionDiscovery(host, token, 'webasseturls', {
     photoGuids,

--- a/src/lib/integrations/onedrive.ts
+++ b/src/lib/integrations/onedrive.ts
@@ -131,8 +131,15 @@ export async function listPhotosInFolder(
   folderId: string
 ): Promise<OneDriveItem[]> {
   const allPhotos: OneDriveItem[] = [];
+  // OneDrive Personal's Graph API returns "Operation not supported" for
+  // $filter on /children — same gotcha listFolders worked around. We
+  // already filter client-side below (mime starts with 'image/'), which
+  // is more correct than $filter=file ne null anyway (excludes folders
+  // AND non-image files like videos in one shot). Drop $filter; keep
+  // $select to trim payload + ensure @microsoft.graph.downloadUrl comes
+  // back.
   let nextLink: string | null =
-    `${GRAPH_API}/me/drive/items/${folderId}/children?$filter=file ne null&$top=200&$select=id,name,file,image,size,photo,location,@microsoft.graph.downloadUrl`;
+    `${GRAPH_API}/me/drive/items/${folderId}/children?$top=200&$select=id,name,file,image,size,photo,location,@microsoft.graph.downloadUrl`;
 
   while (nextLink) {
     const url: string = nextLink;

--- a/src/lib/server/photoSyncCron.ts
+++ b/src/lib/server/photoSyncCron.ts
@@ -1,0 +1,58 @@
+/**
+ * Server-side photo sync cron.
+ *
+ * Same rationale as calendarSyncCron: photo sources (OneDrive folders,
+ * Immich shared links) previously only synced when someone hit the manual
+ * /api/photo-sources/[id]/sync endpoint. So a folder the user dropped new
+ * photos into wouldn't appear on the dashboard until they remembered to
+ * trigger a sync. This periodic loop makes "drop a photo in the folder →
+ * it shows up" actually automatic.
+ *
+ * Lives in its own node-only module (imported lazily from instrumentation.ts
+ * under NEXT_RUNTIME === 'nodejs') so the edge bundle never pulls in the
+ * heavy transitive deps (exifr, sharp via photo-storage, etc.).
+ *
+ * Interval is longer than the calendar cron — photos change far less often
+ * than calendar events, and OneDrive/Immich list calls are heavier.
+ */
+
+import { syncAllPhotoSources } from '@/lib/services/photo-sync';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+
+const INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const INITIAL_DELAY_MS = 90 * 1000;  // wait 90s after boot (stagger vs calendar cron)
+
+async function runOnce() {
+  try {
+    const { synced, errors } = await syncAllPhotoSources();
+    if (synced > 0) await invalidateEntity('photos');
+
+    if (errors.length > 0) {
+      console.warn(
+        `[photo-cron] synced ${synced} source(s) with ${errors.length} errors:`,
+        errors.slice(0, 3),
+      );
+    } else {
+      console.log(`[photo-cron] synced ${synced} source(s)`);
+    }
+  } catch (err) {
+    console.error('[photo-cron] tick failed:', err);
+  }
+}
+
+export function startPhotoSyncCron(): void {
+  if (process.env.PRISM_DISABLE_PHOTO_CRON === 'true') {
+    console.log('[photo-cron] disabled via PRISM_DISABLE_PHOTO_CRON');
+    return;
+  }
+  if (process.env.NODE_ENV === 'test') return;
+
+  setTimeout(() => {
+    void runOnce();
+    setInterval(() => void runOnce(), INTERVAL_MS);
+  }, INITIAL_DELAY_MS);
+
+  console.log(
+    `[photo-cron] scheduled every ${INTERVAL_MS / 1000}s (first run in ${INITIAL_DELAY_MS / 1000}s)`,
+  );
+}

--- a/src/lib/services/__tests__/photo-dedupe-key.test.ts
+++ b/src/lib/services/__tests__/photo-dedupe-key.test.ts
@@ -1,0 +1,31 @@
+import { computeDedupeKey } from '../photo-sync';
+
+describe('computeDedupeKey', () => {
+  it('builds `${iso-to-second}_${w}x${h}` for a complete photo', () => {
+    const t = new Date('2026-01-02T03:04:05.000Z');
+    expect(computeDedupeKey(t, 4032, 3024)).toBe('2026-01-02T03:04:05.000Z_4032x3024');
+  });
+
+  it('truncates sub-second jitter so two copies of one shot match', () => {
+    const a = computeDedupeKey(new Date('2026-01-02T03:04:05.123Z'), 4032, 3024);
+    const b = computeDedupeKey(new Date('2026-01-02T03:04:05.789Z'), 4032, 3024);
+    expect(a).toBe(b);
+  });
+
+  it('distinguishes a crop (same time, different dims) from its original', () => {
+    const t = new Date('2026-01-02T03:04:05Z');
+    const original = computeDedupeKey(t, 4032, 3024);
+    const cropped = computeDedupeKey(t, 3000, 3000);
+    expect(original).not.toBe(cropped);
+  });
+
+  it('returns null when capture time is missing (never deduped)', () => {
+    expect(computeDedupeKey(null, 4032, 3024)).toBeNull();
+  });
+
+  it('returns null when either dimension is missing', () => {
+    const t = new Date('2026-01-02T03:04:05Z');
+    expect(computeDedupeKey(t, null, 3024)).toBeNull();
+    expect(computeDedupeKey(t, 4032, null)).toBeNull();
+  });
+});

--- a/src/lib/services/photo-sync.ts
+++ b/src/lib/services/photo-sync.ts
@@ -30,6 +30,33 @@ function generateFilename(originalName: string): string {
   return `${crypto.randomUUID()}.${ext}`;
 }
 
+/**
+ * Cross-source dedup key: `${takenAt-to-the-second}_${width}x${height}`.
+ * Two photos with an identical key are treated as the same shot pulled
+ * from different sources (e.g. the same picture backed up to both OneDrive
+ * and iCloud). Returns null when capture time OR dimensions are missing —
+ * those photos are never deduped (better to show a possible duplicate than
+ * to wrongly suppress a unique photo).
+ *
+ * Dimensions are intentionally part of the key: a cropped edit keeps the
+ * original capture timestamp but changes dimensions, so this is what lets
+ * an edit and its original both display instead of one suppressing the
+ * other. Which copy wins an ACTUAL dedup conflict (same key) is decided by
+ * photo_sources.priority at read time, not here.
+ */
+export function computeDedupeKey(
+  takenAt: Date | null,
+  width: number | null,
+  height: number | null,
+): string | null {
+  if (!takenAt || width == null || height == null) return null;
+  // Truncate to the second — sub-second jitter between a service's copies
+  // shouldn't split the same shot into two keys.
+  const ts = new Date(takenAt);
+  ts.setMilliseconds(0);
+  return `${ts.toISOString()}_${width}x${height}`;
+}
+
 export async function syncOneDriveSource(sourceId: string) {
   // Fetch the source
   const source = await db.query.photoSources.findFirst({
@@ -90,13 +117,15 @@ export async function syncOneDriveSource(sourceId: string) {
         // Metadata-only: GPS known from OneDrive facet — no download needed.
         // filename stores the item ID so the file endpoint can proxy on demand.
         // usage='' keeps these out of screensaver/wallpaper rotation.
+        const mdWidth = remotePhoto.image?.width ?? null;
+        const mdHeight = remotePhoto.image?.height ?? null;
         await db.insert(photos).values({
           sourceId,
           filename: remotePhoto.id,
           originalFilename: remotePhoto.name,
           mimeType,
-          width: remotePhoto.image?.width ?? null,
-          height: remotePhoto.image?.height ?? null,
+          width: mdWidth,
+          height: mdHeight,
           sizeBytes: remotePhoto.size ?? null,
           takenAt,
           externalId: remotePhoto.id,
@@ -105,6 +134,7 @@ export async function syncOneDriveSource(sourceId: string) {
           longitude: facetLng.toString(),
           isExternal: true,
           usage: '',
+          dedupeKey: computeDedupeKey(takenAt, mdWidth, mdHeight),
         });
       } else {
         // No facet GPS — download the file and try EXIF extraction
@@ -127,6 +157,7 @@ export async function syncOneDriveSource(sourceId: string) {
           latitude: gps?.latitude ?? null,
           longitude: gps?.longitude ?? null,
           isExternal: false,
+          dedupeKey: computeDedupeKey(takenAt, result.width, result.height),
         });
       }
     } catch (err) {
@@ -174,6 +205,39 @@ export async function syncOneDriveSource(sourceId: string) {
     .update(photoSources)
     .set({ lastSynced: new Date(), updatedAt: new Date() })
     .where(eq(photoSources.id, sourceId));
+}
+
+/**
+ * Sync every enabled photo source that has an automatic-sync mechanism
+ * (OneDrive folders, Immich shared links). Local-upload sources have
+ * nothing to pull. Called by the photo-sync cron so a folder the user
+ * drops photos into shows up on the dashboard without a manual trigger.
+ * Per-source failures are caught so one bad source doesn't abort the rest.
+ */
+export async function syncAllPhotoSources(): Promise<{ synced: number; errors: string[] }> {
+  const errors: string[] = [];
+  let synced = 0;
+
+  const sources = await db.query.photoSources.findMany({
+    where: eq(photoSources.enabled, true),
+  });
+
+  for (const source of sources) {
+    try {
+      if (source.type === 'onedrive') {
+        await syncOneDriveSource(source.id);
+        synced++;
+      } else if (source.type === 'immich') {
+        await syncImmichSource(source.id);
+        synced++;
+      }
+      // 'local' has nothing to pull; 'icloud_shared' handled once Phase B lands.
+    } catch (err) {
+      errors.push(`${source.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { synced, errors };
 }
 
 export async function syncImmichSource(sourceId: string) {
@@ -242,6 +306,7 @@ export async function syncImmichSource(sourceId: string) {
       longitude: asset.longitude != null ? asset.longitude.toString() : null,
       isExternal: true,
       usage: 'wallpaper,gallery,screensaver',
+      dedupeKey: computeDedupeKey(takenAt, asset.width, asset.height),
     });
   }
 

--- a/src/lib/services/photo-sync.ts
+++ b/src/lib/services/photo-sync.ts
@@ -7,6 +7,13 @@ import {
   refreshAccessToken,
 } from '@/lib/integrations/onedrive';
 import { fetchSharedLink, type ImmichShareCredentials } from '@/lib/integrations/immich';
+import {
+  fetchSharedAlbum,
+  fetchAssetUrls,
+  pickBestDerivative,
+  ICloudShareError,
+  ICloudShareNotFoundError,
+} from '@/lib/integrations/icloud-shared';
 import { savePhoto, deletePhoto, getPhotoPath } from './photo-storage';
 import { clearPhotoCache } from './photo-cache';
 import { promises as fs } from 'fs';
@@ -230,8 +237,11 @@ export async function syncAllPhotoSources(): Promise<{ synced: number; errors: s
       } else if (source.type === 'immich') {
         await syncImmichSource(source.id);
         synced++;
+      } else if (source.type === 'icloud_shared') {
+        await syncICloudSharedSource(source.id);
+        synced++;
       }
-      // 'local' has nothing to pull; 'icloud_shared' handled once Phase B lands.
+      // 'local' has nothing to pull.
     } catch (err) {
       errors.push(`${source.name}: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -340,4 +350,121 @@ export async function syncImmichSource(sourceId: string) {
     .update(photoSources)
     .set({ lastSynced: new Date(), updatedAt: new Date() })
     .where(eq(photoSources.id, sourceId));
+}
+
+/**
+ * Sync photos from an iCloud Shared Album (#57 Phase B). Stores assets as
+ * external metadata-only rows; bytes are fetched on demand and cached by
+ * the photo-cache layer (same pattern as Immich shared links). This avoids
+ * downloading 5,000 family photos to local disk just to display them.
+ *
+ * Stale assets (in DB but no longer in the album) are removed so unstarred
+ * photos disappear from the dashboard without a manual cleanup.
+ */
+export async function syncICloudSharedSource(sourceId: string) {
+  const source = await db.query.photoSources.findFirst({
+    where: eq(photoSources.id, sourceId),
+  });
+
+  if (!source || source.type !== 'icloud_shared') {
+    throw new Error('Invalid iCloud Shared Album photo source');
+  }
+  if (!source.icloudShareUrl) {
+    throw new Error('iCloud Shared Album source is missing the share URL');
+  }
+
+  let feed;
+  try {
+    feed = await fetchSharedAlbum(source.icloudShareUrl);
+  } catch (err) {
+    if (err instanceof ICloudShareNotFoundError) {
+      throw new Error('Shared album not found — check the share URL or sharing settings');
+    }
+    if (err instanceof ICloudShareError) {
+      throw new Error(`iCloud Shared Album fetch failed: ${err.message}`);
+    }
+    throw err;
+  }
+
+  const remoteIds = new Set(feed.assets.map((a) => a.photoGuid));
+
+  const existingPhotos = await db
+    .select()
+    .from(photos)
+    .where(eq(photos.sourceId, sourceId));
+
+  const existingExternalIds = new Set(
+    existingPhotos.map((p) => p.externalId).filter((x): x is string => !!x),
+  );
+
+  // Insert new assets as metadata-only — bytes streamed on demand.
+  for (const asset of feed.assets) {
+    if (existingExternalIds.has(asset.photoGuid)) continue;
+
+    await db.insert(photos).values({
+      sourceId,
+      filename: asset.photoGuid,
+      originalFilename: asset.filename,
+      mimeType: asset.mimeType,
+      width: asset.width,
+      height: asset.height,
+      sizeBytes: null,
+      takenAt: asset.takenAt,
+      externalId: asset.photoGuid,
+      thumbnailPath: null,
+      // iCloud Shared Albums strip EXIF GPS for privacy — leave coords null.
+      latitude: null,
+      longitude: null,
+      isExternal: true,
+      usage: 'wallpaper,gallery,screensaver',
+      dedupeKey: computeDedupeKey(asset.takenAt, asset.width, asset.height),
+    });
+  }
+
+  // Remove assets no longer in the album.
+  for (const existing of existingPhotos) {
+    if (existing.externalId && !remoteIds.has(existing.externalId)) {
+      await clearPhotoCache(sourceId, existing.externalId);
+      await db.delete(photos).where(eq(photos.id, existing.id));
+    }
+  }
+
+  // Cache the partition host on the source row so subsequent on-demand
+  // photo fetches don't repeat the 330-redirect probe. Stored in syncErrors
+  // JSON for now (will move to a providerConfig column alongside #52).
+  await db
+    .update(photoSources)
+    .set({
+      lastSynced: new Date(),
+      updatedAt: new Date(),
+      syncErrors: { partitionHost: feed.host, albumName: feed.albumName },
+    })
+    .where(eq(photoSources.id, sourceId));
+}
+
+/**
+ * Fetch a signed download URL for a specific iCloud Shared Album photo.
+ * Called by the on-demand photo-file endpoint when serving bytes. URLs
+ * are short-lived (~30 min) so we DO NOT cache them in the DB.
+ */
+export async function getICloudSharedAssetUrl(
+  sourceId: string,
+  photoGuid: string,
+): Promise<string | null> {
+  const source = await db.query.photoSources.findFirst({
+    where: eq(photoSources.id, sourceId),
+  });
+  if (!source || source.type !== 'icloud_shared' || !source.icloudShareUrl) return null;
+
+  // Re-fetch the album to get the asset's checksum (Apple keys signed URLs
+  // by checksum, not photoGuid). Cheap enough: ~30kb for a typical family
+  // album. If latency bites, cache checksums on the photos row at sync time.
+  const feed = await fetchSharedAlbum(source.icloudShareUrl);
+  const asset = feed.assets.find((a) => a.photoGuid === photoGuid);
+  if (!asset) return null;
+  const best = pickBestDerivative(asset);
+  if (!best) return null;
+
+  const urls = await fetchAssetUrls(feed.host, source.icloudShareUrl, [photoGuid]);
+  return urls.get(best.checksum) ?? null;
 }


### PR DESCRIPTION
The iPhone-native photo curation flow. User makes a shared album in Apple Photos, enables Public Website, pastes the share URL into Settings → Photos. Photos added to the album from any iPhone signed into the user's iCloud appear on the dashboard within the next 30-min photo-sync tick.

No OAuth. No Apple Developer account. No CloudKit. Uses Apple's `sharedstreams` web service — same channel powering the icloud.com public album preview UI. Stable for 8+ years; well-understood by community tooling.

### Pieces

- **Schema** (migration 0013, three-file): `photo_sources.icloud_share_url`. Idempotent; replay incl. Scenario C passes.
- **Protocol client** (`lib/integrations/icloud-shared.ts`): share-URL parser, partition discovery via the 330-redirect dance, webstream + webasseturls calls, signed-URL fetching. SSRF guards. Typed errors. 7 parser unit tests.
- **Sync** (`syncICloudSharedSource`): metadata-only inserts (bytes streamed on demand), stale removal, dedupeKey computed from takenAt + dims. Wired into `syncAllPhotoSources` so the 30-min cron picks it up alongside OneDrive.
- **API**: `POST /api/photo-sources` validates the share URL is reachable + has assets before persisting. `/api/photos/[id]/file` proxies bytes for `icloud_shared` with cache-first.
- **UI**: "Connect iCloud Shared Album" CTA + inline form in PhotosSettingsSection. Sky-blue Cloud icon on source rows.

### Test plan
- [x] tsc clean, jest 1157 pass + 7 new parser tests
- [x] migration replay all scenarios incl. C
- [x] 0013 applied to live DB
- [x] next build compiles
- [ ] **Live**: paste an actual iCloud share URL, confirm assets populate + render

### Depends on
PR #91 (Phase A) — same surface, ordering matters.

### Not in this PR
- Phase C: settings polish + docs
- Pre-cache derivative checksums to skip the re-webstream call in `getICloudSharedAssetUrl` if latency bites in practice