### PR TITLE
fix(ci): exclude scan-secrets.sh from the hostname comment scanner

### DIFF
--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -116,7 +116,7 @@ done
 SCAN_FILES_PATTERN='\.(ts|tsx|js|jsx|mjs|cjs|sh|py|md|yml|yaml|json|css|scss|sql)$'
 TARGETS=$(git ls-files \
   | grep -E "$SCAN_FILES_PATTERN" \
-  | grep -v -E '^(scripts/scan-(pii|examples|hostnames)\.sh|docs/code-review-modalities\.md|.*\.snap$|package-lock\.json|.*\.lock$)$' \
+  | grep -v -E '^(scripts/scan-(pii|examples|hostnames|secrets)\.sh|docs/code-review-modalities\.md|.*\.snap$|package-lock\.json|.*\.lock$)$' \
   || true)
 
 if [ -z "$TARGETS" ]; then


### PR DESCRIPTION
## Problem

`scripts/scan-hostnames.sh` (run by the husky pre-push hook) is meant to skip the scanner scripts themselves — their comments legitimately contain example hostnames. But the self-exclusion list named only `scan-pii` / `scan-examples` / `scan-hostnames`; **`scan-secrets.sh` was missing**.

`scan-secrets.sh:7` has an explanatory comment mentioning `healthchecks.io` as an example of what to catch, so the hostname scanner flagged it and failed the pre-push hook:

```
[scan-hostnames] FAIL: 1 line(s) with potentially-real hostnames in comments.
  scripts/scan-secrets.sh:7 ... [hostname(s): healthchecks.io]
```

This surfaces on any checkout where husky hooks are installed (`npm ci`); checkouts without `node_modules` silently skip the hook, which is why it wasn't caught earlier.

## Fix

Add `secrets` to the exclusion alternation:

```
scan-(pii|examples|hostnames|secrets)\.sh
```

Completes the documented "skip the scanners themselves" intent. No change to what gets scanned in real source files.

## Verification

`bash scripts/scan-hostnames.sh` → `Clean: no non-allowlisted hostnames in comments.` (exit 0)