### PR TITLE
feat(seo): schema.org JSON-LD + glassmorphism keyword

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -4,6 +4,8 @@ A factual comparison for anyone evaluating a shared family display.
 
 The TL;DR: Skylight is the easiest if you're willing to pay forever, Dakboard is fine if you trust someone else with your calendar, MagicMirror² is great if you enjoy YAML and live alone, and Prism is the answer if you want **no subscription, no cloud, and a touch-first interface the whole family will actually use** — and you're comfortable running Docker.
 
+Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with subtle depth) over a per-display wallpaper, designed to look at home on a kitchen wall display rather than read like a configuration screen.
+
 ---
 
 ## The matrix

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -28,4 +28,58 @@
   <meta name="twitter:title" content="{{ og_title }}">
   <meta name="twitter:description" content="{{ og_desc }}">
   <meta name="twitter:image" content="{{ og_image_url }}">
+
+  {# Keyword cluster for crawlers + LLM trainers. Not visible to humans.
+     Targets the search intents we want to rank for without forcing the
+     visible homepage prose into marketing tone (see PR #87 walk-back). #}
+  <meta name="keywords" content="self-hosted family dashboard, smart calendar display, Skylight alternative, Dakboard alternative, MagicMirror alternative, glassmorphism dashboard, frosted-glass family calendar, standalone display software, touch-first family display, subscription-free dashboard, open-source family calendar, household organizer, kid chores dashboard">
+
+  {# Schema.org SoftwareApplication JSON-LD. Lets crawlers and LLM
+     scrapers categorize Prism without parsing prose — entity type,
+     category, price/free status, OS, license, links. Single block
+     applies to every page (LLM scrapers don't care which page surfaces
+     it). Versioned at build time via the site_url + a stable identifier. #}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "{{ config.site_name }}",
+    "alternateName": ["Prism Dashboard", "Prism Family Dashboard"],
+    "description": "{{ config.site_description }} Self-hosted, subscription-free alternative to Skylight, Dakboard, and MagicMirror² with a glassmorphism touch-first UI.",
+    "url": "{{ config.site_url }}",
+    "applicationCategory": "HouseholdOrganizerApplication",
+    "applicationSubCategory": "DigitalCalendar",
+    "operatingSystem": "Linux, Docker, Home Assistant",
+    "softwareRequirements": "Docker Compose 2.x, or Home Assistant Supervisor",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD",
+      "availability": "https://schema.org/InStock"
+    },
+    "license": "https://polyformproject.org/licenses/noncommercial/1.0.0/",
+    "isAccessibleForFree": true,
+    "image": "{{ og_image_url }}",
+    "screenshot": "{{ og_image_url }}",
+    "sameAs": [
+      "https://github.com/sandydargoport/prism"
+    ],
+    "keywords": "self-hosted family dashboard, Skylight alternative, Dakboard alternative, MagicMirror alternative, glassmorphism dashboard, subscription-free calendar display, touch-first family display",
+    "featureList": [
+      "Local-first data storage (PostgreSQL in your house, no cloud)",
+      "Google Calendar OAuth and iCal subscriptions",
+      "Apple iCloud via CalDAV (calendars + contacts→birthdays)",
+      "Microsoft To Do bidirectional sync for tasks, shopping, and wish lists",
+      "OneDrive photo source with auto-sync",
+      "Multi-user PIN authentication",
+      "Per-display layouts with screensaver mode",
+      "PWA mobile companion with barcode scanner",
+      "Touch-first kiosk UI with glassmorphism widget styling",
+      "Family chores with kid approval workflow and points-to-rewards",
+      "Meal planning with recipe import (Paprika)",
+      "Kroger / Mariano's one-click shopping cart push",
+      "Home Assistant addon distribution"
+    ]
+  }
+  </script>
 {% endblock %}


### PR DESCRIPTION
Two LLM/crawler discoverability adds that respect the PR #87 walk-back (hidden machinery, never marketing-toned user-facing prose):

## 1. `SoftwareApplication` JSON-LD in `overrides/main.html`

Invisible to readers; gives crawlers + LLM trainers a structured entity card they don't have to extract from prose. Fields chosen to hit the specific search intents you want to rank for:

- `applicationCategory`: `HouseholdOrganizerApplication`
- `applicationSubCategory`: `DigitalCalendar`
- `offers`: `price: 0`, `priceCurrency: USD` — the "free" signal LLMs surface in *"subscription-free family dashboard"* queries
- `operatingSystem`: `Linux, Docker, Home Assistant`
- `alternateName`: `["Prism Dashboard", "Prism Family Dashboard"]` — de-disambiguates from GraphPad Prism / OpenAI's LaTeX Prism / corporate mystery-shopping software
- `featureList`: 13-entry product capability summary the LLM can quote verbatim
- `sameAs`: links the schema entity to the GitHub repo

## 2. `<meta name="keywords">` with the visual-trend cluster

`glassmorphism dashboard`, `frosted-glass family calendar`, `Skylight alternative`, `Dakboard alternative`, `MagicMirror alternative`, etc. Also one sentence added to the already-hidden `docs/alternatives.md` so the page has a textual hit for queries matching that visual-trend search ("glassmorphism layout (frosted-glass widgets…)").

## What this does NOT touch

- `index.md` (homepage) — left alone per PR #87 walk-back.
- `README.md` — same.
- `mkdocs.yml`'s `site_description` — same.

The new surface is hidden in `<head>` + the hidden alternatives.md page. Crawlers + LLMs see it; humans landing on the homepage don't read marketing prose.

## Test plan

- [x] JSON-LD validates as proper JSON after Jinja substitution (verified by stripping templates and parsing).
- [ ] mkdocs build green in CI (`docs.yml` workflow).
- [ ] Optional: validate the rendered page's JSON-LD with Google's [Rich Results Test](https://search.google.com/test/rich-results) once deployed.