### PR TITLE
fix(calendar): refresh last_synced/sync_errors on CalDAV task sync

### DIFF
--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -965,9 +965,27 @@ export async function syncCalDAVTasks(
     if (stale.length > 0) {
       await db.delete(tasks).where(inArray(tasks.id, stale.map(t => t.id)));
     }
+
+    // Refresh the source's health signal on success. For task-only sources
+    // (supportsEvents === false) the event path never runs, so this is the ONLY
+    // thing that advances last_synced and clears a stale error — without it they
+    // look perpetually stuck even while syncing cleanly every cycle. For
+    // event-capable sources the event path owns syncErrors, so only bump the
+    // timestamp there to avoid clobbering a real event-sync error.
+    const taskOnly = config.supportsEvents === false;
+    await db.update(calendarSources)
+      .set({ lastSynced: new Date(), ...(taskOnly ? { syncErrors: {} } : {}) })
+      .where(eq(calendarSources.id, source.id));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     errors.push(`CalDAV task sync failed: ${msg}`);
+    // Surface task-sync failures on the source itself for task-only sources
+    // (event-capable sources have syncErrors managed by the event path).
+    if (config.supportsEvents === false) {
+      await db.update(calendarSources)
+        .set({ syncErrors: { lastError: msg, lastErrorAt: new Date().toISOString() } })
+        .where(eq(calendarSources.id, source.id));
+    }
   }
 
   return { synced, errors };


### PR DESCRIPTION
## Why
Task-only CalDAV sources (`supportsEvents === false` — e.g. iCloud reminder
lists) never run the event-sync path, which was the only code that bumped
`calendarSources.last_synced` and cleared `sync_errors`. Result: those sources
showed a frozen `last_synced` (stuck on their last *event* sync) and held a
stale `lastError` indefinitely — so they looked **failed** in Settings even
while task sync ran cleanly every 30-min cycle.

Discovered while investigating two iCloud reminder lists that appeared dead but
were actually syncing fine (they returned only Apple CloudKit placeholders, so
nothing landed and the timestamp never advanced).

## Change
In `syncCalDAVTasks`, update the source row from the task path:
- bump `last_synced` on every successful run;
- clear `sync_errors` for task-only sources on success;
- record `{ lastError, lastErrorAt }` on failure for task-only sources.

Event-capable sources keep `syncErrors` owned by the event path (only the
timestamp is bumped here), so a genuine event-sync error is never clobbered.
Mirrors the timestamp/error handling the event path already does.

## Note
No local type-check (devDeps not installed on the host); relying on the CI
`Type-check & lint` gate. The `.set({ lastSynced, syncErrors })` shape matches
existing usage in the same file.