### PR TITLE
fix(ui): bundle color emoji webfont so emoji render on fontless clients (#145)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism",
-  "version": "1.8.3",
+  "version": "1.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism",
-      "version": "1.8.3",
+      "version": "1.8.13",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -15,6 +15,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
+        "@fontsource/noto-color-emoji": "^5.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.1.3",
@@ -3144,6 +3145,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/noto-color-emoji": {
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-color-emoji/-/noto-color-emoji-5.2.12.tgz",
+      "integrity": "sha512-UVOh4qxD/y42mcB4XvEdpV1WE01zn7O4+4tAWwzp5QAd4JY5jWPHu3/3T1kQoD04oYbQ5cJ9SI12IfcCKaS8aw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
+    "@fontsource/noto-color-emoji": "^5.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,12 @@
 // Import global styles (including Tailwind CSS)
 import '@/styles/globals.css';
 
+// Bundle a color emoji webfont so emoji (🎯 🎂 🛒 🏆 …) render even on clients
+// with no system emoji font — e.g. a bare Raspberry Pi OS / minimal Chromium
+// kiosk. Subsetted by unicode-range, so a browser only downloads the small
+// chunks for the emoji actually on screen, not the whole font. See #145.
+import '@fontsource/noto-color-emoji/index.css';
+
 // Next.js types for metadata
 import type { Metadata, Viewport } from 'next';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,6 +87,13 @@ module.exports = {
           'Helvetica Neue',
           'Arial',
           'sans-serif',
+          // Emoji fallback (#145): prefer the device's native color emoji font;
+          // fall back to the bundled "Noto Color Emoji" webfont (imported in
+          // layout.tsx) so emoji still render on clients with no emoji font.
+          'Apple Color Emoji',
+          'Segoe UI Emoji',
+          'Segoe UI Symbol',
+          'Noto Color Emoji',
         ],
         mono: [
           'JetBrains Mono',


### PR DESCRIPTION
Closes #145.

## The real root cause (the original #145 Dockerfile diagnosis was wrong)

Prism emits **raw Unicode emoji** straight into the markup — 🎯 Goals, 🎂 Birthdays, the food icons in ShoppingWidget, 🏆 Points, and the `@emoji-mart` avatar picker. Those render **client-side, in the viewing browser**, using whatever emoji font the *display device* has. On a device with no emoji font (e.g. a bare Raspberry Pi OS / minimal Chromium kiosk — @theg00se1030's setup on #125) they show as tofu boxes.

The image's bundled `chromium` is used **only** by `browserFetch.ts` → `recipeParser.ts` to scrape recipe-site HTML past Cloudflare — it never renders the UI or any emoji to an image. So adding an emoji font to the Docker image (the original proposal) would not have fixed anything the user sees. The fix has to reach the **client**.

## Fix

Bundle a color emoji **webfont** so Prism serves the glyphs itself, working on any client regardless of installed fonts:

- Add `@fontsource/noto-color-emoji`, imported globally in `layout.tsx`.
- Append the emoji fonts to the Tailwind `sans` stack **after** the system emoji fonts (`Apple Color Emoji`, `Segoe UI Emoji`, …, then the bundled `Noto Color Emoji`) — so devices with a native emoji font use it (no download), and fontless devices fall back to the bundled webfont.

**Size:** the font is subsetted by `unicode-range`, so a browser downloads only the small chunks for the emoji actually on screen (tens to a few hundred KB), not the whole ~10 MB font.

## Verification
- `npm run build` — exit 0; 10 emoji woff2 chunks emitted to `.next/static/media/`
- `npm run type-check` — clean

Reaches this repo's own VM instance via `deploy-local.sh` too (the webfont bundles into the Next build, unlike a Dockerfile-only change).