### PR TITLE
fix(backup): stop leaking personal healthcheck/endpoints in public config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,28 @@ SONOS_REDIRECT_URI=http://localhost:3000/api/auth/sonos/callback
 # ALEXA_VOICE_TOKEN=your-voice-scoped-api-token
 # ALEXA_SKILL_ID=amzn1.ask.skill.your-skill-id
 
+# --- Backups (prism-backup container) ---
+#
+# The backup container always dumps the database locally to ./backups. The
+# settings below are optional and per-deployment — leave them blank to keep
+# backups local-only.
+#
+# RCLONE_REMOTE: an rclone remote + path to copy backups off-site, e.g.
+#   onedrive:Prism/backups. Requires a configured ./config/rclone.conf.
+#   User assets under data/ are synced to <remote-parent>/data alongside it.
+# RCLONE_RETENTION_DAYS: how long to keep off-site backups (default 30).
+# BACKUP_HOUR: hour of day (0-23) to run the daily backup (default 3).
+# RETENTION_DAYS: how long to keep local backups (default 7).
+# HC_URL: a healthchecks.io (or compatible) ping URL for dead-man monitoring.
+#   The job pings <URL>/start, then <URL> on success or <URL>/fail on error.
+#   Generate your OWN check — do not reuse anyone else's UUID.
+
+# RCLONE_REMOTE=onedrive:Prism/backups
+# RCLONE_RETENTION_DAYS=30
+# BACKUP_HOUR=3
+# RETENTION_DAYS=7
+# HC_URL=https://hc-ping.com/your-own-uuid-here
+
 # --- Future Integrations (leave blank) ---
 
 # HOMEBRIDGE_URL=http://homebridge-host:8581

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,3 @@
 bash scripts/scan-pii.sh
 bash scripts/scan-hostnames.sh
+bash scripts/scan-secrets.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,11 +102,15 @@ services:
     container_name: prism-backup
     environment:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - BACKUP_HOUR=3
-      - RETENTION_DAYS=7
-      - RCLONE_REMOTE=onedrive:Prism/backups
-      - RCLONE_RETENTION_DAYS=30
-      - HC_URL=https://hc-ping.com/f0bff165-06b7-48eb-a0da-10bbd4656786
+      - BACKUP_HOUR=${BACKUP_HOUR:-3}
+      - RETENTION_DAYS=${RETENTION_DAYS:-7}
+      # Off-site sync + dead-man healthcheck are per-deployment. Leave blank
+      # (the defaults) to keep local-only backups and skip the ping; set them
+      # in .env to enable. These MUST NOT be hardcoded here — this file is
+      # public, and a baked-in HC_URL means every clone pings one shared check.
+      - RCLONE_REMOTE=${RCLONE_REMOTE:-}
+      - RCLONE_RETENTION_DAYS=${RCLONE_RETENTION_DAYS:-30}
+      - HC_URL=${HC_URL:-}
     volumes:
       - ./backups:/backups
       # Off-site sync of user assets (avatars, photos, recipe images) lives

