### PR TITLE
fix(integrations): setup prompt instead of raw JSON when OAuth unconfigured (#108)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed — Integrations
+- **Clicking "Connect" before configuring OAuth now shows a setup prompt instead of a raw JSON error.** If you skipped OAuth setup during onboarding and then hit Connect on the Google / Gmail / Microsoft cards, the browser landed on a bare `{"error":"Failed to initiate … authentication"}` page. The init routes now detect the not-configured case and redirect back to the Integrations page with a clear banner — pointing to the Setup Wizard (where you enter your OAuth credentials) and naming the required env vars — instead of a dead JSON page. Thanks @joe-cole1 for the report and the "make this clearer for dummies who skipped onboarding" nudge. Closes [#108](https://github.com/sandydargoport/prism/issues/108).
+
 ## [1.8.10] – 2026-06-19
 
 ### Fixed — Tasks

--- a/src/app/api/auth/google-bus/route.ts
+++ b/src/app/api/auth/google-bus/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { getGmailAuthUrl } from '@/lib/integrations/gmail';
 import { logError } from '@/lib/utils/logError';
+import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -21,6 +22,7 @@ export async function GET(request: Request) {
     const authUrl = await getGmailAuthUrl(state);
     return NextResponse.redirect(authUrl);
   } catch (error) {
+    if (isOAuthNotConfigured(error)) return oauthSetupRedirect('gmail');
     logError('Failed to initiate Gmail OAuth:', error);
     return NextResponse.json(
       { error: 'Failed to initiate Gmail authentication' },

--- a/src/app/api/auth/google-tasks/route.ts
+++ b/src/app/api/auth/google-tasks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
+import { oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const SCOPES = 'https://www.googleapis.com/auth/tasks';
@@ -17,10 +18,7 @@ export async function GET(request: Request) {
     `${process.env.BASE_URL || 'http://localhost:3000'}/api/auth/google-tasks/callback`;
 
   if (!clientId) {
-    return NextResponse.json(
-      { error: 'Google OAuth not configured' },
-      { status: 500 }
-    );
+    return oauthSetupRedirect('google');
   }
 
   try {

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { getGoogleAuthUrl } from '@/lib/integrations/google-calendar';
 import { logError } from '@/lib/utils/logError';
+import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -23,6 +24,7 @@ export async function GET(request: Request) {
 
     return NextResponse.redirect(authUrl);
   } catch (error) {
+    if (isOAuthNotConfigured(error)) return oauthSetupRedirect('google');
     logError('Failed to initiate Google OAuth:', error);
     return NextResponse.json(
       { error: 'Failed to initiate Google authentication' },

--- a/src/app/api/auth/microsoft-tasks/route.ts
+++ b/src/app/api/auth/microsoft-tasks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
+import { oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 
 const MICROSOFT_AUTH_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize';
 const SCOPES = ['Tasks.ReadWrite', 'offline_access'].join(' ');
@@ -17,10 +18,7 @@ export async function GET(request: Request) {
     `${process.env.BASE_URL || 'http://localhost:3000'}/api/auth/microsoft-tasks/callback`;
 
   if (!clientId) {
-    return NextResponse.json(
-      { error: 'Microsoft OAuth not configured' },
-      { status: 500 }
-    );
+    return oauthSetupRedirect('microsoft');
   }
 
   try {

--- a/src/app/api/auth/microsoft/route.ts
+++ b/src/app/api/auth/microsoft/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { getMicrosoftAuthUrl } from '@/lib/integrations/onedrive';
 import { logError } from '@/lib/utils/logError';
+import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -24,6 +25,7 @@ export async function GET(request: Request) {
 
     return NextResponse.redirect(authUrl);
   } catch (error) {
+    if (isOAuthNotConfigured(error)) return oauthSetupRedirect('microsoft');
     logError('Failed to initiate Microsoft OAuth:', error);
     return NextResponse.json(
       { error: 'Failed to initiate Microsoft authentication' },

--- a/src/app/settings/sections/integrations/IntegrationsSection.tsx
+++ b/src/app/settings/sections/integrations/IntegrationsSection.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import * as React from 'react';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import { AlertTriangle, X } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
 import { useIntegrationStatus } from './shared/useIntegrationStatus';
 import { useIntegrationsHashRouter } from './shared/useIntegrationsHashRouter';
@@ -37,10 +39,26 @@ import { PhotoSourcesCard } from './cards/PhotoSourcesCard';
  * Photos sections. The legacy sections continue to handle their OAuth
  * callbacks. Phase 2 deletes them and remaps the callbacks here.
  */
+/**
+ * Friendly copy for the "you clicked Connect before configuring OAuth" banner
+ * (issue #108). Keyed by the `?setup=` provider the init route redirected with.
+ */
+const SETUP_PROMPTS: Record<string, { name: string; env: string }> = {
+  google: { name: 'Google', env: 'GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET and GOOGLE_REDIRECT_URI' },
+  gmail: { name: 'Gmail / Bus tracking', env: 'GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET and GOOGLE_GMAIL_REDIRECT_URI' },
+  microsoft: { name: 'Microsoft', env: 'MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET and MICROSOFT_REDIRECT_URI' },
+};
+
 export function IntegrationsSection() {
   const searchParams = useSearchParams();
   const { hash } = useIntegrationsHashRouter();
   const { status, refetch } = useIntegrationStatus();
+
+  // "Connect" was clicked before OAuth credentials were configured: the init
+  // route redirected here with ?setup=<provider> instead of dumping JSON (#108).
+  const setupProvider = searchParams.get('setup');
+  const setupPrompt = setupProvider ? SETUP_PROMPTS[setupProvider] : undefined;
+  const [setupDismissed, setSetupDismissed] = React.useState(false);
 
   // Surface OAuth callback success/error toasts that targeted this section.
   React.useEffect(() => {
@@ -70,6 +88,35 @@ export function IntegrationsSection() {
           One card per provider. Click any sub-section to wire it up.
         </p>
       </div>
+
+      {setupPrompt && !setupDismissed && (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100">
+          <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0" />
+          <div className="flex-1 text-sm">
+            <p className="font-semibold">{setupPrompt.name} isn&apos;t set up yet</p>
+            <p className="mt-1">
+              You skipped this during onboarding, so there are no OAuth credentials to connect with
+              yet. Open the{' '}
+              <Link href="/setup/rerun" className="font-medium underline">Setup Wizard</Link>{' '}
+              to enter them, or set <code className="text-xs">{setupPrompt.env}</code> in your
+              {' '}<code className="text-xs">.env</code>.
+            </p>
+            <Link
+              href="/setup/rerun"
+              className="mt-3 inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700"
+            >
+              Open Setup Wizard
+            </Link>
+          </div>
+          <button
+            onClick={() => setSetupDismissed(true)}
+            aria-label="Dismiss"
+            className="text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       <div className="space-y-4">
         <GoogleProviderCard

--- a/src/lib/integrations/oauthSetupRedirect.ts
+++ b/src/lib/integrations/oauthSetupRedirect.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+/**
+ * True when an OAuth "initiate" failure is just "credentials aren't configured
+ * yet" rather than a real error. Every provider auth-url helper throws a message
+ * containing "OAuth configuration" in that case (e.g. "Missing Google OAuth
+ * configuration. Configure in Settings → Setup Wizard or set GOOGLE_CLIENT_ID…").
+ */
+export function isOAuthNotConfigured(error: unknown): boolean {
+  return error instanceof Error && /OAuth configuration/i.test(error.message);
+}
+
+/**
+ * Redirect the browser to the Integrations page with a setup prompt for the
+ * given provider, instead of dumping a raw JSON 500 when the user clicks
+ * "Connect" before OAuth credentials exist (issue #108). `provider` is one of
+ * 'google' | 'gmail' | 'microsoft' and drives the on-page banner copy + anchor.
+ */
+export function oauthSetupRedirect(provider: 'google' | 'gmail' | 'microsoft'): NextResponse {
+  const anchor = provider === 'gmail' ? 'gmail-bus' : provider;
+  return NextResponse.redirect(
+    `${BASE_URL}/settings?section=integrations&setup=${provider}#${anchor}`
+  );
+}


### PR DESCRIPTION
Closes #108.

## Bug
Clicking **Connect** on the Google / Gmail / Microsoft integration cards *before* OAuth credentials are configured navigated the browser to the init route, which returned a bare `{"error":"Failed to initiate … authentication"}` JSON 500. Dead end — and @joe-cole1 hit it after skipping OAuth during onboarding, asking us to make the setup path clearer.

## Fix
All 5 init routes (`google`, `google-bus`, `google-tasks`, `microsoft`, `microsoft-tasks`) now detect the not-configured case and **redirect to `/settings?section=integrations&setup=<provider>`** instead of returning JSON. `IntegrationsSection` renders a dismissible banner there:

> ⚠️ **Google isn't set up yet** — You skipped this during onboarding… Open the **Setup Wizard** to enter them, or set `GOOGLE_CLIENT_ID, …` in your `.env`. **[Open Setup Wizard]**

The wizard's Google/Microsoft steps already collect client ID/secret (`/api/setup/credentials/*`), so the CTA actually resolves it. Real (non-config) failures still return 500. Shared detection/redirect helper: `lib/integrations/oauthSetupRedirect.ts`.

## Note
Can't fully exercise the banner in CI (needs an unconfigured provider + browser); relying on CI for compile/types and will verify on the instance if a provider is unconfigured there.