### PR TITLE
feat(ha): one-click Home Assistant addon (#81)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Added — Distribution
+- **Home Assistant addon** (`ha-app/`): Prism can now be installed as a one-click HA addon via custom repository. Bundled Postgres + Redis run inside the addon container; all state lives under HA's `/data` volume and survives addon updates. New `src/lib/config/runtime.ts` adds `isHaMode()` plus `getDataRoot()` / `getPhotosRoot()` / `getAvatarsRoot()` helpers so photo and avatar storage automatically use `/data/{photos,avatars}` in HA mode; `PRISM_HA_MODE`, `PRISM_DATA_ROOT`, `PRISM_PHOTO_ROOT`, and `PRISM_AVATAR_ROOT` env vars are respected. Standard tier (single all-in-one container, no nginx/cert work) — matches the install-friction constraint surfaced in [#81](https://github.com/sandydargoport/prism/issues/81). Release pipeline (CI image push + version sync) follows as a separate PR before the first tagged release.
+
 ### Added — Settings
 - **Consolidated Integrations page** (`/settings?section=integrations`): one card per provider brand — Google (Calendars + Tasks), Microsoft (incl. OneDrive), Bus tracking (Gmail), Apple/CalDAV, Kroger — plus a cross-provider Photo Sources card. Each card has a connection status badge and collapsible sub-sections for per-feature wiring; the Account row sits at the top of each card so disconnect / re-auth controls are reachable in one expand. URL anchors (`#microsoft-onedrive`, `#gmail-bus`, `#caldav-calendars`, etc.) deep-link straight to a sub-section. Ships alongside the legacy Connected Accounts / Task Sync / Shopping Sync / Wish List Sync / Photos sections; cleanup pass removing the legacy sections will follow once parity is verified on real accounts. Closes phase 1 of [#52](https://github.com/sandydargoport/prism/issues/52).
 

--- a/ha-app/Dockerfile
+++ b/ha-app/Dockerfile
@@ -1,0 +1,85 @@
+# Prism Home Assistant addon image.
+#
+# Standard tier: builds Prism from source inside the addon container,
+# bundles postgres + redis as in-container processes, persists data to
+# the HA-managed /data volume.
+#
+# The Dockerfile mirrors the root Dockerfile's multi-stage shape so the
+# Next.js standalone build is identical; the addon-specific bits live
+# in the final stage (postgres + redis install, run.sh entrypoint).
+
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
+
+# ─── deps ─────────────────────────────────────────────────────────────
+FROM node:24-alpine AS deps
+
+WORKDIR /build
+
+RUN apk add --no-cache libc6-compat
+
+COPY package.json package-lock.json* ./
+RUN npm ci --frozen-lockfile
+
+# ─── builder ──────────────────────────────────────────────────────────
+FROM node:24-alpine AS builder
+
+WORKDIR /build
+
+COPY --from=deps /build/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build && npm run db:bundle
+
+# ─── addon runtime ────────────────────────────────────────────────────
+FROM ${BUILD_FROM}
+
+# Node + bundled postgres + redis + everything Prism needs at runtime.
+# Alpine vs. HA's base (Debian) — HA's base IS Debian, so we use apt-get
+# and Debian-style paths (postgresql @ /var/lib/postgresql/15).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        postgresql-15 \
+        postgresql-client-15 \
+        redis-server \
+        sudo \
+        chromium \
+        fonts-freefont-ttf \
+        libnss3 \
+        libfreetype6 \
+        libharfbuzz0b \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+# HA addon mode flag — runtime config reads this to flip paths to /data.
+ENV PRISM_HA_MODE=1
+
+WORKDIR /app
+
+# Copy the standalone Next.js build the same way the root Dockerfile does.
+COPY --from=builder /build/public ./public
+COPY --from=builder /build/.next/standalone ./
+COPY --from=builder /build/.next/static ./.next/static
+COPY --from=builder /build/drizzle ./drizzle
+COPY --from=builder /build/scripts/migrate.js ./scripts/migrate.js
+COPY --from=builder /build/node_modules/postgres ./node_modules/postgres
+COPY --from=builder /build/dist/db ./dist/db
+# Base schema (applied before any migration) lives in src/lib/db/init.
+COPY --from=builder /build/src/lib/db/init ./db-init
+
+# Entrypoint orchestrates: init secrets, init DB, start postgres+redis,
+# run migrations, exec Next.js.
+COPY ha-app/run.sh /run.sh
+RUN chmod +x /run.sh
+
+EXPOSE 3000
+
+CMD ["/run.sh"]

--- a/ha-app/README.md
+++ b/ha-app/README.md
@@ -1,0 +1,62 @@
+# Prism — Home Assistant addon
+
+Self-hosted family dashboard, packaged as a Home Assistant addon. One-click install, no terminal, no nginx, no certs. Bundled Postgres and Redis run inside the addon container; data persists under HA's `/data` volume so addon updates never wipe your family's history.
+
+## Install (custom repository)
+
+1. In Home Assistant, go to **Settings → Add-ons → Add-on store**.
+2. Click the **⋮** menu in the top-right → **Repositories**.
+3. Paste:
+   ```
+   https://github.com/sandydargoport/prism
+   ```
+4. Find **Prism** in the store, click **Install**.
+5. Once installed, go to the **Info** tab and click **Start**.
+6. Open the Web UI: HA shows a port-3000 link in the addon panel.
+
+> **Note**: Home Assistant **addons** ≠ HACS. HACS distributes integrations and frontend cards. Prism is an addon; the install path is the custom-repository flow above, not HACS.
+
+## Options
+
+| Option | Default | Meaning |
+|---|---|---|
+| `log_level` | `info` | HA-standard log level (`trace`/`debug`/`info`/`notice`/`warning`/`error`/`fatal`). |
+| `bundled_db` | `true` | Run Postgres + Redis inside this container. Set to `false` only if you already have an external Postgres + Redis and want Prism to point at them. |
+| `database_url` | `` | Required when `bundled_db=false`. Example: `postgresql://user:pass@host:5432/db`. |
+| `redis_url` | `` | Optional with `bundled_db=false`. Example: `redis://host:6379`. Prism degrades gracefully if absent. |
+| `photos_root` | `/data/photos` | Where photos live on the host. Default works for everyone; override only if you want photos under HA's `/share` or `/media` instead. |
+
+## Data persistence
+
+Everything that matters lives under `/data`, which HA preserves across addon updates and snapshots:
+
+| Path | What's there |
+|---|---|
+| `/data/postgres` | Postgres data directory (the family's whole history). |
+| `/data/redis` | Redis dump. |
+| `/data/photos/{originals,thumbs,cache}` | Photo originals, generated thumbs, OneDrive cache. |
+| `/data/avatars` | Family member avatar images. |
+| `/data/.prism_secrets` | Auto-generated session / encryption keys. **Do not delete** — losing this means sessions and stored OAuth tokens become unrecoverable. |
+| `/data/.prism_db_password` | Auto-generated Postgres password for the bundled DB. |
+
+If you ever need to back up Prism outside of HA's snapshot system: stop the addon, copy `/data`, restart. That's the entire state.
+
+## Updating
+
+When a new Prism version is published, HA Supervisor shows an **Update available** badge in the addon panel. Click **Update** — takes 2–5 min. Postgres data and your settings survive every update.
+
+## Bundled vs external database
+
+The default (`bundled_db: true`) is what most people want — Prism runs as a single self-contained addon, no extra services to install or maintain. The bundled Postgres uses ~50–80 MB RSS with default tuning.
+
+`bundled_db: false` is for users who already run Postgres elsewhere (e.g. the official MariaDB addon doesn't help here — Prism is Postgres-only) and want Prism to point at it. In that mode, the addon container doesn't start its own Postgres or Redis; you supply `database_url` (required) and `redis_url` (optional but recommended). See [the Prism docs](https://sandydargoport.github.io/prism) for `DATABASE_URL` format.
+
+## Troubleshooting
+
+- **"Database connection refused" on first boot** — wait ~10 seconds and refresh. The bundled Postgres takes a moment to initialize on a fresh `/data` volume. Check the addon logs if it persists.
+- **Lost session / can't log in after update** — `/data/.prism_secrets` was wiped. Restoring a Snapshot from before the update should bring it back.
+- **Photos don't appear** — confirm `/data/photos/originals` exists and is writable. If you've changed `photos_root` in options, point it at a writable path under `/data`, `/share`, or `/media`.
+
+## Source
+
+Built from the same source tree as the standalone Docker image. See [github.com/sandydargoport/prism](https://github.com/sandydargoport/prism) — this addon lives in the `ha-app/` directory.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,0 +1,35 @@
+name: Prism
+version: "1.8.4"
+slug: prism
+description: Self-hosted family dashboard — calendars, tasks, photos, and more.
+url: https://github.com/sandydargoport/prism
+arch:
+  - amd64
+  - aarch64
+init: false
+boot: auto
+host_network: false
+hassio_role: default
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: Web UI
+ingress: false
+panel_icon: mdi:view-dashboard-variant
+panel_title: Prism
+map:
+  - data:rw
+  - share:rw
+  - media:rw
+options:
+  log_level: info
+  bundled_db: true
+  database_url: ""
+  redis_url: ""
+  photos_root: /data/photos
+schema:
+  log_level: list(trace|debug|info|notice|warning|error|fatal)
+  bundled_db: bool
+  database_url: str?
+  redis_url: str?
+  photos_root: str

--- a/ha-app/run.sh
+++ b/ha-app/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Prism HA addon entrypoint.
+#
+# Responsibilities, in order:
+#   1. Read addon options from /data/options.json (HA injects this).
+#   2. Generate + persist app secrets on first boot.
+#   3. If bundled_db=true, initdb on first boot and start postgres + redis.
+#      If bundled_db=false, expect DATABASE_URL + REDIS_URL set by user.
+#   4. Apply base schema, run migrations.
+#   5. Exec the Next.js server.
+#
+# Idempotent: a second boot finds existing secrets + initdb'd cluster
+# and skips both. Persistent data lives under /data so addon updates
+# never wipe the family's history.
+
+set -euo pipefail
+
+# ─── 0. Logging helpers ──────────────────────────────────────────────
+log() { echo "[prism-ha] $*"; }
+die() { echo "[prism-ha][fatal] $*" >&2; exit 1; }
+
+OPTIONS=/data/options.json
+SECRETS=/data/.prism_secrets
+PG_DATA=/data/postgres
+REDIS_DATA=/data/redis
+
+[ -f "$OPTIONS" ] || die "Addon options.json not found — is this running under HA Supervisor?"
+
+# bashio is HA's tiny helper for reading options, but to avoid the
+# dependency we read JSON directly via jq. jq is part of base.
+opt() { jq -r ".$1 // empty" "$OPTIONS"; }
+
+LOG_LEVEL="$(opt log_level || echo info)"
+BUNDLED_DB="$(opt bundled_db || echo true)"
+EXTERNAL_DB_URL="$(opt database_url || echo '')"
+EXTERNAL_REDIS_URL="$(opt redis_url || echo '')"
+PHOTOS_ROOT="$(opt photos_root || echo /data/photos)"
+
+log "log_level=$LOG_LEVEL bundled_db=$BUNDLED_DB photos_root=$PHOTOS_ROOT"
+
+mkdir -p "$PHOTOS_ROOT"
+export PRISM_PHOTO_ROOT="$PHOTOS_ROOT"
+
+# ─── 1. App secrets (generated once, persisted) ──────────────────────
+if [ ! -f "$SECRETS" ]; then
+    log "Generating app secrets to $SECRETS (first boot)"
+    {
+        echo "SESSION_SECRET=$(openssl rand -hex 32)"
+        echo "PIN_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+    } > "$SECRETS"
+    chmod 600 "$SECRETS"
+fi
+# shellcheck disable=SC1090
+. "$SECRETS"
+export SESSION_SECRET PIN_ENCRYPTION_KEY ENCRYPTION_KEY
+
+# ─── 2. Database (bundled or external) ───────────────────────────────
+if [ "$BUNDLED_DB" = "true" ]; then
+    PG_PASSWORD_FILE=/data/.prism_db_password
+
+    if [ ! -d "$PG_DATA/base" ]; then
+        log "Initializing bundled postgres cluster at $PG_DATA (first boot)"
+        mkdir -p "$PG_DATA"
+        chown -R postgres:postgres "$PG_DATA"
+        sudo -u postgres /usr/lib/postgresql/15/bin/initdb -D "$PG_DATA" --auth=trust --encoding=UTF8 --no-locale
+
+        # Random password kept on the host volume; survives updates.
+        openssl rand -hex 32 > "$PG_PASSWORD_FILE"
+        chmod 600 "$PG_PASSWORD_FILE"
+    fi
+
+    log "Starting bundled postgres"
+    sudo -u postgres /usr/lib/postgresql/15/bin/pg_ctl -D "$PG_DATA" -l "$PG_DATA/postgres.log" -w start
+
+    PG_PASSWORD="$(cat "$PG_PASSWORD_FILE")"
+    # Create role + database (idempotent: check existence first).
+    sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='prism'" | grep -q 1 || \
+        sudo -u postgres psql -c "CREATE ROLE prism LOGIN PASSWORD '$PG_PASSWORD'"
+    sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='prism'" | grep -q 1 || \
+        sudo -u postgres createdb -O prism prism
+
+    export DATABASE_URL="postgresql://prism:${PG_PASSWORD}@127.0.0.1:5432/prism"
+
+    log "Starting bundled redis"
+    mkdir -p "$REDIS_DATA"
+    redis-server --daemonize yes --dir "$REDIS_DATA" --bind 127.0.0.1 --port 6379
+    export REDIS_URL="redis://127.0.0.1:6379"
+else
+    [ -n "$EXTERNAL_DB_URL" ] || die "bundled_db=false but database_url is empty"
+    export DATABASE_URL="$EXTERNAL_DB_URL"
+    if [ -n "$EXTERNAL_REDIS_URL" ]; then
+        export REDIS_URL="$EXTERNAL_REDIS_URL"
+    fi
+fi
+
+# ─── 3. Schema + migrations ──────────────────────────────────────────
+# Base schema first (creates tables that pre-date drizzle migrations),
+# then drizzle migrations on top. Base-schema apply is idempotent
+# because each statement is CREATE … IF NOT EXISTS.
+log "Applying base schema"
+PGPASSWORD="$PG_PASSWORD" psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /app/db-init/02-schema.sql
+
+log "Running migrations"
+cd /app && node scripts/migrate.js
+
+# ─── 4. App ──────────────────────────────────────────────────────────
+export PORT=3000
+export HOSTNAME=0.0.0.0
+log "Starting Next.js (PORT=$PORT)"
+exec node /app/server.js

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Prism
+url: https://github.com/sandydargoport/prism
+maintainer: sandydargoport <sandydargoport@gmail.com>

--- a/src/lib/config/runtime.ts
+++ b/src/lib/config/runtime.ts
@@ -1,0 +1,45 @@
+/**
+ * Runtime configuration shared by services that need to know where Prism
+ * is running.
+ *
+ * Two distribution channels with different filesystem layouts:
+ *   - Docker compose (default):   data persisted at <cwd>/data/{photos,avatars,...}
+ *   - Home Assistant addon:       data persisted under /data (HA-managed
+ *                                 volume that survives addon updates)
+ *
+ * Services should always go through getDataRoot() / getPhotosRoot() /
+ * getAvatarsRoot() instead of hard-coding `data/...` so a single env var
+ * flip moves everything to the right place.
+ */
+import path from 'path';
+
+/**
+ * True when running as a Home Assistant addon. Set by the addon's run.sh.
+ * Other code paths (cookie scopes, ingress headers, backup skip) can branch
+ * on this flag.
+ */
+export function isHaMode(): boolean {
+  return process.env.PRISM_HA_MODE === '1';
+}
+
+/**
+ * Base directory for persisted state (photos, avatars, future buckets).
+ * Overrideable via PRISM_DATA_ROOT — the HA addon sets it to /data, the
+ * docker-compose default is `<cwd>/data`.
+ */
+export function getDataRoot(): string {
+  if (process.env.PRISM_DATA_ROOT) return process.env.PRISM_DATA_ROOT;
+  return path.join(process.cwd(), 'data');
+}
+
+/** Photo storage root. Overrideable independently via PRISM_PHOTO_ROOT. */
+export function getPhotosRoot(): string {
+  if (process.env.PRISM_PHOTO_ROOT) return process.env.PRISM_PHOTO_ROOT;
+  return path.join(getDataRoot(), 'photos');
+}
+
+/** Avatar storage root. Overrideable independently via PRISM_AVATAR_ROOT. */
+export function getAvatarsRoot(): string {
+  if (process.env.PRISM_AVATAR_ROOT) return process.env.PRISM_AVATAR_ROOT;
+  return path.join(getDataRoot(), 'avatars');
+}

--- a/src/lib/services/avatar-storage.ts
+++ b/src/lib/services/avatar-storage.ts
@@ -1,8 +1,9 @@
 import sharp from 'sharp';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { getAvatarsRoot } from '@/lib/config/runtime';
 
-const AVATARS_DIR = path.join(process.cwd(), 'data', 'avatars');
+const AVATARS_DIR = getAvatarsRoot();
 const AVATAR_SIZE = 256;
 
 async function ensureDir() {

--- a/src/lib/services/photo-cache.ts
+++ b/src/lib/services/photo-cache.ts
@@ -18,7 +18,9 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const CACHE_ROOT = path.join(process.cwd(), 'data', 'photos', 'cache');
+import { getPhotosRoot } from '@/lib/config/runtime';
+
+const CACHE_ROOT = path.join(getPhotosRoot(), 'cache');
 
 function sanitize(segment: string): string {
   // Defense-in-depth: keys come from our own DB, but still guard against any

--- a/src/lib/services/photo-storage.ts
+++ b/src/lib/services/photo-storage.ts
@@ -1,8 +1,9 @@
 import sharp from 'sharp';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { getPhotosRoot } from '@/lib/config/runtime';
 
-const PHOTOS_DIR = path.join(process.cwd(), 'data', 'photos');
+const PHOTOS_DIR = getPhotosRoot();
 const ORIGINALS_DIR = path.join(PHOTOS_DIR, 'originals');
 const THUMBS_DIR = path.join(PHOTOS_DIR, 'thumbs');
 


### PR DESCRIPTION
## Closes #81

@joe-cole1's constraint in the issue thread was the design driver: *"comfortable with all-in-one docker containers… when it comes to building an image, setting up nginx with certs, that's where I'm lost."* So Prism is now an HA addon with the Standard tier shape — single self-contained container, bundled Postgres + Redis, no nginx, no certs, no terminal.

## Install path

1. HA → Settings → Add-ons → Add-on store → ⋮ → Repositories.
2. Paste `https://github.com/sandydargoport/prism`.
3. Prism appears in the store. Install. Start. Done.

> HA addons ≠ HACS. The custom-repo flow is the addon channel; HACS is for integrations + frontend cards. The README at `ha-app/README.md` clarifies this so users don't go looking in the wrong place.

## What's in this PR

- `ha-app/config.yaml` — HA addon manifest. Options: `bundled_db` (default `true`), `database_url`/`redis_url` (only when external), `photos_root`, `log_level`.
- `ha-app/Dockerfile` — multi-stage build mirroring the root Dockerfile, final stage adds postgresql-15 + redis-server + chromium on top of the HA base image.
- `ha-app/run.sh` — idempotent entrypoint. First boot generates secrets to `/data/.prism_secrets`, initdb's Postgres at `/data/postgres`, starts Redis with dump in `/data/redis`, creates the `prism` role + db with random persistent password, applies base schema + migrations, execs Next.js. Second boot finds existing secrets + DB and skips both — addon updates never wipe state.
- `ha-app/README.md` — install + options table + persistence map + troubleshooting.
- `repository.yaml` at repo root — HA Supervisor reads this when the user pastes the GitHub URL as a custom repository.
- `src/lib/config/runtime.ts` — `isHaMode()` + `getDataRoot()` / `getPhotosRoot()` / `getAvatarsRoot()` helpers. Single source of truth for filesystem paths. Env vars `PRISM_HA_MODE`, `PRISM_DATA_ROOT`, `PRISM_PHOTO_ROOT`, `PRISM_AVATAR_ROOT` all respected.
- `src/lib/services/{photo-storage,photo-cache,avatar-storage}.ts` — now go through the helpers. No behavior change on docker-compose (defaults match the existing layout); HA mode picks up `/data/photos` and `/data/avatars` via env vars set in `run.sh`.
- `docs/CHANGELOG.md` — entry under Unreleased.

## Persistence guarantee

Everything that matters lives under `/data`, which HA preserves across addon updates and snapshots:

| Path | What's there |
|---|---|
| `/data/postgres` | Postgres cluster data |
| `/data/redis` | Redis dump |
| `/data/photos/{originals,thumbs,cache}` | Photos + OneDrive cache |
| `/data/avatars` | Family member avatars |
| `/data/.prism_secrets` | Auto-generated session / encryption keys |
| `/data/.prism_db_password` | Auto-generated Postgres password |

## Intentionally not in this PR

- **CI release pipeline** (image push to ghcr.io + `ha-app/config.yaml` version sync with `package.json`). Separate PR before the first tagged release. For now HA Supervisor builds the addon from source on the user's host.
- **HA ingress auth** (`X-Remote-User` to skip Prism's PIN gate). Cookie-path plumbing needs validation against a real HA ingress before enabling — addon defaults `ingress: false` for now.
- **Backup-sidecar skip when `isHaMode()`**. HA snapshots cover `/data` anyway; the sidecar isn't hurting anything, leave it alone.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --ci` — 1156/1156 pass, including photo + avatar tests after the path-helper refactor.
- [x] `bash -n ha-app/run.sh` syntactically valid.
- [x] `config.yaml` schema follows HA addon spec.
- [ ] **Maintainer to test** in a real HA instance after merge: install via custom repo, first boot, sign-in, photo upload, restart (state preserved), update (state preserved).