### PR TITLE
fix(integrations): SSRF guards for CalDAV / CardDAV / Immich outbound fetches

### DIFF
--- a/src/lib/integrations/__tests__/caldav.test.ts
+++ b/src/lib/integrations/__tests__/caldav.test.ts
@@ -1,0 +1,113 @@
+/**
+ * SSRF-guard tests for the CalDAV client (audit 2026-07 · H5).
+ *
+ * Every exported entry point must reject a private / loopback / metadata
+ * serverUrl BEFORE it hands the URL to tsdav (which performs the outbound
+ * request). testCalDAVConnection returns a friendly {success:false}; the
+ * remaining functions throw UnsafeUrlError. In all cases createDAVClient
+ * must never be reached, so the guard cannot be used as an internal-host
+ * existence oracle.
+ */
+
+// --- tsdav mock: a spy so we can assert it is never called on rejection ---
+const mockCreateDAVClient = jest.fn();
+jest.mock('tsdav', () => ({
+  createDAVClient: (...a: unknown[]) => mockCreateDAVClient(...a),
+}));
+// ical.js is only exercised on the (unreached) success path here.
+jest.mock('ical.js', () => ({}));
+
+import {
+  testCalDAVConnection,
+  discoverCalendars,
+  fetchCalDAVEvents,
+  fetchCalDAVTasks,
+  createCalDAVEvent,
+  updateCalDAVEvent,
+  deleteCalDAVEvent,
+} from '../caldav';
+import { UnsafeUrlError } from '@/lib/utils/safeFetch';
+
+// Guard only blocks private targets in production; force prod so the dev
+// loopback escape hatch does not mask the rejection.
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+});
+
+const PRIVATE_URLS = [
+  'http://127.0.0.1:5232',
+  'http://10.0.0.5/dav',
+  'http://192.168.1.10/remote.php/dav',
+  'http://169.254.169.254/latest/meta-data',
+  'http://[::1]:5232',
+  'http://localhost:5232',
+];
+
+const EV = {
+  uid: 'u1',
+  title: 'T',
+  startTime: new Date('2026-01-01T10:00:00Z'),
+  endTime: new Date('2026-01-01T11:00:00Z'),
+};
+
+describe('testCalDAVConnection', () => {
+  it.each(PRIVATE_URLS)('returns {success:false} without contacting tsdav for %s', async (url) => {
+    const result = await testCalDAVConnection(url, 'user', 'pass');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not allowed|private or local/i);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+
+  it('does not distinguish an existing internal host from a missing one (no oracle)', async () => {
+    const a = await testCalDAVConnection('http://10.0.0.5', 'u', 'p');
+    const b = await testCalDAVConnection('http://10.0.0.6', 'u', 'p');
+    expect(a).toEqual(b);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('exported functions throw UnsafeUrlError on a private serverUrl', () => {
+  it('discoverCalendars', async () => {
+    await expect(discoverCalendars('http://10.0.0.5', 'u', 'p')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+  it('fetchCalDAVEvents', async () => {
+    await expect(
+      fetchCalDAVEvents('http://127.0.0.1', 'u', 'p', '/cal', new Date(), new Date()),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+  it('fetchCalDAVTasks', async () => {
+    await expect(
+      fetchCalDAVTasks('http://192.168.0.2', 'u', 'p', '/cal'),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+  it('createCalDAVEvent', async () => {
+    await expect(
+      createCalDAVEvent('http://169.254.169.254', 'u', 'p', '/cal', EV),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+  it('updateCalDAVEvent', async () => {
+    await expect(
+      updateCalDAVEvent('http://[::1]', 'u', 'p', '/cal/o.ics', undefined, EV),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+  it('deleteCalDAVEvent', async () => {
+    await expect(
+      deleteCalDAVEvent('http://localhost', 'u', 'p', '/cal/o.ics'),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('public serverUrl is allowed through to tsdav', () => {
+  it('discoverCalendars reaches createDAVClient for a public host', async () => {
+    mockCreateDAVClient.mockResolvedValue({ fetchCalendars: jest.fn().mockResolvedValue([]) });
+    await discoverCalendars('https://caldav.icloud.com', 'u', 'p');
+    expect(mockCreateDAVClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/integrations/__tests__/carddav.test.ts
+++ b/src/lib/integrations/__tests__/carddav.test.ts
@@ -1,0 +1,72 @@
+/**
+ * SSRF-guard tests for the CardDAV client (audit 2026-07 · M-SSRF).
+ *
+ * fetchCardDAVBirthdays validates the *derived* URL (deriveCardDAVUrl swaps
+ * the iCloud CalDAV host for the CardDAV one) — that derived URL is what
+ * tsdav actually fetches, so a private target must be rejected there before
+ * createDAVClient runs.
+ */
+
+const mockCreateDAVClient = jest.fn();
+jest.mock('tsdav', () => ({
+  createDAVClient: (...a: unknown[]) => mockCreateDAVClient(...a),
+}));
+jest.mock('ical.js', () => ({}));
+
+import { fetchCardDAVBirthdays, deriveCardDAVUrl } from '../carddav';
+import { UnsafeUrlError } from '@/lib/utils/safeFetch';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+});
+
+describe('deriveCardDAVUrl', () => {
+  it('swaps the iCloud CalDAV host for the CardDAV host', () => {
+    expect(deriveCardDAVUrl('https://caldav.icloud.com/123/calendars')).toBe(
+      'https://contacts.icloud.com/123/calendars',
+    );
+  });
+  it('passes non-iCloud hosts through unchanged', () => {
+    expect(deriveCardDAVUrl('https://cloud.example.com/remote.php/dav')).toBe(
+      'https://cloud.example.com/remote.php/dav',
+    );
+  });
+});
+
+describe('fetchCardDAVBirthdays SSRF guard', () => {
+  const PRIVATE_URLS = [
+    'http://127.0.0.1/dav',
+    'http://10.0.0.5/remote.php/dav',
+    'http://192.168.1.10/dav',
+    'http://169.254.169.254/',
+    'http://[::1]/dav',
+    'http://localhost/dav',
+  ];
+
+  it.each(PRIVATE_URLS)('rejects %s without contacting tsdav', async (url) => {
+    await expect(fetchCardDAVBirthdays(url, 'u', 'p')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects when a public iCloud CalDAV host derives to something private (guards the derived URL)', async () => {
+    // deriveCardDAVUrl only rewrites the iCloud host; this asserts the guard
+    // runs on the post-derivation URL, not the raw input.
+    await expect(
+      fetchCardDAVBirthdays('http://10.0.0.5/caldav.icloud.com', 'u', 'p'),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(mockCreateDAVClient).not.toHaveBeenCalled();
+  });
+
+  it('allows a public host through and fetches the derived URL', async () => {
+    mockCreateDAVClient.mockResolvedValue({
+      fetchAddressBooks: jest.fn().mockResolvedValue([]),
+      fetchVCards: jest.fn().mockResolvedValue([]),
+    });
+    await fetchCardDAVBirthdays('https://caldav.icloud.com/123/principal', 'u', 'p');
+    expect(mockCreateDAVClient).toHaveBeenCalledTimes(1);
+    expect(mockCreateDAVClient.mock.calls[0][0].serverUrl).toBe(
+      'https://contacts.icloud.com/123/principal',
+    );
+  });
+});

--- a/src/lib/integrations/__tests__/immich.test.ts
+++ b/src/lib/integrations/__tests__/immich.test.ts
@@ -505,4 +505,20 @@ describe('SSRF guard on Immich serverUrl', () => {
       downloadImmichAsset({ serverUrl: 'http://[::1]', shareKey: 'k' }, 'asset-1'),
     ).rejects.toBeInstanceOf(UnsafeUrlError);
   });
+
+  it('blocks a public share URL that 30x-redirects to an internal host', async () => {
+    // The initial (public) host passes the guard, but the response redirects
+    // to the cloud metadata IP. safeFetch must re-validate the Location and
+    // refuse to follow it — the old `redirect: 'follow'` would have fetched it.
+    mockFetchOnce(() => ({
+      status: 302,
+      headers: new Headers({ location: 'http://169.254.169.254/latest/meta-data' }),
+    }));
+
+    await expect(
+      downloadImmichAsset({ serverUrl: 'https://immich.example.com', shareKey: 'k' }, 'asset-1'),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    // Only the first (public) hop was fetched; the internal target never was.
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
 });

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -7,6 +7,25 @@
 
 import { createDAVClient, type DAVCalendar, type DAVObject } from 'tsdav';
 import ICAL from 'ical.js';
+import { validatePublicUrl, UnsafeUrlError } from '@/lib/utils/safeFetch';
+
+/**
+ * Guard a user-supplied CalDAV server URL before handing it to tsdav.
+ *
+ * Every exported entry point below forwards `serverUrl` straight into tsdav,
+ * which performs the outbound request — so without this an authenticated
+ * parent could paste a loopback / RFC1918 / 169.254.169.254 address into the
+ * server-URL field and use Prism to probe the internal network (the /test
+ * endpoint's distinct connect-vs-401 errors make it a clean existence oracle).
+ *
+ * tsdav owns the fetch and follows HTTP redirects internally, so — like the
+ * caveat documented in safeFetch.ts — this validates only the initial host
+ * literal, not redirect targets or the DNS-resolved IP. That still closes the
+ * primary vector. Throws UnsafeUrlError on a private / non-http(s) target.
+ */
+function assertSafeCalDAVUrl(serverUrl: string): void {
+  validatePublicUrl(serverUrl);
+}
 
 export interface CalDAVCalendar {
   href: string;
@@ -69,6 +88,11 @@ export async function testCalDAVConnection(
   password: string,
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    // Reject private/loopback/metadata targets *before* the fetch so this
+    // endpoint can't be used as an internal-host existence oracle (the
+    // rejection is identical whether or not the internal host exists).
+    assertSafeCalDAVUrl(serverUrl);
+
     const client = await createDAVClient({
       serverUrl,
       credentials: { username, password },
@@ -81,6 +105,9 @@ export async function testCalDAVConnection(
 
     return { success: true };
   } catch (error) {
+    if (error instanceof UnsafeUrlError) {
+      return { success: false, error: 'Server URL is not allowed (points at a private or local address).' };
+    }
     const msg = error instanceof Error ? error.message : String(error);
     if (msg.includes('401') || msg.includes('Unauthorized')) {
       return { success: false, error: 'Authentication failed. Check username and password.' };
@@ -100,6 +127,8 @@ export async function discoverCalendars(
   username: string,
   password: string,
 ): Promise<CalDAVCalendar[]> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },
@@ -157,6 +186,8 @@ export async function fetchCalDAVEvents(
   timeMin: Date,
   timeMax: Date,
 ): Promise<CalDAVEvent[]> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },
@@ -288,6 +319,8 @@ export async function fetchCalDAVTasks(
   password: string,
   calendarHref: string,
 ): Promise<CalDAVTask[]> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },
@@ -458,6 +491,8 @@ export async function createCalDAVEvent(
   calendarHref: string,
   ev: CalDAVEventWrite,
 ): Promise<{ href: string }> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },
@@ -496,6 +531,8 @@ export async function updateCalDAVEvent(
   etag: string | undefined,
   ev: CalDAVEventWrite,
 ): Promise<void> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },
@@ -527,6 +564,8 @@ export async function deleteCalDAVEvent(
   calendarObjectHref: string,
   etag?: string,
 ): Promise<void> {
+  assertSafeCalDAVUrl(serverUrl);
+
   const client = await createDAVClient({
     serverUrl,
     credentials: { username, password },

--- a/src/lib/integrations/carddav.ts
+++ b/src/lib/integrations/carddav.ts
@@ -9,6 +9,7 @@
 
 import { createDAVClient, type DAVCollection } from 'tsdav';
 import ICAL from 'ical.js';
+import { validatePublicUrl } from '@/lib/utils/safeFetch';
 
 export interface ContactBirthday {
   /** Full display name from FN or N. Used as the dedupe key. */
@@ -36,8 +37,16 @@ export async function fetchCardDAVBirthdays(
   username: string,
   password: string,
 ): Promise<ContactBirthday[]> {
+  // Validate the *derived* URL, since deriveCardDAVUrl() (icloud host swap)
+  // is what tsdav actually fetches. Blocks an authenticated parent from
+  // pointing this at a private / loopback / metadata address. Throws
+  // UnsafeUrlError on rejection. tsdav follows redirects internally, so —
+  // as noted in safeFetch.ts — only the initial host literal is validated.
+  const targetUrl = deriveCardDAVUrl(serverUrl);
+  validatePublicUrl(targetUrl);
+
   const client = await createDAVClient({
-    serverUrl: deriveCardDAVUrl(serverUrl),
+    serverUrl: targetUrl,
     credentials: { username, password },
     authMethod: 'Basic',
     defaultAccountType: 'carddav',

--- a/src/lib/integrations/immich.ts
+++ b/src/lib/integrations/immich.ts
@@ -15,7 +15,7 @@
  * the share URL field and use Prism as a proxy to probe the home network.
  */
 
-import { validatePublicUrl, UnsafeUrlError } from '@/lib/utils/safeFetch';
+import { validatePublicUrl, safeFetch, UnsafeUrlError } from '@/lib/utils/safeFetch';
 
 export interface ImmichShareCredentials {
   serverUrl: string;
@@ -202,7 +202,7 @@ async function fetchAlbumAssets(
   const headers: Record<string, string> = {};
   if (cookie) headers.Cookie = cookie;
 
-  const res = await fetch(url, { headers });
+  const res = await safeFetch(url, { headers });
   if (!res.ok) {
     throw new Error(
       `Failed to fetch Immich album ${albumId}: ${res.status} ${res.statusText}`,
@@ -239,7 +239,7 @@ async function loginShare(
 ): Promise<{ raw: RawSharedLinkResponse; cookie: string | null }> {
   assertSafeServerUrl(serverUrl);
   const url = `${serverUrl}/api/shared-links/login?key=${encodeURIComponent(shareKey)}`;
-  const res = await fetch(url, {
+  const res = await safeFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ password }),
@@ -271,7 +271,7 @@ async function fetchSharedLinkRaw(
   }
 
   const url = `${creds.serverUrl}/api/shared-links/me?key=${encodeURIComponent(creds.shareKey)}`;
-  const res = await fetch(url);
+  const res = await safeFetch(url);
 
   if (res.status === 401 || res.status === 403) {
     throw new ImmichPasswordRequiredError();
@@ -343,7 +343,10 @@ export async function downloadImmichAsset(
   const headers: Record<string, string> = {};
   if (cookie) headers.Cookie = cookie;
 
-  const res = await fetch(`${creds.serverUrl}${path}`, { headers, redirect: 'follow' });
+  // safeFetch re-validates any redirect Location, so a share URL that 30x-
+  // redirects to an internal host can no longer be used to exfiltrate the
+  // internal response (was `redirect: 'follow'`, which bypassed the guard).
+  const res = await safeFetch(`${creds.serverUrl}${path}`, { headers });
   if (!res.ok) {
     // If the cache returned a stale cookie that the server rejected, drop
     // it and let the next call re-login. We don't auto-retry here because

--- a/src/lib/utils/__tests__/safeFetch.test.ts
+++ b/src/lib/utils/__tests__/safeFetch.test.ts
@@ -8,7 +8,7 @@
 
 export {};
 
-import { validatePublicUrl, UnsafeUrlError } from '../safeFetch';
+import { validatePublicUrl, safeFetch, UnsafeUrlError } from '../safeFetch';
 
 describe('validatePublicUrl', () => {
   it('accepts a public https URL', () => {
@@ -130,5 +130,151 @@ describe('validatePublicUrl', () => {
       expect(() => validatePublicUrl('http://10.0.0.1/', { isProduction: false }))
         .toThrow(UnsafeUrlError);
     });
+  });
+});
+
+describe('safeFetch (redirect re-validation)', () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  /** A minimal 3xx redirect response carrying a Location header. */
+  function redirect(status: number, location: string): Partial<Response> {
+    return { status, headers: new Headers({ location }) };
+  }
+  /** A terminal 200 response. */
+  function ok(): Partial<Response> {
+    return { ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve('body') };
+  }
+
+  it('fetches a public URL with redirect:manual and returns the response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(ok());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await safeFetch('https://example.com/api', { headers: { X: '1' } }, { isProduction: true });
+
+    expect(res.status).toBe(200);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.com/api');
+    expect(init.redirect).toBe('manual');
+    expect(init.headers).toEqual({ X: '1' });
+  });
+
+  it('rejects the initial URL when it is private (never calls fetch)', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      safeFetch('http://169.254.169.254/latest/meta-data', {}, { isProduction: true }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('follows a redirect to another public host', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(302, 'https://cdn.example.net/asset'))
+      .mockResolvedValueOnce(ok());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await safeFetch('https://example.com/asset', {}, { isProduction: true });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe('https://cdn.example.net/asset');
+  });
+
+  it('blocks a redirect whose Location points at a private host (the core SSRF bypass)', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(302, 'http://169.254.169.254/latest/meta-data'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      safeFetch('https://public-decoy.example.com/img', {}, { isProduction: true }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    // The internal target is never fetched — only the first (public) hop ran.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a redirect to loopback', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(307, 'http://127.0.0.1:2283/api/assets'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      safeFetch('https://public.example.com/x', {}, { isProduction: true }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves and validates a relative Location against the current URL', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(302, '/moved/here'))
+      .mockResolvedValueOnce(ok());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await safeFetch('https://example.com/start', {}, { isProduction: true });
+
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.com/moved/here');
+  });
+
+  it('downgrades POST to GET and drops the body on a 303', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(303, 'https://example.com/result'))
+      .mockResolvedValueOnce(ok());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await safeFetch(
+      'https://example.com/submit',
+      { method: 'POST', body: JSON.stringify({ a: 1 }) },
+      { isProduction: true },
+    );
+
+    const secondInit = fetchMock.mock.calls[1][1];
+    expect(secondInit.method).toBe('GET');
+    expect(secondInit.body).toBeUndefined();
+  });
+
+  it('preserves method and body across a 308', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(redirect(308, 'https://example.com/v2/submit'))
+      .mockResolvedValueOnce(ok());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await safeFetch(
+      'https://example.com/submit',
+      { method: 'POST', body: 'payload' },
+      { isProduction: true },
+    );
+
+    const secondInit = fetchMock.mock.calls[1][1];
+    expect(secondInit.method).toBe('POST');
+    expect(secondInit.body).toBe('payload');
+  });
+
+  it('throws after exceeding maxRedirects instead of looping forever', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(redirect(302, 'https://example.com/loop'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      safeFetch('https://example.com/loop', {}, { isProduction: true, maxRedirects: 3 }),
+    ).rejects.toThrow(/Too many redirects/);
+    // Initial hop + 3 followed redirects = 4 fetch calls, then it gives up.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns a redirect status unchanged when it carries no Location', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ status: 302, headers: new Headers() });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await safeFetch('https://example.com/weird', {}, { isProduction: true });
+    expect(res.status).toBe(302);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/utils/safeFetch.ts
+++ b/src/lib/utils/safeFetch.ts
@@ -148,3 +148,64 @@ export function validatePublicUrl(
 
   return parsed;
 }
+
+export interface SafeFetchOptions extends ValidatePublicUrlOptions {
+  /** Maximum redirect hops to follow, each re-validated. Default 5. */
+  maxRedirects?: number;
+}
+
+// 3xx statuses that carry a Location we would otherwise auto-follow.
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * SSRF-safe wrapper around fetch().
+ *
+ * validatePublicUrl() only guards the *initial* host. Left to the platform,
+ * fetch follows 3xx redirects automatically — so a public host that 30x-
+ * redirects to an internal address (loopback / RFC1918 / 169.254.169.254)
+ * slips past the guard and the internal target is fetched. safeFetch closes
+ * that: it validates the initial URL, fetches with `redirect: 'manual'`, and
+ * re-runs validatePublicUrl() on the Location of every hop before following
+ * it. Cross-host or private redirect targets throw UnsafeUrlError.
+ *
+ * Per-hop method handling mirrors the fetch spec: 303 (and 301/302 on a
+ * non-GET/HEAD request) downgrade to GET and drop the body; 307/308 preserve
+ * both. The DNS-rebinding caveat documented on validatePublicUrl() still
+ * applies — each hop validates the hostname literal, not the resolved IP.
+ */
+export async function safeFetch(
+  rawUrl: string,
+  init: RequestInit = {},
+  options: SafeFetchOptions = {},
+): Promise<Response> {
+  const maxRedirects = options.maxRedirects ?? 5;
+  let currentUrl = validatePublicUrl(rawUrl, options).toString();
+  let method = init.method ?? 'GET';
+  let body = init.body;
+
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const res = await fetch(currentUrl, { ...init, method, body, redirect: 'manual' });
+
+    if (!REDIRECT_STATUSES.has(res.status)) return res;
+
+    const location = res.headers.get('location');
+    // A 3xx with no Location is not followable; hand it back unchanged.
+    if (!location) return res;
+
+    // Resolve relative Locations against the current URL, then re-validate
+    // the absolute target before the next hop touches the network.
+    const next = new URL(location, currentUrl);
+    validatePublicUrl(next.toString(), options);
+    currentUrl = next.toString();
+
+    const downgradeToGet =
+      res.status === 303 ||
+      ((res.status === 301 || res.status === 302) && method !== 'GET' && method !== 'HEAD');
+    if (downgradeToGet) {
+      method = 'GET';
+      body = undefined;
+    }
+  }
+
+  throw new UnsafeUrlError(`Too many redirects (>${maxRedirects})`);
+}


### PR DESCRIPTION
Implements **Step 3** of the [2026-07 codebase audit](docs/audit-2026-07.md) remediation order: the outbound-fetch SSRF cluster (**H5**, **M-SSRF**). CalDAV, CardDAV, and Immich fetched user-supplied server URLs without the `validatePublicUrl()` guard the codebase already applies elsewhere — so an authenticated parent could paste a loopback / RFC1918 / `169.254.169.254` address into a server-URL field and use Prism to probe the internal network.

## Changes

| Audit ID | Fix |
|---|---|
| **new** | `safeFetch()` in `safeFetch.ts` — SSRF-safe `fetch` wrapper: validates the initial URL, fetches with `redirect: 'manual'`, and re-runs `validatePublicUrl()` on **every redirect Location** before following it. Spec-correct method handling (303/301/302 → GET + drop body; 307/308 preserved) and a bounded hop count. |
| **H5** | `caldav.ts` — `validatePublicUrl(serverUrl)` at the top of all seven exported entry points (`test`/`discover`/`fetch events`/`fetch tasks`/`create`/`update`/`delete`). `testCalDAVConnection` now returns a **uniform** rejection so `/api/caldav/test` can no longer be used as an internal-host existence oracle. |
| **M-SSRF** | `immich.ts` — all outbound calls routed through `safeFetch`; removed the `redirect: 'follow'` that let a public share URL 30x-redirect to an internal host and return its body. |
| **M-SSRF** | `carddav.ts` — validates the **derived** URL (after the iCloud CalDAV→CardDAV host swap), which is what tsdav actually fetches. |

## Known limitation (documented inline)

tsdav owns its own fetch and follows redirects internally, so the CalDAV/CardDAV guards validate only the **initial host literal** — not redirect targets or the DNS-resolved IP (same DNS-rebinding caveat already documented in `safeFetch.ts`). This closes the primary vector; Immich (which uses the platform `fetch`) additionally gets full per-hop redirect re-validation via `safeFetch`.

## Tests

- `safeFetch` redirect re-validation: follows public→public, **blocks** redirect to metadata IP / loopback, resolves relative Locations, method downgrade/preservation, `maxRedirects` cap.
- Per-client private-target rejection for CalDAV (7 fns) and CardDAV, asserting `createDAVClient` is **never reached**; CardDAV derived-URL validation.
- End-to-end Immich test: a public share URL that 302-redirects to `169.254.169.254` throws `UnsafeUrlError` and never fetches the internal target.
- Full suite green — **1191 passing**.

## Notes

- Branched off `master` (independent of the Step-1 authorization sweep in #153).
- Follow-ups still open from the audit: Step 4 dependency bumps (H6/H7/M-DEPS), Step 5 session/OAuth/SW hardening.
