### PR TITLE
fix(setup): don't lose the family entry on Continue (setup lockout)

### DIFF
--- a/src/app/api/setup/complete/__tests__/complete.test.ts
+++ b/src/app/api/setup/complete/__tests__/complete.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the setup completion endpoint.
+ *
+ * Mocks the DB to verify:
+ * - Refuses to mark setup complete when no parent exists (prevents lockout)
+ * - Inserts setupComplete when none exists and a parent is present
+ * - Updates setupComplete when a row already exists and a parent is present
+ */
+
+import { NextResponse } from 'next/server';
+
+const mockSelect = jest.fn();
+const mockInsert = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    select: (...a: unknown[]) => mockSelect(...a),
+    insert: (...a: unknown[]) => mockInsert(...a),
+    update: (...a: unknown[]) => mockUpdate(...a),
+  },
+}));
+
+jest.mock('@/lib/db/schema', () => ({
+  settings: { key: 'key', value: 'value' },
+  users: { id: 'id', role: 'role' },
+}));
+
+import { POST } from '../route';
+
+/** Build a chainable select() mock that resolves to `rows` for the parent lookup. */
+function mockParentLookup(rows: unknown[]) {
+  mockSelect.mockReturnValueOnce({
+    from: () => ({ where: () => ({ limit: () => Promise.resolve(rows) }) }),
+  });
+}
+
+/** Build a chainable select() mock for the existing-setupComplete lookup. */
+function mockSettingsLookup(rows: unknown[]) {
+  mockSelect.mockReturnValueOnce({
+    from: () => ({ where: () => Promise.resolve(rows) }),
+  });
+}
+
+describe('POST /api/setup/complete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) });
+    mockUpdate.mockReturnValue({
+      set: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) }),
+    });
+  });
+
+  it('refuses to complete setup when no parent exists', async () => {
+    mockParentLookup([]); // no parent
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('parent');
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('inserts setupComplete when a parent exists and no row is present', async () => {
+    mockParentLookup([{ id: 'parent-1' }]);
+    mockSettingsLookup([]); // no existing setupComplete row
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('updates setupComplete when a parent exists and a row is present', async () => {
+    mockParentLookup([{ id: 'parent-1' }]);
+    mockSettingsLookup([{ key: 'setupComplete', value: { completedAt: 'old' } }]);
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the query throws', async () => {
+    mockSelect.mockImplementationOnce(() => {
+      throw new Error('db down');
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect(res).toBeInstanceOf(NextResponse);
+  });
+});

--- a/src/app/api/setup/complete/__tests__/complete.test.ts
+++ b/src/app/api/setup/complete/__tests__/complete.test.ts
@@ -3,21 +3,20 @@
  *
  * Mocks the DB to verify:
  * - Refuses to mark setup complete when no parent exists (prevents lockout)
- * - Inserts setupComplete when none exists and a parent is present
- * - Updates setupComplete when a row already exists and a parent is present
+ * - Upserts setupComplete when a parent exists (idempotent, race-safe)
+ * - Surfaces a 500 on unexpected DB errors
  */
 
 import { NextResponse } from 'next/server';
 
 const mockSelect = jest.fn();
 const mockInsert = jest.fn();
-const mockUpdate = jest.fn();
+const mockOnConflictDoUpdate = jest.fn();
 
 jest.mock('@/lib/db/client', () => ({
   db: {
     select: (...a: unknown[]) => mockSelect(...a),
     insert: (...a: unknown[]) => mockInsert(...a),
-    update: (...a: unknown[]) => mockUpdate(...a),
   },
 }));
 
@@ -35,19 +34,14 @@ function mockParentLookup(rows: unknown[]) {
   });
 }
 
-/** Build a chainable select() mock for the existing-setupComplete lookup. */
-function mockSettingsLookup(rows: unknown[]) {
-  mockSelect.mockReturnValueOnce({
-    from: () => ({ where: () => Promise.resolve(rows) }),
-  });
-}
-
 describe('POST /api/setup/complete', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockInsert.mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) });
-    mockUpdate.mockReturnValue({
-      set: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) }),
+    mockOnConflictDoUpdate.mockResolvedValue(undefined);
+    mockInsert.mockReturnValue({
+      values: jest.fn().mockReturnValue({
+        onConflictDoUpdate: (...a: unknown[]) => mockOnConflictDoUpdate(...a),
+      }),
     });
   });
 
