### PR TITLE
feat(views): mobile scroll-snap carousel for per-person lists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Changed — Mobile
+- **Per-person list views become a swipeable carousel on phones**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all switch to a CSS scroll-snap carousel when viewed on mobile with more than one group — each profile takes the full viewport width and the user swipes left/right between people while still scrolling vertically inside the active profile's list. Desktop / tablet behavior unchanged (min-width columns + horizontal scroll). Cleaner than the previous "1.5 profiles visible at 220 px each" feel on phones.
+
 ### Fixed — List views
 - **Chores person filter now actually filters the rendered columns**: `ChoresView`'s `choresByUser` memo iterated every family member when building columns, so selecting a single-person filter under Group:Person still showed empty columns for everyone else. Tasks and Wishes already filtered correctly; Chores now matches. Unassigned column also hides when a person filter is active (the user explicitly asked to see only those people).
 - **Per-person grids no longer squeeze when the family is large**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all used `grid-cols-2 md:grid-cols-3` which crammed 7 people (5 kids + 2 adults) into 3 narrow columns × 3 rows on a portrait tablet. Switched all five views to `gridTemplateColumns: repeat(N, minmax(220px, 1fr))` + `overflow-x-auto`. Each column gets at least 220px; if the viewport can't fit every column comfortably, the grid scrolls horizontally — same shape across all list views. Closes [#105](https://github.com/sandydargoport/prism/issues/105).

--- a/src/app/chores/ChoreGroupGrid.tsx
+++ b/src/app/chores/ChoreGroupGrid.tsx
@@ -73,17 +73,24 @@ export function ChoreGroupGrid({
     return effectiveOrder.map((k) => map.get(k)).filter(Boolean) as ChoreGroupEntry[];
   }, [choresByUser, effectiveOrder]);
 
