### PR TITLE
fix(ci): use native arm64 runner for HA addon build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,24 @@ permissions:
 jobs:
   build:
     name: Build & push (${{ matrix.arch }})
-    runs-on: ubuntu-latest
-    # arm64 via QEMU emulation is slow (~30-60 min for a build this size)
-    # but acceptable for a tag-triggered workflow. If it becomes a problem,
-    # the arm64 matrix entry can be moved to a self-hosted runner.
-    timeout-minutes: 90
+    # Native runners per arch — `ubuntu-24.04-arm` is the free arm64
+    # runner GitHub publishes for public repos. QEMU emulation was
+    # tried first; SWC/Next.js hits ARM instructions QEMU TCG can't
+    # emulate (Illegal instruction during `npm run build`), so we
+    # switched to native ARM hardware. amd64 stays on the standard
+    # ubuntu-latest runner.
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-latest
           - arch: aarch64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -68,9 +73,7 @@ jobs:
             exit 1
           fi
 
-      - name: Set up QEMU
-        if: matrix.arch != 'amd64'
-        uses: docker/setup-qemu-action@v3
+      # No setup-qemu — both runners are native to their target arch.
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
v1.8.6 release workflow shipped amd64 cleanly but the aarch64 job died with `qemu: uncaught target signal 4 (Illegal instruction)` during `npm run build`. Known QEMU TCG gap — SWC (Next.js's Rust-based compiler) uses ARM NEON instructions that x86-host QEMU can't translate.

Fix: switch the aarch64 matrix entry from `ubuntu-latest + setup-qemu-action` to `ubuntu-24.04-arm`, GitHub's free public-repo arm64 runner. Native arm64 hardware, no emulation. Drops the setup-qemu step entirely (amd64 is also native to ubuntu-latest).

Side benefits:
- aarch64 build time should match amd64 (~5 min) instead of 30-60 min QEMU.
- timeout-minutes back from 90 to 30.

Standard CI on this PR won't fire the release workflow (tag-triggered). Actual validation is the next tag push.