### PR TITLE
chore(release): 1.8.10

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.10] – 2026-06-19
+
 ### Fixed — Tasks
 - **Newly-added tasks no longer vanish once a household has 100+ tasks.** The Tasks list fetches a capped number of rows (100) ordered by due date; with many tasks — especially ones without a due date, which sort last — the newest tasks fell past the row limit and were silently dropped from the fetch. They saved to the database fine but never appeared in any view (touch display or PWA). The fetch now orders **incomplete tasks first** with a newest-first tiebreaker, so active tasks are never truncated out. Display order is unchanged (the client still sorts the visible list).
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.9"
+version: "1.8.10"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Cuts **1.8.10** — bundles the touch-keyboard Shift fix (#125) and the tasks-vanishing-at-100+ fix (#136).

Bumps package.json / docs/CHANGELOG.md / ha-app/config.yaml in lockstep; moves the Unreleased entries into a dated section.

After merge: tag `v1.8.10` → HA addon build (amd64 + aarch64 → ghcr) + GitHub release.