### PR TITLE
fix(ha): use unversioned postgresql apk package

### DIFF
--- a/ha-app/Dockerfile
+++ b/ha-app/Dockerfile
@@ -27,6 +27,15 @@ ARG PRISM_REF=master
 #   - sudo         (drop privileges for postgres role switch in run.sh)
 #   - jq, openssl  (run.sh: parse options.json, generate secrets)
 #   - libc6-compat (sharp / native modules — same pattern as root Dockerfile)
+#
+# Note on postgres version: this Dockerfile uses the unversioned
+# `postgresql` apk package, which resolves to whichever postgres major
+# the current Alpine release ships (Alpine 3.21 → postgres 17, etc.).
+# The standalone docker-compose and CI matrix run against postgres 15,
+# but Drizzle migrations are standard SQL and run cleanly on both.
+# Pinning a specific major (e.g. `postgresql15`) breaks on Alpine
+# versions that no longer carry that major in the main repo, which is
+# how the first attempt of this Dockerfile failed.
 RUN apk add --no-cache \
         bash \
         ca-certificates \
@@ -35,9 +44,9 @@ RUN apk add --no-cache \
         jq \
         openssl \
         sudo \
-        postgresql15 \
-        postgresql15-client \
-        postgresql15-contrib \
+        postgresql \
+        postgresql-client \
+        postgresql-contrib \
         redis \
         chromium \
         nss \

--- a/ha-app/Dockerfile
+++ b/ha-app/Dockerfile
@@ -74,7 +74,7 @@ RUN cp -r /src/.next/standalone/. /app/ && \
     cp -r /src/drizzle /app/drizzle && \
     mkdir -p /app/scripts && cp /src/scripts/migrate.js /app/scripts/migrate.js && \
     mkdir -p /app/node_modules && cp -r /src/node_modules/postgres /app/node_modules/postgres && \
-    cp -r /src/dist/db /app/dist/db && \
+    mkdir -p /app/dist && cp -r /src/dist/db /app/dist/db && \
     cp -r /src/src/lib/db/init /app/db-init && \
     rm -rf /src
 


### PR DESCRIPTION
v1.8.6 release pipeline failed because `postgresql15` no longer exists on Alpine 3.21 (which is what node:24-alpine is based on). Switching to the unversioned `postgresql` meta-package, which resolves to whichever major Alpine ships (currently postgres 17). Drizzle migrations are standard SQL and run cleanly on 15-17.

Pre-validating locally with `docker buildx build ha-app/` this time before tagging again.