### PR TITLE
fix(tasks): show newly-added tasks when a household has 100+ tasks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed — Tasks
+- **Newly-added tasks no longer vanish once a household has 100+ tasks.** The Tasks list fetches a capped number of rows (100) ordered by due date; with many tasks — especially ones without a due date, which sort last — the newest tasks fell past the row limit and were silently dropped from the fetch. They saved to the database fine but never appeared in any view (touch display or PWA). The fetch now orders **incomplete tasks first** with a newest-first tiebreaker, so active tasks are never truncated out. Display order is unchanged (the client still sorts the visible list).
+
 ### Fixed — Touch keyboard
 - **On-screen keyboard no longer dismisses itself when you tap Shift.** On touch displays (e.g. Raspberry Pi kiosks), tapping Shift (or a symbol key) blurred the focused input, so the global focusout handler hid the keyboard. The keyboard container now keeps the input focused on tap — a `mousedown` preventDefault, since simple-keyboard swallows the pointerdown the existing handler relied on. Thanks @theg00se1030 for the precise root-cause analysis. Closes [#125](https://github.com/sandydargoport/prism/issues/125).
 

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -89,7 +89,13 @@ export async function GET(request: NextRequest) {
         .from(tasks)
         .leftJoin(users, eq(tasks.assignedTo, users.id))
         .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(sortFn(getSortColumn()))
+        // Incomplete tasks first, then the requested sort, then newest-first as a
+        // stable tiebreaker. Without this, a household with >limit tasks (e.g. many
+        // with no due date) would have its newest/active tasks sorted past the row
+        // limit and silently dropped from the fetch — they'd never appear in the
+        // list. The client re-sorts for display, so this only affects which rows
+        // are fetched, not their on-screen order.
+        .orderBy(asc(tasks.completed), sortFn(getSortColumn()), desc(tasks.createdAt))
         .limit(limit)
         .offset(offset);
 


### PR DESCRIPTION
Closes #136.

## Bug
On a household with 100+ tasks, newly-added tasks save to the DB but **never appear** in the Tasks view (touch display *or* PWA). The fetch caps at 100 rows ordered by due date; tasks without a due date sort last, so the newest ones rank past the limit and are dropped.

Found while debugging #125 — the "lost" tasks were all sitting in the DB (e.g. #117 and #118 of 118), just never fetched.

## Fix
`/api/tasks` GET now orders **incomplete tasks first**, then the requested sort, then `created_at desc` as a stable tiebreaker — so active tasks always fall within the row limit. The Tasks view re-sorts client-side, so the visible order is unchanged; this only affects *which* rows get fetched.

## Verified
On the affected instance (118 tasks, all no due date), the two newest tasks ranked #117/#118 under the old ordering; under the new ordering all 30 incomplete tasks rank 1–30, well within the 100-row fetch.