### PR TITLE
tests(reverse-proxy): nginx fixture for full TLS-termination test (modality TODO #1 path B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,96 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  e2e-nginx-fixture:
+    name: E2E nginx TLS fixture (modality TODO #1 path B)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Same Playwright container as e2e-modality — Chromium preinstalled,
+    # Ubuntu Jammy base so apt-get can add nginx-light and openssl.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-jammy
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: prism
+          POSTGRES_PASSWORD: ci_test_password
+          POSTGRES_DB: prism
+        options: >-
+          --health-cmd "pg_isready -U prism"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://prism:ci_test_password@postgres:5432/prism
+      REDIS_URL: redis://redis:6379
+      PORT: '3000'
+      # APP_URL intentionally left as http — confirms the fix reads
+      # X-Forwarded-Proto rather than APP_URL to decide cookie Secure flag.
+      APP_URL: http://localhost:3000
+      SESSION_SECRET: ci_test_session_secret_padding32
+      PIN_ENCRYPTION_KEY: ci_test_pin_encryption_key_pad32
+      ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      E2E_HAS_TEST_DB: '1'
+      E2E_PIN: '1234'
+      # Enables the path-B spec (skipped without this flag).
+      E2E_NGINX_PROXY: '1'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install psql, openssl, nginx-light
+        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client openssl nginx-light
+
+      - name: Apply base schema
+        env:
+          PGPASSWORD: ci_test_password
+        run: psql -h postgres -U prism -d prism -v ON_ERROR_STOP=1 -f src/lib/db/init/02-schema.sql
+
+      - name: Apply migrations
+        run: node scripts/migrate.js
+
+      - name: Seed database
+        run: npm run db:seed
+
+      - name: Generate self-signed cert
+        run: bash e2e/fixtures/generate-self-signed.sh
+
+      - name: Start nginx (TLS proxy on 443 → Next.js on 3000)
+        run: |
+          mkdir -p /tmp/nginx-client-body /tmp/nginx-proxy /tmp/nginx-fastcgi /tmp/nginx-uwsgi /tmp/nginx-scgi
+          nginx -t -c "$(pwd)/e2e/fixtures/nginx.conf"
+          nginx -c "$(pwd)/e2e/fixtures/nginx.conf"
+
+      - name: Run nginx fixture spec
+        run: npx playwright test e2e/reverse-proxy-nginx.spec.ts --reporter=list
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-nginx
+          path: playwright-report/
+          retention-days: 7
+
   visual-regression:
     name: Visual regression (modality TODO #2)
     runs-on: ubuntu-latest

--- a/e2e/fixtures/generate-self-signed.sh
+++ b/e2e/fixtures/generate-self-signed.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Generates /tmp/prism-test-cert.{crt,key} for the nginx TLS fixture.
+# Idempotent: skips if both files already exist.
+set -euo pipefail
+
+CERT=/tmp/prism-test-cert.crt
+KEY=/tmp/prism-test-cert.key
+
+if [[ -f "$CERT" && -f "$KEY" ]]; then
+  echo "prism-test-cert already exists, skipping."
+  exit 0
+fi
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$KEY" \
+  -out    "$CERT" \
+  -days 1 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+echo "Generated: $CERT  $KEY"

--- a/e2e/fixtures/nginx.conf
+++ b/e2e/fixtures/nginx.conf
@@ -1,0 +1,40 @@
+# Minimal TLS-terminating reverse-proxy for integration tests.
+# Cert and key live at /tmp/prism-test-cert.{crt,key} — see generate-self-signed.sh.
+
+worker_processes 1;
+pid              /tmp/nginx-test.pid;
+error_log        /tmp/nginx-error.log warn;
+
+events {
+    worker_connections 16;
+}
+
+http {
+    # Proxy module writes temp files; /tmp avoids permission issues in the test container.
+    client_body_temp_path /tmp/nginx-client-body;
+    proxy_temp_path       /tmp/nginx-proxy;
+    fastcgi_temp_path     /tmp/nginx-fastcgi;
+    uwsgi_temp_path       /tmp/nginx-uwsgi;
+    scgi_temp_path        /tmp/nginx-scgi;
+
+    server {
+        # TLS entry point — mirrors what a production load-balancer does.
+        listen      443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /tmp/prism-test-cert.crt;
+        ssl_certificate_key /tmp/prism-test-cert.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        location / {
+            # Forward all traffic to the local Next.js server.
+            proxy_pass http://127.0.0.1:3000;
+
+            # This is the header the app reads to decide whether cookies get Secure.
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/e2e/reverse-proxy-nginx.spec.ts
+++ b/e2e/reverse-proxy-nginx.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, APIResponse } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+/**
+ * Modality TODO #1 — path B: nginx fixture for full TLS-termination test.
+ *
+ * Path A (reverse-proxy.spec.ts) injects X-Forwarded-Proto directly into the
+ * request, which catches the live bug class (the app honoring the header).
+ * Path B adds marginal integration coverage by running a real nginx process in
+ * front of Next.js: it catches misconfigurations of the reference nginx.conf
+ * we ship and actual TLS handshake behavior that path A cannot exercise.
+ *
+ * Setup required before running:
+ *   bash e2e/fixtures/generate-self-signed.sh
+ *   nginx -c <abs-path>/e2e/fixtures/nginx.conf
+ *
+ * TEST-ENVIRONMENT DEPENDENCY:
+ * - Requires a seeded DB (E2E_HAS_TEST_DB=1) AND nginx running on port 443
+ *   configured per e2e/fixtures/nginx.conf (E2E_NGINX_PROXY=1).
+ * - Without both flags every test here is skipped — by design.
+ */
+
+const HAS_TEST_DB = process.env.E2E_HAS_TEST_DB === '1';
+const HAS_NGINX = process.env.E2E_NGINX_PROXY === '1';
+const PIN = process.env.E2E_PIN || '1234';
+const NGINX_BASE = 'https://localhost:443';
+
+/**
+ * Query the seeded parent's id directly from the DB.
+ * Mirrors the same helper in reverse-proxy.spec.ts — see that file for the
+ * full explanation of the dev-vs-CI dual-path logic.
+ */
+function getSeededParentId(): string {
+  const cmd = process.env.DATABASE_URL
+    ? `psql "${process.env.DATABASE_URL}" -At -c "SELECT id FROM users WHERE role = 'parent' ORDER BY created_at LIMIT 1"`
+    : `docker exec prism-db psql -U prism -d prism -At -c "SELECT id FROM users WHERE role = 'parent' ORDER BY created_at LIMIT 1"`;
+  const out = execSync(cmd, { encoding: 'utf-8' }).trim();
+  if (!out) throw new Error('No seeded parent in DB — did seeds run?');
+  return out;
+}
+
+function setCookies(response: APIResponse): string[] {
+  return response
+    .headersArray()
+    .filter((h) => h.name.toLowerCase() === 'set-cookie')
+    .map((h) => h.value);
+}
+
+function findCookie(cookies: string[], name: string): string | undefined {
+  return cookies.find((c) => c.startsWith(`${name}=`));
+}
+
+test.describe('Reverse-proxy cookie security — nginx TLS fixture (path B)', () => {
+  // Accept the self-signed cert for the API request context in this describe block.
+  test.use({ ignoreHTTPSErrors: true });
+
+  let parentId: string;
+
+  test.beforeAll(() => {
+    if (HAS_TEST_DB && HAS_NGINX) {
+      parentId = getSeededParentId();
+    }
+  });
+
+  test('login via nginx TLS: Set-Cookie has Secure; HttpOnly', async ({ request }) => {
+    test.skip(
+      !HAS_TEST_DB || !HAS_NGINX,
+      'Set E2E_HAS_TEST_DB=1 and E2E_NGINX_PROXY=1 with nginx running on port 443',
+    );
+    const response = await request.post(`${NGINX_BASE}/api/auth/login`, {
+      data: { userId: parentId, pin: PIN },
+    });
+    expect(response.ok()).toBe(true);
+
+    const session = findCookie(setCookies(response), 'prism_session');
+    expect(session, 'prism_session cookie should be set').toBeDefined();
+    expect(session, 'Secure flag expected — nginx injected X-Forwarded-Proto: https').toMatch(
+      /;\s*Secure(;|$)/i,
+    );
+    expect(session, 'HttpOnly flag expected').toMatch(/;\s*HttpOnly(;|$)/i);
+  });
+
+  test('logout via nginx TLS: cleared Set-Cookie still carries Secure; HttpOnly', async ({ request }) => {
+    test.skip(
+      !HAS_TEST_DB || !HAS_NGINX,
+      'Set E2E_HAS_TEST_DB=1 and E2E_NGINX_PROXY=1 with nginx running on port 443',
+    );
+
+    // Establish a session so logout has something to clear.
+    const loginResponse = await request.post(`${NGINX_BASE}/api/auth/login`, {
+      data: { userId: parentId, pin: PIN },
+    });
+    expect(loginResponse.ok(), 'precondition: login via nginx must succeed').toBe(true);
+
+    const response = await request.post(`${NGINX_BASE}/api/auth/logout`);
+    expect(response.ok()).toBe(true);
+
+    const session = findCookie(setCookies(response), 'prism_session');
+    expect(session, 'logout should re-emit prism_session as a cleared Set-Cookie').toBeDefined();
+    expect(session, 'cleared cookie must still carry Secure').toMatch(/;\s*Secure(;|$)/i);
+    expect(session, 'cleared cookie must still carry HttpOnly').toMatch(/;\s*HttpOnly(;|$)/i);
+  });
+});


### PR DESCRIPTION
## What this is

This is the **path B** scaffold for modality TODO #1 — the heavier nginx-fixture version of the reverse-proxy cookie security test.

### Why path A and path B are both useful

**Path A** (`e2e/reverse-proxy.spec.ts`, already merged) injects `X-Forwarded-Proto: https` directly into the Playwright request context. It catches the live bug class: auth endpoints that compute the `Secure` flag from `APP_URL` / `NODE_ENV` instead of from `requestIsSecure(req)`. This is where the actual regression lived and where the fix lives.

**Path B** (this PR) runs a real nginx process in front of Next.js, terminating TLS on port 443 with a self-signed cert and proxying to Next.js on port 3000. The marginal coverage over path A is small but non-zero:
- Catches misconfigurations in the **reference `nginx.conf` we ship** to users who self-host (e.g. missing `proxy_set_header X-Forwarded-Proto`, wrong `proxy_pass` upstream, protocol mismatch).
- Exercises the actual **TLS handshake path** through the proxy stack, not just header injection.
- Path A continues to be the primary gate for the bug class; path B is integration insurance for the config artefact.

## Files changed

| File | Purpose |
|---|---|
| `e2e/fixtures/nginx.conf` | 38-line self-contained nginx config: TLS on 443, proxies to `127.0.0.1:3000`, injects `X-Forwarded-Proto: https`. All temp paths in `/tmp` to avoid permission issues in the Playwright container. |
| `e2e/fixtures/generate-self-signed.sh` | Idempotent `openssl req -x509` script. Produces `/tmp/prism-test-cert.{crt,key}` with `CN=localhost` and `subjectAltName=DNS:localhost,IP:127.0.0.1`. 1-day validity (ephemeral). |
| `e2e/reverse-proxy-nginx.spec.ts` | Path B spec. Gated on `E2E_HAS_TEST_DB=1` **and** `E2E_NGINX_PROXY=1` — skips silently unless both flags are set. Uses `test.use({ ignoreHTTPSErrors: true })` so Playwright's APIRequestContext accepts the self-signed cert. Tests: login and logout, asserting `Secure; HttpOnly` on `prism_session`. |
| `.github/workflows/ci.yml` | New `e2e-nginx-fixture` job: same postgres/redis services and DB setup as `e2e-modality`; adds `apt-get install nginx-light openssl`, the cert-gen script, nginx startup (with `nginx -t` pre-flight), then runs the new spec. Artifact upload on failure. |

## Decisions made

- **`APP_URL` stays `http://localhost:3000`** in the new CI job (not `https://localhost:443`). This is intentional: it confirms the fix reads `X-Forwarded-Proto` rather than `APP_URL` when deciding the `Secure` flag.
- **nginx daemonises in CI** via the default behaviour (no `daemon off;`). The step completes, nginx keeps running in the container for the duration of the playwright step. All temp files (`pid`, `error_log`, proxy buffers) go to `/tmp`.
- **Self-signed cert is ephemeral** (`-days 1`, `/tmp/` path, not committed). The `generate-self-signed.sh` script is idempotent so it's safe to call multiple times within a job.
- **Only login + logout tests** in path B (not `verify-pin`). The marginal value of a third nginx-proxied test is negligible; the two tests already cover the full cookie lifecycle.

## Draft status

Awaiting human review of:
1. The `nginx.conf` — does it match what we'd actually ship?
2. The cert generation approach — acceptable for CI?
3. The new `e2e-nginx-fixture` CI job structure.

**Do not merge until the above are reviewed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_019exbT5iTtadN3FuQ7UpaTJ)_