### PR TITLE
feat(lists): carousel arrows, Tasks PersonFilter columns, mobile Shopping swipe; needs-reply workflow

### DIFF
--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -1,0 +1,81 @@
+name: needs-reply triage
+
+# Auto-label issues and PRs that are waiting on a response from the maintainer.
+#
+# Rules:
+#   - A comment from anyone OTHER than the repo owner (sandydargoport) or a bot
+#     adds the `needs-reply` label.
+#   - A comment from the repo owner removes the `needs-reply` label.
+#   - An issue/PR opened by anyone other than the owner gets `needs-reply` on
+#     creation. (Self-opened issues stay clean until someone else weighs in.)
+#
+# The label powers a Project board view filter: `label:needs-reply` surfaces
+# anything an external user is waiting on a reply for.
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute actor and target
+        id: ctx
+        env:
+          GH_EVENT: ${{ toJson(github.event) }}
+        run: |
+          # Actor: who triggered the event (commenter / opener / reviewer)
+          ACTOR="${{ github.event.comment.user.login || github.event.review.user.login || github.event.sender.login }}"
+          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
+
+          # Issue/PR number — works across issues, issue_comment (on issues OR PRs),
+          # PR review, PR review_comment, pull_request_target.
+          NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+          # Is this the bot / owner?
+          OWNER="sandydargoport"
+          if [ "$ACTOR" = "$OWNER" ]; then
+            echo "is_owner=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_owner=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Filter out bots
+          case "$ACTOR" in
+            *"[bot]"|github-actions|dependabot|renovate|codecov*)
+              echo "is_bot=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "is_bot=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Add needs-reply (external activity)
+        if: steps.ctx.outputs.is_owner != 'true' && steps.ctx.outputs.is_bot != 'true' && steps.ctx.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ steps.ctx.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label needs-reply || true
+
+      - name: Remove needs-reply (owner replied)
+        if: steps.ctx.outputs.is_owner == 'true' && steps.ctx.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ steps.ctx.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label needs-reply || true

--- a/src/app/chores/ChoreGroupGrid.tsx
+++ b/src/app/chores/ChoreGroupGrid.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useRef } from 'react';
 import { ClipboardList, GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useDragReorder } from '@/lib/hooks/useDragReorder';
 import { useIsTouch } from '@/lib/hooks/useIsTouch';
+import { CarouselArrows } from '@/components/ui/CarouselArrows';
 import { ChoreGroupCard } from './ChoreGroupCard';
 import { cn } from '@/lib/utils';
 
