### PR TITLE
fix(views): grid-rows-1 + Tasks page wrapper height

### DIFF
--- a/src/app/chores/ChoreGroupGrid.tsx
+++ b/src/app/chores/ChoreGroupGrid.tsx
@@ -91,7 +91,11 @@ export function ChoreGroupGrid({
   return (
     <div
       className={cn(
-        'grid gap-2 h-full overflow-x-auto',
+        // grid-rows-1 constrains the row to grid height (minmax(0, 1fr))
+        // so each column has a finite height — without this the row's
+        // height grows to fit content and the inner overflow-y-auto on
+        // the column body never engages on desktop.
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{

--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -69,7 +69,8 @@ export function GroupedTaskGrid({
   return (
     <div
       className={cn(
-        'grid gap-2 h-full overflow-x-auto',
+        // See ChoreGroupGrid for the grid-rows-1 reasoning.
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -65,7 +65,8 @@ export function NestedGroupedTaskGrid({
   return (
     <div
       className={cn(
-        'grid gap-2 h-full overflow-x-auto',
+        // See ChoreGroupGrid for the grid-rows-1 reasoning.
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -91,7 +91,13 @@ export function TasksView() {
 
   return (
     <PageWrapper>
-      <div className="h-full flex flex-col">
+      {/*
+        h-screen + flex-col + inner overflow-y-auto pins the SubpageHeader
+        and FilterBar to the top so they don't scroll away when the user
+        scrolls within a task list. Matches Chores, Shopping, Meals.
+        Was `h-full` which left the page-level scroll unconstrained.
+      */}
+      <div className="h-screen flex flex-col">
         <SubpageHeader
           icon={<CheckSquare className="h-5 w-5 text-primary" />}
           title="Tasks"

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -109,7 +109,8 @@ export function GiftIdeasView() {
     <>
       <div
         className={cn(
-          'grid gap-3 h-full overflow-x-auto',
+          // See ChoreGroupGrid for the grid-rows-1 reasoning.
+          'grid grid-rows-1 gap-3 h-full overflow-x-auto',
           isCarousel && 'snap-x snap-mandatory'
         )}
         style={{

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -280,7 +280,8 @@ export function WishesView() {
             return (
           <div
             className={cn(
-              'grid gap-3 h-full overflow-x-auto',
+              // See ChoreGroupGrid for the grid-rows-1 reasoning.
+              'grid grid-rows-1 gap-3 h-full overflow-x-auto',
               isCarousel && 'snap-x snap-mandatory'
             )}
             style={{


### PR DESCRIPTION
Two related regressions:

## 1. Desktop columns wouldn't scroll

After #117, on desktop you couldn't scroll up/down within a profile column on Chores or Tasks. The grid had `grid-template-columns: repeat(N, ...)` with an implicit single row sized `auto` — column grew to fit all chores instead of being constrained to grid height, so the inner `flex-1 overflow-y-auto` body had nothing to scroll against.

Fix: `grid-rows-1` on the grid container forces the row to `minmax(0, 1fr)` of grid height. Column gets a finite height, inner body's overflow-y-auto engages.

Applied to all 5 list views: Chores, Tasks (flat + nested), Wishes, Gift Ideas.

## 2. PWA toolbar moves on Tasks specifically

`TasksView` used `h-full flex flex-col` for the outer wrapper while Chores, Shopping, and Meals all use `h-screen flex flex-col`. `h-full` propagates from the parent (PageWrapper) which is unconstrained — so the page-level scroll runs instead of the inner flex-1 scroll, and the toolbar scrolls away with the page.

Fix: TasksView now uses `h-screen flex flex-col` like the other views.

(Wishes / Gift Ideas have a different multi-tab header structure that doesn't fit this wrapping cleanly — separate PR if the same issue shows up there.)

## Test plan

- [x] tsc clean.
- [ ] Manual: desktop chores/tasks → scroll within a profile, list scrolls + toolbar stays.
- [ ] Manual: PWA tasks → scroll within a profile, page toolbar stays pinned (this is the issue from your report).