### PR TITLE
fix(integrations): derive OAuth redirect URI from request (fixes redirect_uri_mismatch) (#124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,12 +40,13 @@ ENCRYPTION_KEY=generate_a_64_hex_character_string_here
 
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-# Replace localhost:3000 with your APP_URL (e.g. https://your-domain.com)
-# Register ALL redirect URIs you use in Google Cloud Console (you can add multiple)
-GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
-
-# Gmail OAuth redirect for bus tracking (uses same Client ID/Secret as above)
-GOOGLE_GMAIL_REDIRECT_URI=http://localhost:3000/api/auth/google-bus/callback
+# Redirect URIs are now derived automatically from the host you reach Prism on
+# (honoring X-Forwarded-Host behind a reverse proxy), so these *_REDIRECT_URI
+# vars are OPTIONAL fallbacks. You still must register your real callback URL(s)
+# in the Google Cloud Console — e.g. https://your-domain.com/api/auth/google/callback
+# and .../api/auth/google-bus/callback — exactly (https, no trailing slash).
+# GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
+# GOOGLE_GMAIL_REDIRECT_URI=http://localhost:3000/api/auth/google-bus/callback
 
 # --- Apple iCloud/Calendar ---
 # Use an APP-SPECIFIC PASSWORD (not your regular password).
@@ -62,9 +63,10 @@ APPLE_APP_PASSWORD=your-app-specific-password
 
 MICROSOFT_CLIENT_ID=your-microsoft-client-id
 MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret
-# Replace localhost:3000 with your APP_URL (e.g. https://your-domain.com)
-# Register ALL redirect URIs you use in Azure (you can add multiple)
-MICROSOFT_REDIRECT_URI=http://localhost:3000/api/auth/microsoft/callback
+# Redirect URI is derived automatically from the request host now (optional
+# fallback below). Register your real callback URL in Azure exactly, e.g.
+# https://your-domain.com/api/auth/microsoft/callback
+# MICROSOFT_REDIRECT_URI=http://localhost:3000/api/auth/microsoft/callback
 
 # --- Weather ---
 # Select provider: "meteo" (Open-Meteo, default — no API key required),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Fixed — Integrations
+- **Google & Microsoft OAuth redirect URIs are now derived from the request, fixing `redirect_uri_mismatch`.** Previously the redirect URI came from a static `*_REDIRECT_URI` env var (defaulting to `localhost`), so anyone whose env var didn't byte-match what they'd registered in the provider console hit `Error 400: redirect_uri_mismatch` on Connect. All Google (Calendar, Gmail/Bus, Tasks) and Microsoft (OneDrive, Tasks) flows now build the redirect URI from the incoming request's host/proto (honoring `X-Forwarded-Host`/`-Proto` behind a reverse proxy), the same approach Kroger already uses — so the URI always matches the host you started from, and `/authorize` and `/token` stay in lockstep. The env vars still work as a fallback. Existing connections are unaffected (token refresh doesn't use the redirect URI). Closes [#124](https://github.com/sandydargoport/prism/issues/124).
+
 - **Clicking "Connect" before configuring OAuth now shows a setup prompt instead of a raw JSON error.** If you skipped OAuth setup during onboarding and then hit Connect on the Google / Gmail / Microsoft cards, the browser landed on a bare `{"error":"Failed to initiate … authentication"}` page. The init routes now detect the not-configured case and redirect back to the Integrations page with a clear banner — pointing to the Setup Wizard (where you enter your OAuth credentials) and naming the required env vars — instead of a dead JSON page. Thanks @joe-cole1 for the report and the "make this clearer for dummies who skipped onboarding" nudge. Closes [#108](https://github.com/sandydargoport/prism/issues/108).
 
 ## [1.8.10] – 2026-06-19

--- a/src/app/api/auth/google-bus/callback/route.ts
+++ b/src/app/api/auth/google-bus/callback/route.ts
@@ -7,6 +7,7 @@ import { exchangeGmailCodeForTokens } from '@/lib/integrations/gmail';
 import { encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
@@ -44,7 +45,7 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=missing_code${anchor}`);
     }
 
-    const tokens = await exchangeGmailCodeForTokens(code);
+    const tokens = await exchangeGmailCodeForTokens(code, resolveRedirectUri(request, '/api/auth/google-bus/callback')); // dynamic redirect URI per request (#124)
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     // Encrypt tokens before storing

--- a/src/app/api/auth/google-bus/route.ts
+++ b/src/app/api/auth/google-bus/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { getGmailAuthUrl } from '@/lib/integrations/gmail';
 import { logError } from '@/lib/utils/logError';
 import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -19,7 +20,8 @@ export async function GET(request: Request) {
     const returnSection = searchParams.get('returnSection') || 'bus';
 
     const state = JSON.stringify({ returnSection });
-    const authUrl = await getGmailAuthUrl(state);
+    const redirectUri = resolveRedirectUri(request, '/api/auth/google-bus/callback'); // dynamic redirect URI per request (#124)
+    const authUrl = await getGmailAuthUrl(state, redirectUri);
     return NextResponse.redirect(authUrl);
   } catch (error) {
     if (isOAuthNotConfigured(error)) return oauthSetupRedirect('gmail');

--- a/src/app/api/auth/google-tasks/callback/route.ts
+++ b/src/app/api/auth/google-tasks/callback/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { encrypt } from '@/lib/utils/crypto';
 import { getRedisClient } from '@/lib/cache/getRedisClient';
 import { logError } from '@/lib/utils/logError';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
@@ -14,10 +15,10 @@ interface GoogleTokens {
   expires_in: number;
 }
 
-async function exchangeCodeForTokens(code: string): Promise<GoogleTokens> {
+async function exchangeCodeForTokens(code: string, redirectUriOverride?: string): Promise<GoogleTokens> {
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-  const redirectUri = process.env.GOOGLE_TASKS_REDIRECT_URI ||
+  const redirectUri = redirectUriOverride || process.env.GOOGLE_TASKS_REDIRECT_URI ||
     `${BASE_URL}/api/auth/google-tasks/callback`;
 
   if (!clientId || !clientSecret) {
@@ -90,7 +91,7 @@ export async function GET(request: Request) {
       );
     }
 
-    const tokens = await exchangeCodeForTokens(code);
+    const tokens = await exchangeCodeForTokens(code, resolveRedirectUri(request, '/api/auth/google-tasks/callback')); // dynamic redirect URI per request (#124)
     const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     const encryptedAccessToken = encrypt(tokens.access_token);

--- a/src/app/api/auth/google-tasks/route.ts
+++ b/src/app/api/auth/google-tasks/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
 import { oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const SCOPES = 'https://www.googleapis.com/auth/tasks';
@@ -14,8 +15,7 @@ export async function GET(request: Request) {
   if (forbidden) return forbidden;
 
   const clientId = process.env.GOOGLE_CLIENT_ID;
-  const redirectUri = process.env.GOOGLE_TASKS_REDIRECT_URI ||
-    `${process.env.BASE_URL || 'http://localhost:3000'}/api/auth/google-tasks/callback`;
+  const redirectUri = resolveRedirectUri(request, '/api/auth/google-tasks/callback'); // dynamic redirect URI per request (#124)
 
   if (!clientId) {
     return oauthSetupRedirect('google');

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/integrations/google-calendar';
 import { encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
@@ -71,7 +72,9 @@ export async function GET(request: Request) {
       }
     }
 
-    const tokens = await exchangeCodeForTokens(code);
+    // Re-derive the same request-host redirect URI used at /authorize so the
+    // token exchange's redirect_uri matches byte-for-byte (#124).
+    const tokens = await exchangeCodeForTokens(code, resolveRedirectUri(request, '/api/auth/google/callback'));
     const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     // Encrypt tokens before storing

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { getGoogleAuthUrl } from '@/lib/integrations/google-calendar';
 import { logError } from '@/lib/utils/logError';
 import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -20,7 +21,8 @@ export async function GET(request: Request) {
     if (userId) stateObj.userId = userId;
     if (reauth) stateObj.reauth = reauth;
     const state = JSON.stringify(stateObj);
-    const authUrl = await getGoogleAuthUrl(state);
+    const redirectUri = resolveRedirectUri(request, '/api/auth/google/callback');
+    const authUrl = await getGoogleAuthUrl(state, redirectUri);
 
     return NextResponse.redirect(authUrl);
   } catch (error) {

--- a/src/app/api/auth/microsoft-tasks/callback/route.ts
+++ b/src/app/api/auth/microsoft-tasks/callback/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { encrypt } from '@/lib/utils/crypto';
 import { getRedisClient } from '@/lib/cache/getRedisClient';
 import { logError } from '@/lib/utils/logError';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const MICROSOFT_TOKEN_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
@@ -15,10 +16,10 @@ interface MicrosoftTokens {
   expires_in: number;
 }
 
-async function exchangeCodeForTokens(code: string): Promise<MicrosoftTokens> {
+async function exchangeCodeForTokens(code: string, redirectUriOverride?: string): Promise<MicrosoftTokens> {
   const clientId = process.env.MICROSOFT_CLIENT_ID;
   const clientSecret = process.env.MICROSOFT_CLIENT_SECRET;
-  const redirectUri = process.env.MICROSOFT_TASKS_REDIRECT_URI ||
+  const redirectUri = redirectUriOverride || process.env.MICROSOFT_TASKS_REDIRECT_URI ||
     `${BASE_URL}/api/auth/microsoft-tasks/callback`;
 
   if (!clientId || !clientSecret) {
@@ -104,7 +105,7 @@ export async function GET(request: Request) {
     }
 
     // Exchange code for tokens
-    const tokens = await exchangeCodeForTokens(code);
+    const tokens = await exchangeCodeForTokens(code, resolveRedirectUri(request, '/api/auth/microsoft-tasks/callback')); // dynamic redirect URI per request (#124)
     const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     // Encrypt tokens for storage

--- a/src/app/api/auth/microsoft-tasks/route.ts
+++ b/src/app/api/auth/microsoft-tasks/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
 import { oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const MICROSOFT_AUTH_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize';
 const SCOPES = ['Tasks.ReadWrite', 'offline_access'].join(' ');
@@ -14,8 +15,7 @@ export async function GET(request: Request) {
   if (forbidden) return forbidden;
 
   const clientId = process.env.MICROSOFT_CLIENT_ID;
-  const redirectUri = process.env.MICROSOFT_TASKS_REDIRECT_URI ||
-    `${process.env.BASE_URL || 'http://localhost:3000'}/api/auth/microsoft-tasks/callback`;
+  const redirectUri = resolveRedirectUri(request, '/api/auth/microsoft-tasks/callback'); // dynamic redirect URI per request (#124)
 
   if (!clientId) {
     return oauthSetupRedirect('microsoft');

--- a/src/app/api/auth/microsoft/callback/route.ts
+++ b/src/app/api/auth/microsoft/callback/route.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { exchangeCodeForTokens } from '@/lib/integrations/onedrive';
 import { encrypt } from '@/lib/utils/crypto';
 import { logError } from '@/lib/utils/logError';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
@@ -42,7 +43,7 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${BASE_URL}/settings?section=${errorSection}&error=missing_code${errorAnchor}`);
     }
 
-    const tokens = await exchangeCodeForTokens(code);
+    const tokens = await exchangeCodeForTokens(code, resolveRedirectUri(request, '/api/auth/microsoft/callback')); // dynamic redirect URI per request (#124)
     const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     const encryptedAccessToken = encrypt(tokens.access_token);

--- a/src/app/api/auth/microsoft/route.ts
+++ b/src/app/api/auth/microsoft/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { getMicrosoftAuthUrl } from '@/lib/integrations/onedrive';
 import { logError } from '@/lib/utils/logError';
 import { isOAuthNotConfigured, oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();
@@ -21,7 +22,8 @@ export async function GET(request: Request) {
     const returnSection = searchParams.get('returnSection') || '';
 
     const state = JSON.stringify({ sourceName, returnSection });
-    const authUrl = await getMicrosoftAuthUrl(state);
+    const redirectUri = resolveRedirectUri(request, '/api/auth/microsoft/callback'); // dynamic redirect URI per request (#124)
+    const authUrl = await getMicrosoftAuthUrl(state, redirectUri);
 
     return NextResponse.redirect(authUrl);
   } catch (error) {

--- a/src/lib/integrations/credentialStore.ts
+++ b/src/lib/integrations/credentialStore.ts
@@ -48,9 +48,11 @@ export async function getGoogleCredentials(): Promise<GoogleCredentials | null> 
   }
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-  const redirectUri = process.env.GOOGLE_REDIRECT_URI;
+  // redirectUri is derived per-request now (#124); the env var is an optional
+  // fallback and no longer required for the config to count as "set up".
+  const redirectUri = process.env.GOOGLE_REDIRECT_URI ?? '';
   const gmailRedirectUri = process.env.GOOGLE_GMAIL_REDIRECT_URI ?? redirectUri ?? '';
-  if (!clientId || !clientSecret || !redirectUri) return null;
+  if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret, redirectUri, gmailRedirectUri };
 }
 
