### PR TITLE
feat(integrations): OAuth callbacks redirect to Integrations page (#52 phase 2A)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Prism are documented in this file.
 ### Fixed — Settings
 - **Sub-section links inside Integrations cards now navigate**: `SettingsView` read the `?section=` query param only at mount, so when an Integrations card's "Open Calendars settings" link changed the URL the content panel stayed put. Added a `useEffect` that syncs `activeSection` with the live URL.
 
+### Changed — Integrations
+- **OAuth callbacks land on the Integrations page when initiated from it**: Google, Google Tasks (errors), Microsoft (OneDrive), and Microsoft Tasks (errors) callbacks now honor a `returnSection=integrations` flag bubbled through OAuth state, redirecting to `?section=integrations#<provider>` with the right sub-section auto-expanded. Legacy callers (the still-mounted Connected Accounts section, etc.) keep their existing destinations. Step toward removing the legacy sections — phase 2A of [#52](https://github.com/sandydargoport/prism/issues/52).
+
 ### Fixed — Mobile
 - **/settings now reachable on iPhone PWA**: `MobileNav` had no Settings entry, so a Prism installed as a home-screen PWA on iPhone had zero path to settings (the original "PWA can't reach Photos settings" report turned out to be the entire route being unreachable, not a Photos-specific link). The More menu now includes Settings, and the desktop sidebar collapses to a section selector on `<md` viewports so every section remains reachable after landing.
 

--- a/src/app/api/auth/google-tasks/callback/route.ts
+++ b/src/app/api/auth/google-tasks/callback/route.ts
@@ -55,6 +55,11 @@ export async function GET(request: Request) {
   const state = searchParams.get('state');
 
   let taskListId: string | null = null;
+  // Default returnSection is still 'tasks' — Google Tasks OAuth flows
+  // ALWAYS end in a list-selection modal which currently only lives in
+  // the legacy TaskIntegrationsSection. Until that modal is extracted into
+  // the new Integrations cards (later phase), success redirects stay
+  // pointed at 'tasks'. Error redirects can honor returnSection.
   let returnSection = 'tasks';
   if (state) {
     try {
@@ -64,6 +69,10 @@ export async function GET(request: Request) {
     } catch { /* ignore */ }
   }
 
+  // Anchor for error redirects when returnSection === 'integrations'.
+  const errorAnchor =
+    returnSection === 'integrations' ? '#google-tasks' : '';
+
   try {
     const code = searchParams.get('code');
     const error = searchParams.get('error');
@@ -71,13 +80,13 @@ export async function GET(request: Request) {
     if (error) {
       logError('Google Tasks OAuth error:', error);
       return NextResponse.redirect(
-        `${BASE_URL}/settings?section=${returnSection}&error=google_tasks_auth_denied`
+        `${BASE_URL}/settings?section=${returnSection}&error=google_tasks_auth_denied${errorAnchor}`
       );
     }
 
     if (!code) {
       return NextResponse.redirect(
-        `${BASE_URL}/settings?section=${returnSection}&error=missing_code`
+        `${BASE_URL}/settings?section=${returnSection}&error=missing_code${errorAnchor}`
       );
     }
 
@@ -120,7 +129,7 @@ export async function GET(request: Request) {
   } catch (error) {
     logError('Google Tasks OAuth callback error:', error);
     return NextResponse.redirect(
-      `${BASE_URL}/settings?section=${returnSection}&error=google_tasks_auth_failed`
+      `${BASE_URL}/settings?section=${returnSection}&error=google_tasks_auth_failed${errorAnchor}`
     );
   }
 }

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -26,36 +26,46 @@ export async function GET(request: Request) {
     const error = searchParams.get('error');
     const state = searchParams.get('state');
 
-    // Parse state early to get returnSection for error redirects
-    let earlyReturnSection = 'connections';
+    // Parse state early to get returnSection for error redirects.
+    // Default to 'integrations' (the new consolidated section). Legacy
+    // callers (ConnectedAccountsSection) pass explicit returnSection=connections
+    // and still land on the old section while it's mounted.
+    let earlyReturnSection = 'integrations';
     if (state) {
       try {
         const parsed = JSON.parse(state);
-        earlyReturnSection = parsed.returnSection || 'connections';
+        earlyReturnSection = parsed.returnSection || 'integrations';
       } catch { /* ignore */ }
     }
+
+    // Anchor to use when redirecting back into the consolidated Integrations
+    // page — drops the user on the Google card with the Calendars sub-section
+    // auto-expanded (see useIntegrationsHashRouter).
+    const integrationsAnchor = '#google-calendars';
+    const anchorFor = (section: string) =>
+      section === 'integrations' ? integrationsAnchor : '';
 
     // Check for errors from Google
     if (error) {
       logError('Google OAuth error:', error);
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${earlyReturnSection}&error=google_auth_denied`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${earlyReturnSection}&error=google_auth_denied${anchorFor(earlyReturnSection)}`);
     }
 
     // Ensure we have an authorization code
     if (!code) {
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${earlyReturnSection}&error=missing_code`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${earlyReturnSection}&error=missing_code${anchorFor(earlyReturnSection)}`);
     }
 
     // Parse state to get user ID, reauth source ID, and return section
     let userId: string | null = null;
     let reauthSourceId: string | null = null;
-    let returnSection = 'connections';
+    let returnSection = 'integrations';
     if (state) {
       try {
         const parsed = JSON.parse(state);
         userId = parsed.userId || null;
         reauthSourceId = parsed.reauth || null;
-        returnSection = parsed.returnSection || 'connections';
+        returnSection = parsed.returnSection || 'integrations';
       } catch {
         // State parsing failed, continue without user ID
       }
@@ -117,7 +127,7 @@ export async function GET(request: Request) {
         summary: 'Re-authenticated Google Calendar integration',
       });
 
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_reauth`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_reauth${anchorFor(returnSection)}`);
     }
 
     // Fetch calendars using the plaintext token (before we discard it)
@@ -179,16 +189,17 @@ export async function GET(request: Request) {
     });
 
     // Redirect back to settings with success message
-    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_connected`);
+    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_connected${anchorFor(returnSection)}`);
   } catch (error) {
     logError('Google OAuth callback error:', error);
     // returnSection may not be in scope if parsing failed early; parse state again
-    let fallbackSection = 'connections';
+    let fallbackSection = 'integrations';
     try {
       const { searchParams } = new URL(request.url);
       const s = searchParams.get('state');
-      if (s) fallbackSection = JSON.parse(s).returnSection || 'connections';
+      if (s) fallbackSection = JSON.parse(s).returnSection || 'integrations';
     } catch { /* ignore */ }
-    return NextResponse.redirect(`${BASE_URL}/settings?section=${fallbackSection}&error=google_auth_failed`);
+    const fallbackAnchor = fallbackSection === 'integrations' ? '#google-calendars' : '';
+    return NextResponse.redirect(`${BASE_URL}/settings?section=${fallbackSection}&error=google_auth_failed${fallbackAnchor}`);
   }
 }

