### PR TITLE
fix(correctness): rate-limit lockout, weather TZ buckets, Google 404 auto-disable, globe deps

### DIFF
--- a/src/app/travel/components/TravelGlobe.tsx
+++ b/src/app/travel/components/TravelGlobe.tsx
@@ -167,7 +167,11 @@ export function TravelGlobe({
       markersRef.current.set(pin.id, marker);
     }
     updateCullingRef.current?.();
-  }, [pins, trips, selectedPinId, zoomTier]); // eslint-disable-line react-hooks/exhaustive-deps
+    // selectedTripId feeds buildTripContextMap above; without it in the deps,
+    // selecting/deselecting a trip (while selectedPinId is unchanged) never
+    // re-highlighted the stop markers. The sibling trip-line effects already
+    // list it.
+  }, [pins, trips, selectedPinId, selectedTripId, zoomTier]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Trip lines — all trips rendered; active gets full style, others are faded
   useEffect(() => {

--- a/src/lib/cache/__tests__/rateLimit.test.ts
+++ b/src/lib/cache/__tests__/rateLimit.test.ts
@@ -46,22 +46,38 @@ describe('checkRateLimit', () => {
     expect(result.remaining).toBe(9);
   });
 
-  it('sets expiry only on first request (count=1)', async () => {
+  it('sets expiry on the first request (key has no TTL yet)', async () => {
     setupRedisClient();
     mockIncr.mockResolvedValue(1);
+    mockTtl.mockResolvedValue(-1); // fresh key from INCR has no expiry
 
     await checkRateLimit('user-1', 'test', 10, 60);
 
     expect(mockExpire).toHaveBeenCalledWith('ratelimit:user-1:test', 60);
   });
 
-  it('does not set expiry on subsequent requests (count>1)', async () => {
+  it('does not re-issue expiry while the window is active (TTL>0)', async () => {
     setupRedisClient();
     mockIncr.mockResolvedValue(5);
+    mockTtl.mockResolvedValue(42);
 
     await checkRateLimit('user-1', 'test', 10, 60);
 
     expect(mockExpire).not.toHaveBeenCalled();
+  });
+
+  it('re-issues expiry when a prior EXPIRE was dropped, preventing a permanent lockout', async () => {
+    // Regression (M-RATELIMIT): a crash between INCR and EXPIRE leaves the key
+    // with no TTL. Here count is already past the limit and TTL is -1 — without
+    // the self-heal the key would live forever and the user could never reset.
+    setupRedisClient();
+    mockIncr.mockResolvedValue(50);
+    mockTtl.mockResolvedValue(-1);
+
+    const result = await checkRateLimit('user-1', 'test', 10, 60);
+
+    expect(mockExpire).toHaveBeenCalledWith('ratelimit:user-1:test', 60);
+    expect(result.resetIn).toBe(60); // recovered window, not left as -1
   });
 
   it('blocks when count exceeds maxRequests', async () => {

--- a/src/lib/cache/rateLimit.ts
+++ b/src/lib/cache/rateLimit.ts
@@ -73,12 +73,18 @@ export async function checkRateLimit(
   try {
     const count = await client.incr(key);
 
-    // Set expiry only on the first request in the window
-    if (count === 1) {
+    // After INCR the key always exists, so TTL is either >0 (window active) or
+    // -1 (no expiry). -1 happens on the first request in a window AND when a
+    // prior EXPIRE was dropped (e.g. a crash between INCR and EXPIRE). Re-issue
+    // the expiry whenever there is none: otherwise the key would live forever,
+    // the counter could never reset, and the user would be permanently locked
+    // out once past maxRequests. This makes the window self-healing rather than
+    // setting the expiry only on count === 1.
+    let ttl = await client.ttl(key);
+    if (ttl < 0) {
       await client.expire(key, windowSeconds);
+      ttl = windowSeconds;
     }
-
-    const ttl = await client.ttl(key);
 
     return {
       allowed: count <= maxRequests,

--- a/src/lib/integrations/__tests__/openmeteo.test.ts
+++ b/src/lib/integrations/__tests__/openmeteo.test.ts
@@ -330,6 +330,44 @@ describe('openmeteo.fetchWeatherData', () => {
     }
   });
 
+  it('buckets day-part periods by the location timezone, not container UTC (M-WEATHER)', async () => {
+    // Pin the clock so absolute Chicago hours are deterministic. now = 11:00Z
+    // = 06:00 CDT, so an 08:00-Chicago (13:00Z) and a 14:00-Chicago (19:00Z)
+    // hour both fall inside the (now-1h, now+12h] window. Fake only the Date
+    // clock; leave timer fns real (the fetch path uses none).
+    jest.useFakeTimers({
+      now: new Date('2026-07-15T11:00:00Z').getTime(),
+      doNotFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask', 'nextTick'],
+    });
+    try {
+      const response = buildResponse('America/Chicago');
+      // 08:00 Chicago → 13:00Z (UTC hour 13 = "Afternoon" under the old bug).
+      // 14:00 Chicago → 19:00Z (UTC hour 19 = "Evening" under the old bug).
+      response.hourly.time = ['2026-07-15T08:00', '2026-07-15T14:00'];
+      response.hourly.temperature_2m = [50, 80];
+      response.hourly.precipitation_probability = [0, 0];
+      response.hourly.precipitation = [0, 0];
+      response.hourly.weather_code = [0, 0];
+
+      jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+        ok: true,
+        json: async () => response,
+      } as never);
+
+      const { fetchWeatherData } = await import('../openmeteo');
+      const result = await fetchWeatherData();
+
+      const byLabel = Object.fromEntries((result.periods ?? []).map((p) => [p.label, p]));
+      // Correct (location-TZ) bucketing: 08:00 → Morning, 14:00 → Afternoon.
+      expect(byLabel.Morn?.temp).toBe(50);
+      expect(byLabel.Aft?.temp).toBe(80);
+      // The old UTC bucketing would have pushed 19:00Z into an Evening period.
+      expect(byLabel.Eve).toBeUndefined();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('does not require any API key (zero env-var configuration)', async () => {
     // Strip any provider key env vars to prove openmeteo doesn't read them.
     const stripped = { ...process.env };

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -323,7 +323,18 @@ export async function fetchWeatherData(
   );
 
   // ── Periods (Morning / Afternoon / Evening) ───────────────────────────────
-  const todayStr = new Date().toLocaleDateString('en-CA');
+  // Bucket by the *location's* timezone, not the container's runtime TZ (UTC).
+  // h.time is a correct UTC instant; getHours()/toLocaleDateString() would read
+  // it in UTC, so e.g. Chicago 8am (13:00 UTC) fell into "Afternoon" and late
+  // evening hours rolled to the wrong calendar day and dropped. Intl formatters
+  // pinned to `timezone` give the local hour/date. `todayLocalStr` (already the
+  // location-TZ date, computed above) is the correct "today" anchor.
+  const hourInTz = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    hour: '2-digit',
+    hourCycle: 'h23',
+  });
+  const dateInTz = new Intl.DateTimeFormat('en-CA', { timeZone: timezone });
   const periodDefs = [
     { label: 'Morn', minHour: 6, maxHour: 12 },
     { label: 'Aft', minHour: 12, maxHour: 18 },
@@ -332,10 +343,11 @@ export async function fetchWeatherData(
   const periods: ForecastPeriod[] = [];
   for (const def of periodDefs) {
     const matching = hourlyData.filter((h) => {
+      const localHour = parseInt(hourInTz.format(h.time), 10);
       return (
-        h.time.toLocaleDateString('en-CA') === todayStr &&
-        h.time.getHours() >= def.minHour &&
-        h.time.getHours() < def.maxHour
+        dateInTz.format(h.time) === todayLocalStr &&
+        localHour >= def.minHour &&
+        localHour < def.maxHour
       );
     });
     if (matching.length > 0) {

--- a/src/lib/services/__tests__/calendar-sync.test.ts
+++ b/src/lib/services/__tests__/calendar-sync.test.ts
@@ -287,6 +287,72 @@ describe('syncGoogleCalendarSource', () => {
   });
 });
 
+describe('syncGoogleCalendarSource — auto-disable gated on consecutive 404s (M-CALSYNC)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+  });
+
+  /** The object handed to db.update().set() in the fetch-failure branch. */
+  function lastSetArg() {
+    return mockUpdateSet.mock.calls[0]![0] as {
+      enabled?: boolean;
+      syncErrors: { consecutive404: number; consecutiveFailures: number };
+    };
+  }
+
+  it('does not auto-disable on the first 404 after transient (non-404) failures', async () => {
+    // Two prior transient failures already reset the 404 streak to 0.
+    mockFindFirst.mockResolvedValue(
+      makeSource({ syncErrors: { consecutiveFailures: 2, consecutive404: 0 } }),
+    );
+    mockFetchCalendarEvents.mockRejectedValue(new Error('Google API error: 404 Not Found'));
+
+    await syncGoogleCalendarSource('source-1');
+
+    const set = lastSetArg();
+    expect(set.syncErrors.consecutive404).toBe(1);
+    expect(set.enabled).toBeUndefined(); // NOT disabled on the first real 404
+  });
+
+  it('auto-disables only after 3 consecutive 404s', async () => {
+    mockFindFirst.mockResolvedValue(
+      makeSource({ syncErrors: { consecutiveFailures: 5, consecutive404: 2 } }),
+    );
+    mockFetchCalendarEvents.mockRejectedValue(new Error('404 Not Found'));
+
+    await syncGoogleCalendarSource('source-1');
+
+    const set = lastSetArg();
+    expect(set.syncErrors.consecutive404).toBe(3);
+    expect(set.enabled).toBe(false);
+  });
+
+  it('resets the 404 streak on a non-404 failure', async () => {
+    mockFindFirst.mockResolvedValue(
+      makeSource({ syncErrors: { consecutiveFailures: 2, consecutive404: 2 } }),
+    );
+    mockFetchCalendarEvents.mockRejectedValue(new Error('500 Internal Server Error'));
+
+    await syncGoogleCalendarSource('source-1');
+
+    const set = lastSetArg();
+    expect(set.syncErrors.consecutive404).toBe(0);
+    expect(set.enabled).toBeUndefined();
+  });
+
+  it('never auto-disables a source the user manually re-enabled (userOverride)', async () => {
+    mockFindFirst.mockResolvedValue(
+      makeSource({ syncErrors: { consecutive404: 5, userOverride: true } }),
+    );
+    mockFetchCalendarEvents.mockRejectedValue(new Error('404 Not Found'));
+
+    await syncGoogleCalendarSource('source-1');
+
+    expect(lastSetArg().enabled).toBeUndefined();
+  });
+});
+
 describe('syncAllGoogleCalendars', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -139,10 +139,18 @@ export async function syncGoogleCalendarSource(
     const prevErrors = (source.syncErrors as Record<string, unknown>) || {};
     const prevFailures = (typeof prevErrors.consecutiveFailures === 'number' ? prevErrors.consecutiveFailures : 0);
     const consecutiveFailures = prevFailures + 1;
+    // Auto-disable is gated on *consecutive 404s* specifically: a calendar the
+    // user deleted in Google keeps returning 404, whereas transient network /
+    // 5xx blips must not count toward disabling. The 404 streak resets on any
+    // non-404 failure (and a successful sync clears syncErrors entirely). The
+    // old code counted all failures, so two transient errors + one real 404
+    // disabled the calendar on its *first* 404 — contradicting this comment.
+    const prev404 = (typeof prevErrors.consecutive404 === 'number' ? prevErrors.consecutive404 : 0);
+    const consecutive404 = is404 ? prev404 + 1 : 0;
     const DISABLE_THRESHOLD = 3; // Only auto-disable after 3 consecutive 404s
 
     const shouldAutoDisable = is404
-      && consecutiveFailures >= DISABLE_THRESHOLD
+      && consecutive404 >= DISABLE_THRESHOLD
       && !prevErrors.userOverride; // Never auto-disable if user manually re-enabled
 
     await db
@@ -151,9 +159,10 @@ export async function syncGoogleCalendarSource(
         ...(shouldAutoDisable ? { enabled: false, showInEventModal: false } : {}),
         syncErrors: {
           lastError: is404
-            ? `Calendar not found in Google (404). Failure ${consecutiveFailures}/${DISABLE_THRESHOLD}.`
+            ? `Calendar not found in Google (404). Failure ${consecutive404}/${DISABLE_THRESHOLD}.`
             : errorStr,
           consecutiveFailures,
+          consecutive404,
           is404,
           ...(shouldAutoDisable ? { autoDisabled: true, autoDisabledAt: new Date().toISOString() } : {}),
           ...(prevErrors.userOverride ? { userOverride: true } : {}),


### PR DESCRIPTION
Implements **Step 6** of the [2026-07 codebase audit](docs/audit-2026-07.md) remediation order — the correctness cluster. Four independent bugs, each with a regression test.

## Fixes

### M-RATELIMIT — permanent lockout on a dropped EXPIRE
`checkRateLimit` set the key's `EXPIRE` only when `count === 1`. A crash between `INCR` and `EXPIRE` left the key with **no TTL** — the counter never reset, so the user was **permanently locked out** once past `maxRequests` (the code read `ttl` but never acted on `-1`). Now every request re-issues the expiry whenever the observed TTL is missing (`< 0`), so the window self-heals within one window even after a dropped `EXPIRE`.

### M-WEATHER — day-part buckets computed in container UTC
The Morning/Afternoon/Evening buckets used `getHours()` / `toLocaleDateString()`, reading each hour in the **container's** TZ (UTC) rather than the forecast location's. Chicago 8am (13:00 UTC) landed in *Afternoon*, and evening hours rolled to the wrong calendar day and dropped. Now bucketed via `Intl.DateTimeFormat` pinned to the location timezone (the same pattern already used for the daily/hourly paths), reusing the correct `todayLocalStr` anchor.

### M-CALSYNC — Google auto-disable counted all failures, not consecutive 404s
Auto-disable was gated on `consecutiveFailures` (incremented on *any* failure, never reset), so two transient network/5xx blips plus one real 404 disabled the calendar on its **first** 404 — contradicting the "3 consecutive 404s" comment. Added a separate `consecutive404` counter that resets on any non-404 failure (a successful sync already clears `syncErrors`).

### M-GLOBE — stale trip highlight
The marker-sync effect passed `selectedTripId` into `buildTripContextMap` but omitted it from the dependency array, so selecting/deselecting a trip (with `selectedPinId` unchanged) never re-highlighted the stop markers. Added the dep — the sibling trip-line effects already list it.

## Verification
- `tsc --noEmit` — clean
- New tests: rate-limit **dropped-EXPIRE recovery** (the lockout regression); weather **location-TZ bucketing** using a fake clock at a UTC-vs-Chicago day-part boundary (fails under the old code); Google **consecutive-404 gating** + non-404 reset + `userOverride`
- **Full suite: 1162 passing**

## Notes
- M-GLOBE is a one-line React dep-array fix (caught by `react-hooks/exhaustive-deps`); the map effect isn't practically unit-testable, so no dedicated test — consistent with the audit marking it auto-fixable (#38).
- Branched off `master`; independent of the earlier audit PRs (#153, #155, #156, #157).

## Audit status after this PR
Remaining: **M-TEST #66** (Linux visual baselines — a CI/PNG task), the deferred **next-pwa migration** (M-DEPS #54), and the **low-severity cleanup batch** (dead code, indexes, type-safety, docs).
