### PR TITLE
chore(release): 1.9.0 — security-hardening release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,7 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **The travel globe re-highlights trip stops correctly** when you select or deselect a trip.
 
 ### Fixed — Photos
-- **Immich album photo sources now sync on Immich v3.** An album-backed source synced **zero photos** on Immich v3: the old `GET /api/albums/{id}` listing returns an empty asset array over a share key, so the sync finished without error and added nothing. Prism now lists album assets via the paginated `POST /api/search/metadata` endpoint (requesting EXIF so photo GPS still reaches the Travel Map); thumbnail and original downloads were already fine and are unchanged. Thanks @guylenical (Guy Stanley) for the fix and for verifying it against a live v3 instance. Closes [#154](https://github.com/sandydargoport/prism/pull/154).
+- **Immich album photo sources now sync on Immich v3.** An album-backed source synced **zero photos** on Immich v3: the old `GET /api/albums/{id}` listing returns an empty asset array over a share key, so the sync finished without error and added nothing. Prism now lists album assets via the paginated `POST /api/search/metadata` endpoint (requesting EXIF so photo GPS still reaches the Travel Map); thumbnail and original downloads were already fine and are unchanged. Thanks @guylenical for the report and the suggested fix (verified against a live v3 instance). Closes [#154](https://github.com/sandydargoport/prism/pull/154).
 
 ## [1.8.14] – 2026-06-29
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,9 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **A Google calendar is only auto-disabled after 3 *consecutive* 404s**, not three assorted failures — transient network/5xx blips no longer count toward disabling a calendar that still exists.
 - **The travel globe re-highlights trip stops correctly** when you select or deselect a trip.
 
+### Fixed — Photos
+- **Immich album photo sources now sync on Immich v3.** An album-backed source synced **zero photos** on Immich v3: the old `GET /api/albums/{id}` listing returns an empty asset array over a share key, so the sync finished without error and added nothing. Prism now lists album assets via the paginated `POST /api/search/metadata` endpoint (requesting EXIF so photo GPS still reaches the Travel Map); thumbnail and original downloads were already fine and are unchanged. Thanks @guylenical (Guy Stanley) for the fix and for verifying it against a live v3 instance. Closes [#154](https://github.com/sandydargoport/prism/pull/154).
+
 ## [1.8.14] – 2026-06-29
 
 ### Fixed — Display

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.9.0] – 2026-07-24
+
+Security-hardening release from a full codebase audit. It closes a cluster of access-control gaps on the API, adds server-side-request-forgery guards to the calendar/photo integrations, hardens sessions and OAuth, and updates dependencies carrying published advisories. No changes to how Prism behaves for you day-to-day, and no database migration — but if you run Prism on a network-exposed Home Assistant ingress, this is a recommended upgrade.
+
+### Security — Access control
+- **Item-level edit/delete on events, chores, calendars, and photo sources now enforce the same permissions as the rest of the app.** Several `PATCH`/`DELETE` endpoints checked only that you were signed in, not *which* role you had — so a child, guest, or a narrowly-scoped API token could edit or delete family data (and, for calendars/photo sources, cascade-delete the linked source and its on-disk originals) by addressing it directly by id. Every one of these now applies the owner-or-role check the collection routes already used. Chore completion is now anchored to the signed-in caller, closing an approval bypass where a child could self-approve by supplying a parent's id.
+- **API-token scopes are enforced on the admin routes.** Bearer tokens were treated as full parent on the database and backup routes regardless of their scope; a `voice`-scoped token could truncate/seed the database or download/restore/delete backups. Scopes are now honored.
+- **Kiosk PIN lockout can no longer be brute-forced** (the lockout counter is keyed on the resolved user, so failed attempts actually accumulate).
+
+### Security — Server-side request forgery (SSRF)
+- **CalDAV, CardDAV, and Immich outbound fetches now validate the target address.** A signed-in parent could previously point one of these at a loopback / private / cloud-metadata address and use Prism to probe the internal network. All three now reject private targets before connecting, the CalDAV *test* endpoint no longer leaks whether an internal host exists, and Immich no longer follows a redirect to an internal host.
+
+### Security — Sessions, OAuth & storage
+- **Sessions now have an absolute lifetime** (parent 30 days / child 7 / guest 1 hour) on top of the existing sliding window, so a stolen session cookie can't be kept alive indefinitely.
+- **Google and Microsoft OAuth now verify a single-use state nonce**, matching the Kroger flow — closing a window where a valid `code` could bind an attacker's account (or an attacker-chosen owner) to the dashboard. The Microsoft photo-source callback, previously unauthenticated, now requires a signed-in parent.
+- **The service worker no longer caches authenticated `/api` responses to disk** — previously messages, family, tokens, and other per-session data were written into on-disk Cache Storage and outlived the session on a shared kiosk.
+- **Avatar and recipe-image URLs validate the id** before reading from disk, rejecting path-traversal payloads.
+
+### Security — Dependencies
+- Updated dependencies carrying published advisories: **Next.js** (`15.5.21`), **drizzle-orm** (`0.45.2`), **node-ical** (`0.27.1`, which also drops a vulnerable bundled `axios`), **undici** (`6.27.0`), and **dompurify** (`3.4.x`), plus dev tooling (postcss, next-tooling alignment). The abandoned `next-pwa`/Workbox build chain is a known remaining item slated for a separate migration.
+
+### Fixed — Correctness
+- **The API rate limiter can no longer permanently lock you out.** If Redis dropped the window's expiry (e.g. a crash at the wrong moment), the counter never reset and you'd stay blocked; the window now self-heals.
+- **Weather "Morning / Afternoon / Evening" temperatures now bucket by the forecast location's timezone**, not the server's UTC clock — so day-parts land on the right hours and don't roll to the wrong day.
+- **A Google calendar is only auto-disabled after 3 *consecutive* 404s**, not three assorted failures — transient network/5xx blips no longer count toward disabling a calendar that still exists.
+- **The travel globe re-highlights trip stops correctly** when you select or deselect a trip.
+
 ## [1.8.14] – 2026-06-29
 
 ### Fixed — Display

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.8.14"
+version: "1.9.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism",
-  "version": "1.8.14",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism",
-      "version": "1.8.14",
+      "version": "1.9.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.8.14",
+  "version": "1.9.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Cuts **v1.9.0**, the security-hardening release from the 2026-07 codebase audit. Bundles the six merged PRs — #153 (authorization sweep), #155 (SSRF guards), #156 (session/OAuth/SW/path), #157 (dependency upgrades), #158 (correctness fixes), #159 (dead-code cleanup).

## Version bump
- `package.json`, `package-lock.json`, `ha-app/config.yaml`: `1.8.14 → 1.9.0`
- `docs/CHANGELOG.md`: new `[1.9.0]` section (user-facing prose, grouped by area)

## Why minor (1.9.0), not patch
Clears **7 High** security findings plus a swath of Medium, and modernizes the dependency tree (Next / drizzle-orm / node-ical majors) — too significant for a patch, but **no breaking changes** to Prism's own behavior, so not a major.

## Deploy notes
- **No database migration** in this release — code + deps only (`drizzle-kit check` confirmed no schema drift). The schema-change hand-copy gotcha does **not** apply.
- Integrated master (all six PRs) verified: `tsc` clean, **1282 tests passing**, `next build` OK.

## ⚠️ This PR does NOT tag or deploy
Merging it only lands the version bump. **Tagging `v1.9.0` (which fires the Home Assistant image build) is a separate manual step** — do that when you're ready to ship. Adjust the version number or changelog here first if you'd prefer something different.
