### PR TITLE
fix(views): consistent list-view layout + Chores filter (#105)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed — List views
+- **Chores person filter now actually filters the rendered columns**: `ChoresView`'s `choresByUser` memo iterated every family member when building columns, so selecting a single-person filter under Group:Person still showed empty columns for everyone else. Tasks and Wishes already filtered correctly; Chores now matches. Unassigned column also hides when a person filter is active (the user explicitly asked to see only those people).
+- **Per-person grids no longer squeeze when the family is large**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all used `grid-cols-2 md:grid-cols-3` which crammed 7 people (5 kids + 2 adults) into 3 narrow columns × 3 rows on a portrait tablet. Switched all five views to `gridTemplateColumns: repeat(N, minmax(220px, 1fr))` + `overflow-x-auto`. Each column gets at least 220px; if the viewport can't fit every column comfortably, the grid scrolls horizontally — same shape across all list views. Closes [#105](https://github.com/sandydargoport/prism/issues/105).
+
 ## [1.8.7] – 2026-06-01
 
 ### Fixed — Distribution

--- a/src/app/chores/ChoreGroupGrid.tsx
+++ b/src/app/chores/ChoreGroupGrid.tsx
@@ -73,18 +73,18 @@ export function ChoreGroupGrid({
     return effectiveOrder.map((k) => map.get(k)).filter(Boolean) as ChoreGroupEntry[];
   }, [choresByUser, effectiveOrder]);
 
+  // Each column gets a minimum readable width (220px); the grid spans as
+  // wide as needed and overflows horizontally when the viewport can't fit
+  // every column comfortably. Replaces the previous `grid-cols-2 md:grid-
+  // cols-3` squeeze which crammed 7 people (5 kids + 2 adults) into 3
+  // narrow columns × 3 rows (bug #105). Same shape now used in
+  // GroupedTaskGrid and WishesView for UX consistency.
   return (
     <div
-      className={cn(
-        'grid gap-2 h-full',
-        isMobile
-          ? 'grid-cols-1'
-          : sortedGroups.length <= 2
-          ? 'grid-cols-1 md:grid-cols-2'
-          : sortedGroups.length <= 4
-          ? 'grid-cols-2'
-          : 'grid-cols-2 md:grid-cols-3'
-      )}
+      className="grid gap-2 h-full overflow-x-auto"
+      style={{
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+      }}
     >
       {sortedGroups.map(({ user, chores }, idx) => {
         const userColor = user?.color || '#6B7280';

--- a/src/app/chores/ChoresView.tsx
+++ b/src/app/chores/ChoresView.tsx
@@ -87,15 +87,23 @@ export function ChoresView() {
     const assigneeMap = new Map<string, { id: string; name: string; color: string }>();
     effectiveFilteredChores.forEach(c => { if (c.assignedTo) assigneeMap.set(c.assignedTo.id, c.assignedTo); });
 
+    // When the person filter is active, only render columns for the
+    // selected people — without this, all family members appear as columns
+    // and the non-filtered ones are empty (bug #105). Matches the pattern
+    // Tasks (TaskContentArea.tsx) and Wishes (WishesView.tsx) already use.
+    const personFilterActive = filterPerson !== null && filterPerson.length > 0;
+    const isMemberAllowed = (id: string) =>
+      !personFilterActive || filterPerson!.includes(id);
+
     // All family members always get a column; append any extra assignees not in family
     const ordered: { id: string; name: string; color: string }[] = [];
     familyMembers.forEach(member => {
-      if (member.id) {
+      if (member.id && isMemberAllowed(member.id)) {
         ordered.push(member);
         assigneeMap.delete(member.id);
       }
     });
-    assigneeMap.forEach(a => ordered.push(a));
+    assigneeMap.forEach(a => { if (isMemberAllowed(a.id)) ordered.push(a); });
 
     const groups: { user: { id: string; name: string; color: string } | null; chores: typeof effectiveFilteredChores }[] = [];
     ordered.forEach(member => {
@@ -103,10 +111,14 @@ export function ChoresView() {
       groups.push({ user: member, chores: userChores });
     });
 
-    const unassigned = effectiveFilteredChores.filter(c => !c.assignedTo);
-    if (unassigned.length > 0) groups.push({ user: null, chores: unassigned });
+    // Unassigned column is hidden when a person filter is active — the user
+    // explicitly asked to see only those people, not the "no one" bucket.
+    if (!personFilterActive) {
+      const unassigned = effectiveFilteredChores.filter(c => !c.assignedTo);
+      if (unassigned.length > 0) groups.push({ user: null, chores: unassigned });
+    }
     return groups;
-  }, [groupByUser, effectiveFilteredChores, familyMembers]);
+  }, [groupByUser, effectiveFilteredChores, familyMembers, filterPerson]);
 
   const handleAddWithAuth = async () => {
     const user = await requireAuth('Add Chore', 'Please log in to add a chore');

--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -57,14 +57,18 @@ export function GroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as GroupDef[];
   }, [groups, effectiveOrder]);
 
+  // Each column gets a minimum readable width (220px); the grid overflows
+  // horizontally when the viewport can't fit every column comfortably.
+  // Replaces the previous `grid-cols-2 md:grid-cols-3` squeeze (see
+  // ChoreGroupGrid for the bug context). Same shape used in
+  // ChoreGroupGrid and WishesView for UX consistency.
   return (
-    <div className={cn(
-      'grid gap-2 h-full',
-      isMobile ? 'grid-cols-1' :
-      sortedGroups.length <= 2 ? 'grid-cols-1 md:grid-cols-2' :
-      sortedGroups.length <= 4 ? 'grid-cols-2' :
-      'grid-cols-2 md:grid-cols-3'
-    )}>
+    <div
+      className="grid gap-2 h-full overflow-x-auto"
+      style={{
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+      }}
+    >
       {sortedGroups.map((group, idx) => {
         const completedCount = group.tasks.filter((t) => t.completed).length;
         const isDragging = draggedId === group.key;

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -53,14 +53,16 @@ export function NestedGroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as NestedGroupDef[];
   }, [primaryGroups, effectiveOrder]);
 
+  // See ChoreGroupGrid for the bug context. Same min-width + horizontal-
+  // scroll shape used across Chores / Tasks (flat + nested) / Wishes /
+  // Gift Ideas for UX consistency.
   return (
-    <div className={cn(
-      'grid gap-2 h-full',
-      isMobile ? 'grid-cols-1' :
-      sortedGroups.length <= 2 ? 'grid-cols-1 md:grid-cols-2' :
-      sortedGroups.length <= 4 ? 'grid-cols-2' :
-      'grid-cols-2 md:grid-cols-3'
-    )}>
+    <div
+      className="grid gap-2 h-full overflow-x-auto"
+      style={{
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+      }}
+    >
       {sortedGroups.map((group, idx) => {
         const completedCount = group.tasks.filter(t => t.completed).length;
         const isDragging = draggedId === group.key;

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -96,15 +96,17 @@ export function GiftIdeasView() {
     return <div className="text-destructive text-center py-8">{error}</div>;
   }
 
+  // Min-width columns + horizontal scroll when group count outgrows the
+  // viewport — same shape as Chores / Tasks / Wishes. Avoids cramming
+  // many members into 3 fixed columns at 5+ kids (bug #105).
   return (
     <>
-      <div className={cn(
-        'grid gap-3 h-full',
-        isMobile ? 'grid-cols-1' :
-        isPortrait
-          ? otherMembers.length <= 2 ? 'grid-cols-1' : 'grid-cols-2'
-          : otherMembers.length <= 2 ? 'grid-cols-2' : 'grid-cols-3'
-      )}>
+      <div
+        className="grid gap-3 h-full overflow-x-auto"
+        style={{
+          gridTemplateColumns: `repeat(${Math.max(otherMembers.length, 1)}, minmax(220px, 1fr))`,
+        }}
+      >
         {otherMembers.map((member) => {
           const memberIdeas = ideasByUser[member.id] || [];
           return (

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -266,11 +266,18 @@ export function WishesView() {
         ) : error ? (
           <div className="text-destructive text-center py-8">{error}</div>
         ) : (
-          /* Grid view: one card per family member (filtered if selection active), draggable */
-          <div className={cn(
-            'grid gap-3 h-full',
-            isMobile ? 'grid-cols-1' : isPortrait ? 'grid-cols-2' : 'grid-cols-3'
-          )}>
+          /* Grid view: one card per family member (filtered if selection active), draggable.
+             Min-width columns + horizontal scroll when group count outgrows the viewport —
+             same UX shape as Chores/Tasks. Avoids cramming many members into 3 fixed columns. */
+          (() => {
+            const visibleMemberCount = orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id)).length;
+            return (
+          <div
+            className="grid gap-3 h-full overflow-x-auto"
+            style={{
+              gridTemplateColumns: `repeat(${Math.max(visibleMemberCount, 1)}, minmax(220px, 1fr))`,
+            }}
+          >
             {orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id)).map(member => {
               const memberItems = groupedItems?.[member.id] || [];
               const isDragging = draggedMemberId === member.id;
@@ -292,6 +299,8 @@ export function WishesView() {
               );
             })}
           </div>
+            );
+          })()
         )}
       </div>
 


### PR DESCRIPTION
Closes #105.

## The bugs

Two reported on the Chores page:

1. **Person filter under Group:Person didn't filter the rendered columns.** Selecting Group:Person + filtering to a single person left the other family members' columns rendered (empty). Expected: only the selected people show.
2. **Grid squeezed everyone instead of scrolling.** With 5 kids + 2 adults (7 columns), the chores grid crammed everyone into 3 narrow columns × 3 rows on a portrait tablet. Each column was ~288 px and unreadable.

## Survey across the list-shaped views

Before fixing, surveyed Chores / Tasks / Wishes / Gift Ideas / Shopping to find shared patterns:

| Page | Filter wired correctly? | Same layout-squeeze pattern? |
|---|---|---|
| Chores | ✗ bug | ✓ shared |
| Tasks (flat) | ✓ already correct | ✓ shared |
| Tasks (nested) | n/a | ✓ shared |
| Wishes | ✓ already correct | ✓ shared |
| Gift Ideas | ✓ already correct | ✓ shared |
| Shopping | n/a (groups by category) | n/a (different shape) |
| Weekend places, Travel, Recipes | n/a (flat card grids) | n/a |

Filter bug was Chores-only. **Layout squeeze was shared across 5 views** — all used the same `grid-cols-2 md:grid-cols-3` pattern. So the consistency fix is one shape applied everywhere.

## Fix

### Filter fix (`ChoresView.tsx`)
- `choresByUser` memo now honors `filterPerson` when building columns. Members not in the filter are skipped.
- Unassigned column hides when a person filter is active (the user explicitly asked to see only those people).
- `filterPerson` added to the memo's dep array.

### Layout fix (5 files)
- `ChoreGroupGrid.tsx`, `GroupedTaskGrid.tsx`, `NestedGroupedTaskGrid.tsx`, `WishesView.tsx`, `GiftIdeasView.tsx` all switch from:
  ```tsx
  className={cn('grid', isMobile ? 'grid-cols-1' : 'grid-cols-2 md:grid-cols-3', ...)}
  ```
  to:
  ```tsx
  className="grid gap-X overflow-x-auto"
  style={{ gridTemplateColumns: `repeat(${N}, minmax(220px, 1fr))` }}
  ```

Each column gets at least 220 px of readable width. When the viewport can't fit all columns comfortably, the grid scrolls horizontally instead of cramming.

Mobile naturally falls through — single column at 220 px+ = full-width column with horizontal swipe through people if there are many.

## What's intentionally not touched

- **Shopping** — groups by category, not person; doesn't hit the squeeze case.
- **Weekend places, Travel pins, Recipes** — flat card grids, not per-person.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --ci` — 1156/1156 pass.
- [x] Local docker rebuild + manual test against synthetic seed (4 family members).
- [ ] Manual test on a real family with 5+ people to confirm horizontal scroll feels natural.