### PR TITLE
fix(auth): configurable family-wide PIN length (4–6); fixes #123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # Migration runner and SQL files
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/scripts/migrate.js ./scripts/migrate.js
-# postgres (postgres.js) is bundled into Next.js server chunks and not included
-# in the standalone node_modules — copy it explicitly for the migration runner.
+# reset-pin.js: offline PIN recovery, run via `docker compose exec`.
+COPY --from=builder /app/scripts/reset-pin.js ./scripts/reset-pin.js
+# postgres (postgres.js) and bcryptjs are bundled into Next.js server chunks and
+# not included in the standalone node_modules — copy them explicitly for the
+# migration runner and the reset-pin recovery script.
 COPY --from=builder /app/node_modules/postgres ./node_modules/postgres
+COPY --from=builder /app/node_modules/bcryptjs ./node_modules/bcryptjs
 # Bundled DB scripts (seed + clear) for the Settings → Backups buttons.
 # Self-contained CJS bundles with all deps inlined via esbuild — no need
 # to ship src/ or the dev node_modules.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed — Security / Login
+- **5–6 digit PINs can now actually be used.** PIN length is now a uniform family-wide setting (4–6 digits, like an iPhone passcode) — chosen in the setup wizard and changeable in Settings → Security. Previously PIN *creation* allowed up to 6 digits while every login/unlock pad was hard-coded to 4 and auto-submitted at 4, so any 5–6 digit PIN could never be entered and the member was locked out. All five PIN surfaces (login, settings gate, quick-switch, away-exit, babysitter-exit), `PinEditModal`, and the family API now read and enforce the configured length. Added `scripts/reset-pin.js` for offline recovery of a locked-out member. Closes [#123](https://github.com/sandydargoport/prism/issues/123).
+
 ## [1.8.8] – 2026-06-16
 
 ### Changed — Mobile

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -89,3 +89,21 @@ docker run --rm -v "$PWD/data":/d alpine chown -R 1001:1001 /d
 ```
 
 No container restart is needed — permissions are checked at write time.
+
+### Locked out — forgot a PIN, or can't log in after changing the PIN length
+
+PINs are a single length for the whole family (set in **Settings → Security**,
+or during the setup wizard). If someone forgets their PIN, or you change the
+family PIN length and an existing PIN no longer matches, that member can be
+locked out. Reset it from the server with the recovery script:
+
+```bash
+# List family members:
+docker compose exec app node scripts/reset-pin.js --list
+
+# Reset a member's PIN (must match the family PIN length):
+docker compose exec app node scripts/reset-pin.js "Jordan" 1234
+```
+
+It hashes the new PIN exactly like the app and updates only that member. They
+can log in immediately with the new PIN — no restart needed.

--- a/scripts/reset-pin.js
+++ b/scripts/reset-pin.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * scripts/reset-pin.js
+ *
+ * Offline PIN recovery — reset a family member's PIN without being logged in.
+ * Use when someone is locked out: they forgot their PIN, or set one that no
+ * longer matches the family PIN length (Settings → Security).
+ *
+ * Run INSIDE the app container (it has DATABASE_URL and the deps):
+ *
+ *   # See member names:
+ *   docker compose exec app node scripts/reset-pin.js --list
+ *
+ *   # Reset a member's PIN (new PIN must match the family PIN length):
+ *   docker compose exec app node scripts/reset-pin.js "Jordan" 1234
+ *
+ * It hashes the PIN exactly like the app (bcrypt, 12 rounds) and updates only
+ * that member's row. Nothing else is touched.
+ */
+
+const postgres = require('postgres');
+const bcrypt = require('bcryptjs');
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('[reset-pin] ERROR: DATABASE_URL is not set — run this inside the app container.');
+  process.exit(1);
+}
+
+const MIN_PIN_LENGTH = 4;
+const MAX_PIN_LENGTH = 6;
+const DEFAULT_PIN_LENGTH = 4;
+
+async function main() {
+  const args = process.argv.slice(2);
+  const sql = postgres(DATABASE_URL, { max: 1, connect_timeout: 10, onnotice: () => {} });
+
+  try {
+    const members = await sql`
+      SELECT id, name, role, (pin IS NOT NULL) AS has_pin
+      FROM users ORDER BY sort_order, created_at
+    `;
+
+    if (args.length === 0 || args[0] === '--list') {
+      console.log('Family members:');
+      for (const m of members) {
+        console.log(`  - ${m.name}  (${m.role}${m.has_pin ? ', PIN set' : ', no PIN'})`);
+      }
+      console.log('\nUsage: node scripts/reset-pin.js "<member name>" <new-pin>');
+      return;
+    }
+
+    const [name, newPin] = args;
+    if (!name || !newPin) {
+      console.error('Usage: node scripts/reset-pin.js "<member name>" <new-pin>   (or --list)');
+      process.exit(1);
+    }
+
+    // Resolve the family-wide PIN length so the reset PIN can actually be entered.
+    const [setting] = await sql`SELECT value FROM settings WHERE key = 'pinLength'`;
+    let pinLength = DEFAULT_PIN_LENGTH;
+    const parsed = Math.round(Number(setting && setting.value));
+    if (Number.isFinite(parsed) && parsed >= MIN_PIN_LENGTH && parsed <= MAX_PIN_LENGTH) {
+      pinLength = parsed;
+    }
+
+    if (!new RegExp(`^\\d{${pinLength}}$`).test(newPin)) {
+      console.error(
+        `[reset-pin] ERROR: PIN must be exactly ${pinLength} digits (the family PIN length). ` +
+        `Change it in Settings → Security if you want a different length.`
+      );
+      process.exit(1);
+    }
+
+    const matches = members.filter((m) => m.name.toLowerCase() === name.toLowerCase());
+    if (matches.length === 0) {
+      console.error(`[reset-pin] ERROR: no member named "${name}". Run with --list to see names.`);
+      process.exit(1);
+    }
+    if (matches.length > 1) {
+      console.error(`[reset-pin] ERROR: ${matches.length} members are named "${name}" — rename one, or reset via the UI.`);
+      process.exit(1);
+    }
+
+    const hash = await bcrypt.hash(newPin, 12);
+    await sql`UPDATE users SET pin = ${hash}, updated_at = NOW() WHERE id = ${matches[0].id}`;
+    console.log(`[reset-pin] ✓ Reset PIN for "${matches[0].name}". They can log in now with the new ${pinLength}-digit PIN.`);
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('[reset-pin] Fatal error:', err.message);
+  process.exit(1);
+});

--- a/src/app/api/family/[id]/route.ts
+++ b/src/app/api/family/[id]/route.ts
@@ -7,6 +7,7 @@ import bcrypt from 'bcryptjs';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
+import { getConfiguredPinLength } from '@/lib/services/pinLength';
 
 export async function GET(
   request: NextRequest,
@@ -123,7 +124,11 @@ export async function PATCH(
 
     // Handle PIN change
     if (body.pin !== undefined) {
-      // If user has existing PIN, require current PIN verification
+      // Changing an existing PIN requires proving the current one — including
+      // when an admin edits another member. We deliberately do NOT let a parent
+      // silently reset another member's PIN (that would let one parent lock out
+      // a co-parent). Recovery for a forgotten/locked-out PIN is the offline
+      // `scripts/reset-pin.js` helper instead, which needs server access.
       if (currentMember.pin) {
         if (!body.currentPin) {
           return NextResponse.json(
@@ -142,18 +147,21 @@ export async function PATCH(
         }
       }
 
-      // Validate and hash new PIN
+      // Validate and hash new PIN — must match the family-wide configured length.
       if (body.pin === null || body.pin === '') {
         // Remove PIN
         updates.pin = null;
-      } else if (/^\d{4,6}$/.test(body.pin)) {
-        // Hash and set new PIN
-        updates.pin = await bcrypt.hash(body.pin, 12);
       } else {
-        return NextResponse.json(
-          { error: 'PIN must be 4-6 digits' },
-          { status: 400 }
-        );
+        const expectedLen = await getConfiguredPinLength();
+        if (new RegExp(`^\\d{${expectedLen}}$`).test(body.pin)) {
+          // Hash and set new PIN
+          updates.pin = await bcrypt.hash(body.pin, 12);
+        } else {
+          return NextResponse.json(
+            { error: `PIN must be exactly ${expectedLen} digits` },
+            { status: 400 }
+          );
+        }
       }
     }
 

--- a/src/app/api/family/route.ts
+++ b/src/app/api/family/route.ts
@@ -9,6 +9,7 @@ import { getCached } from '@/lib/cache/redis';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
+import { getConfiguredPinLength } from '@/lib/services/pinLength';
 
 interface FamilyMemberResponse {
   id: string;
@@ -168,9 +169,10 @@ export async function POST(request: NextRequest) {
 
     let hashedPin: string | null = null;
     if (body.pin) {
-      if (!/^\d{4,6}$/.test(body.pin)) {
+      const expectedLen = await getConfiguredPinLength();
+      if (!new RegExp(`^\\d{${expectedLen}}$`).test(body.pin)) {
         return NextResponse.json(
-          { error: 'PIN must be 4-6 digits' },
+          { error: `PIN must be exactly ${expectedLen} digits` },
           { status: 400 }
         );
       }

--- a/src/app/settings/SettingsPinGate.tsx
+++ b/src/app/settings/SettingsPinGate.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily, useAuth } from '@/components/providers';
+import { usePinLength } from '@/lib/hooks/usePinLength';
 import { SettingsView } from './SettingsView';
 
 type GateState = 'checking' | 'prompt' | 'verified';
@@ -89,7 +90,7 @@ function SettingsPinPrompt({
   const [isShaking, setIsShaking] = useState(false);
   const [mounted, setMounted] = useState(false);
 
-  const pinLength = 4;
+  const { pinLength } = usePinLength();
 
   useEffect(() => {
     setMounted(true);

--- a/src/app/settings/components/PinEditModal.tsx
+++ b/src/app/settings/components/PinEditModal.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { usePinLength } from '@/lib/hooks/usePinLength';
+import { MAX_PIN_LENGTH } from '@/lib/constants';
 
 import type { FamilyMember } from '@/types';
 export type { FamilyMember };
@@ -22,13 +24,14 @@ export function PinEditModal({
   const [confirmPin, setConfirmPin] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const { pinLength } = usePinLength();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
-    if (newPin && !/^\d{4,6}$/.test(newPin)) {
-      setError('PIN must be 4-6 digits');
+    if (newPin && !new RegExp(`^\\d{${pinLength}}$`).test(newPin)) {
+      setError(`PIN must be exactly ${pinLength} digits`);
       return;
     }
 
@@ -93,7 +96,7 @@ export function PinEditModal({
                 type="password"
                 inputMode="numeric"
                 pattern="[0-9]*"
-                maxLength={6}
+                maxLength={MAX_PIN_LENGTH}
                 value={currentPin}
                 onChange={(e) => setCurrentPin(e.target.value.replace(/\D/g, ''))}
                 placeholder="Enter current PIN"
@@ -108,10 +111,10 @@ export function PinEditModal({
               type="password"
               inputMode="numeric"
               pattern="[0-9]*"
-              maxLength={6}
+              maxLength={pinLength}
               value={newPin}
               onChange={(e) => setNewPin(e.target.value.replace(/\D/g, ''))}
-              placeholder="4-6 digits"
+              placeholder={`${pinLength} digits`}
               autoFocus={!member.hasPin}
             />
             <p className="text-xs text-muted-foreground mt-1">
@@ -125,7 +128,7 @@ export function PinEditModal({
               type="password"
               inputMode="numeric"
               pattern="[0-9]*"
-              maxLength={6}
+              maxLength={pinLength}
               value={confirmPin}
               onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, ''))}
               placeholder="Re-enter new PIN"

--- a/src/app/settings/sections/SecuritySection.tsx
+++ b/src/app/settings/sections/SecuritySection.tsx
@@ -7,6 +7,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
+import { usePinLength } from '@/lib/hooks/usePinLength';
+import { MIN_PIN_LENGTH, MAX_PIN_LENGTH } from '@/lib/constants';
 import { PinEditModal } from '../components/PinEditModal';
 import type { FamilyMember } from '../components/PinEditModal';
 
@@ -33,6 +35,21 @@ const SCOPE_DESCRIPTIONS: Record<TokenScopeChoice, string> = {
 export function SecuritySection() {
   const { members: familyMembers, refresh: refreshFamily } = useFamily();
   const [editingPinMember, setEditingPinMember] = useState<FamilyMember | null>(null);
+  const { pinLength, setPinLength } = usePinLength();
+
+  const handlePinLengthChange = async (len: number) => {
+    if (len === pinLength) return;
+    const anyPins = familyMembers.some((m) => m.hasPin);
+    if (
+      anyPins &&
+      !window.confirm(
+        `Changing the PIN length to ${len} digits means every member must set a new ${len}-digit PIN before they can log in again — including you. Existing PINs of a different length will stop working. Continue?`
+      )
+    ) {
+      return;
+    }
+    await setPinLength(len);
+  };
 
   // API Tokens state
   const [tokens, setTokens] = useState<ApiToken[]>([]);
@@ -166,6 +183,39 @@ export function SecuritySection() {
               </Button>
             </div>
           ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>PIN Length</CardTitle>
+          <CardDescription>
+            How many digits every member&apos;s PIN must have (uniform across the family, like an iPhone passcode).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-2">
+            {Array.from(
+              { length: MAX_PIN_LENGTH - MIN_PIN_LENGTH + 1 },
+              (_, i) => MIN_PIN_LENGTH + i
+            ).map((len) => (
+              <Button
+                key={len}
+                variant={len === pinLength ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => handlePinLengthChange(len)}
+                aria-pressed={len === pinLength}
+              >
+                {len} digits
+              </Button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Changing this affects PINs set from now on. Any member whose current PIN
+            isn&apos;t this length will need to set a new one before logging in. If
+            someone gets locked out, an admin with server access can run{' '}
+            <code>scripts/reset-pin.js</code> to reset their PIN.
+          </p>
         </CardContent>
       </Card>
 

--- a/src/app/setup/steps/FamilyStep.tsx
+++ b/src/app/setup/steps/FamilyStep.tsx
@@ -9,6 +9,8 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Users, Plus, Check, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { usePinLength } from '@/lib/hooks/usePinLength';
+import { MIN_PIN_LENGTH, MAX_PIN_LENGTH } from '@/lib/constants';
 
 const COLOR_OPTIONS = [
   '#3B82F6', '#EC4899', '#10B981', '#F59E0B',
@@ -33,6 +35,7 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
   const [pin, setPin] = useState('');
   const [saving, setSaving] = useState(false);
   const [added, setAdded] = useState<AddedMember[]>([]);
+  const { pinLength, setPinLength } = usePinLength();
 
   const canAdd = name.trim().length > 0;
 
@@ -82,6 +85,34 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
+        {/* Family-wide PIN length (uniform for everyone, like an iPhone passcode) */}
+        <div className="space-y-1">
+          <Label>PIN length</Label>
+          <div className="flex gap-2">
+            {Array.from(
+              { length: MAX_PIN_LENGTH - MIN_PIN_LENGTH + 1 },
+              (_, i) => MIN_PIN_LENGTH + i
+            ).map((len) => (
+              <button
+                key={len}
+                type="button"
+                onClick={() => setPinLength(len)}
+                className={cn(
+                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                  len === pinLength
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'hover:bg-muted',
+                )}
+              >
+                {len} digits
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Applies to every member&apos;s PIN. You can change this later in Settings → Security.
+          </p>
+        </div>
+
         {/* Already added */}
         {added.length > 0 && (
           <div className="space-y-2">
@@ -152,8 +183,8 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
             <Input
               id="member-pin"
               type="password"
-              maxLength={8}
-              placeholder="4–8 digits"
+              maxLength={pinLength}
+              placeholder={`${pinLength} digits`}
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/g, ''))}
             />

--- a/src/components/auth/PinPad.tsx
+++ b/src/components/auth/PinPad.tsx
@@ -26,6 +26,7 @@ import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
 
 import { usePinPad } from './usePinPad';
+import { usePinLength } from '@/lib/hooks/usePinLength';
 import { MemberSelection, getDemoFamilyMembers } from './MemberSelection';
 import { PinDisplay } from './PinDisplay';
 import { NumberPad } from './NumberPad';
@@ -63,7 +64,7 @@ export function PinPad({
   onPinSubmit,
   onSuccess,
   onError,
-  pinLength = 4,
+  pinLength,
   showCancel = false,
   onCancel,
   className,
@@ -73,6 +74,10 @@ export function PinPad({
 
   const familyMembers =
     providedMembers || (contextMembers.length > 0 ? contextMembers : getDemoFamilyMembers());
+
+  // Family-wide PIN length; an explicit prop still wins (e.g. tests / demos).
+  const { pinLength: configuredPinLength } = usePinLength();
+  const effectivePinLength = pinLength ?? configuredPinLength;
 
   const {
     selectedMember,
@@ -86,7 +91,7 @@ export function PinPad({
     handleClear,
     clearSelectedMember,
   } = usePinPad({
-    pinLength,
+    pinLength: effectivePinLength,
     controlledSelectedMember,
     onMemberSelect,
     onPinSubmit,
@@ -130,7 +135,7 @@ export function PinPad({
           </div>
 
           <PinDisplay
-            length={pinLength}
+            length={effectivePinLength}
             filled={pin.length}
             error={!!error}
             isShaking={isShaking}

--- a/src/components/auth/QuickPinModal.tsx
+++ b/src/components/auth/QuickPinModal.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
+import { usePinLength } from '@/lib/hooks/usePinLength';
 
 /**
  * FAMILY MEMBER TYPE
@@ -93,7 +94,7 @@ export function QuickPinModal({
   const [isVerifying, setIsVerifying] = useState(false);
   const [isShaking, setIsShaking] = useState(false);
 
-  const pinLength = 4;
+  const { pinLength } = usePinLength();
 
   // Reset state when modal closes
   useEffect(() => {

--- a/src/components/away-mode/ExitAwayModeModal.tsx
+++ b/src/components/away-mode/ExitAwayModeModal.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
+import { usePinLength } from '@/lib/hooks/usePinLength';
 
 interface ExitAwayModeModalProps {
   open: boolean;
@@ -37,7 +38,7 @@ export function ExitAwayModeModal({
   const [isVerifying, setIsVerifying] = useState(false);
   const [isShaking, setIsShaking] = useState(false);
 
-  const pinLength = 4;
+  const { pinLength } = usePinLength();
 
   // Reset state when modal closes
   useEffect(() => {

--- a/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
+++ b/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
+import { usePinLength } from '@/lib/hooks/usePinLength';
 
 interface ExitBabysitterModeModalProps {
   open: boolean;
@@ -37,7 +38,7 @@ export function ExitBabysitterModeModal({
   const [isVerifying, setIsVerifying] = useState(false);
   const [isShaking, setIsShaking] = useState(false);
 
-  const pinLength = 4;
+  const { pinLength } = usePinLength();
 
   // Reset state when modal closes
   useEffect(() => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,6 +13,10 @@ export const SESSION_DURATION = {
 
 export const MIN_PIN_LENGTH = 4;
 export const MAX_PIN_LENGTH = 6;
+/** Default family-wide PIN length when none has been configured. */
+export const DEFAULT_PIN_LENGTH = 4;
+/** Settings key holding the family-wide PIN length (uniform for all members). */
+export const PIN_LENGTH_SETTING_KEY = 'pinLength';
 export const MAX_LOGIN_ATTEMPTS = 5;
 export const LOCKOUT_DURATION = 5 * 60; // kept for backward compat — use LOCKOUT_TIERS for new code
 /** Progressive lockout durations in seconds: 5 min → 15 min → 1 hr → 4 hr */

--- a/src/lib/hooks/usePinLength.ts
+++ b/src/lib/hooks/usePinLength.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  DEFAULT_PIN_LENGTH,
+  MIN_PIN_LENGTH,
+  MAX_PIN_LENGTH,
+  PIN_LENGTH_SETTING_KEY,
+} from '@/lib/constants';
+
+const STORAGE_KEY = 'prism:pin-length';
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_PIN_LENGTH;
+  return Math.min(MAX_PIN_LENGTH, Math.max(MIN_PIN_LENGTH, Math.round(n)));
+}
+
+/**
+ * Family-wide PIN length (uniform for all members, like an iPhone passcode).
+ * Reads from the settings API on mount, caches in localStorage so the PIN pads
+ * render the right number of slots immediately on next load. Defaults to 4.
+ */
+export function usePinLength(): {
+  pinLength: number;
+  setPinLength: (value: number) => Promise<void>;
+  loading: boolean;
+} {
+  const [value, setValue] = useState<number>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = Number(localStorage.getItem(STORAGE_KEY));
+      if (saved) return clamp(saved);
+    }
+    return DEFAULT_PIN_LENGTH;
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings');
+        if (res.ok) {
+          const data = await res.json();
+          const raw = data.settings?.[PIN_LENGTH_SETTING_KEY];
+          if (raw !== undefined && raw !== null && raw !== '') {
+            const next = clamp(Number(raw));
+            setValue(next);
+            localStorage.setItem(STORAGE_KEY, String(next));
+          }
+        }
+      } catch {
+        /* use cached/default */
+      }
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const setPinLength = useCallback(async (newValue: number) => {
+    const next = clamp(newValue);
+    setValue(next);
+    localStorage.setItem(STORAGE_KEY, String(next));
+    await fetch('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: PIN_LENGTH_SETTING_KEY, value: String(next) }),
+    });
+  }, []);
+
+  return { pinLength: value, setPinLength, loading };
+}
+
+/**
+ * Synchronous read from localStorage for non-hook contexts. Falls back to the
+ * default; the authoritative value still comes from the settings API via the hook.
+ */
+export function getPinLength(): number {
+  if (typeof window !== 'undefined') {
+    const saved = Number(localStorage.getItem(STORAGE_KEY));
+    if (saved) return clamp(saved);
+  }
+  return DEFAULT_PIN_LENGTH;
+}

--- a/src/lib/services/pinLength.ts
+++ b/src/lib/services/pinLength.ts
@@ -1,0 +1,29 @@
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import {
+  DEFAULT_PIN_LENGTH,
+  MIN_PIN_LENGTH,
+  MAX_PIN_LENGTH,
+  PIN_LENGTH_SETTING_KEY,
+} from '@/lib/constants';
+
+/**
+ * Family-wide PIN length, read from the settings table (server-side source of
+ * truth). Used to validate that a PIN being set matches the configured length
+ * so a member can never be created with a PIN the login pad can't enter.
+ * Falls back to the default if unset or malformed.
+ */
+export async function getConfiguredPinLength(): Promise<number> {
+  try {
+    const [row] = await db
+      .select({ value: settings.value })
+      .from(settings)
+      .where(eq(settings.key, PIN_LENGTH_SETTING_KEY));
+    const n = Math.round(Number(row?.value));
+    if (Number.isFinite(n) && n >= MIN_PIN_LENGTH && n <= MAX_PIN_LENGTH) return n;
+  } catch {
+    /* fall through to default */
+  }
+  return DEFAULT_PIN_LENGTH;
+}


### PR DESCRIPTION
Fixes #123 — a 5–6 digit PIN could be *set* but never *entered* (every login/unlock pad was hard-coded to 4 and auto-submitted at 4), locking the member out.

## Approach — uniform family PIN length (iPhone-style)
PIN length becomes one family-wide setting (4–6), so the pads know when entry is complete and **auto-submit is preserved**.

- New `pinLength` global setting (default 4) · `usePinLength` hook · `getConfiguredPinLength` server reader.
- **All 5 PIN surfaces** read it: login (`PinPad`/`usePinPad`), settings gate, quick-switch, away-exit, babysitter-exit.
- `PinEditModal` + family create/update APIs **enforce exactly** the configured length.
- Set it in **Settings → Security** (with a lockout-warning confirm) and in the **setup wizard** Family step ("change later in Settings").

## Recovery (the locked-out case)
New offline `scripts/reset-pin.js` — `docker compose exec app node scripts/reset-pin.js "Name" 1234`. Documented in install troubleshooting. **Auth model unchanged**: admins still can't reset another member's PIN without the current one (so one parent can't silently take over a co-parent) — recovery is deliberately server-side only.

## Note on the reporter (jordan2718)
Deploying this does **not** auto-unlock his existing 5–6 digit PIN (length defaults to 4 for back-comat). He runs the reset script once (or an admin sets the family length to match). Both paths are in the docs / his issue reply.

## Validation
Relying on CI (typecheck/lint/unit/build). Will smoke-test the running app before merge given this is auth-critical.