@@ -88,14 +89,17 @@ export function ChoreGroupGrid({
       ? 'calc(100vw - 32px)'
       : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
     : 'minmax(220px, 1fr)';
+  const scrollRef = useRef<HTMLDivElement>(null);
   return (
+    <div className="relative h-full">
     <div
+      ref={scrollRef}
       className={cn(
         // grid-rows-1 constrains the row to grid height (minmax(0, 1fr))
         // so each column has a finite height — without this the row's
         // height grows to fit content and the inner overflow-y-auto on
         // the column body never engages on desktop.
-        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto scroll-smooth',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
@@ -197,6 +201,8 @@ export function ChoreGroupGrid({
           </div>
         );
       })}
+    </div>
+      {isCarousel && !isMobile && <CarouselArrows scrollRef={scrollRef} />}
     </div>
   );
 }

--- a/src/app/shopping/ShoppingView.tsx
+++ b/src/app/shopping/ShoppingView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { toast } from '@/components/ui/use-toast';
-import { ShoppingCart, Plus, Settings, Maximize2, Minimize2, Tags, Send } from 'lucide-react';
+import { ShoppingCart, Plus, Settings, Maximize2, Minimize2, Tags, Send, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
@@ -25,6 +25,7 @@ import { useShoppingScanFlow } from './useShoppingScanFlow';
 import { useShoppingCrudHandlers } from './useShoppingCrudHandlers';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
+import { useSwipeNavigation } from '@/lib/hooks/useSwipeNavigation';
 import { cn } from '@/lib/utils';
 import type { ShoppingItem } from '@/types';
 import dynamic from 'next/dynamic';
@@ -128,6 +129,25 @@ export function ShoppingView() {
   const isPortrait = orientation === 'portrait';
   const [shoppingMode, setShoppingMode] = useState(false);
 
+  // Mobile-only: swipe to switch lists. The pill bar collapses into a
+  // compact prev/dots/next indicator when there's more than one list.
+  // Single-list households skip the affordance entirely (UX recommendation).
+  const currentListIdx = lists.findIndex((l) => l.id === activeListId);
+  const goPrevList = () => {
+    if (currentListIdx > 0) setActiveListId(lists[currentListIdx - 1]!.id);
+  };
+  const goNextList = () => {
+    if (currentListIdx >= 0 && currentListIdx < lists.length - 1) {
+      setActiveListId(lists[currentListIdx + 1]!.id);
+    }
+  };
+  const swipeRef = useSwipeNavigation<HTMLDivElement>({
+    onSwipeLeft: goNextList,
+    onSwipeRight: goPrevList,
+    enabled: isMobile && lists.length > 1 && !shoppingMode,
+    threshold: 60,
+  });
+
   const groceryCategoryItems = effectiveCategoryOrder.map((cat) => ({
     category: cat,
     items: (filteredItems[cat] || []) as ShoppingItem[],
@@ -197,26 +217,52 @@ export function ShoppingView() {
               ] as OverflowItem[]}
             />
 
-            <div className="flex-shrink-0 border-b border-border bg-card/85 backdrop-blur-sm px-3 py-1">
-              <div className="overflow-x-auto">
-                <div className="flex gap-1 items-center min-w-max">
-                  {lists.map((list) => {
-                    const assignedMember = list.assignedTo ? familyMembers.find(m => m.id === list.assignedTo) : null;
-                    return (
-                      <Button key={list.id} variant={activeListId === list.id ? 'secondary' : 'ghost'} size="sm"
-                        onClick={() => setActiveListId(list.id)} className="relative">
-                        {list.name}
-                        {assignedMember && (
-                          <span className="ml-1.5 w-3 h-3 rounded-full inline-block"
-                            style={{ backgroundColor: assignedMember.color }} title={`Assigned to ${assignedMember.name}`} />
-                        )}
-                        <Badge variant="outline" className="ml-2 text-xs">{list.items.length}</Badge>
-                      </Button>
-                    );
-                  })}
+            {isMobile && lists.length > 1 ? (
+              <div className="flex-shrink-0 border-b border-border bg-card/85 backdrop-blur-sm px-2 py-1">
+                <div className="flex items-center justify-between gap-2">
+                  <Button size="icon" variant="ghost" onClick={goPrevList}
+                    disabled={currentListIdx <= 0} aria-label="Previous list" className="h-8 w-8 shrink-0">
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <div className="flex flex-col items-center min-w-0 flex-1">
+                    <span className="font-semibold text-sm truncate max-w-full">{activeList?.name}</span>
+                    <div className="flex gap-1 mt-0.5">
+                      {lists.map((l, i) => (
+                        <span key={l.id} className={cn(
+                          'rounded-full transition-all',
+                          i === currentListIdx ? 'bg-primary w-3 h-1.5' : 'bg-muted-foreground/40 w-1.5 h-1.5'
+                        )} />
+                      ))}
+                    </div>
+                  </div>
+                  <Button size="icon" variant="ghost" onClick={goNextList}
+                    disabled={currentListIdx >= lists.length - 1} aria-label="Next list" className="h-8 w-8 shrink-0">
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
                 </div>
               </div>
-            </div>
+            ) : !isMobile ? (
+              <div className="flex-shrink-0 border-b border-border bg-card/85 backdrop-blur-sm px-3 py-1">
+                <div className="overflow-x-auto">
+                  <div className="flex gap-1 items-center min-w-max">
+                    {lists.map((list) => {
+                      const assignedMember = list.assignedTo ? familyMembers.find(m => m.id === list.assignedTo) : null;
+                      return (
+                        <Button key={list.id} variant={activeListId === list.id ? 'secondary' : 'ghost'} size="sm"
+                          onClick={() => setActiveListId(list.id)} className="relative">
+                          {list.name}
+                          {assignedMember && (
+                            <span className="ml-1.5 w-3 h-3 rounded-full inline-block"
+                              style={{ backgroundColor: assignedMember.color }} title={`Assigned to ${assignedMember.name}`} />
+                          )}
+                          <Badge variant="outline" className="ml-2 text-xs">{list.items.length}</Badge>
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </>
         )}
 
@@ -249,7 +295,7 @@ export function ShoppingView() {
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto p-2 pb-24">
+        <div ref={swipeRef} className="flex-1 overflow-y-auto p-2 pb-24">
           {loading ? (
             <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
               <ShoppingCart className="h-12 w-12 mb-4 opacity-50 animate-pulse" /><p className="text-lg">Loading shopping lists...</p>

--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useDragReorder } from '@/lib/hooks/useDragReorder';
 import { useIsTouch } from '@/lib/hooks/useIsTouch';
+import { CarouselArrows } from '@/components/ui/CarouselArrows';
 import { TaskRow } from '@/app/tasks/TaskRow';
 import type { Task } from '@/types';
 import type { GroupDef } from '@/app/tasks/taskGroupTypes';
@@ -66,11 +67,14 @@ export function GroupedTaskGrid({
       ? 'calc(100vw - 32px)'
       : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
     : 'minmax(220px, 1fr)';
+  const scrollRef = useRef<HTMLDivElement>(null);
   return (
+    <div className="relative h-full">
     <div
+      ref={scrollRef}
       className={cn(
         // See ChoreGroupGrid for the grid-rows-1 reasoning.
-        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto scroll-smooth',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
@@ -160,6 +164,8 @@ export function GroupedTaskGrid({
           </div>
         );
       })}
+    </div>
+      {isCarousel && !isMobile && <CarouselArrows scrollRef={scrollRef} />}
     </div>
   );
 }

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useDragReorder } from '@/lib/hooks/useDragReorder';
 import { useIsTouch } from '@/lib/hooks/useIsTouch';
+import { CarouselArrows } from '@/components/ui/CarouselArrows';
 import { TaskRow } from '@/app/tasks/TaskRow';
 import type { Task } from '@/types';
 import type { NestedGroupDef } from '@/app/tasks/taskGroupTypes';
@@ -62,11 +63,14 @@ export function NestedGroupedTaskGrid({
       ? 'calc(100vw - 32px)'
       : `calc((100% - ${(groupsPerScreen - 1) * 8}px) / ${groupsPerScreen})`
     : 'minmax(220px, 1fr)';
+  const scrollRef = useRef<HTMLDivElement>(null);
   return (
+    <div className="relative h-full">
     <div
+      ref={scrollRef}
       className={cn(
         // See ChoreGroupGrid for the grid-rows-1 reasoning.
-        'grid grid-rows-1 gap-2 h-full overflow-x-auto',
+        'grid grid-rows-1 gap-2 h-full overflow-x-auto scroll-smooth',
         isCarousel && 'snap-x snap-mandatory'
       )}
       style={{
@@ -161,6 +165,8 @@ export function NestedGroupedTaskGrid({
           </div>
         );
       })}
+    </div>
+      {isCarousel && !isMobile && <CarouselArrows scrollRef={scrollRef} />}
     </div>
   );
 }

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -55,7 +55,7 @@ export function TasksView() {
     inlineTaskByList, setInlineTaskByList,
     handleInlineAdd,
     tasksByUser, tasksByList, tasksByPersonThenList, tasksByListThenPerson,
-  } = useTaskGrouping({ filteredTasks, familyMembers, taskLists, filterList, refreshTasks, requireAuth });
+  } = useTaskGrouping({ filteredTasks, familyMembers, taskLists, filterList, filterPerson, refreshTasks, requireAuth });
 
   const hasActiveFilters = (filterPerson !== null && filterPerson.length > 0) || filterPriority !== null || filterList !== null;
   const clearFilters = () => { setFilterPerson(null); setFilterPriority(null); setFilterList(null); };

--- a/src/app/tasks/useTaskGrouping.ts
+++ b/src/app/tasks/useTaskGrouping.ts
@@ -10,6 +10,7 @@ interface UseTaskGroupingParams {
   familyMembers: Array<{ id: string; name: string; color: string }>;
   taskLists: Array<{ id: string; name: string; color?: string | null }>;
   filterList: string | null;
+  filterPerson: string[] | null;
   refreshTasks: () => void;
   requireAuth: (title: string, message: string) => Promise<{ id: string } | null>;
 }
@@ -19,9 +20,22 @@ export function useTaskGrouping({
   familyMembers,
   taskLists,
   filterList,
+  filterPerson,
   refreshTasks,
   requireAuth,
 }: UseTaskGroupingParams) {
+  // When the user has narrowed the PersonFilter, hide the columns/sub-columns
+  // for unselected people entirely (not just empty them). Matches Chores and
+  // Wishes. Also suppresses the "Unassigned" bucket — the user has explicitly
+  // asked to see only those people.
+  const personFilterActive = filterPerson !== null && filterPerson.length > 0;
+  const isMemberAllowed = (id: string) =>
+    !personFilterActive || filterPerson!.includes(id);
+  const allowedMembers = useMemo(
+    () => familyMembers.filter(m => !m.id || isMemberAllowed(m.id)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [familyMembers, personFilterActive, filterPerson?.join(',')]
+  );
   const [primaryGroup, setPrimaryGroup] = useState<GroupBy>('person');
   const [secondaryGroup, setSecondaryGroup] = useState<GroupBy>('none');
 
@@ -88,13 +102,13 @@ export function useTaskGrouping({
     // All family members always get a column; append any extra assignees not in family
     const ordered: { id: string; name: string; color: string }[] = [];
     familyMembers.forEach(member => {
-      if (member.id) {
+      if (member.id && isMemberAllowed(member.id)) {
         ordered.push(member);
         assigneeMap.delete(member.id);
       }
     });
     // Any assignees not yet in familyMembers (e.g., before family refresh post-login)
-    assigneeMap.forEach(a => ordered.push(a));
+    assigneeMap.forEach(a => { if (isMemberAllowed(a.id)) ordered.push(a); });
 
     const groups: { user: { id: string; name: string; color: string } | null; tasks: Task[] }[] = [];
     ordered.forEach(member => {
@@ -102,11 +116,14 @@ export function useTaskGrouping({
       groups.push({ user: member, tasks: userTasks });
     });
 
-    const unassigned = filteredTasks.filter(t => !t.assignedTo);
-    if (unassigned.length > 0) groups.push({ user: null, tasks: unassigned });
+    if (!personFilterActive) {
+      const unassigned = filteredTasks.filter(t => !t.assignedTo);
+      if (unassigned.length > 0) groups.push({ user: null, tasks: unassigned });
+    }
 
     return groups;
-  }, [groupMode, filteredTasks, familyMembers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupMode, filteredTasks, familyMembers, personFilterActive, filterPerson?.join(',')]);
 
   // Group tasks by list
   const tasksByList = useMemo(() => {
@@ -146,18 +163,20 @@ export function useTaskGrouping({
 
     const result: { member: typeof familyMembers[0] | null; tasks: Task[]; subGroups: SubGroupDef[] }[] = [];
 
-    familyMembers.forEach((member) => {
+    allowedMembers.forEach((member) => {
       const memberTasks = filteredTasks.filter(t => t.assignedTo?.id === member.id);
       result.push({ member, tasks: memberTasks, subGroups: buildSubGroups(memberTasks) });
     });
 
-    const unassigned = filteredTasks.filter(t => !t.assignedTo);
-    if (unassigned.length > 0) {
-      result.push({ member: null, tasks: unassigned, subGroups: buildSubGroups(unassigned) });
+    if (!personFilterActive) {
+      const unassigned = filteredTasks.filter(t => !t.assignedTo);
+      if (unassigned.length > 0) {
+        result.push({ member: null, tasks: unassigned, subGroups: buildSubGroups(unassigned) });
+      }
     }
 
     return result;
-  }, [groupMode, filteredTasks, familyMembers, taskLists]);
+  }, [groupMode, filteredTasks, allowedMembers, taskLists, personFilterActive]);
 
   // Group tasks by list → person (nested)
   const tasksByListThenPerson = useMemo(() => {
@@ -165,12 +184,14 @@ export function useTaskGrouping({
 
     const buildSubGroups = (listTasks: Task[]): SubGroupDef[] => {
       const subs: SubGroupDef[] = [];
-      familyMembers.forEach((member) => {
+      allowedMembers.forEach((member) => {
         const t = listTasks.filter(task => task.assignedTo?.id === member.id);
         if (t.length > 0) subs.push({ key: member.id, label: member.name, color: member.color, tasks: t });
       });
-      const unassigned = listTasks.filter(task => !task.assignedTo);
-      if (unassigned.length > 0) subs.push({ key: 'unassigned', label: 'Unassigned', color: '#6B7280', tasks: unassigned });
+      if (!personFilterActive) {
+        const unassigned = listTasks.filter(task => !task.assignedTo);
+        if (unassigned.length > 0) subs.push({ key: 'unassigned', label: 'Unassigned', color: '#6B7280', tasks: unassigned });
+      }
       return subs;
     };
 
@@ -189,7 +210,7 @@ export function useTaskGrouping({
     }
 
     return result;
-  }, [groupMode, filteredTasks, familyMembers, taskLists]);
+  }, [groupMode, filteredTasks, allowedMembers, taskLists, personFilterActive]);
 
   return {
     primaryGroup,

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -24,7 +24,12 @@ import { useOrientation } from '@/lib/hooks/useOrientation';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import type { GiftIdea, FamilyMember } from '@/types';
 
-export function GiftIdeasView() {
+interface GiftIdeasViewProps {
+  /** PersonFilter selection from the parent. null/empty = show all members. */
+  selectedMemberIds?: string[] | null;
+}
+
+export function GiftIdeasView({ selectedMemberIds }: GiftIdeasViewProps = {}) {
   const { members } = useFamily();
   const { activeUser, requireAuth } = useAuth();
   const { ideas, loading, error, addIdea, updateIdea, deleteIdea, togglePurchased } = useGiftIdeas(activeUser?.id);
@@ -37,7 +42,12 @@ export function GiftIdeasView() {
   const [quickAddByUser, setQuickAddByUser] = useState<Record<string, string>>({});
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const otherMembers = useMemo(() => members, [members]);
+  const otherMembers = useMemo(() => {
+    const hasFilter = selectedMemberIds && selectedMemberIds.length > 0;
+    if (!hasFilter) return members;
+    return members.filter((m) => selectedMemberIds!.includes(m.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [members, selectedMemberIds?.join(',')]);
 
   // Group ideas by forUserId
   const ideasByUser = useMemo(() => {

--- a/src/app/wishes/GiftIdeasView.tsx
+++ b/src/app/wishes/GiftIdeasView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { toast } from '@/components/ui/use-toast';
 import {
   Lightbulb,
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { CarouselArrows } from '@/components/ui/CarouselArrows';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { useFamily } from '@/components/providers/FamilyProvider';
 import { useAuth } from '@/components/providers';
@@ -34,6 +35,7 @@ export function GiftIdeasView() {
 
   const [editingIdea, setEditingIdea] = useState<GiftIdea | null>(null);
   const [quickAddByUser, setQuickAddByUser] = useState<Record<string, string>>({});
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const otherMembers = useMemo(() => members, [members]);
 
@@ -107,10 +109,12 @@ export function GiftIdeasView() {
     : 'minmax(220px, 1fr)';
   return (
     <>
+      <div className="relative h-full">
       <div
+        ref={scrollRef}
         className={cn(
           // See ChoreGroupGrid for the grid-rows-1 reasoning.
-          'grid grid-rows-1 gap-3 h-full overflow-x-auto',
+          'grid grid-rows-1 gap-3 h-full overflow-x-auto scroll-smooth',
           isCarousel && 'snap-x snap-mandatory'
         )}
         style={{
@@ -177,6 +181,8 @@ export function GiftIdeasView() {
             </div>
           );
         })}
+      </div>
+        {isCarousel && !isMobile && <CarouselArrows scrollRef={scrollRef} />}
       </div>
 
       {/* Edit modal (inline for simplicity) */}

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { toast } from '@/components/ui/use-toast';
 import { pushUndo } from '@/lib/hooks/useUndoStack';
 import {
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PageWrapper, SubpageHeader, PersonFilter, UndoButton } from '@/components/layout';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { CarouselArrows } from '@/components/ui/CarouselArrows';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { useDragReorder } from '@/lib/hooks/useDragReorder';
 import { useFamily } from '@/components/providers/FamilyProvider';
@@ -64,6 +65,7 @@ export function WishesView() {
   const isMobile = useIsMobile();
   const isPortrait = orientation === 'portrait';
   const showingAll = !selectedMemberIds || selectedMemberIds.length === 0;
+  const wishGridRef = useRef<HTMLDivElement>(null);
 
   // --- Card drag-to-swap ---
   const memberIds = useMemo(() => members.map(m => m.id), [members]);
@@ -278,10 +280,12 @@ export function WishesView() {
                 : `calc((100% - ${(groupsPerScreen - 1) * 12}px) / ${groupsPerScreen})`
               : 'minmax(220px, 1fr)';
             return (
+          <div className="relative h-full">
           <div
+            ref={wishGridRef}
             className={cn(
               // See ChoreGroupGrid for the grid-rows-1 reasoning.
-              'grid grid-rows-1 gap-3 h-full overflow-x-auto',
+              'grid grid-rows-1 gap-3 h-full overflow-x-auto scroll-smooth',
               isCarousel && 'snap-x snap-mandatory'
             )}
             style={{
@@ -309,6 +313,8 @@ export function WishesView() {
                 </div>
               );
             })}
+          </div>
+            {isCarousel && !isMobile && <CarouselArrows scrollRef={wishGridRef} />}
           </div>
             );
           })()

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -212,6 +212,14 @@ export function WishesView() {
 
   return (
     <PageWrapper>
+      {/*
+        h-screen + flex-col so the inner flex-1 overflow-auto content area
+        fills remaining vertical space. Without this wrapper the toolbar
+        and content stack at natural heights and the per-member columns
+        collapse to their content — matches the Tasks / Chores / Shopping
+        pattern.
+      */}
+      <div className="h-screen flex flex-col">
       <SubpageHeader
         title="Wishes"
         icon={<Gift className="h-6 w-6" />}
@@ -250,7 +258,7 @@ export function WishesView() {
           </button>
         </div>
 
-        {activeTab === 'wishes' && !familyLoading && members.length > 0 && (
+        {!familyLoading && members.length > 0 && (
           <PersonFilter
             members={members}
             selected={selectedMemberIds}
@@ -262,7 +270,7 @@ export function WishesView() {
       {/* Content */}
       <div className="flex-1 overflow-auto px-4 pb-4">
         {activeTab === 'ideas' ? (
-          <GiftIdeasView />
+          <GiftIdeasView selectedMemberIds={selectedMemberIds} />
         ) : loading || familyLoading ? (
           <div className="text-muted-foreground text-center py-8">Loading...</div>
         ) : error ? (
@@ -337,6 +345,7 @@ export function WishesView() {
       />
 
       <ConfirmDialog {...dialogProps} />
+      </div>
     </PageWrapper>
   );
 }
@@ -372,7 +381,13 @@ function MemberWishCard({
     <div
       {...dragProps}
       className={cn(
-        'flex flex-col rounded-xl border-2 bg-card/50 overflow-hidden min-h-0',
+        // h-full so the card fills its (grid-stretched) wrapper — without
+        // this it collapses to natural content height, leaving the
+        // per-member columns short and the inner body's flex-1 unable to
+        // engage. GiftIdeasView avoids this by making the card the grid
+        // cell directly; here a wrapper div sits between the grid and
+        // the card to attach snap-start without changing the card API.
+        'flex flex-col h-full rounded-xl border-2 bg-card/50 overflow-hidden min-h-0',
         'transition-all',
         !isMobile && 'cursor-grab active:cursor-grabbing touch-none',
         isDragging && 'opacity-50 scale-95 ring-4 ring-primary/50',

--- a/src/components/ui/CarouselArrows.tsx
+++ b/src/components/ui/CarouselArrows.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState, type RefObject } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface CarouselArrowsProps {
+  scrollRef: RefObject<HTMLElement | null>;
+}
+
+// Pointer-only affordance for horizontal carousels: touch users get the
+// snap-swipe gesture; mouse users would otherwise have no obvious way to
+// reveal the off-screen columns. Render only when the parent has decided
+// the carousel is active AND the device isn't touch.
+export function CarouselArrows({ scrollRef }: CarouselArrowsProps) {
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const update = () => {
+      setCanLeft(el.scrollLeft > 4);
+      setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+    };
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      ro.disconnect();
+    };
+  }, [scrollRef]);
+
+  const scrollByPage = (dir: -1 | 1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * el.clientWidth * 0.85, behavior: 'smooth' });
+  };
+
+  const btn =
+    'absolute top-1/2 -translate-y-1/2 z-10 h-10 w-10 rounded-full ' +
+    'bg-background/95 border border-border shadow-md flex items-center ' +
+    'justify-center hover:bg-accent transition-opacity';
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => scrollByPage(-1)}
+        disabled={!canLeft}
+        aria-label="Scroll left"
+        className={cn(btn, 'left-1', !canLeft && 'opacity-0 pointer-events-none')}
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => scrollByPage(1)}
+        disabled={!canRight}
+        aria-label="Scroll right"
+        className={cn(btn, 'right-1', !canRight && 'opacity-0 pointer-events-none')}
+      >
+        <ChevronRight className="h-5 w-5" />
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- **Desktop carousel arrows** on Chores / Tasks (flat + nested) / Wishes / GiftIdeas — chevron buttons appear at the edges when there are more profiles than fit on screen. Mouse users no longer have a hidden affordance. New shared component: \`src/components/ui/CarouselArrows.tsx\`.
- **Tasks PersonFilter now hides unselected columns** (and the Unassigned bucket) when group-by-person is on. Matches Chores / Wishes. Implemented in \`useTaskGrouping\` (new \`filterPerson\` param).
- **GiftIdeasView hook-order fix** — \`useRef\` was called after three conditional early returns, causing intermittent "Something went wrong / An unexpected error occurred" on refresh. Moved up to top of component.
- **Mobile Shopping**: pill bar collapses into a compact prev/dots/next indicator, and swipe-left/right switches between shopping lists. Desktop 3-col category grid untouched (per UX recommendation — "categories aren't peer entities, they're a taxonomy of one trip; lists are peer entities").
- **\`needs-reply\` triage workflow** — when anyone other than @sandydargoport opens or comments on an issue/PR, auto-add \`needs-reply\`. When the owner replies, remove it. Pairs with a Project view filter (\`label:needs-reply\` OR \`author != sandydargoport\`).

## Test plan
- [ ] Desktop: ≥5 profiles → carousel arrows visible on Chores; click them to scroll; they hide at the edges
- [ ] Desktop: PersonFilter (1 person) + group-by-person on Tasks → only that column renders
- [ ] Desktop: Gift Ideas refresh 5× → no "Something went wrong"
- [ ] Mobile: Shopping with ≥2 lists → swipe content area left/right cycles lists; dots indicate position; chevron buttons work too
- [ ] Mobile: Shopping with 1 list → no indicator, no swipe affordance
- [ ] Workflow: leave a comment on an issue as a different user → \`needs-reply\` appears; reply as owner → label removed