### PR TITLE
docs(icloud): cross-entity integration overview + doctrine

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Added — Docs
+- **Apple iCloud integration overview** (`docs/features/ICLOUD.md`): single-page summary of which iCloud surfaces Prism can integrate and which it can't, with the structural rule (open IETF standards work, CloudKit dead-ends don't). Covers Calendars, Contacts, Reminders, Notes, Photos (shared + library), Find My, Health, iMessage, Apple Music. Cross-linked from Calendar and Photos guides. Saves prospective users from "wait, can't we just pull X from iCloud?" investigations that always hit the same wall.
+
+### Changed — Docs
+- **Photos guide drops the "iCloud Shared Album coming in a follow-up" hint**: Phase B of the photo sources work was abandoned in late May after Apple migrated public share URLs to a CloudKit-only backend with no public API. The Photos doc now points at OneDrive + the iOS Shortcut as the canonical iPhone path and links to ICLOUD.md for the explanation.
+
 ## [1.8.4] – 2026-05-23
 
 ### Added — Integrations

--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -51,6 +51,8 @@ The same flow works for **Nextcloud** (`https://your-server/remote.php/dav`), **
 
 Caveats: this path is currently **read-only** — events and tasks pulled from CalDAV appear in the dashboard but can't be edited from Prism (two-way write is on the roadmap). App-specific passwords are stored encrypted in the Prism database and never leave your server. Apple Reminders sync into Prism's Tasks list with the same priorities and due dates the iOS app uses.
 
+> Wondering what *else* you can pull from iCloud (Reminders, Notes, Photos, Find My)? See the [iCloud integration overview](ICLOUD.md) — short answer: calendars and contacts work, nothing else does, and there's a structural reason.
+
 ### Per-calendar customization
 
 In *Settings → Calendars*, each source supports:

