### PR TITLE
chore(release): 1.8.13

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.13] – 2026-06-29
+
+### Added — Integrations
+- **Each Integrations card now shows which account it's connected to — "Connected as `you@example.com`".** Previously the cards showed *that* a provider was connected but not *which account*, so anyone running split accounts under one provider (e.g. a personal Google for calendars plus a family Gmail for school-bus emails) couldn't tell from the card which account each feature used. Prism now captures the account's email during the OAuth login (Google, Microsoft, and Gmail) and shows it on the provider card and its Account sub-section; split-account setups show the primary plus a "+N more". **Existing connections show no email until you click Re-authenticate on the card** — the email is only captured on a fresh login, and there's intentionally no backfill of stored tokens. The new login adds read-only identity scopes (Google `openid email`, Microsoft `User.Read`); Gmail reuses its existing scope. Closes [#100](https://github.com/sandydargoport/prism/issues/100).
+
 ## [1.8.12] – 2026-06-28
 
 ### Fixed — Integrations

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.12"
+version: "1.8.13"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.8.13.

### Added — Integrations
- "Connected as &lt;email&gt;" on the provider cards (#100, merged in #148). Captures the OAuth account email on login and shows which account each provider card is wired to. Existing connections show no email until Re-authenticated; no token backfill.

Version bumped in lockstep across `package.json`, `ha-app/config.yaml`, and `docs/CHANGELOG.md` (sync check passes).

**Not yet tagged** — merge this, then the `v1.8.13` tag is pushed separately to fire the HA addon image build.