### PR TITLE
chore(cleanup): remove dead defaultAuthor prop and MsListSelectionModal alias

### DIFF
--- a/src/app/settings/sections/ShoppingIntegrationsSection.tsx
+++ b/src/app/settings/sections/ShoppingIntegrationsSection.tsx
@@ -8,7 +8,7 @@ import type { ShoppingListSource } from './integrations/types';
 import {
   StatusBanner,
   ConnectedSourcesCard,
-  MsListSelectionModal,
+  ListSelectionModal,
   ProviderPickerModal,
   EntityListCard,
   ConfirmDialog,
@@ -108,7 +108,7 @@ export function ShoppingIntegrationsSection({
         }}
       />
 
-      <MsListSelectionModal
+      <ListSelectionModal
         open={integration.showMsListModal}
         onClose={integration.closeMsListModal}
         lists={integration.msLists}

--- a/src/app/settings/sections/WishListIntegrationsSection.tsx
+++ b/src/app/settings/sections/WishListIntegrationsSection.tsx
@@ -8,7 +8,7 @@ import type { WishItemSource } from './integrations/types';
 import {
   StatusBanner,
   ConnectedSourcesCard,
-  MsListSelectionModal,
+  ListSelectionModal,
   ProviderPickerModal,
   EntityListCard,
   ConfirmDialog,
@@ -101,7 +101,7 @@ export function WishListIntegrationsSection({
         }}
       />
 
-      <MsListSelectionModal
+      <ListSelectionModal
         open={integration.showMsListModal}
         onClose={integration.closeMsListModal}
         lists={integration.msLists}

--- a/src/app/settings/sections/integrations/components.tsx
+++ b/src/app/settings/sections/integrations/components.tsx
@@ -344,9 +344,6 @@ export function ListSelectionModal({
   );
 }
 
-/** @deprecated Use ListSelectionModal instead */
-export const MsListSelectionModal = ListSelectionModal;
-
 // ---- ProviderPickerModal ----
 
 export function ProviderPickerModal({

--- a/src/components/modals/AddMessageModal.tsx
+++ b/src/components/modals/AddMessageModal.tsx
@@ -70,8 +70,6 @@ export interface AddMessageModalProps {
     color: string;
     avatarUrl?: string | null;
   } | null;
-  /** @deprecated Use currentUser instead */
-  defaultAuthor?: string;
 }
 
 /**
@@ -82,11 +80,10 @@ export function AddMessageModal({
   onOpenChange,
   onMessageCreated,
   currentUser,
-  defaultAuthor,
 }: AddMessageModalProps) {
-  // Form state - use currentUser.id if available, otherwise defaultAuthor
+  // Form state — author defaults to the current user when one is provided.
   const [message, setMessage] = useState('');
-  const [authorId, setAuthorId] = useState<string>(currentUser?.id || defaultAuthor || '');
+  const [authorId, setAuthorId] = useState<string>(currentUser?.id || '');
   const [pinned, setPinned] = useState(false);
   const [important, setImportant] = useState(false);
   const [expiresIn, setExpiresIn] = useState<string>('never');
@@ -105,13 +102,13 @@ export function AddMessageModal({
   useEffect(() => {
     if (!open) {
       setMessage('');
-      setAuthorId(currentUser?.id || defaultAuthor || '');
+      setAuthorId(currentUser?.id || '');
       setPinned(false);
       setImportant(false);
       setExpiresIn('never');
       setError(null);
     }
-  }, [open, currentUser, defaultAuthor]);
+  }, [open, currentUser]);
 
   // Update authorId when currentUser changes
   useEffect(() => {


### PR DESCRIPTION
Two safe dead-code removals from the [2026-07 audit](docs/audit-2026-07.md) low-severity batch.

## Removed

- **#44 — `defaultAuthor` prop** on `AddMessageModal`. It was `@deprecated` and passed by **no caller** (both `MessagesView` and `Dashboard` omit it), so the fallback always collapsed to `currentUser?.id`. Dropped the prop, the destructure, both fallback expressions, and the stale effect dependency.
- **#45 — `MsListSelectionModal` alias**. A bare `@deprecated` re-export of `ListSelectionModal`. Switched its two callers (Shopping + WishList integration sections) to `ListSelectionModal` and deleted the alias.

## Deliberately excluded (flagged in the same batch, but not safe as code cleanup)

- **#42 `weekend_visits`** — this is a **DB table**, not dead code. Removing it from the Drizzle schema would generate a destructive DROP migration (data-loss risk). It needs a dedicated, reviewed migration, not a cleanup sweep.
- **#46 `useCelsius`** — **not actually dead**: it has a passing test and real `formatTempDisplay` logic (a dormant Celsius-display feature). Removing it would delete tested, coherent functionality rather than cruft.

## Verification
- `tsc --noEmit` — clean
- Full suite — **1156 passing**
- `next lint` on the four touched files — clean (only pre-existing style warnings)
