### PR TITLE
fix(backup): cover avatars/photos off-site, persist data dir, add healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,10 @@ services:
       - ./uploads:/app/uploads
       - ./backups:/app/backups
       - photos-cache:/app/cache/photos
-      - ./data/photos:/app/data/photos
+      # Mount the whole data dir so avatars and recipe-images persist too,
+      # not just data/photos (otherwise they live only in the container layer
+      # and are lost on rebuild).
+      - ./data:/app/data
     depends_on:
       db:
         condition: service_healthy
@@ -103,10 +106,15 @@ services:
       - RETENTION_DAYS=7
       - RCLONE_REMOTE=onedrive:Prism/backups
       - RCLONE_RETENTION_DAYS=30
+      - HC_URL=https://hc-ping.com/f0bff165-06b7-48eb-a0da-10bbd4656786
     volumes:
       - ./backups:/backups
-      - ./uploads:/uploads:ro
-      - ./config/rclone.conf:/root/.config/rclone/rclone.conf:ro
+      # Off-site sync of user assets (avatars, photos, recipe images) lives
+      # under data/, not uploads/. Mounted read-only for the backup job.
+      - ./data:/data:ro
+      # Read-write so rclone can persist its refreshed OAuth token; a
+      # read-only mount makes every run log a config-save error.
+      - ./config/rclone.conf:/root/.config/rclone/rclone.conf
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/Dockerfile.backup
+++ b/scripts/Dockerfile.backup
@@ -3,8 +3,8 @@
 
 FROM postgres:15-alpine
 
-# Install rclone for cloud storage sync
-RUN apk add --no-cache rclone
+# rclone for cloud storage sync; curl for healthcheck pings
+RUN apk add --no-cache rclone curl
 
 # Copy scripts
 COPY backup.sh /scripts/backup.sh

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -10,7 +10,16 @@ RETENTION_DAYS=${RETENTION_DAYS:-7}
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="$BACKUP_DIR/prism_$TIMESTAMP.sql.gz"
 
+# Healthcheck ping helper. HC_URL is optional; no-op if unset or curl missing.
+# Suffix "" = success, "/start" = job started, "/fail" = job failed.
+ping_hc() {
+  [ -n "${HC_URL:-}" ] || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  curl -fsS -m 10 --retry 3 "${HC_URL}$1" >/dev/null 2>&1 || true
+}
+
 echo "[$(date)] Starting backup..."
+ping_hc /start
 
 # Create backup with compression
 PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
@@ -21,12 +30,15 @@ PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
   --no-acl \
   | gzip > "$BACKUP_FILE"
 
-# Check if backup was created successfully
-if [ -f "$BACKUP_FILE" ] && [ -s "$BACKUP_FILE" ]; then
+# Check if backup was created successfully and is plausibly non-empty.
+# A valid gzipped dump of an initialised schema is comfortably over 10KB; a
+# smaller file means pg_dump errored out mid-stream.
+if [ -f "$BACKUP_FILE" ] && [ "$(stat -c%s "$BACKUP_FILE")" -gt 10000 ]; then
   SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
   echo "[$(date)] Backup completed: $BACKUP_FILE ($SIZE)"
 else
-  echo "[$(date)] ERROR: Backup failed!"
+  echo "[$(date)] ERROR: Backup failed or too small!"
+  ping_hc /fail
   exit 1
 fi
 
@@ -39,6 +51,7 @@ echo "[$(date)] Current backups:"
 ls -lh "$BACKUP_DIR"/prism_*.sql.gz 2>/dev/null || echo "  (none)"
 
 # Off-site backup via rclone (if configured)
+SYNC_FAILED=0
 if [ -n "$RCLONE_REMOTE" ] && command -v rclone >/dev/null 2>&1; then
   echo "[$(date)] Syncing database backup to off-site storage: $RCLONE_REMOTE..."
   if rclone copy "$BACKUP_FILE" "$RCLONE_REMOTE" --progress; then
@@ -51,22 +64,32 @@ if [ -n "$RCLONE_REMOTE" ] && command -v rclone >/dev/null 2>&1; then
     fi
   else
     echo "[$(date)] WARNING: Database backup off-site sync failed!"
+    SYNC_FAILED=1
   fi
 
