### PR TITLE
fix(ha): switch addon base to node:24-alpine (apt-get → apk add)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,8 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
-            base: ghcr.io/home-assistant/amd64-base:latest
           - arch: aarch64
             platform: linux/arm64
-            base: ghcr.io/home-assistant/aarch64-base:latest
 
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +89,6 @@ jobs:
           file: ha-app/Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
-            BUILD_FROM=${{ matrix.base }}
             PRISM_REF=${{ steps.ver.outputs.tag }}
           push: true
           tags: |

--- a/ha-app/Dockerfile
+++ b/ha-app/Dockerfile
@@ -2,53 +2,57 @@
 #
 # HA Supervisor uses the addon's own folder (ha-app/) as the Docker build
 # context, so the Dockerfile can't reach `../package.json` or anything else
-# in the parent repo. To stay buildable on a user's HA host without
-# requiring a separate published image, we clone the Prism source at
-# build time and build inside this container.
+# in the parent repo. To stay buildable on a user's HA host, we clone the
+# Prism source at build time and build inside this container.
 #
-# When the release pipeline (#104) publishes pre-built multi-arch images
-# to ghcr.io, this Dockerfile gets replaced with a tiny wrapper that just
-# `FROM`s the published image and copies run.sh — install drops from
-# ~10 min to ~30 s.
+# Why node:24-alpine instead of HA's official `ghcr.io/home-assistant/
+# <arch>-base`: package.json requires Node >=24, and HA's base images
+# (Alpine 3.x) ship Node 20 via the `nodejs` apk package. Pulling a real
+# Node 24 onto HA's base is more friction than just using the official
+# node:24-alpine multi-arch image and adding what we need on top.
+# Supervisor doesn't care which base — it just runs the container's CMD.
 
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
-FROM ${BUILD_FROM}
+FROM node:24-alpine
 
 # Pin which Prism ref the addon builds from. Defaults to master so a
-# fresh `Update` from the HA UI grabs the latest. Override via HA build
-# args if you want a tagged release.
+# fresh `Update` from the HA UI grabs the latest. The release pipeline
+# overrides this to the version tag (`v1.8.5`) for reproducible builds.
 ARG PRISM_REF=master
 
-# Install everything in a single layer: postgres + redis (bundled DB),
-# node 24 (build + runtime), chromium (Puppeteer screenshots), git (to
-# fetch the source).
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+# Single-layer install of everything the build + runtime needs:
+#   - bash         (run.sh shebang; alpine ships ash by default)
+#   - git          (clone Prism source at build time)
+#   - postgres + redis  (bundled DB + cache)
+#   - chromium     (Puppeteer screenshots for share-card rendering)
+#   - sudo         (drop privileges for postgres role switch in run.sh)
+#   - jq, openssl  (run.sh: parse options.json, generate secrets)
+#   - libc6-compat (sharp / native modules — same pattern as root Dockerfile)
+RUN apk add --no-cache \
+        bash \
         ca-certificates \
         curl \
         git \
-        postgresql-15 \
-        postgresql-client-15 \
-        redis-server \
-        sudo \
-        chromium \
-        fonts-freefont-ttf \
-        libnss3 \
-        libfreetype6 \
-        libharfbuzz0b \
-        openssl \
         jq \
-    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+        openssl \
+        sudo \
+        postgresql15 \
+        postgresql15-client \
+        postgresql15-contrib \
+        redis \
+        chromium \
+        nss \
+        freetype \
+        harfbuzz \
+        ttf-freefont \
+        libc6-compat
 
 # Clone + build Prism inside the container. `--depth 1` keeps the clone
-# small; `${PRISM_REF}` lets you build a specific tag if you want.
+# small; `${PRISM_REF}` lets the release pipeline pin a specific tag.
 RUN git clone --depth 1 --branch ${PRISM_REF} https://github.com/sandydargoport/prism.git /src
 
 WORKDIR /src
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm ci --frozen-lockfile && \
+RUN npm ci && \
     npm run build && \
     npm run db:bundle
 
@@ -66,7 +70,8 @@ RUN cp -r /src/.next/standalone/. /app/ && \
     rm -rf /src
 
 ENV NODE_ENV=production
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+# Alpine's chromium apk package installs the binary as chromium-browser.
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 # HA addon mode flag — runtime config reads this to flip paths to /data.
 ENV PRISM_HA_MODE=1