@@ -66,9 +68,10 @@ export async function getMicrosoftCredentials(): Promise<MicrosoftCredentials | 
   }
   const clientId = process.env.MICROSOFT_CLIENT_ID;
   const clientSecret = process.env.MICROSOFT_CLIENT_SECRET;
-  const redirectUri = process.env.MICROSOFT_REDIRECT_URI;
+  // redirectUri is derived per-request now (#124); env var is an optional fallback.
+  const redirectUri = process.env.MICROSOFT_REDIRECT_URI ?? '';
   const tasksRedirectUri = process.env.MICROSOFT_TASKS_REDIRECT_URI ?? redirectUri ?? '';
-  if (!clientId || !clientSecret || !redirectUri) return null;
+  if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret, redirectUri, tasksRedirectUri };
 }
 

--- a/src/lib/integrations/gmail.ts
+++ b/src/lib/integrations/gmail.ts
@@ -54,12 +54,12 @@ async function getConfig() {
   return { clientId: creds.clientId, clientSecret: creds.clientSecret, redirectUri: creds.gmailRedirectUri };
 }
 
-export async function getGmailAuthUrl(state?: string): Promise<string> {
+export async function getGmailAuthUrl(state?: string, redirectUriOverride?: string): Promise<string> {
   const { clientId, redirectUri } = await getConfig();
 
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: redirectUri,
+    redirect_uri: redirectUriOverride || redirectUri,
     response_type: 'code',
     scope: SCOPES,
     access_type: 'offline',
@@ -73,7 +73,7 @@ export async function getGmailAuthUrl(state?: string): Promise<string> {
   return `${GOOGLE_OAUTH_URL}?${params.toString()}`;
 }
 
-export async function exchangeGmailCodeForTokens(code: string): Promise<GmailTokens> {
+export async function exchangeGmailCodeForTokens(code: string, redirectUriOverride?: string): Promise<GmailTokens> {
   const { clientId, clientSecret, redirectUri } = await getConfig();
 
   const response = await fetch(GOOGLE_TOKEN_URL, {
@@ -83,7 +83,7 @@ export async function exchangeGmailCodeForTokens(code: string): Promise<GmailTok
       code,
       client_id: clientId,
       client_secret: clientSecret,
-      redirect_uri: redirectUri,
+      redirect_uri: redirectUriOverride || redirectUri,
       grant_type: 'authorization_code',
     }),
   });

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -90,12 +90,12 @@ async function getConfig() {
 /**
  * Generate the Google OAuth authorization URL
  */
-export async function getGoogleAuthUrl(state?: string): Promise<string> {
+export async function getGoogleAuthUrl(state?: string, redirectUriOverride?: string): Promise<string> {
   const { clientId, redirectUri } = await getConfig();
 
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: redirectUri,
+    redirect_uri: redirectUriOverride || redirectUri,
     response_type: 'code',
     scope: SCOPES,
     access_type: 'offline', // Get refresh token
@@ -112,7 +112,7 @@ export async function getGoogleAuthUrl(state?: string): Promise<string> {
 /**
  * Exchange authorization code for tokens
  */
-export async function exchangeCodeForTokens(code: string): Promise<GoogleTokens> {
+export async function exchangeCodeForTokens(code: string, redirectUriOverride?: string): Promise<GoogleTokens> {
   const { clientId, clientSecret, redirectUri } = await getConfig();
 
   const response = await fetch(GOOGLE_TOKEN_URL, {
@@ -124,7 +124,7 @@ export async function exchangeCodeForTokens(code: string): Promise<GoogleTokens>
       code,
       client_id: clientId,
       client_secret: clientSecret,
-      redirect_uri: redirectUri,
+      redirect_uri: redirectUriOverride || redirectUri,
       grant_type: 'authorization_code',
     }),
   });

--- a/src/lib/integrations/onedrive.ts
+++ b/src/lib/integrations/onedrive.ts
@@ -39,12 +39,12 @@ async function getConfig() {
   return creds;
 }
 
-export async function getMicrosoftAuthUrl(state?: string): Promise<string> {
+export async function getMicrosoftAuthUrl(state?: string, redirectUriOverride?: string): Promise<string> {
   const { clientId, redirectUri } = await getConfig();
 
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: redirectUri,
+    redirect_uri: redirectUriOverride || redirectUri,
     response_type: 'code',
     scope: SCOPES,
     response_mode: 'query',
@@ -57,7 +57,7 @@ export async function getMicrosoftAuthUrl(state?: string): Promise<string> {
   return `${MICROSOFT_AUTH_URL}?${params.toString()}`;
 }
 
-export async function exchangeCodeForTokens(code: string): Promise<MicrosoftTokens> {
+export async function exchangeCodeForTokens(code: string, redirectUriOverride?: string): Promise<MicrosoftTokens> {
   const { clientId, clientSecret, redirectUri } = await getConfig();
 
   const response = await fetch(MICROSOFT_TOKEN_URL, {
@@ -67,7 +67,7 @@ export async function exchangeCodeForTokens(code: string): Promise<MicrosoftToke
       code,
       client_id: clientId,
       client_secret: clientSecret,
-      redirect_uri: redirectUri,
+      redirect_uri: redirectUriOverride || redirectUri,
       grant_type: 'authorization_code',
     }),
   });

--- a/src/lib/integrations/resolveRedirectUri.ts
+++ b/src/lib/integrations/resolveRedirectUri.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolve an OAuth redirect URI from the current request, honoring reverse-proxy
+ * forwarded headers (Cloudflare Tunnel, nginx, etc.).
+ *
+ * Prism is commonly reached via more than one host — a public https hostname
+ * over WAN and an http://192.168.x.x:3000 LAN address. The OAuth redirect URI
+ * must match the host the user actually started the flow from: the provider
+ * validates that /token's `redirect_uri` equals /authorize's, and the post-auth
+ * redirect has to land back on the same origin so the Prism session cookie is
+ * sent. Deriving it from the request — instead of a single static
+ * `*_REDIRECT_URI` env var — removes the most common self-host footgun, a
+ * `redirect_uri_mismatch` when the env var doesn't byte-match what was
+ * registered in the provider console (#124). Generalizes
+ * `resolveKrogerRedirectUri` to any callback path.
+ *
+ * The user still registers the resulting URI(s) in their provider app; this just
+ * picks the right one per request and keeps /authorize and /token in lockstep.
+ */
+export function resolveRedirectUri(request: Request, callbackPath: string): string {
+  const headers = request.headers;
+  const xfHost = headers.get('x-forwarded-host');
+  const xfProto = headers.get('x-forwarded-proto');
+  const url = new URL(request.url);
+  const host = xfHost ?? headers.get('host') ?? url.host;
+  const proto = xfProto ?? url.protocol.replace(':', '');
+  return `${proto}://${host}${callbackPath}`;
+}


### PR DESCRIPTION
Closes #124.

## Bug
Google (Calendar, Gmail/Bus, Tasks) and Microsoft (OneDrive, Tasks) OAuth used a **static `*_REDIRECT_URI` env var** (default `localhost`) for `redirect_uri`. If it didn't byte-match what the user registered in the provider console, Connect failed with **Error 400: redirect_uri_mismatch** — what @joe-cole1 hit.

## Fix
Derive the redirect URI from the **incoming request's host/proto** (honoring `X-Forwarded-Host`/`-Proto`), the same approach **Kroger already uses** — so `/authorize` and `/token` stay in lockstep and the URI always matches the host the user started from. New shared helper `resolveRedirectUri(request, path)`. Auth-URL + token-exchange functions take an optional `redirectUriOverride` (env vars remain a fallback). `credentialStore` no longer treats a missing `*_REDIRECT_URI` as "not configured". `.env.example`/docs updated.

## Safety
- **Existing connections unaffected** — token *refresh* uses `grant_type=refresh_token`, which has no `redirect_uri`. Only connect/reconnect changes.
- Working setups already access Prism via the host they registered, so the derived URI matches.

## Caveat
Can't run a live OAuth round-trip in CI/here. Relying on CI for compile/types + the proven Kroger pattern; **will verify on a real provider on the instance before merge.**