### PR TITLE
fix(backup): seed rclone config to writable path so token refresh persists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,9 +112,11 @@ services:
       # Off-site sync of user assets (avatars, photos, recipe images) lives
       # under data/, not uploads/. Mounted read-only for the backup job.
       - ./data:/data:ro
-      # Read-write so rclone can persist its refreshed OAuth token; a
-      # read-only mount makes every run log a config-save error.
-      - ./config/rclone.conf:/root/.config/rclone/rclone.conf
+      # Mounted read-only as a seed; backup-scheduler.sh copies it to rclone's
+      # default path inside the container so rclone can rename-replace it when
+      # refreshing its OAuth token (a direct single-file mount can't be renamed
+      # over — "device or resource busy").
+      - ./config/rclone.conf:/etc/rclone/rclone.conf:ro
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,8 +68,12 @@ environment:
   - RCLONE_REMOTE=onedrive:Prism/backups
   - RCLONE_RETENTION_DAYS=30
 volumes:
-  - ./config/rclone.conf:/root/.config/rclone/rclone.conf:ro
+  - ./config/rclone.conf:/etc/rclone/rclone.conf:ro
 ```
+
+The config is mounted read-only as a seed; the scheduler copies it into the
+container's own filesystem at startup so rclone can persist refreshed OAuth
+tokens (a directly-mounted config file can't be rename-replaced).
 
 ### Step 4: Restart backup container
 

--- a/scripts/backup-scheduler.sh
+++ b/scripts/backup-scheduler.sh
@@ -4,6 +4,16 @@
 
 BACKUP_HOUR=${BACKUP_HOUR:-3}  # Default: 3 AM
 
+# Seed rclone's config into a writable location. The host file is mounted
+# read-only at /etc/rclone/rclone.conf; copying it to rclone's default path
+# (inside the container's own filesystem, not a bind mount) lets rclone
+# atomically rename-replace it when it refreshes its OAuth token. Mounting the
+# config file directly makes that rename fail with "device or resource busy".
+if [ -f /etc/rclone/rclone.conf ]; then
+  mkdir -p /root/.config/rclone
+  cp /etc/rclone/rclone.conf /root/.config/rclone/rclone.conf
+fi
+
 echo "[$(date)] Backup scheduler started (daily at ${BACKUP_HOUR}:00)"
 
 # Loop forever, running backup at the scheduled hour


### PR DESCRIPTION
Follow-up to #127. That PR mounted `rclone.conf` read-write to stop the
config-save error, but that wasn't the real cause: a **single-file** bind mount
can't be `rename()`-replaced (the path is the mount point → "device or resource
busy"), so rclone's OAuth token refresh failed on every run regardless of rw.

## Fix
- Mount `./config/rclone.conf` **read-only** at `/etc/rclone/rclone.conf` (a seed).
- `backup-scheduler.sh` copies it to rclone's default path (`/root/.config/rclone/rclone.conf`) inside the container's own filesystem at startup, where rclone can rename-replace it freely.
- Documented host location (`./config/rclone.conf`) is unchanged; README mount example updated.

## Verified live
- Rebuilt + recreated the backup container.
- `rclone sync /data …` runs clean — the `Failed to save config … device or resource busy` error is gone.
- `rclone lsd onedrive:Prism` still works (config readable from the seeded copy).