--- a/src/app/api/auth/microsoft-tasks/callback/route.ts
+++ b/src/app/api/auth/microsoft-tasks/callback/route.ts
@@ -73,6 +73,18 @@ export async function GET(request: Request) {
     }
   }
 
+  // Anchor for error redirects when caller asked for the integrations
+  // page. Success redirects below always go through the list-selection
+  // modal that currently only lives in the legacy section, so they stay
+  // unchanged until that modal is extracted.
+  const errorAnchorByEntity = wishMemberId
+    ? '#microsoft-wish'
+    : shoppingListId
+      ? '#microsoft-shopping'
+      : '#microsoft-tasks';
+  const errorAnchor =
+    returnSection === 'integrations' ? errorAnchorByEntity : '';
+
   try {
     const code = searchParams.get('code');
     const error = searchParams.get('error');
@@ -81,13 +93,13 @@ export async function GET(request: Request) {
       const errorDescription = searchParams.get('error_description');
       console.error('Microsoft Tasks OAuth error:', error, errorDescription);
       return NextResponse.redirect(
-        `${BASE_URL}/settings?section=${returnSection}&error=microsoft_auth_denied`
+        `${BASE_URL}/settings?section=${returnSection}&error=microsoft_auth_denied${errorAnchor}`
       );
     }
 
     if (!code) {
       return NextResponse.redirect(
-        `${BASE_URL}/settings?section=${returnSection}&error=missing_code`
+        `${BASE_URL}/settings?section=${returnSection}&error=missing_code${errorAnchor}`
       );
     }
 
@@ -143,7 +155,7 @@ export async function GET(request: Request) {
   } catch (error) {
     logError('Microsoft Tasks OAuth callback error:', error);
     return NextResponse.redirect(
-      `${BASE_URL}/settings?section=${returnSection}&error=microsoft_auth_failed`
+      `${BASE_URL}/settings?section=${returnSection}&error=microsoft_auth_failed${errorAnchor}`
     );
   }
 }