--- a/scripts/scan-secrets.sh
+++ b/scripts/scan-secrets.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Prism — Secret / Personal-Endpoint Scanner
+# ============================================================================
+# Catches the bug class that scan-pii.sh and scan-hostnames.sh both miss:
+# a *secret-shaped value* hardcoded into real config or code (NOT a comment,
+# NOT a known denylist word). This is precisely how a personal healthchecks.io
+# ping UUID once shipped baked into the public docker-compose.yml — every
+# clone then pinged the maintainer's check. See backup HC_URL history.
+#
+# Unlike scan-pii (needs a curated denylist) and scan-hostnames (comment-only,
+# allowlist of hostnames), this scanner is zero-config and pattern-based: it
+# looks for value SHAPES that are almost never legitimate in a public repo —
+# dead-man ping URLs carrying a real UUID, private LAN IPs with real octets,
+# cloud-provider tokens, private keys, etc.
+#
+# Anything matching a placeholder shape (your-own-uuid-here, x.x, <...>,
+# example.com, REDACTED) is deliberately NOT a secret and won't match the
+# real-value patterns, so .env.example documentation stays clean.
+#
+# USAGE
+# -----
+#   bash scripts/scan-secrets.sh
+#
+# Exits 0 if clean, 1 if any tracked file contains a secret-shaped value.
+# If a legitimate value trips the scan, anonymize it (move the real value to
+# an uncommitted .env and reference it as ${VAR}) rather than weakening a
+# pattern. Wire into .husky/pre-push so it runs before every push.
+# ============================================================================
+
+set -euo pipefail
+
+# UUID fragment reused below. A real v4-ish UUID; placeholders like
+# "your-own-uuid-here" do not match it, so example files stay clean.
+UUID='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+
+# Each rule: a label and an ERE pattern. A match on any is a violation.
+# Patterns are intentionally tight to keep the false-positive rate near zero.
+PATTERNS=(
+  # Dead-man / healthcheck ping URLs carrying a real UUID (the leak that
+  # started all this). Placeholder forms have no UUID, so they don't match.
+  "healthcheck-ping-url|(hc-ping\.com|healthchecks\.io/ping)/${UUID}"
+  # Private LAN IPv4 with real octets (192.168.x.x docs use literal 'x.x'
+  # which has no digits, so it won't match).
+  "private-lan-ipv4|(\b192\.168\.[0-9]{1,3}\.[0-9]{1,3}\b|\b10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b|\b172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}\b)"
+  # Cloudflare tunnel token (base64 of {"a":"...}) — starts eyJhIjoi.
+  "cloudflare-tunnel-token|eyJhIjoi[A-Za-z0-9_-]{40,}"
+  # Cloud / service credential prefixes.
+  "aws-access-key|\bAKIA[0-9A-Z]{16}\b"
+  "github-token|\bgh[pousr]_[A-Za-z0-9]{36,}\b"
+  "slack-token|\bxox[baprs]-[A-Za-z0-9-]{10,}\b"
+  "google-api-key|\bAIza[0-9A-Za-z_-]{35}\b"
+  "openai-key|\bsk-[A-Za-z0-9]{40,}\b"
+  "private-key-block|-----BEGIN ([A-Z]+ )?PRIVATE KEY-----"
+)
+
+# Files to scan: every tracked file except binaries, lockfiles, snapshots,
+# and the scanners themselves (which contain these patterns as literals).
+TARGETS=$(git ls-files \
+  | grep -v -E '^(scripts/scan-(pii|examples|hostnames|secrets)\.sh|docs/code-review-modalities\.md|package-lock\.json|.*\.lock|.*\.snap)$' \
+  || true)
+
+if [ -z "$TARGETS" ]; then
+  echo "[scan-secrets] No files to scan."
+  exit 0
+fi
+
+violations=""
+for rule in "${PATTERNS[@]}"; do
+  label="${rule%%|*}"
+  pat="${rule#*|}"
+  files="$TARGETS"
+  # Private-IP literals are legitimate — and required — under src/: the recipe
+  # URL importer's SSRF guard (safeFetch.ts, recipeParser.ts) must name the
+  # RFC1918 ranges it blocks, and tests exercise them with textbook addresses.
+  # A real *personal* LAN IP leaks through config/deploy/docs, so scope there.
+  if [ "$label" = "private-lan-ipv4" ]; then
+    files=$(printf '%s\n' "$TARGETS" | grep -v -E '^src/' || true)
+  fi
+  [ -n "$files" ] || continue
+  hits=$(printf '%s\n' "$files" | xargs -d '\n' grep -nHE -I "$pat" 2>/dev/null || true)
+  if [ -n "$hits" ]; then
+    violations="${violations}${violations:+$'\n'}$(printf '%s\n' "$hits" | sed "s/^/  [$label] /")"
+  fi
+done
+
+if [ -z "$violations" ]; then
+  echo "[scan-secrets] Clean: no secret-shaped values in tracked files."
+  exit 0
+fi
+
+count=$(printf '%s\n' "$violations" | wc -l)
+echo "[scan-secrets] SECRET-SHAPED VALUES IN TRACKED FILES:"
+printf '%s\n' "$violations"
+echo ""
+echo "[scan-secrets] FAIL: $count match(es)."
+echo "Move the real value to an uncommitted .env and reference it as \${VAR}."
+echo "Placeholders (your-own-uuid-here, x.x, example.com) are fine — use those in .env.example."
+exit 1

--- a/scripts/setup-https.ps1
+++ b/scripts/setup-https.ps1
@@ -5,14 +5,25 @@
 #
 # After running this script:
 #   1. docker compose up -d --build   (starts nginx on port 443)