--- a/ha-app/run.sh
+++ b/ha-app/run.sh
@@ -59,11 +59,14 @@ export SESSION_SECRET PIN_ENCRYPTION_KEY ENCRYPTION_KEY
 if [ "$BUNDLED_DB" = "true" ]; then
     PG_PASSWORD_FILE=/data/.prism_db_password
 
+    # Alpine puts postgres binaries on PATH at /usr/bin (initdb, pg_ctl,
+    # psql, createdb) under the `postgres` user, unlike Debian's
+    # /usr/lib/postgresql/15/bin/ layout.
     if [ ! -d "$PG_DATA/base" ]; then
         log "Initializing bundled postgres cluster at $PG_DATA (first boot)"
         mkdir -p "$PG_DATA"
         chown -R postgres:postgres "$PG_DATA"
-        sudo -u postgres /usr/lib/postgresql/15/bin/initdb -D "$PG_DATA" --auth=trust --encoding=UTF8 --no-locale
+        sudo -u postgres initdb -D "$PG_DATA" --auth=trust --encoding=UTF8 --no-locale
 
         # Random password kept on the host volume; survives updates.
         openssl rand -hex 32 > "$PG_PASSWORD_FILE"
@@ -71,7 +74,7 @@ if [ "$BUNDLED_DB" = "true" ]; then
     fi
 
     log "Starting bundled postgres"
-    sudo -u postgres /usr/lib/postgresql/15/bin/pg_ctl -D "$PG_DATA" -l "$PG_DATA/postgres.log" -w start
+    sudo -u postgres pg_ctl -D "$PG_DATA" -l "$PG_DATA/postgres.log" -w start
 
     PG_PASSWORD="$(cat "$PG_PASSWORD_FILE")"
     # Create role + database (idempotent: check existence first).


### PR DESCRIPTION
v1.8.5 release pipeline failed at the first install layer (exit 127) — HA's base images are Alpine, my Dockerfile used `apt-get`. Compounded by a second issue I would have hit next: HA's base ships Node 20 via the alpine `nodejs` package, but `package.json` requires Node >=24.

## The fix

Switch the addon base from `ghcr.io/home-assistant/<arch>-base` to `node:24-alpine`. Official Node.js Alpine image is published multi-arch, guarantees the version we need, and HA Supervisor doesn't care which base the addon uses — it just runs the container's CMD.

- `ha-app/Dockerfile`: hard-codes `FROM node:24-alpine`. Drops the `BUILD_FROM` arg entirely (Supervisor's `--build-arg` is silently ignored if it sets one). Rewrites the install block as `apk add` with Alpine package names: `postgresql15`, `redis`, `chromium`, `nss`, `freetype`, `harfbuzz`, `ttf-freefont`, `libc6-compat`. Drops the nodesource curl install — we don't need it, Node is in the base.
- `ha-app/run.sh`: switches from Debian-style postgres binary paths (`/usr/lib/postgresql/15/bin/initdb`) to bare names on PATH for the `postgres` user on Alpine.
- `.github/workflows/release.yml`: drops the per-arch `base:` matrix entries and the `BUILD_FROM` passthrough. Matrix shrinks to arch + platform.

## Self-flag

I should have verified the v1.8.5 release workflow's `conclusion: success` before posting the publication status to @joe-cole1 on #81. He surfaced the failure himself, which is the wrong order. Memory note added: never link a user to a still-running workflow.

## Test plan

- [x] `bash -n ha-app/run.sh` clean.
- [x] `js-yaml` validates `release.yml`.
- [ ] **Maintainer to re-tag** after merge — the tag-triggered workflow is the actual verification surface. Suggested path:
  ```
  git tag -d v1.8.5  # delete the broken tag locally
  git push origin :refs/tags/v1.8.5  # delete from remote
  git tag -a v1.8.5 -m "Release 1.8.5"  # re-tag at the new master
  git push origin v1.8.5  # fires the workflow
  ```
  Alternatively bump to v1.8.6 to keep history clean — depends on whether v1.8.5 was advertised anywhere beyond the broken release page.
- [ ] After both matrix jobs go `conclusion: success`, post follow-up to @joe-cole1.