--- a/src/app/api/auth/microsoft/callback/route.ts
+++ b/src/app/api/auth/microsoft/callback/route.ts
@@ -12,30 +12,34 @@ export async function GET(request: Request) {
   // Note: no requireAuth here — Microsoft calls back without a Prism session cookie.
   // The state param carries enough context; sensitive ops are gated by the token exchange itself.
 
-  try {
-    const { searchParams } = new URL(request.url);
-    const code = searchParams.get('code');
-    const error = searchParams.get('error');
-    const state = searchParams.get('state');
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+  const error = searchParams.get('error');
+  const state = searchParams.get('state');
 
+  // Parse state once at top so error redirects (including the catch
+  // block) can honor returnSection without re-parsing.
+  let sourceName = 'OneDrive Photos';
+  let returnSection = '';
+  if (state) {
+    try {
+      const parsed = JSON.parse(state);
+      sourceName = parsed.sourceName || sourceName;
+      returnSection = parsed.returnSection || '';
+    } catch { /* ignore */ }
+  }
+  const errorSection = returnSection === 'integrations' ? 'integrations' : 'connections';
+  const errorAnchor = returnSection === 'integrations' ? '#microsoft' : '';
+
+  try {
     if (error) {
       const errorDescription = searchParams.get('error_description');
       console.error('Microsoft OAuth error:', error, errorDescription);
-      return NextResponse.redirect(`${BASE_URL}/settings?section=connections&error=microsoft_auth_denied`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${errorSection}&error=microsoft_auth_denied${errorAnchor}`);
     }
 
     if (!code) {
-      return NextResponse.redirect(`${BASE_URL}/settings?section=connections&error=missing_code`);
-    }
-
-    let sourceName = 'OneDrive Photos';
-    if (state) {
-      try {
-        const parsed = JSON.parse(state);
-        sourceName = parsed.sourceName || sourceName;
-      } catch {
-        // Ignore parse errors
-      }
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${errorSection}&error=missing_code${errorAnchor}`);
     }
 
     const tokens = await exchangeCodeForTokens(code);
@@ -64,9 +68,15 @@ export async function GET(request: Request) {
       sourceId = created?.id ?? '';
     }
 
+    // When initiated from the new Integrations card, land on the OneDrive
+    // sub-section so the user sees what they just connected. Legacy callers
+    // (no returnSection in state) fall through to the existing photos page.
+    if (returnSection === 'integrations') {
+      return NextResponse.redirect(`${BASE_URL}/settings?section=integrations&success=onedrive_connected&sourceId=${sourceId}#microsoft-onedrive`);
+    }
     return NextResponse.redirect(`${BASE_URL}/settings?section=photos&success=onedrive_connected&sourceId=${sourceId}`);
   } catch (error) {
     logError('Microsoft OAuth callback error:', error);
-    return NextResponse.redirect(`${BASE_URL}/settings?section=connections&error=microsoft_auth_failed`);
+    return NextResponse.redirect(`${BASE_URL}/settings?section=${errorSection}&error=microsoft_auth_failed${errorAnchor}`);
   }
 }

--- a/src/app/api/auth/microsoft/route.ts
+++ b/src/app/api/auth/microsoft/route.ts
@@ -13,8 +13,13 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const sourceName = searchParams.get('sourceName') || 'OneDrive Photos';
+    // returnSection lets the new MicrosoftProviderCard route the callback
+    // back to /settings?section=integrations#microsoft-onedrive. Legacy
+    // callers (ConnectedAccountsSection's Connect OneDrive button) omit
+    // the param and keep the existing ?section=photos behavior.
+    const returnSection = searchParams.get('returnSection') || '';
 
-    const state = JSON.stringify({ sourceName });
+    const state = JSON.stringify({ sourceName, returnSection });
     const authUrl = await getMicrosoftAuthUrl(state);
 
     return NextResponse.redirect(authUrl);

--- a/src/app/settings/sections/integrations/cards/MicrosoftProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/MicrosoftProviderCard.tsx
@@ -30,7 +30,10 @@ const MicrosoftIcon = () => (
 );
 
 const handleConnect = () => {
-  window.location.href = '/api/auth/microsoft';
+  // Tells /api/auth/microsoft/callback to route back to the consolidated
+  // Integrations page (with the OneDrive sub-section auto-expanded) instead
+  // of the legacy ?section=photos default.
+  window.location.href = '/api/auth/microsoft?returnSection=integrations';
 };
 
 export function MicrosoftProviderCard({


### PR DESCRIPTION
## Phase 2A of the legacy-section deletion sweep

Updates Google, Google Tasks, Microsoft (OneDrive), and Microsoft Tasks OAuth callbacks to land users on `/settings?section=integrations#<provider>` when the flow was initiated from the new Integrations cards. Legacy callers (Connected Accounts / Task Sync / Shopping Sync / Wish List Sync sections, still mounted) keep their existing destinations because they pass explicit `returnSection=connections|tasks|shopping|wish` in state.

## Mechanism

Opt-in `returnSection` field in OAuth state. The `MicrosoftProviderCard`'s Connect button now passes `?returnSection=integrations` to `/api/auth/microsoft`, which bundles it into state, and the callback redirects accordingly. The `GoogleProviderCard` already passed `returnSection=integrations` from phase 1.

## Files

- `src/app/api/auth/google/callback/route.ts` — default `returnSection` flipped from `connections` to `integrations`; redirects append `#google-calendars` anchor when target is Integrations.
- `src/app/api/auth/google-tasks/callback/route.ts` — error redirects honor `returnSection`; success redirect stays pointed at `?section=tasks` (list-selection modal lives there until phase 2B).
- `src/app/api/auth/microsoft/route.ts` — accepts `returnSection` query param, bundles into state.
- `src/app/api/auth/microsoft/callback/route.ts` — state-parse hoisted out of try so error redirects respect it; success path branches to `?section=integrations#microsoft-onedrive` when state has `returnSection=integrations`, falls through to `?section=photos` otherwise.
- `src/app/api/auth/microsoft-tasks/callback/route.ts` — error redirects honor `returnSection` with per-entity anchors (`#microsoft-tasks`/`#microsoft-shopping`/`#microsoft-wish`). Success path unchanged for the same list-selection-modal reason.
- `src/app/settings/sections/integrations/cards/MicrosoftProviderCard.tsx` — Connect URL passes `?returnSection=integrations`.
- `docs/CHANGELOG.md` — entry under Unreleased.

## Deferred to phase 2B

- **Kroger callback** — uses request-derived URLs (`settingsUrl(request, ...)`), hardcoded `section=shopping`. Stays valid as long as legacy shopping section is mounted. Move when 2B deletes that section.
- **Google Tasks + Microsoft Tasks success paths** — end in a list-selection modal that currently only lives in `TaskIntegrationsSection`. Move when that modal is extracted into the new card sub-sections.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --ci` — 1156/1156 pass, no new failures.
- [ ] **Manual smoke test after merge — this is the verification gate before phase 2B:**
  1. From the Integrations page, click Re-authenticate on the Google card. Confirm you land back on `?section=integrations#google-calendars` after authenticating.
  2. From the Integrations page, click Connect on the Microsoft card (or add an OneDrive source). Confirm you land back on `?section=integrations#microsoft-onedrive` after authenticating.
  3. From the legacy Connected Accounts page, click Re-authenticate on Google. Confirm the existing behavior — land back on `?section=connections`. (Sanity check that legacy still works.)
- [ ] Visual regression: no UI changes; baselines unchanged.

If all three manual checks pass, phase 2B can delete the legacy sections safely.