-#   2. Install the CA on the Wyse — see instructions printed at the end.
+#   2. Install the CA on the display device — see instructions printed at the end.
+#
+# Usage:
+#   .\setup-https.ps1 -ServerIP <your-server-ip>
+#   .\setup-https.ps1 -ServerIP prism.local
+
+param(
+    # Your server's local IP or hostname the cert should cover. Required —
+    # do not hardcode a personal address here (this file is public).
+    [Parameter(Mandatory = $true)]
+    [string]$ServerIP
+)
 
 $ErrorActionPreference = "Stop"
 
 # --- Config ---
-# Add your server's local IP and any hostnames you want the cert to cover.
-# Separate multiple values with spaces.
-$DOMAINS = "192.168.1.236 localhost 127.0.0.1"
+# The cert covers your server address plus loopback. Add more space-separated
+# hostnames here if you reach Prism by several names.
+$DOMAINS = "$ServerIP localhost 127.0.0.1"
 
 # Where certs land (mounted into the nginx container)
 $CERT_DIR = "$PSScriptRoot\..\config\certs"
@@ -61,18 +72,18 @@ Write-Host ""
 Write-Host "1. Bring up the nginx service:" -ForegroundColor White
 Write-Host "   docker compose up -d --build" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "2. Copy the CA cert to the Wyse:" -ForegroundColor White
+Write-Host "2. Copy the CA cert to the display device:" -ForegroundColor White
 Write-Host "   CA cert is at: $caCert" -ForegroundColor Yellow
-Write-Host "   scp `"$caCert`" dietpi@192.168.1.236:~/prism-ca.pem" -ForegroundColor Yellow
+Write-Host "   scp `"$caCert`" user@${ServerIP}:~/prism-ca.pem" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "3. On the Wyse, run:" -ForegroundColor White
+Write-Host "3. On the display device, run:" -ForegroundColor White
 Write-Host "   sudo cp ~/prism-ca.pem /usr/local/share/ca-certificates/prism-ca.crt" -ForegroundColor Yellow
 Write-Host "   sudo update-ca-certificates" -ForegroundColor Yellow
 Write-Host "   mkdir -p ~/.pki/nssdb" -ForegroundColor Yellow
 Write-Host "   certutil -d sql:`$HOME/.pki/nssdb -A -t 'CT,,' -n 'Prism Local CA' -i ~/prism-ca.pem" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "4. Update the Wyse kiosk URL to:" -ForegroundColor White
-Write-Host "   https://192.168.1.236" -ForegroundColor Yellow
+Write-Host "4. Update the display device's kiosk URL to:" -ForegroundColor White
+Write-Host "   https://$ServerIP" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "Done. Prism will be available at https://192.168.1.236" -ForegroundColor Green
+Write-Host "Done. Prism will be available at https://$ServerIP" -ForegroundColor Green
 Write-Host ""


### PR DESCRIPTION
## Problem

Healthchecks.io kept emailing that `prism-db-backup` was DOWN for ~23h50m, briefly UP, then DOWN again — daily.

Root cause was **not** a dead-man cadence mismatch (the 1 day / 2h-grace schedule is correct). The check's event log showed **three different source IPs** pinging it: the intended backup job succeeding once a day, plus two *other* machines sending failure pings minutes later that flipped it down for the rest of the day.

Those other machines are other people's Prism installs: `docker-compose.yml` had `HC_URL` (a personal healthchecks.io ping UUID) **and** `RCLONE_REMOTE` hardcoded and committed to this **public** repo. Every clone that runs `docker compose up` pinged the maintainer's check, and since their off-site sync targeted an rclone remote they don't have, their backup failed and pinged `/fail`.

## Fix

- **`docker-compose.yml`** — `HC_URL`, `RCLONE_REMOTE`, and the backup tunables are now `${VAR:-}` env-driven with empty/safe defaults. `backup.sh` already no-ops the ping when `HC_URL` is unset, so foreign installs neither ping nor sync to anything personal.
- **`.env.example`** — documented a Backups section ("generate your OWN check — do not reuse anyone else's UUID").
- **`scripts/setup-https.ps1`** — replaced a hardcoded personal LAN IP with a required `-ServerIP` parameter.
- **`scripts/scan-secrets.sh` + `.husky/pre-push`** — new pre-push guard blocking secret-shaped values (healthcheck ping URLs carrying a UUID, private LAN IPs in config/deploy/docs, cloud tokens, private keys). This is the leak class the existing denylist + hostname-in-comment scanners missed. Private-IP literals under `src/` (the recipe-import SSRF guard and its tests) are intentionally exempt.

## Operational follow-up (done out-of-band)

The leaked UUID was rotated to a fresh check; the old one is being deleted. Existing public clones will keep pinging the old UUID, which now 404s harmlessly.
