### PR TITLE
feat(views): 4-per-screen desktop carousel + sticky inner scroll (#105)

### DIFF
--- a/src/app/chores/ChoreGroupGrid.tsx
+++ b/src/app/chores/ChoreGroupGrid.tsx
@@ -73,24 +73,29 @@ export function ChoreGroupGrid({
     return effectiveOrder.map((k) => map.get(k)).filter(Boolean) as ChoreGroupEntry[];
   }, [choresByUser, effectiveOrder]);
 
-  // Desktop / tablet: each column gets a minimum readable width (220px);
-  // grid overflows horizontally when the viewport can't fit every column.
-  // Mobile (with multiple groups): each column is sized to the viewport
-  // width and CSS scroll-snap turns the row into a swipeable carousel —
-  // user swipes left/right between profiles, scrolls up/down inside each.
-  // Replaces the previous `grid-cols-2 md:grid-cols-3` squeeze (bug #105).
-  // Same shape now used across all per-person list views.
-  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
+  // Carousel layout: N profiles visible at a time, swipe left/right to
+  // shift between them. N = 1 on mobile, 4 on desktop. Snap kicks in
+  // when total profiles exceed N. For ≤N profiles the grid stretches
+  // them to fill (no snap, no overflow).
+  // User scrolls up/down INSIDE each profile's column via its own
+  // overflow-y context — `overscroll-contain` on the body stops iOS PWA
+  // from bubbling vertical scrolls past the column into the page
+  // wrapper, which is what was making the page toolbar move.
+  const groupsPerScreen = isMobile ? 1 : 4;
+  const isCarousel = sortedGroups.length > groupsPerScreen;
+  const colTrack = isCarousel
+    ? isMobile
+      ? 'calc(100vw - 32px)'
+      : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
+    : 'minmax(220px, 1fr)';
   return (
     <div
       className={cn(
         'grid gap-2 h-full overflow-x-auto',
-        isSwipeCarousel && 'snap-x snap-mandatory'
+        isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
-        gridTemplateColumns: isSwipeCarousel
-          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
-          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, ${colTrack})`,
       }}
     >
       {sortedGroups.map(({ user, chores }, idx) => {
@@ -105,7 +110,7 @@ export function ChoreGroupGrid({
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
               isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
-              isSwipeCarousel && 'snap-start'
+              isCarousel && 'snap-start'
             )}
             style={{ borderColor: userColor }}
           >
@@ -148,7 +153,7 @@ export function ChoreGroupGrid({
                 {chores.length}
               </Badge>
             </div>
-            <div className="flex-1 overflow-y-auto p-2 space-y-1">
+            <div className="flex-1 overflow-y-auto overscroll-contain p-2 space-y-1">
               <Input
                 placeholder="Add chore..."
                 value={inlineChoreByUser[key] || ''}

--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -57,20 +57,23 @@ export function GroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as GroupDef[];
   }, [groups, effectiveOrder]);
 
-  // See ChoreGroupGrid for full context. Desktop: min-width columns +
-  // horizontal scroll. Mobile (multi-group): viewport-wide columns +
-  // scroll-snap carousel — swipe between profiles, vertical scroll inside.
-  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
+  // See ChoreGroupGrid for full context. N profiles visible at a time
+  // (1 mobile, 4 desktop); snap carousel when total exceeds N.
+  const groupsPerScreen = isMobile ? 1 : 4;
+  const isCarousel = sortedGroups.length > groupsPerScreen;
+  const colTrack = isCarousel
+    ? isMobile
+      ? 'calc(100vw - 32px)'
+      : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
+    : 'minmax(220px, 1fr)';
   return (
     <div
       className={cn(
         'grid gap-2 h-full overflow-x-auto',
-        isSwipeCarousel && 'snap-x snap-mandatory'
+        isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
-        gridTemplateColumns: isSwipeCarousel
-          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
-          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, ${colTrack})`,
       }}
     >
       {sortedGroups.map((group, idx) => {
@@ -84,7 +87,7 @@ export function GroupedTaskGrid({
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
               isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
-              isSwipeCarousel && 'snap-start'
+              isCarousel && 'snap-start'
             )}
             style={{ borderColor: group.color }}
           >
@@ -112,7 +115,7 @@ export function GroupedTaskGrid({
                 {completedCount}/{group.tasks.length}
               </Badge>
             </div>
-            <div className="flex-1 overflow-y-auto p-2 space-y-1">
+            <div className="flex-1 overflow-y-auto overscroll-contain p-2 space-y-1">
               <div className="pb-1">
                 <Input
                   placeholder="Add a task..."

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -53,20 +53,23 @@ export function NestedGroupedTaskGrid({
     return effectiveOrder.map(k => map.get(k)).filter(Boolean) as NestedGroupDef[];
   }, [primaryGroups, effectiveOrder]);
 
-  // See ChoreGroupGrid for full context. Desktop: min-width columns +
-  // horizontal scroll. Mobile (multi-group): viewport-wide columns +
-  // scroll-snap carousel — swipe between groups, vertical scroll inside.
-  const isSwipeCarousel = isMobile && sortedGroups.length > 1;
+  // See ChoreGroupGrid for full context. N groups visible at a time
+  // (1 mobile, 4 desktop); snap carousel when total exceeds N.
+  const groupsPerScreen = isMobile ? 1 : 4;
+  const isCarousel = sortedGroups.length > groupsPerScreen;
+  const colTrack = isCarousel
+    ? isMobile
+      ? 'calc(100vw - 32px)'
+      : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
+    : 'minmax(220px, 1fr)';
   return (
     <div
       className={cn(
         'grid gap-2 h-full overflow-x-auto',
-        isSwipeCarousel && 'snap-x snap-mandatory'
+        isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
-        gridTemplateColumns: isSwipeCarousel
-          ? `repeat(${sortedGroups.length}, calc(100vw - 32px))`
-          : `repeat(${Math.max(sortedGroups.length, 1)}, minmax(220px, 1fr))`,
+        gridTemplateColumns: `repeat(${Math.max(sortedGroups.length, 1)}, ${colTrack})`,
       }}
     >
       {sortedGroups.map((group, idx) => {
@@ -80,7 +83,7 @@ export function NestedGroupedTaskGrid({
               'flex flex-col border-2 rounded-lg overflow-hidden bg-card/90 backdrop-blur-sm transition-all',
               !isTouch && !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
               isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',
-              isSwipeCarousel && 'snap-start'
+              isCarousel && 'snap-start'
             )}
             style={{ borderColor: group.color }}
           >
@@ -120,7 +123,7 @@ export function NestedGroupedTaskGrid({
             </div>
 
             {/* Sub-groups */}
-            <div className="flex-1 overflow-y-auto px-2 pb-2 space-y-2">
+            <div className="flex-1 overflow-y-auto overscroll-contain px-2 pb-2 space-y-2">
               {group.subGroups.length === 0 && (
                 <p className="text-center text-muted-foreground text-sm py-4">No tasks</p>
               )}

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -96,20 +96,24 @@ export function GiftIdeasView() {
     return <div className="text-destructive text-center py-8">{error}</div>;
   }
 
-  // Desktop: min-width columns + horizontal scroll. Mobile (multi-member):
-  // viewport-wide columns + scroll-snap carousel — same UX as Chores/Tasks.
-  const isSwipeCarousel = isMobile && otherMembers.length > 1;
+  // See ChoreGroupGrid for full context. N members visible at a time
+  // (1 mobile, 4 desktop); snap carousel when total exceeds N.
+  const groupsPerScreen = isMobile ? 1 : 4;
+  const isCarousel = otherMembers.length > groupsPerScreen;
+  const colTrack = isCarousel
+    ? isMobile
+      ? 'calc(100vw - 32px)'
+      : `calc((100% - ${(groupsPerScreen - 1) * 12}px) / ${groupsPerScreen})`
+    : 'minmax(220px, 1fr)';
   return (
     <>
       <div
         className={cn(
           'grid gap-3 h-full overflow-x-auto',
-          isSwipeCarousel && 'snap-x snap-mandatory'
+          isCarousel && 'snap-x snap-mandatory'
         )}
         style={{
-          gridTemplateColumns: isSwipeCarousel
-            ? `repeat(${otherMembers.length}, calc(100vw - 32px))`
-            : `repeat(${Math.max(otherMembers.length, 1)}, minmax(220px, 1fr))`,
+          gridTemplateColumns: `repeat(${Math.max(otherMembers.length, 1)}, ${colTrack})`,
         }}
       >
         {otherMembers.map((member) => {
@@ -119,7 +123,7 @@ export function GiftIdeasView() {
               key={member.id}
               className={cn(
                 'flex flex-col rounded-xl border-2 bg-card/50 overflow-hidden min-h-0',
-                isSwipeCarousel && 'snap-start'
+                isCarousel && 'snap-start'
               )}
               style={{ borderColor: member.color }}
             >
@@ -142,7 +146,7 @@ export function GiftIdeasView() {
               </div>
 
               {/* Quick add + item list */}
-              <div className="flex-1 overflow-y-auto p-2 space-y-1">
+              <div className="flex-1 overflow-y-auto overscroll-contain p-2 space-y-1">
                 <Input
                   placeholder={`Gift idea for ${member.name}...`}
                   value={quickAddByUser[member.id] || ''}

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -266,29 +266,32 @@ export function WishesView() {
         ) : error ? (
           <div className="text-destructive text-center py-8">{error}</div>
         ) : (
-          /* Grid view: one card per family member (filtered if selection active), draggable.
-             Min-width columns + horizontal scroll on desktop. Mobile (multi-member):
-             viewport-wide columns + scroll-snap carousel — same UX as Chores/Tasks. */
+          /* See ChoreGroupGrid for full context. N members visible at a time
+             (1 mobile, 4 desktop); snap carousel when total exceeds N. */
           (() => {
             const visibleMembers = orderedMembers.filter(m => showingAll || selectedMemberIds!.includes(m.id));
-            const isSwipeCarousel = isMobile && visibleMembers.length > 1;
+            const groupsPerScreen = isMobile ? 1 : 4;
+            const isCarousel = visibleMembers.length > groupsPerScreen;
+            const colTrack = isCarousel
+              ? isMobile
+                ? 'calc(100vw - 32px)'
+                : `calc((100% - ${(groupsPerScreen - 1) * 12}px) / ${groupsPerScreen})`
+              : 'minmax(220px, 1fr)';
             return (
           <div
             className={cn(
               'grid gap-3 h-full overflow-x-auto',
-              isSwipeCarousel && 'snap-x snap-mandatory'
+              isCarousel && 'snap-x snap-mandatory'
             )}
             style={{
-              gridTemplateColumns: isSwipeCarousel
-                ? `repeat(${visibleMembers.length}, calc(100vw - 32px))`
-                : `repeat(${Math.max(visibleMembers.length, 1)}, minmax(220px, 1fr))`,
+              gridTemplateColumns: `repeat(${Math.max(visibleMembers.length, 1)}, ${colTrack})`,
             }}
           >
             {visibleMembers.map(member => {
               const memberItems = groupedItems?.[member.id] || [];
               const isDragging = draggedMemberId === member.id;
               return (
-                <div key={member.id} className={cn(isSwipeCarousel && 'snap-start')}>
+                <div key={member.id} className={cn(isCarousel && 'snap-start')}>
                   <MemberWishCard
                     member={member}
                     items={memberItems}
@@ -397,7 +400,7 @@ function MemberWishCard({
       </div>
 
       {/* Scrollable item list */}
-      <div className="flex-1 overflow-y-auto p-2 space-y-1">
+      <div className="flex-1 overflow-y-auto overscroll-contain p-2 space-y-1">
         {items.length === 0 ? (
           <p className="text-xs text-muted-foreground text-center py-4">No wishes yet</p>
         ) : (


### PR DESCRIPTION
Follow-up to #116. Two things:

1. **Desktop now shows 4 profiles at a time** instead of stretching to fit all of them with a min-width. When total profiles exceed 4 on desktop (or 1 on mobile), the grid becomes a scroll-snap carousel where each column is exactly viewport/N wide. ≤N profiles still stretch with the previous `minmax(220px, 1fr)` (no snap, no overflow needed).

2. **Page toolbar stays put when you scroll inside a profile's list.** Each column body gets `overscroll-contain` so iOS PWA doesn't bubble vertical scrolls past the inner column into the page wrapper — previously, vertical scrolling inside a profile would also scroll the page-level toolbar away.

5 files touched, same pattern across Chores, Tasks (flat + nested), Wishes, Gift Ideas.

## Test plan

- [x] tsc clean, jest 1156/1156.
- [ ] Manual: desktop with 5+ profiles → 4 visible, snap to shift; mobile PWA scrolling inside a profile keeps toolbar pinned.