### PR TITLE
chore(release): 1.8.9

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.9] – 2026-06-16
+
 ### Fixed — Security / Login
 - **5–6 digit PINs can now actually be used.** PIN length is now a uniform family-wide setting (4–6 digits, like an iPhone passcode) — chosen in the setup wizard and changeable in Settings → Security. Previously PIN *creation* allowed up to 6 digits while every login/unlock pad was hard-coded to 4 and auto-submitted at 4, so any 5–6 digit PIN could never be entered and the member was locked out. All five PIN surfaces (login, settings gate, quick-switch, away-exit, babysitter-exit), `PinEditModal`, and the family API now read and enforce the configured length. Added `scripts/reset-pin.js` for offline recovery of a locked-out member. Closes [#123](https://github.com/sandydargoport/prism/issues/123).
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.8"
+version: "1.8.9"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Cuts **1.8.9** so the #123 PIN fix (and the offline `reset-pin.js` recovery script) ships in a real, pullable release — needed before replying to the reporter.

Bumps package.json / docs/CHANGELOG.md / ha-app/config.yaml in lockstep; moves the Unreleased entry into a dated section. Includes everything from the untagged 1.8.8 plus #123.

After merge: tag `v1.8.9` → fires the HA addon build (amd64 + aarch64 → ghcr) + GitHub release.