### PR TITLE
chore(release): 1.8.6

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.6] – 2026-06-01
+
+### Fixed — Distribution
+- **HA addon release pipeline now builds successfully**: v1.8.5's tagged release was the first run of the release pipeline and exposed two compounding bugs — the addon `Dockerfile` used `apt-get` (Debian) against HA's Alpine-based supervisor base images, and even with `apk add` HA's base ships Node 20 while `package.json` requires Node ≥24. Switching the addon base from `ghcr.io/home-assistant/<arch>-base` to `node:24-alpine` resolves both: it's a published multi-arch image with the guaranteed Node version and lets HA Supervisor run the container as-is (Supervisor doesn't care which base the addon uses). `apt-get` block rewritten as `apk add` with Alpine package names; `run.sh` switched from Debian-style `/usr/lib/postgresql/15/bin/` paths to bare `initdb` / `pg_ctl` on PATH. Surfaced by @joe-cole1 in [#81](https://github.com/sandydargoport/prism/issues/81).
+
+### Added — SEO / Docs
+- **`SoftwareApplication` JSON-LD in the docs site**: structured-data entity card crawlers + LLM trainers can scrape without parsing prose — `applicationCategory`, `offers.price: 0`, `operatingSystem`, `alternateName` (de-disambiguates from GraphPad Prism / LaTeX Prism), `featureList` with 13 capabilities. Plus a `<meta name="keywords">` cluster with `glassmorphism dashboard`, `Skylight alternative`, `Dakboard alternative`, `MagicMirror alternative`, etc. Hidden from human readers (lives in `<head>` + the already-hidden `alternatives.md`) — respects the PR #87 walk-back of marketing-toned prose in user-facing surfaces.
+
 ## [1.8.5] – 2026-06-01
 
 ### Added — Distribution

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.5"
+version: "1.8.6"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
v1.8.6 includes the Alpine fix from PR #110 — the v1.8.5 release pipeline failed at the apt-get layer, this re-tags at master so the workflow can publish a working addon image. Also rolls up the docs SEO additions from PR #109. CHANGELOG updated.