--- a/docs/features/ICLOUD.md
+++ b/docs/features/ICLOUD.md
@@ -1,0 +1,54 @@
+# iCloud integration
+
+What Prism can and can't pull from iCloud, and why.
+
+If you have an Apple household and want Prism to surface family data living in iCloud — calendars, contacts, photos, Reminders, Notes, Find My — read this once. The answer is consistent across the table, the rule explains the table, and the rule isn't going to change.
+
+---
+
+## What works, what doesn't
+
+| iCloud surface | Supported? | How / why not |
+|---|---|---|
+| **Calendars** | ✅ Yes, two-way | CalDAV (`caldav.icloud.com`). See [Calendar setup](CALENDAR.md#apple-icloud-caldav--private-calendars--reminders--alpha). |
+| **Contacts** (incl. birthdays) | ✅ Yes, read-only | CardDAV (`contacts.icloud.com`). Used by the planned [family contacts page](https://github.com/sandydargoport/prism/issues/75). |
+| **Reminders / Tasks** | ❌ No | Apple migrated Reminders off CalDAV-VTODO years ago; iCloud Reminders are CloudKit-only with no public web API. |
+| **Notes** | ❌ No | iCloud-synced Notes have always been CloudKit-only. No IMAP-style or web API. |
+| **Photos (shared album)** | ❌ No (was attempted) | Apple migrated public shares from the old `sharedstreams` endpoint to a new "iCloud Links" CloudKit backend in 2024–2025. The legacy endpoint returns 404 for modern shares; no public replacement exists, and no community library targets the new backend as of mid-2026. See [photo source setup](PHOTOS.md#sources) for the OneDrive-based workaround. |
+| **Photos (full library)** | ❌ No | Would require CloudKit Web, which requires an Apple Developer subscription, container ID per app, and per-user consent flow — wrong shape for a self-hosted family dashboard. |
+| **Find My** (devices / people) | ❌ No | The iCloud.com web client uses an undocumented private CloudKit endpoint. Community libraries like `pyicloud` scrape it, but Apple breaks them with each iOS release, and **Advanced Data Protection** end-to-end encrypts Find My data so the scrape no longer returns it at all. Best upstream path today: [Home Assistant's iCloud3 / FindMy integration](https://github.com/gcobb321/icloud3), which has a community actively wrangling these breaks; Prism could in principle read HA's `device_tracker` entities. Not on the roadmap, but the door isn't closed. |
+| **Health / Activity** | ❌ No | HealthKit data is on-device + iCloud-encrypted; only accessible via a paired iOS app, no web API. |
+| **iMessage** | ❌ No | No public API, ever. |
+| **Apple Music** | ❌ No (no plan) | MusicKit Web exists but the consent flow is single-user and the wrong fit for a shared household display. |
+
+---
+
+## The rule that explains the table
+
+**Apple integration is possible if and only if the underlying protocol is an open standard.** CalDAV and CardDAV are IETF standards Apple chose to support; Prism rides those standards exactly like Nextcloud, Radicale, or any other DAV consumer.
+
+Everything else lives in CloudKit, which is:
+
+1. Proprietary
+2. Not publicly documented for third-party server access
+3. Designed around per-user iOS-app consent, not server-to-server federation
+4. Increasingly end-to-end encrypted via Advanced Data Protection — even if you reverse-engineer the endpoints, the payloads are useless without the user's device keys
+
+This means there's no "more research" path that turns a ❌ into a ✅. If you see a community library that claims iCloud Reminders or Find My, it is either:
+
+- A wrapper around the private CloudKit web endpoints (will break, and already broken for ADP users), or
+- Hardware-side (e.g. AirTag-finding via Bluetooth, not cloud data access)
+
+---
+
+## Practical advice for Apple households
+
+- **Calendars + birthdays:** wire them up via CalDAV / CardDAV in *Settings → Connected Accounts*. These genuinely work and stay working.
+- **Photos:** use OneDrive (or another supported source) as the canonical backup target. iOS's OneDrive app + a one-tap iOS Shortcut covers the "share to Prism" workflow without iCloud Shared Albums. See [Photos setup](PHOTOS.md#getting-photos-into-the-folder-from-your-iphone).
+- **Reminders / Notes / Find My:** mirror them somewhere else first (Microsoft To Do supports two-way sync with Prism Tasks; Home Assistant for presence). Prism integrates the mirror, not iCloud directly.
+
+---
+
+## Why this page exists
+
+Because every six months somebody (often me) asks "wait, can't we just hit the iCloud API for X?" and goes off to investigate, finds a stale community library, builds half of an integration, and discovers the same wall. This page is the doctrine note: the wall is structural, not "we haven't tried hard enough," and the energy is better spent on the mirror approach.

--- a/docs/features/PHOTOS.md
+++ b/docs/features/PHOTOS.md
@@ -52,16 +52,16 @@ OneDrive backs up your whole camera roll to one big folder, but doesn't map iOS 
 2. **OneDrive app** — open OneDrive, select photos in your Camera Roll backup → **Copy to** → Prism folder.
 3. **From a computer** — drag files into the folder in the OneDrive web UI or synced desktop folder.
 
-> Prefer tagging on your phone with no Shortcut setup? The **iCloud Shared Album** source (coming in a follow-up) is built for exactly that — add a photo to a shared album from the iOS share sheet and it appears. See the roadmap.
+> Why not iCloud Shared Albums? Apple migrated public share URLs to a CloudKit-only backend that has no public API. See [iCloud integration](ICLOUD.md#what-works-what-doesnt) for the full story; OneDrive + the iOS Shortcut above is the workflow for iPhone users.
 
 ### Cross-source dedup + priority
 
-If you back up the same photos to **more than one** source (e.g. both OneDrive and iCloud), Prism shows each photo **once** rather than twice. When the same shot is found in multiple sources:
+If you back up the same photos to **more than one** source (e.g. local uploads plus an OneDrive folder, or two OneDrive folders that overlap), Prism shows each photo **once** rather than twice. When the same shot is found in multiple sources:
 
 - Photos are matched by **capture time + dimensions** (a cropped edit keeps the original timestamp but changes dimensions, so edits and originals both show — only true duplicates are collapsed).
 - The copy from your **preferred source wins**. Order your sources in *Settings → Photos* with the ▲▼ controls — top of the list = preferred. Reordering takes effect immediately; no re-sync needed.
 
-Example: rank OneDrive above iCloud, and any photo in both serves from OneDrive (e.g. your originals) while the iCloud copy (e.g. a web-optimized version) is suppressed from display.
+Example: rank "OneDrive: originals" above "OneDrive: web-optimized" and any photo in both folders serves from the originals folder while the smaller copy is suppressed from display.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Mobile (PWA): features/MOBILE.md
       - Global input: features/global-input-system.md
   - Integrations:
+      - Apple iCloud: features/ICLOUD.md
       - Kroger / Mariano's: features/KROGER.md
       - Home Assistant: home-assistant.md
       - Voice API: voice-api.md


### PR DESCRIPTION
## What's in this PR

A new single-page summary of which iCloud surfaces Prism can integrate and which it can't — addressing the recurring "wait, can't we just pull X from iCloud?" question after #57 Phase B (iCloud Shared Album) was abandoned.

### New: `docs/features/ICLOUD.md`

Full table — Calendars, Contacts, Reminders, Notes, Photos (shared + library), Find My, Health, iMessage, Apple Music — each row with the why. Pulled into mkdocs nav under **Integrations**.

The structural rule that explains the table: **Apple integration is possible iff the underlying protocol is an open IETF standard.** CalDAV and CardDAV stay open at Apple's servers, so Prism rides them like any other DAV consumer. Everything CloudKit-backed is undocumented, designed around per-user iOS-app consent, and increasingly end-to-end encrypted via Advanced Data Protection — so even successful endpoint reverse-engineering returns useless ciphertext.

Find My specifically: documented as ❌ with the realistic upstream path (Home Assistant's iCloud3 / FindMy community integration), since the user flagged it as a "killer feature" worth at least noting the workaround.

### Updated: `docs/features/PHOTOS.md`

- Removed the stale "iCloud Shared Album coming in a follow-up" hint — Phase B was abandoned 2026-05-30 because Apple migrated public share URLs to a CloudKit-only backend with no public API.
- Cross-source dedup example switched from OneDrive/iCloud to OneDrive/OneDrive since iCloud isn't a planned source.
- Brief "why not iCloud Shared Albums?" callout linking to ICLOUD.md.

### Updated: `docs/features/CALENDAR.md`

Added a cross-link from the CalDAV section pointing at ICLOUD.md for the broader "what else can you pull from iCloud" question.

## Why this exists

Because every six months somebody (often me) asks the same question, goes off to investigate, finds a stale community library, builds half an integration, and discovers the same wall. The wall is structural; this page makes that explicit so future investigations cost zero.

## Test plan

- [x] mkdocs nav entry added (no build to verify locally, but YAML syntactically valid)
- [x] CHANGELOG entry under Unreleased
- [x] Cross-links use stable anchor IDs (matched against rendered Markdown anchor format)
- [x] No code touched