### PR TITLE
fix(install): chown bind-mounted data/uploads to app uid (1001)

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -74,3 +74,18 @@ docker-compose up -d
 Open **<http://localhost:3000>** and log in with PIN `1234` (parent) or `0000` (child).
 
 Next: [first-time setup](first-time-setup.md).
+
+## Troubleshooting
+
+### Photo or avatar uploads return a 500
+
+The app container runs as uid `1001`. If the bind-mounted `data/` directory is
+owned by a different user, the app can't write photos/avatars and uploads fail
+with a 500 (`EACCES … mkdir '/app/data/...'` in `docker logs prism-app`). The
+installer chowns it for you; if you created the directory manually, fix it with:
+
+```bash
+docker run --rm -v "$PWD/data":/d alpine chown -R 1001:1001 /d
+```
+
+No container restart is needed — permissions are checked at write time.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,6 +135,18 @@ fi
 # Create necessary directories
 mkdir -p uploads backups data/photos config
 
+# The app container runs as uid 1001 (the "nextjs" user). Bind-mounted dirs it
+# writes to — photos, avatars and recipe images under data/, plus uploads —
+# must be owned by that uid or every upload/sync fails with EACCES (a 500 in the
+# UI). The host dirs were just created owned by the current user, so chown them
+# via a throwaway root container (works without host sudo, unlike `sudo chown`).
+if ! docker run --rm -v "$PWD/data":/d -v "$PWD/uploads":/u alpine \
+        sh -c 'chown -R 1001:1001 /d /u' 2>/dev/null; then
+    warn "Could not set data/uploads ownership to uid 1001."
+    warn "If photo or avatar uploads return a 500, run:"
+    warn "  docker run --rm -v \"\$PWD/data\":/d alpine chown -R 1001:1001 /d"
+fi
+
 # Build and start containers
 log "Building and starting containers (this may take a few minutes)..."
 $COMPOSE up -d --build


### PR DESCRIPTION
## Why
The app container runs as uid `1001` (`nextjs`), but `install.sh` created `data/`
and `uploads/` owned by the host user (mode 755). The app therefore had no write
permission, so **every photo/avatar upload and the photo sync failed with EACCES**
— surfaced as a 500 in the UI (`EACCES … mkdir '/app/data/photos/originals'`).
This affected the project's own install path; the data dir was never writable by
the container.

## Fix
- After `mkdir`, `chown -R 1001:1001 data uploads` via a throwaway `alpine` root
  container — works without host sudo (`install.sh` assumes docker access, not root).
- Falls back to a clear `warn` with the manual command if the chown can't run.
- Troubleshooting note added for existing installs.

## Verified
On a live deployment hitting this exact 500, the chown made the failing
`mkdir '/app/data/photos/originals'` succeed (write test OK, app healthy, no new
EACCES). `bash -n scripts/install.sh` passes.