@@ -60,12 +54,10 @@ describe('POST /api/setup/complete', () => {
     expect(res.status).toBe(400);
     expect(data.error).toContain('parent');
     expect(mockInsert).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it('inserts setupComplete when a parent exists and no row is present', async () => {
+  it('upserts setupComplete when a parent exists', async () => {
     mockParentLookup([{ id: 'parent-1' }]);
-    mockSettingsLookup([]); // no existing setupComplete row
 
     const res = await POST();
     const data = await res.json();
@@ -73,20 +65,18 @@ describe('POST /api/setup/complete', () => {
     expect(res.status).toBe(200);
     expect(data.ok).toBe(true);
     expect(mockInsert).toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockOnConflictDoUpdate).toHaveBeenCalled();
   });
 
-  it('updates setupComplete when a parent exists and a row is present', async () => {
+  it('is idempotent across concurrent calls (no unique-constraint error)', async () => {
     mockParentLookup([{ id: 'parent-1' }]);
-    mockSettingsLookup([{ key: 'setupComplete', value: { completedAt: 'old' } }]);
+    mockParentLookup([{ id: 'parent-1' }]);
 
-    const res = await POST();
-    const data = await res.json();
+    const [a, b] = await Promise.all([POST(), POST()]);
 
-    expect(res.status).toBe(200);
-    expect(data.ok).toBe(true);
-    expect(mockUpdate).toHaveBeenCalled();
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(2);
   });
 
   it('returns 500 when the query throws', async () => {

--- a/src/app/api/setup/complete/route.ts
+++ b/src/app/api/setup/complete/route.ts
@@ -1,10 +1,27 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
-import { settings } from '@/lib/db/schema';
+import { settings, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
 export async function POST() {
   try {
+    // Guard against a lockout: refuse to mark setup complete unless at least
+    // one parent account exists. Otherwise setupComplete=true with zero users
+    // leaves a login screen with no profiles and no way to add one, since
+    // /api/family only allows unauthenticated member creation while setup is
+    // still incomplete.
+    const [parent] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.role, 'parent'))
+      .limit(1);
+    if (!parent) {
+      return NextResponse.json(
+        { error: 'Add at least one parent before finishing setup' },
+        { status: 400 }
+      );
+    }
+
     const existing = await db.select().from(settings).where(eq(settings.key, 'setupComplete'));
     if (existing.length > 0) {
       await db.update(settings)

--- a/src/app/api/setup/complete/route.ts
+++ b/src/app/api/setup/complete/route.ts
@@ -22,17 +22,20 @@ export async function POST() {
       );
     }
 
-    const existing = await db.select().from(settings).where(eq(settings.key, 'setupComplete'));
-    if (existing.length > 0) {
-      await db.update(settings)
-        .set({ value: { completedAt: new Date().toISOString() } })
-        .where(eq(settings.key, 'setupComplete'));
-    } else {
-      await db.insert(settings).values({
+    // Idempotent upsert: concurrent calls (e.g. React strict-mode double-invoke
+    // in dev, or a double-submit) must not race between SELECT and INSERT and
+    // violate the settings_key_unique constraint.
+    await db
+      .insert(settings)
+      .values({
         key: 'setupComplete',
         value: { completedAt: new Date().toISOString() },
+      })
+      .onConflictDoUpdate({
+        target: settings.key,
+        set: { value: { completedAt: new Date().toISOString() } },
       });
-    }
+
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error('[setup/complete]', error);

--- a/src/app/setup/steps/CompleteStep.tsx
+++ b/src/app/setup/steps/CompleteStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { toast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { PartyPopper, Settings } from 'lucide-react';
@@ -15,7 +16,14 @@ export function CompleteStep() {
     const markComplete = async () => {
       setMarking(true);
       try {
-        await fetch('/api/setup/complete', { method: 'POST' });
+        const res = await fetch('/api/setup/complete', { method: 'POST' });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          toast({
+            title: data.error || 'Could not finish setup',
+            variant: 'destructive',
+          });
+        }
       } finally {
         setMarking(false);
       }

--- a/src/app/setup/steps/FamilyStep.tsx
+++ b/src/app/setup/steps/FamilyStep.tsx
@@ -37,17 +37,18 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
   const [added, setAdded] = useState<AddedMember[]>([]);
   const { pinLength, setPinLength } = usePinLength();
 
-  const canAdd = name.trim().length > 0;
-  const hasParent = added.some((m) => m.role === 'parent');
+  const hasPendingEntry = name.trim().length > 0;
+  const canAdd = hasPendingEntry;
+  const hasParent = added.some((m) => m.role === 'parent') || (hasPendingEntry && role === 'parent');
 
-  const addMember = async () => {
-    if (!canAdd) return;
+  const addMember = async (): Promise<boolean> => {
+    if (!canAdd) return false;
     setSaving(true);
     try {
       const trimmedPin = pin.trim();
       if (trimmedPin && trimmedPin.length !== pinLength) {
         toast({ title: `PIN must be exactly ${pinLength} digits`, variant: 'destructive' });
-        return;
+        return false;
       }
 
       const body: Record<string, string> = {
@@ -66,7 +67,7 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
       if (!res.ok) {
         const data = await res.json();
         toast({ title: data.error || 'Failed to add member', variant: 'destructive' });
-        return;
+        return false;
       }
 
       setAdded((prev) => [...prev, { name: name.trim(), role, color }]);
@@ -75,9 +76,21 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
       setRole('child');
       setColor(COLOR_OPTIONS[added.length % COLOR_OPTIONS.length] ?? COLOR_OPTIONS[0]!);
       toast({ title: `Added ${name.trim()}` });
+      return true;
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleContinue = async () => {
+    // Auto-commit whatever the user typed but didn't explicitly "Add" — the
+    // separate Add member button is easy to miss, and losing the entry here
+    // is what caused people to finish setup with no account.
+    if (hasPendingEntry) {
+      const ok = await addMember();
+      if (!ok) return;
+    }
+    onNext();
   };
 
   return (
@@ -199,20 +212,20 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
 
           <Button onClick={addMember} disabled={!canAdd || saving} className="w-full" variant="secondary">
             <Plus className="h-4 w-4 mr-1" />
-            Add member
+            {added.length === 0 ? 'Add member' : 'Add another member'}
           </Button>
         </div>
 
         <div className="flex gap-3 pt-1">
           <Button variant="ghost" onClick={onBack} className="flex-1">Back</Button>
-          <Button onClick={onNext} disabled={!hasParent} className="flex-1">
+          <Button onClick={handleContinue} disabled={!hasParent || saving} className="flex-1">
             Continue <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         </div>
 
         {!hasParent && (
           <p className="text-xs text-center text-muted-foreground -mt-1">
-            Add at least one parent above to continue.
+            Enter a parent&apos;s name above, then Continue — no need to click Add first.
           </p>
         )}
       </CardContent>

--- a/src/app/setup/steps/FamilyStep.tsx
+++ b/src/app/setup/steps/FamilyStep.tsx
@@ -38,17 +38,24 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
   const { pinLength, setPinLength } = usePinLength();
 
   const canAdd = name.trim().length > 0;
+  const hasParent = added.some((m) => m.role === 'parent');
 
   const addMember = async () => {
     if (!canAdd) return;
     setSaving(true);
     try {
+      const trimmedPin = pin.trim();
+      if (trimmedPin && trimmedPin.length !== pinLength) {
+        toast({ title: `PIN must be exactly ${pinLength} digits`, variant: 'destructive' });
+        return;
+      }
+
       const body: Record<string, string> = {
         name: name.trim(),
         role,
         color,
       };
-      if (pin.trim()) body.pin = pin.trim();
+      if (trimmedPin) body.pin = trimmedPin;
 
       const res = await fetch('/api/family', {
         method: 'POST',
@@ -198,14 +205,14 @@ export function FamilyStep({ onNext, onBack }: FamilyStepProps) {
 
         <div className="flex gap-3 pt-1">
           <Button variant="ghost" onClick={onBack} className="flex-1">Back</Button>
-          <Button onClick={onNext} className="flex-1">
+          <Button onClick={onNext} disabled={!hasParent} className="flex-1">
             Continue <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         </div>
 
-        {added.length === 0 && (
+        {!hasParent && (
           <p className="text-xs text-center text-muted-foreground -mt-1">
-            Add a member above, or skip if your family is already set up.
+            Add at least one parent above to continue.
           </p>
         )}
       </CardContent>


### PR DESCRIPTION
## Problem

On a fresh install it's easy to finish the setup wizard with **zero user accounts**, which hard-locks the app: you land on a profile/login screen with no profiles, and there's no way to add one (`POST /api/family` only allows unauthenticated creation *while setup is incomplete*).

### Root cause (UX trap)
In the **Family** step you fill in Name/Role/Color/PIN, but that form is only committed when you click the **separate "Add member" button**. Clicking **Continue** without first clicking Add silently discards the typed-in entry. So a user who types their name and clicks Continue proceeds through the rest of the wizard, which marks setup complete — with no account ever created.

Secondary: `POST /api/setup/complete` did a SELECT-then-INSERT/UPDATE that races on React strict-mode's double-invoke (or any double-submit), throwing a duplicate-key 500.

## Fix
- **FamilyStep**: `Continue` now auto-commits the in-progress form entry, so the separate "Add member" button is only needed to add *additional* people. Continue enables as soon as a parent name is entered; helper text clarifies you don't need to click Add first. **PIN stays optional**, and is validated against the configured length before submit.
- **/api/setup/complete**: authoritative guard refusing to complete with no parent (prevents the lockout even if the UI regresses), now implemented as an idempotent `onConflictDoUpdate` upsert so concurrent calls both return 200.
- **CompleteStep**: surfaces an error toast if completion is rejected instead of failing silently.

## Verification
Reproduced and fixed against a real Chromium browser (Playwright) on both a dev server and a production Docker build:
- Fill name + **Continue directly** (no Add click, no PIN) → parent created, setup completes, dashboard loads.
- Fill + **Add** + Continue → single member, no duplicate.
- Fill + PIN + Continue → parent created with PIN.
- Two concurrent `/api/setup/complete` calls → both 200 (no duplicate-key 500).

## Tests
`src/app/api/setup/complete/__tests__/complete.test.ts`: no-parent refusal, upsert path, concurrent-call idempotency, and the 500 error path. Full suite green: **1160 passing**, `type-check` clean.
