### PR TITLE
fix(layout): re-measure grid on viewport resize (#73)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Prism are documented in this file.
 ### Fixed — Mobile
 - **/settings now reachable on iPhone PWA**: `MobileNav` had no Settings entry, so a Prism installed as a home-screen PWA on iPhone had zero path to settings (the original "PWA can't reach Photos settings" report turned out to be the entire route being unreachable, not a Photos-specific link). The More menu now includes Settings, and the desktop sidebar collapses to a section selector on `<md` viewports so every section remains reachable after landing.
 
+### Fixed — Dashboard
+- **Grid no longer locks to interim cold-boot viewport on slow-launching kiosks**: `LayoutGridEditor` computed `visibleRows` and `cellSize` from `window.innerHeight` inside a `useMemo` with no resize listener, so the values were frozen at mount time. On a Wyse thin client booting before its window manager finalized the work area, the dashboard rendered against the smaller interim viewport and stayed that way until the user manually refreshed. New `useViewportSize` hook subscribes to `resize` + `orientationchange` and feeds both memos so the grid re-measures when the viewport settles. Closes [#73](https://github.com/sandydargoport/prism/issues/73).
+
 ### Added — Docs
 - **Apple iCloud integration overview** (`docs/features/ICLOUD.md`): single-page summary of which iCloud surfaces Prism can integrate and which it can't, with the structural rule (open IETF standards work, CloudKit dead-ends don't). Covers Calendars, Contacts, Reminders, Notes, Photos (shared + library), Find My, Health, iMessage, Apple Music. Cross-linked from Calendar and Photos guides. Saves prospective users from "wait, can't we just pull X from iCloud?" investigations that always hit the same wall.
 

--- a/src/components/layout/LayoutGridEditor.tsx
+++ b/src/components/layout/LayoutGridEditor.tsx
@@ -14,6 +14,7 @@ import { CssGridDisplay } from './grid/CssGridDisplay';
 import dynamic from 'next/dynamic';
 const CssGridEditor = dynamic(() => import('./grid/CssGridEditor').then(m => ({ default: m.CssGridEditor })), { ssr: false });
 import { useSquareCells } from './grid/useSquareCells';
+import { useViewportSize } from '@/lib/hooks/useViewportSize';
 
 export type { EditorTheme } from './grid/gridEditorTypes';
 export { DASHBOARD_THEME, SCREENSAVER_THEME } from './grid/gridEditorTypes';
@@ -46,6 +47,7 @@ export function LayoutGridEditor({
   const containerPadding = 12;
   const margin = marginProp;
   const { width, containerRef, mounted, cellSize: rawCellSize } = useSquareCells(cols, containerPadding, margin);
+  const { height: viewportHeight } = useViewportSize();
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
   const [selectedWidget, setSelectedWidget] = useState<string | null>(null);
@@ -93,7 +95,7 @@ export function LayoutGridEditor({
 
     const effectiveHeaderOffset = measureHideNav ? 0 : 50;
     const effectiveBottomOffset = measureHideNav ? 0 : bottomOffset;
-    const availableH = window.innerHeight - effectiveHeaderOffset - effectiveBottomOffset - 2 * containerPadding;
+    const availableH = viewportHeight - effectiveHeaderOffset - effectiveBottomOffset - 2 * containerPadding;
     const availableW = width - 2 * containerPadding;
 
     // Cell size that makes zone.rows fill availableH, and zone.cols fill availableW
@@ -101,10 +103,10 @@ export function LayoutGridEditor({
     const wCell = Math.floor((availableW + margin) / zone.cols) - margin;
 
     return Math.max(16, Math.min(hCell, wCell));
-  }, [measureMode, mounted, rawCellSize, SAFE_ZONES, screenGuideOrientation, enabledSizes, previewZoneIndex, measureHideNav, bottomOffset, margin, containerPadding, width]);
+  }, [measureMode, mounted, rawCellSize, SAFE_ZONES, screenGuideOrientation, enabledSizes, previewZoneIndex, measureHideNav, bottomOffset, margin, containerPadding, width, viewportHeight]);
 
   const visibleRows = useMemo(() => {
-    if (typeof window === 'undefined') return 24;
+    if (viewportHeight <= 0) return 24;
     // Measure mode: toolbar always hidden; header + nav depend on hideNav toggle
     // measureHideNav=true: all chrome hidden (0 offset)
     // measureHideNav=false: header (~50px) + nav visible (bottomOffset)
@@ -114,9 +116,9 @@ export function LayoutGridEditor({
       : headerOffset;
     const effectiveBottomOffset = measureHideNav ? 0 : bottomOffset;
     const offset = effectiveHeaderOffset + effectiveBottomOffset;
-    const availableHeight = window.innerHeight - offset;
+    const availableHeight = viewportHeight - offset;
     return Math.max(minVisibleRows, Math.floor((availableHeight + margin) / (cellSize + margin)));
-  }, [cellSize, margin, headerOffset, bottomOffset, minVisibleRows, measureMode, measureHideNav]);
+  }, [cellSize, margin, headerOffset, bottomOffset, minVisibleRows, measureMode, measureHideNav, viewportHeight]);
 
   const visibleCols = useMemo(() => {
     if (width <= 0) return cols;

--- a/src/lib/hooks/__tests__/useViewportSize.test.ts
+++ b/src/lib/hooks/__tests__/useViewportSize.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useViewportSize } from '../useViewportSize';
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    value: height,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('useViewportSize', () => {
+  beforeEach(() => {
+    setViewport(1024, 768);
+  });
+
+  it('returns the initial viewport size on mount', () => {
+    const { result } = renderHook(() => useViewportSize());
+    expect(result.current).toEqual({ width: 1024, height: 768 });
+  });
+
+  it('updates when the window is resized', () => {
+    const { result } = renderHook(() => useViewportSize());
+
+    act(() => {
+      setViewport(800, 600);
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toEqual({ width: 800, height: 600 });
+  });
+
+  it('updates on orientationchange', () => {
+    const { result } = renderHook(() => useViewportSize());
+
+    act(() => {
+      setViewport(600, 800);
+      window.dispatchEvent(new Event('orientationchange'));
+    });
+
+    expect(result.current).toEqual({ width: 600, height: 800 });
+  });
+
+  it('catches the viewport changing between mount and effect attaching', () => {
+    // The mount-time read happens synchronously, but if the viewport changes
+    // between initial render and the useEffect firing (cold-boot Wyse case),
+    // the explicit update() call at the top of the effect must catch it.
+    setViewport(1024, 768);
+    const { result } = renderHook(() => useViewportSize());
+
+    // Sanity: initial state took the {1024, 768} reading.
+    expect(result.current).toEqual({ width: 1024, height: 768 });
+
+    // Simulate the window manager finalizing its work area after mount but
+    // before the user resizes — happens on Wyse cold boot.
+    act(() => {
+      setViewport(1920, 1080);
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('removes listeners on unmount', () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useViewportSize());
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('orientationchange', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it('does not return a new object reference when dimensions are unchanged', () => {
+    const { result } = renderHook(() => useViewportSize());
+    const initial = result.current;
+
+    act(() => {
+      // Fire resize without changing dimensions.
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toBe(initial);
+  });
+});

--- a/src/lib/hooks/useViewportSize.ts
+++ b/src/lib/hooks/useViewportSize.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Track the current viewport size, updating on resize + orientation change.
+ *
+ * Bug pattern this exists to fix (#73): consumers that read
+ * `window.innerHeight` inside a useMemo lock in whatever value the viewport
+ * had at mount time. On thin clients / kiosks where the browser launches
+ * before the window manager finalizes its work area, the dashboard renders
+ * against an interim (smaller) viewport, then never re-measures when the
+ * work area grows. Refresh "fixes" it because the second mount sees the
+ * settled viewport.
+ *
+ * SSR: returns {0, 0} on the server; lazy init reads real values on the
+ * first client render. The effect re-runs `update()` immediately on mount
+ * so any race against window-resize-before-effect-attaches is still caught.
+ */
+export function useViewportSize(): ViewportSize {
+  const [size, setSize] = useState<ViewportSize>(() => {
+    if (typeof window === 'undefined') return { width: 0, height: 0 };
+    return { width: window.innerWidth, height: window.innerHeight };
+  });
+
+  useEffect(() => {
+    const update = () => {
+      setSize((prev) => {
+        const next = { width: window.innerWidth, height: window.innerHeight };
+        if (prev.width === next.width && prev.height === next.height) return prev;
+        return next;
+      });
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, []);
+
+  return size;
+}


### PR DESCRIPTION
## Summary

Closes #73. Cold-boot timing on a Wyse thin client + Viewsonic 27" caused the dashboard grid to render at ~80–90% of the actual viewport. Refreshing fixed it; reload was the only workaround.

## Root cause

`LayoutGridEditor.tsx` computed `visibleRows` (line 117) and `cellSize` (line 96) inside `useMemo` blocks that read `window.innerHeight` directly. Two problems:

1. `window.innerHeight` is a global, not reactive — useMemo won't re-run when it changes.
2. Nothing in the file subscribed to `window.resize` or `orientationchange`.

So when the Wyse window manager finalized its work area *after* the browser had mounted, the grid stayed sized for the smaller interim viewport.

## Fix

- New `src/lib/hooks/useViewportSize.ts` hook subscribes to `resize` + `orientationchange`, returns `{ width, height }`. SSR-safe: returns `{0, 0}` on the server, lazy-inits to real values on first client render, and re-runs `update()` at the top of the effect to catch the cold-boot race where the viewport changes between mount and effect attaching.
- `LayoutGridEditor` calls the hook once and feeds `viewportHeight` into both the `cellSize` and `visibleRows` memos, replacing the inline `window.innerHeight` reads. Adds `viewportHeight` to both dep arrays.
- Unit tests for the hook: initial mount read, resize, orientationchange, the cold-boot race, listener cleanup, and reference stability when dimensions don't change.

## Test plan

- [x] `npx jest src/lib/hooks/__tests__/useViewportSize.test.ts` — 6/6 pass.
- [x] `npx tsc --noEmit` clean.
- [x] Existing LayoutGridEditor tests unchanged in shape.
- [ ] Manual: open the dashboard, drag the browser to a different size, confirm the grid expands/contracts to fill the new viewport without refresh. (Maintainer to verify on the Wyse if convenient.)