### PR TITLE
chore(release): 1.8.14

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.8.14] – 2026-06-29
+
+### Fixed — Display
+- **Emoji now render on devices without a system emoji font.** Prism uses Unicode emoji throughout the UI (Goals 🎯, Birthdays 🎂, shopping categories 🛒, Points 🏆, the avatar picker, …); these render in the *viewing browser* using the device's emoji font, so on a minimal client with none installed — e.g. a bare Raspberry Pi OS / Chromium kiosk — they showed as empty "tofu" boxes (□). Prism now bundles the Noto Color Emoji webfont and adds it to the font stack after the system emoji fonts, so it serves the glyphs itself and emoji render on any client regardless of installed fonts. The font is subsetted by Unicode range, so a browser only downloads the small chunks for the emoji actually on screen. Devices that already have a native emoji font keep using it (no extra download). Thanks @theg00se1030 for the report. Closes [#145](https://github.com/sandydargoport/prism/issues/145).
+
 ## [1.8.13] – 2026-06-29
 
 ### Added — Integrations

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.13"
+version: "1.8.14"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.8.14.

### Fixed — Display
- Bundle the Noto Color Emoji webfont so emoji render on clients without a system emoji font (bare Raspberry Pi OS / minimal Chromium kiosk) — previously tofu boxes. Subsetted by Unicode range; native emoji fonts still preferred where present. #145 (merged in #150). Thanks @theg00se1030.

Version bumped in lockstep across `package.json`, `ha-app/config.yaml`, `docs/CHANGELOG.md` (sync check passes). No migration, no re-auth needed.

**Not yet tagged** — merge this, then `v1.8.14` is pushed separately to fire the HA addon image build.