-  // Each column gets a minimum readable width (220px); the grid spans as
-  // wide as needed and overflows horizontally when the viewport can't fit
-  // every column comfortably. Replaces the previous `grid-cols-2 md:grid-
-  // cols-3` squeeze which crammed 7 people (5 kids + 2 adults) into 3
-  // narrow columns × 3 rows (bug #105). Same shape now used in
-  // GroupedTaskGrid and WishesView for UX consistency.
+  // Desktop / tablet: each column gets a minimum readable width (220px);
+  // grid overflows horizontally when the viewport can't fit every column.
+  // Mobile (with multiple groups): each column is sized to the viewport
+  // width and CSS scroll-snap turns the row into a swipeable carousel —
+  // user swipes left/right between profiles, scrolls up/down inside each.
+  // Replaces the previous `grid-cols-2 md:grid-cols-3` squeeze (bug #105).
+  // Same shape now used across all per-person list views.
+  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
   return (
     <div
-      className="grid gap-2 h-full overflow-x-auto"
+      className={cn(
+        'grid gap-2 h-full overflow-x-auto',
+        isSwipeCarousel && 'snap-x snap-mandatory'
+      )}
       style={{
-        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: isSwipeCarousel
+          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
+          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
       }}
     >
       {sortedGroups.map(({ user, chores }, idx) => {
@@ -97,7 +104,8 @@ export function ChoreGroupGrid({
             className={cn(
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
-              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50'
+              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
+              isSwipeCarousel && 'snap-start'
             )}
             style={{ borderColor: userColor }}
           >

--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -57,16 +57,20 @@ export function GroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as GroupDef[];
   }, [groups, effectiveOrder]);
 
-  // Each column gets a minimum readable width (220px); the grid overflows
-  // horizontally when the viewport can't fit every column comfortably.
-  // Replaces the previous `grid-cols-2 md:grid-cols-3` squeeze (see
-  // ChoreGroupGrid for the bug context). Same shape used in
-  // ChoreGroupGrid and WishesView for UX consistency.
+  // See ChoreGroupGrid for full context. Desktop: min-width columns +
+  // horizontal scroll. Mobile (multi-group): viewport-wide columns +
+  // scroll-snap carousel — swipe between profiles, vertical scroll inside.
+  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
   return (
     <div
-      className="grid gap-2 h-full overflow-x-auto"
+      className={cn(
+        'grid gap-2 h-full overflow-x-auto',
+        isSwipeCarousel && 'snap-x snap-mandatory'
+      )}
       style={{
-        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: isSwipeCarousel
+          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
+          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
       }}
     >
       {sortedGroups.map((group, idx) => {
@@ -79,7 +83,8 @@ export function GroupedTaskGrid({
             className={cn(
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
-              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50'
+              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
+              isSwipeCarousel && 'snap-start'
             )}
             style={{ borderColor: group.color }}
           >

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -53,14 +53,20 @@ export function NestedGroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as NestedGroupDef[];
   }, [primaryGroups, effectiveOrder]);
 
-  // See ChoreGroupGrid for the bug context. Same min-width + horizontal-
-  // scroll shape used across Chores / Tasks (flat + nested) / Wishes /
-  // Gift Ideas for UX consistency.
+  // See ChoreGroupGrid for full context. Desktop: min-width columns +
+  // horizontal scroll. Mobile (multi-group): viewport-wide columns +
+  // scroll-snap carousel — swipe between groups, vertical scroll inside.
+  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
   return (
     <div
-      className="grid gap-2 h-full overflow-x-auto"
+      className={cn(
+        'grid gap-2 h-full overflow-x-auto',
+        isSwipeCarousel && 'snap-x snap-mandatory'
+      )}
       style={{
-        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: isSwipeCarousel
+          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
+          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
       }}
     >
       {sortedGroups.map((group, idx) => {
@@ -73,7 +79,8 @@ export function NestedGroupedTaskGrid({
             className={cn(
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
-              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50'
+              isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
+              isSwipeCarousel && 'snap-start'
             )}
             style={{ borderColor: group.color }}
           >

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -96,15 +96,20 @@ export function GiftIdeasView() {
     return <div className="text-destructive text-center py-8">{error}</div>;
   }
 
-  // Min-width columns + horizontal scroll when group count outgrows the
-  // viewport — same shape as Chores / Tasks / Wishes. Avoids cramming
-  // many members into 3 fixed columns at 5+ kids (bug #105).
+  // Desktop: min-width columns + horizontal scroll. Mobile (multi-member):
+  // viewport-wide columns + scroll-snap carousel — same UX as Chores/Tasks.
+  const isSwipeCarousel = isMobile && otherMembers.length > 1;
   return (
     <>
       <div
-        className="grid gap-3 h-full overflow-x-auto"
+        className={cn(
+          'grid gap-3 h-full overflow-x-auto',
+          isSwipeCarousel && 'snap-x snap-mandatory'
+        )}
         style={{
-          gridTemplateColumns: `repeat(${Math.max(otherMembers.length, 1)}, minmax(220px, 1fr))`,
+          gridTemplateColumns: isSwipeCarousel
+            ? `repeat(${otherMembers.length}, calc(100vw - 32px))`
+            : `repeat(${Math.max(otherMembers.length, 1)}, minmax(220px, 1fr))`,
         }}
       >
         {otherMembers.map((member) => {
@@ -112,7 +117,10 @@ export function GiftIdeasView() {
           return (
             <div
               key={member.id}
-              className="flex flex-col rounded-xl border-2 bg-card/50 overflow-hidden min-h-0"
+              className={cn(
+                'flex flex-col rounded-xl border-2 bg-card/50 overflow-hidden min-h-0',
+                isSwipeCarousel && 'snap-start'
+              )}
               style={{ borderColor: member.color }}
             >
               {/* Card header */}

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -267,35 +267,42 @@ export function WishesView() {
           <div className="text-destructive text-center py-8">{error}</div>
         ) : (
           /* Grid view: one card per family member (filtered if selection active), draggable.
-             Min-width columns + horizontal scroll when group count outgrows the viewport —
-             same UX shape as Chores/Tasks. Avoids cramming many members into 3 fixed columns. */
+             Min-width columns + horizontal scroll on desktop. Mobile (multi-member):
+             viewport-wide columns + scroll-snap carousel — same UX as Chores/Tasks. */
           (() => {
-            const visibleMemberCount = orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id)).length;
+            const visibleMembers = orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id));
+            const isSwipeCarousel = isMobile && visibleMembers.length > 1;
             return (
           <div
-            className="grid gap-3 h-full overflow-x-auto"
+            className={cn(
+              'grid gap-3 h-full overflow-x-auto',
+              isSwipeCarousel && 'snap-x snap-mandatory'
+            )}
             style={{
-              gridTemplateColumns: `repeat(${Math.max(visibleMemberCount, 1)}, minmax(220px, 1fr))`,
+              gridTemplateColumns: isSwipeCarousel
+                ? `repeat(${visibleMembers.length}, calc(100vw - 32px))`
+                : `repeat(${Math.max(visibleMembers.length, 1)}, minmax(220px, 1fr))`,
             }}
           >
-            {orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id)).map(member => {
+            {visibleMembers.map(member => {
               const memberItems = groupedItems?.[member.id] || [];
               const isDragging = draggedMemberId === member.id;
               return (
-                <MemberWishCard
-                  key={member.id}
-                  member={member}
-                  items={memberItems}
-                  isOwnList={isOwnList(member.id)}
-                  viewerId={viewerId}
-                  isDragging={isDragging}
-                  dragProps={isMobile ? {} : getDragProps(member.id)}
-                  isMobile={isMobile}
-                  onEdit={handleOpenEditModal}
-                  onDelete={handleDelete}
-                  onClaim={handleClaim}
-                  onAdd={() => handleOpenAddModal(member.id)}
-                />
+                <div key={member.id} className={cn(isSwipeCarousel && 'snap-start')}>
+                  <MemberWishCard
+                    member={member}
+                    items={memberItems}
+                    isOwnList={isOwnList(member.id)}
+                    viewerId={viewerId}
+                    isDragging={isDragging}
+                    dragProps={isMobile ? {} : getDragProps(member.id)}
+                    isMobile={isMobile}
+                    onEdit={handleOpenEditModal}
+                    onDelete={handleDelete}
+                    onClaim={handleClaim}
+                    onAdd={() => handleOpenAddModal(member.id)}
+                  />
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
Follow-up to #115. On phones, the new horizontal-scroll layout left ~1.5 profiles visible at 220 px each — neither "one at a time" nor "everyone visible." Switching to a swipeable carousel on mobile.

## What changes

Trigger: `isMobile && groups.length > 1`.

- Each column sized to viewport width (`calc(100vw - 32px)`).
- Container gets `snap-x snap-mandatory`.
- Each child column gets `snap-start`.

User experience:
- **Swipe left/right** between profiles.
- **Scroll up/down** inside the active profile's chore / task / wish / gift idea list (the existing column's vertical overflow context still works).
- Single-profile mobile case: still uses the 1fr column (no snap to nothing).

Desktop / tablet behavior unchanged.

## Files

Same five views as #115:
- `src/app/chores/ChoreGroupGrid.tsx`
- `src/app/tasks/GroupedTaskGrid.tsx`
- `src/app/tasks/NestedGroupedTaskGrid.tsx`
- `src/app/wishes/WishesView.tsx` (wrapped MemberWishCard in a snap-start div)
- `src/app/wishes/GiftIdeasView.tsx`

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --ci` — 1156/1156 pass.
- [ ] Manual mobile test on PWA after merge.