-  # Sync user-uploaded file assets (avatars, etc.)
-  UPLOADS_REMOTE="${RCLONE_REMOTE%/*}/uploads"
-  if [ -d "/uploads" ] && [ "$(ls -A /uploads 2>/dev/null)" ]; then
-    echo "[$(date)] Syncing uploads directory to off-site storage: $UPLOADS_REMOTE..."
-    if rclone sync /uploads "$UPLOADS_REMOTE" --progress; then
-      echo "[$(date)] Uploads sync completed successfully"
+  # Sync user file assets: avatars, uploaded photos, recipe images. These all
+  # live under data/ (see src/lib/config/runtime.ts), NOT uploads/. The photo
+  # cache (data/photos/cache) is regenerable on demand, so it is excluded.
+  DATA_REMOTE="${RCLONE_REMOTE%/*}/data"
+  if [ -d "/data" ] && [ "$(ls -A /data 2>/dev/null)" ]; then
+    echo "[$(date)] Syncing data directory to off-site storage: $DATA_REMOTE..."
+    if rclone sync /data "$DATA_REMOTE" --exclude 'photos/cache/**' --progress; then
+      echo "[$(date)] Data sync completed successfully"
     else
-      echo "[$(date)] WARNING: Uploads off-site sync failed!"
+      echo "[$(date)] WARNING: Data off-site sync failed!"
+      SYNC_FAILED=1
     fi
   else
-    echo "[$(date)] Uploads directory is empty or missing, skipping."
+    echo "[$(date)] Data directory is empty or missing, skipping."
   fi
 elif [ -n "$RCLONE_REMOTE" ]; then
   echo "[$(date)] WARNING: RCLONE_REMOTE set but rclone not installed"
 fi
 
-echo "[$(date)] Backup process complete."
+if [ "$SYNC_FAILED" -ne 0 ]; then
+  echo "[$(date)] Backup completed locally but off-site sync had failures."
+  ping_hc /fail
+else
+  echo "[$(date)] Backup process complete."
+  ping_hc ""
+fi


### PR DESCRIPTION
## Why

The containerised `prism-backup` job synced an empty `uploads/` directory, while every user asset — avatars, uploaded photos, recipe images — actually lives under `data/` (`src/lib/config/runtime.ts`). **No images ever reached OneDrive.** Confirmed live: `onedrive:Prism/{uploads,photos,avatars}` all return "directory not found".

Worse, two of those buckets weren't even persisted: the app only bind-mounted `data/photos`, so `data/avatars` and `data/recipe-images` lived solely in the container's writable layer and were destroyed on any `docker compose up --build`.

This also consolidates a redundant second DB-dump job: the standalone `~/bin/backup-prism.sh` cron was dumping the same database to the same OneDrive folder ~20 min after the container. This PR ports the cron's two extras (healthcheck ping + size check) into the container so the cron can be retired. *(Disabling the crontab line is a host-side step, done separately from this repo change.)*

## Changes

- **compose (app):** mount the whole `./data` (was `./data/photos` only) → avatars + recipe-images now persist across rebuilds.
- **compose (backup):** mount `./data:ro` and sync it off-site instead of the unused `uploads/`; exclude regenerable `photos/cache`.
- **backup.sh:** off-site asset sync now targets `data/` → `onedrive:Prism/data`; added `HC_URL` pings (start/success/fail) and a >10KB dump size check.
- **compose (backup):** `rclone.conf` mounted read-write so rclone can persist its refreshed OAuth token (was logging a config-save error every run).
- **Dockerfile.backup:** install `curl` for the healthcheck pings.

## Validation

- `docker compose config -q` passes; effective mounts confirmed (`./data → /app/data`, `./data → /data:ro`).
- `docker compose build backup` succeeds; `curl` present in image; `sh -n backup.sh` passes.

## Deploy notes (not part of the repo)

1. `docker compose up -d` (recreates `prism-app` to pick up the new `./data` mount + restarts `prism-backup`).
2. Retire the duplicate cron: comment out the `backup-prism.sh` line in `crontab -e`.
3. One-time backfill of existing local assets: `docker exec prism-backup rclone sync /data onedrive:Prism/data --exclude 'photos/cache/**'`.