### PR TITLE
fix(ha-addon): make bundled DB actually start and survive restarts (#81)

### DIFF
--- a/ha-app/run.sh
+++ b/ha-app/run.sh
@@ -73,8 +73,23 @@ if [ "$BUNDLED_DB" = "true" ]; then
         chmod 600 "$PG_PASSWORD_FILE"
     fi
 
+    # Postgres on Alpine defaults its Unix socket to /run/postgresql, which
+    # does not exist in the container — and /run is a fresh tmpfs each boot,
+    # so this must run every start, not just first boot. Without it pg_ctl
+    # dies with: could not create lock file "/run/postgresql/.s.PGSQL.5432
+    # .lock": No such file or directory. See issue #81.
+    mkdir -p /run/postgresql
+    chown postgres:postgres /run/postgresql
+
     log "Starting bundled postgres"
-    sudo -u postgres pg_ctl -D "$PG_DATA" -l "$PG_DATA/postgres.log" -w start
+    # On failure, surface the server log — pg_ctl only says "could not start
+    # server / Examine the log output", and set -e would otherwise kill the
+    # script before anyone sees why.
+    if ! sudo -u postgres pg_ctl -D "$PG_DATA" -l "$PG_DATA/postgres.log" -w start; then
+        log "bundled postgres failed to start — dumping $PG_DATA/postgres.log:"
+        cat "$PG_DATA/postgres.log" >&2 2>/dev/null || true
+        die "bundled postgres did not start"
+    fi
 
     PG_PASSWORD="$(cat "$PG_PASSWORD_FILE")"
     # Create role + database (idempotent: check existence first).
@@ -98,11 +113,21 @@ else
 fi
 
 # ─── 3. Schema + migrations ──────────────────────────────────────────
-# Base schema first (creates tables that pre-date drizzle migrations),
-# then drizzle migrations on top. Base-schema apply is idempotent
-# because each statement is CREATE … IF NOT EXISTS.
-log "Applying base schema"
-PGPASSWORD="$PG_PASSWORD" psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /app/db-init/02-schema.sql
+# The base schema (02-schema.sql) is a full pg_dump and is NOT idempotent:
+# its ADD CONSTRAINT statements have no IF NOT EXISTS and error out on a
+# second apply. So run it only when the database has no schema yet —
+# mirroring the standalone deploy, where Postgres' docker-entrypoint-initdb.d
+# runs it exactly once. On every later boot, migrate.js (idempotent) brings
+# the schema up to date. Detect "empty" by the absence of the migration
+# bookkeeping table. Auth comes from DATABASE_URL (works for both the bundled
+# trust-auth socket and an external password URL). See issue #81.
+SCHEMA_PRESENT="$(psql "$DATABASE_URL" -tAc "SELECT to_regclass('public.__prism_migrations') IS NOT NULL" 2>/dev/null || echo f)"
+if [ "$SCHEMA_PRESENT" != "t" ]; then
+    log "Fresh database — applying base schema"
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /app/db-init/02-schema.sql
+else
+    log "Existing database — skipping base schema (migrate.js handles updates)"
+fi
 
 log "Running migrations"
 cd /app && node scripts/migrate.js


### PR DESCRIPTION
## Problem

The Home Assistant addon's bundled-Postgres path (`bundled_db: true`, the default) never worked end to end. @joe-cole1 reported it in #81: the addon installs fine but won't start, with logs showing `pg_ctl: could not start server / Examine the log output` (the real cause was swallowed).

Two independent bugs, both invisible to CI because CI builds the addon image but never **boots** it. I reproduced and fixed both by running the addon image directly with a faked `/data/options.json` (no HA needed).

### Bug 1 — Postgres won't start
Alpine's Postgres defaults its Unix socket to `/run/postgresql`, which doesn't exist in the container (and `/run` is a fresh tmpfs each boot). So the server died with:

```
FATAL: could not create lock file "/run/postgresql/.s.PGSQL.5432.lock": No such file or directory
```

`run.sh` now creates `/run/postgresql` (owned by `postgres`) on every start, and **dumps `$PG_DATA/postgres.log` on a start failure** — previously `set -e` killed the script right after `pg_ctl`'s unhelpful message, so the real error never reached the addon log.

### Bug 2 — crash-loop on first restart
Even with Bug 1 fixed, the addon crash-looped on the first restart/update. `run.sh` re-applied the base schema (`02-schema.sql`, a full `pg_dump`) on **every** boot, but its `ADD CONSTRAINT` statements have no `IF NOT EXISTS` and error on the second apply (`ON_ERROR_STOP=1` → exit):

```
ERROR: relation "__prism_migrations_name_key" already exists
```

The base schema is now applied **only when the database is empty** (detected via `to_regclass` on the migration table) — mirroring the standalone deploy, where Postgres' `docker-entrypoint-initdb.d` runs it exactly once. `migrate.js` (idempotent) handles every later boot. This also fixes a latent crash in the **external-DB** path, where `PGPASSWORD="$PG_PASSWORD"` referenced an unset var under `set -u`; auth now comes from `DATABASE_URL`.

## Verification

Built `ha-app/` locally and booted the image with a faked `/data`:
- **Fresh boot** → "Fresh database — applying base schema" → migrations → Next.js → **HTTP 200**
- **Restart** → "Existing database — skipping base schema" → **HTTP 200, zero errors**

## Follow-up
After merge + release (so the published `prism-ha` image carries the fix), validate on a real HA OS install, then update #81.