### PR TITLE
fix(settings): nav stuck on bus page after Gmail auth (#52 phase 2A.1)

### DIFF
--- a/src/app/api/auth/google-bus/callback/route.ts
+++ b/src/app/api/auth/google-bus/callback/route.ts
@@ -17,18 +17,31 @@ export async function GET(request: Request) {
   const forbidden = requireRole(auth, 'canModifySettings');
   if (forbidden) return forbidden;
 
+  // Parse state once at top so all redirects honor returnSection. Default
+  // 'bus' preserves legacy callers (BusTrackingSection's Connect Gmail
+  // button still uses /api/auth/google-bus with no returnSection).
+  const { searchParams } = new URL(request.url);
+  const state = searchParams.get('state');
+  let returnSection = 'bus';
+  if (state) {
+    try {
+      const parsed = JSON.parse(state);
+      returnSection = parsed.returnSection || 'bus';
+    } catch { /* ignore */ }
+  }
+  const anchor = returnSection === 'integrations' ? '#google-bus' : '';
+
   try {
-    const { searchParams } = new URL(request.url);
     const code = searchParams.get('code');
     const error = searchParams.get('error');
 
     if (error) {
       logError('Gmail OAuth error:', error);
-      return NextResponse.redirect(`${BASE_URL}/settings?section=bus&error=gmail_auth_denied`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=gmail_auth_denied${anchor}`);
     }
 
     if (!code) {
-      return NextResponse.redirect(`${BASE_URL}/settings?section=bus&error=missing_code`);
+      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=missing_code${anchor}`);
     }
 
     const tokens = await exchangeGmailCodeForTokens(code);
@@ -66,9 +79,9 @@ export async function GET(request: Request) {
       summary: 'Connected Gmail for bus tracking',
     });
 
-    return NextResponse.redirect(`${BASE_URL}/settings?section=bus&success=gmail_connected`);
+    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=gmail_connected${anchor}`);
   } catch (error) {
     logError('Gmail OAuth callback error:', error);
-    return NextResponse.redirect(`${BASE_URL}/settings?section=bus&error=gmail_auth_failed`);
+    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=gmail_auth_failed${anchor}`);
   }
 }

--- a/src/app/api/auth/google-bus/route.ts
+++ b/src/app/api/auth/google-bus/route.ts
@@ -3,7 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { getGmailAuthUrl } from '@/lib/integrations/gmail';
 import { logError } from '@/lib/utils/logError';
 
-export async function GET() {
+export async function GET(request: Request) {
   const auth = await requireAuth();
   if (auth instanceof NextResponse) return auth;
 
@@ -11,7 +11,13 @@ export async function GET() {
   if (forbidden) return forbidden;
 
   try {
-    const state = JSON.stringify({ returnSection: 'bus' });
+    const { searchParams } = new URL(request.url);
+    // returnSection lets the new GoogleProviderCard route the callback back
+    // to /settings?section=integrations#google-bus. Default 'bus' preserves
+    // legacy callers (BusTrackingSection's Connect Gmail button).
+    const returnSection = searchParams.get('returnSection') || 'bus';
+
+    const state = JSON.stringify({ returnSection });
     const authUrl = await getGmailAuthUrl(state);
     return NextResponse.redirect(authUrl);
   } catch (error) {

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -133,16 +133,23 @@ export function SettingsView() {
   const initialSection = searchParams.get('section') || 'account';
   const [activeSection, setActiveSection] = useState<string>(initialSection);
 
-  // Sync activeSection when the URL changes mid-mount. Without this, in-app
-  // links like <Link href="/settings?section=calendars"> from inside one
-  // section update the address bar but never re-render the content panel
+  // Sync activeSection when the URL section changes mid-mount. Without this,
+  // in-app links like <Link href="/settings?section=calendars"> from inside
+  // one section update the address bar but never re-render the content panel
   // — SettingsView only read the search param at first mount.
+  //
+  // Deps are [urlSection] only. Including activeSection here breaks sidebar
+  // clicks: clicking a different section in the nav updates activeSection
+  // but leaves urlSection unchanged, so on the next render the effect would
+  // see (urlSection !== activeSection) and snap activeSection back to the
+  // stale URL value. (This is the "stuck on bus tracking after Gmail auth"
+  // bug.) Only the URL changing should trigger a sync.
   const urlSection = searchParams.get('section');
   React.useEffect(() => {
-    if (urlSection && urlSection !== activeSection) {
+    if (urlSection) {
       setActiveSection(urlSection);
     }
-  }, [urlSection, activeSection]);
+  }, [urlSection]);
 
   const sections = [
     { id: 'account', label: 'Account & Profile', icon: User },

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -87,7 +87,8 @@ export function GoogleProviderCard({
       '/api/auth/google?reauth=all&returnSection=integrations';
   };
   const handleConnectGmail = () => {
-    window.location.href = '/api/auth/google-bus';
+    window.location.href =
+      '/api/auth/google-bus?returnSection=integrations';
   };
 
   const handleDisconnectGoogle = async () => {


### PR DESCRIPTION
## Two bugs from the phase 2A smoke test

### 1. Sidebar nav was getting overridden by stale URL

My PR #96 added a useEffect that synced `activeSection` from the URL — necessary because in-card Links update the URL but SettingsView read it only at mount. I included **both** `urlSection` and `activeSection` in the dep array. Result: clicking a different section in the sidebar updated `activeSection`, but `urlSection` stayed pointed at the previous URL. The next render fired the effect, saw `urlSection !== activeSection`, and snapped `activeSection` back. The user got trapped on whatever page the URL last reflected (in this case, Bus Tracking after a Gmail callback).

Fix: dep array is `[urlSection]` only. The effect now only fires when the URL section value genuinely changes (e.g. via a `<Link>` click), not when the user just clicked the sidebar.

### 2. Gmail callback always landed on `?section=bus`

`/api/auth/google-bus/callback` hardcoded `?section=bus` on every redirect, even when the flow was initiated from the new Integrations card's Bus Tracking sub-section. Threaded `returnSection` through state the same way the Phase 2A Google/Microsoft callbacks do; default stays `'bus'` so the legacy `BusTrackingSection` Connect Gmail button is unchanged.

The Google card's Bus tracking sub-section now passes `?returnSection=integrations` to `/api/auth/google-bus`, the init route bundles it into state, and the callback redirects to `?section=integrations#google-bus` on success.

## Files

- `src/app/settings/SettingsView.tsx` — drop `activeSection` from useEffect deps.
- `src/app/api/auth/google-bus/route.ts` — accept `returnSection` query param, default `'bus'`.
- `src/app/api/auth/google-bus/callback/route.ts` — honor `returnSection` from state with `#google-bus` anchor.
- `src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx` — Gmail Connect URL passes `?returnSection=integrations`.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [ ] Manual smoke after merge:
  1. Integrations → Google card → Bus tracking sub-section → Connect Gmail. After auth, lands on `?section=integrations#google-bus`.
  2. Integrations → click a different sidebar section (e.g. Family). Stays on Family — does not snap back.
  3. Legacy Bus Tracking page → Connect Gmail. After auth, lands on `?section=bus` (existing behavior).