### PR TITLE
fix(immich): sync shared-album assets on Immich v3 (rebased #154 + SSRF-safe)

### DIFF
--- a/src/lib/integrations/__tests__/immich.test.ts
+++ b/src/lib/integrations/__tests__/immich.test.ts
@@ -144,7 +144,7 @@ describe('fetchSharedLink (public)', () => {
 });
 
 describe('fetchSharedLink (ALBUM-type follow-up)', () => {
-  it('follows up with /albums/{id} when share type is ALBUM (assets live there, not on the share)', async () => {
+  it('follows up with search/metadata when share type is ALBUM (Immich v3 serves album assets there)', async () => {
     mockFetchSequence([
       // /shared-links/me — ALBUM-type shares return album metadata only, no assets.
       () => ({
@@ -160,27 +160,31 @@ describe('fetchSharedLink (ALBUM-type follow-up)', () => {
             assets: [],
           }),
       }),
-      // /albums/{id} — the actual asset list.
+      // /search/metadata — the actual asset list, in the paginated envelope.
       () => ({
         ok: true,
         status: 200,
         headers: new Headers(),
         json: () =>
           Promise.resolve({
-            id: 'album-uuid',
-            albumName: 'Cats',
-            assets: [
-              {
-                id: 'a1',
-                originalFileName: 'kitten.jpg',
-                originalMimeType: 'image/jpeg',
-                type: 'IMAGE',
-                fileCreatedAt: '2025-06-01T00:00:00.000Z',
-                width: 1920,
-                height: 1080,
-                exifInfo: { latitude: null, longitude: null },
-              },
-            ],
+            albums: { total: 0, count: 0, items: [] },
+            assets: {
+              total: 1,
+              count: 1,
+              nextPage: null,
+              items: [
+                {
+                  id: 'a1',
+                  originalFileName: 'kitten.jpg',
+                  originalMimeType: 'image/jpeg',
+                  type: 'IMAGE',
+                  fileCreatedAt: '2025-06-01T00:00:00.000Z',
+                  width: 1920,
+                  height: 1080,
+                  exifInfo: { latitude: null, longitude: null },
+                },
+              ],
+            },
           }),
       }),
     ]);
@@ -190,11 +194,63 @@ describe('fetchSharedLink (ALBUM-type follow-up)', () => {
     const calls = (global.fetch as jest.Mock).mock.calls;
     expect(calls).toHaveLength(2);
     expect(calls[0][0]).toBe('https://im/api/shared-links/me?key=k');
-    expect(calls[1][0]).toBe('https://im/api/albums/album-uuid?key=k');
+    expect(calls[1][0]).toBe('https://im/api/search/metadata?key=k');
+    // The album id is sent as a search filter in the POST body.
+    expect(calls[1][1].method).toBe('POST');
+    expect(JSON.parse(calls[1][1].body)).toMatchObject({ albumIds: ['album-uuid'] });
 
     expect(link.albumId).toBe('album-uuid');
     expect(link.assets).toHaveLength(1);
     expect(link.assets[0]).toMatchObject({ id: 'a1', originalFileName: 'kitten.jpg' });
+  });
+
+  it('paginates search/metadata via nextPage until it is null', async () => {
+    const makeAsset = (id: string) => ({
+      id,
+      originalFileName: `${id}.jpg`,
+      originalMimeType: 'image/jpeg',
+      type: 'IMAGE',
+      fileCreatedAt: '2025-06-01T00:00:00.000Z',
+      width: 1,
+      height: 1,
+      exifInfo: { latitude: null, longitude: null },
+    });
+    mockFetchSequence([
+      () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            type: 'ALBUM',
+            album: { id: 'album-uuid', albumName: 'Big' },
+            password: null,
+            assets: [],
+          }),
+      }),
+      // page 1 -> nextPage 2
+      () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.resolve({ assets: { nextPage: '2', items: [makeAsset('a1')] } }),
+      }),
+      // page 2 -> nextPage null (last page)
+      () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.resolve({ assets: { nextPage: null, items: [makeAsset('a2')] } }),
+      }),
+    ]);
+
+    const link = await fetchSharedLink({ serverUrl: 'https://im', shareKey: 'k' });
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(3);
+    expect(JSON.parse(calls[1][1].body)).toMatchObject({ page: 1 });
+    expect(JSON.parse(calls[2][1].body)).toMatchObject({ page: 2 });
+    expect(link.assets.map((a) => a.id)).toEqual(['a1', 'a2']);
   });
 
   it('forwards the login session cookie on the album request for password-protected ALBUM shares', async () => {
@@ -218,14 +274,14 @@ describe('fetchSharedLink (ALBUM-type follow-up)', () => {
         ok: true,
         status: 200,
         headers: new Headers(),
-        json: () => Promise.resolve({ assets: [] }),
+        json: () => Promise.resolve({ assets: { nextPage: null, items: [] } }),
       }),
     ]);
 
     await fetchSharedLink({ serverUrl: 'https://im', shareKey: 'k', password: 'pw' });
 
     const albumCall = (global.fetch as jest.Mock).mock.calls[1];
-    expect(albumCall[0]).toBe('https://im/api/albums/album-uuid?key=k');
+    expect(albumCall[0]).toBe('https://im/api/search/metadata?key=k');
     expect(albumCall[1].headers.Cookie).toContain('immich_shared_link_token=abc');
   });
 

--- a/src/lib/integrations/immich.ts
+++ b/src/lib/integrations/immich.ts
@@ -198,19 +198,48 @@ async function fetchAlbumAssets(
   cookie: string | null,
 ): Promise<RawAsset[]> {
   assertSafeServerUrl(serverUrl);
-  const url = `${serverUrl}/api/albums/${albumId}?key=${encodeURIComponent(shareKey)}`;
-  const headers: Record<string, string> = {};
+  // Immich v3 serves a shared album's assets through the search API, not
+  // GET /api/albums/{id}: over a share key that endpoint returns the album's
+  // assetCount but an EMPTY assets array, so the old call silently synced zero
+  // photos. POST /api/search/metadata returns the assets in a paginated
+  // envelope ({ assets: { items, nextPage } }). withExif keeps GPS so the
+  // Travel Map photo strip still works.
+  const url = `${serverUrl}/api/search/metadata?key=${encodeURIComponent(shareKey)}`;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (cookie) headers.Cookie = cookie;
 
-  const res = await safeFetch(url, { headers });
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch Immich album ${albumId}: ${res.status} ${res.statusText}`,
-    );
+  const all: RawAsset[] = [];
+  let page = 1;
+  // Bounded so a misbehaving nextPage can never loop forever (100 * 1000
+  // assets is far beyond any realistic shared album).
+  for (let i = 0; i < 100; i += 1) {
+    // safeFetch (not raw fetch) so a share URL that 30x-redirects to an
+    // internal host is still re-validated per hop — same SSRF guard the rest
+    // of this client uses.
+    const res = await safeFetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ albumIds: [albumId], page, size: 1000, withExif: true }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch Immich album ${albumId}: ${res.status} ${res.statusText}`,
+      );
+    }
+
+    const data = (await res.json()) as {
+      assets?: { items?: RawAsset[]; nextPage?: string | number | null };
+    };
+    all.push(...(data.assets?.items ?? []));
+
+    const next = data.assets?.nextPage;
+    if (next == null) break;
+    const nextPage = Number(next);
+    if (!Number.isFinite(nextPage) || nextPage <= page) break;
+    page = nextPage;
   }
 
-  const data = (await res.json()) as { assets?: RawAsset[] };
-  return data.assets ?? [];
+  return all;
 }
 
 function extractCookies(headers: Headers): string | null {


### PR DESCRIPTION
Rebased version of **#154** (by @guylenical / Guy Stanley) onto current `master`, resolving its conflict with the merged SSRF PR (#155) so it can ride in the 1.9.0 release. Original authorship preserved on the commit.

## What it fixes
On **Immich v3**, an album-backed photo source syncs **zero photos**: `GET /api/albums/{id}?key=…` returns the album's `assetCount` but an empty `assets` array over a share key, so the sync completes without error and inserts nothing. The listing now uses `POST /api/search/metadata` filtered by `albumIds`, paginated via `nextPage` with a hard 100-iteration runaway cap, and `withExif: true` so photo GPS still reaches the Travel Map. Only the **listing** call changed — thumbnail/original downloads were already fine on v3 and are untouched.

## The one change I made resolving the conflict
#154 predates #155, so its new listing call used raw `fetch(...)`. Landing that as-is would **reintroduce the redirect-based SSRF hole** #155 just closed on the album path. I changed that single call from `fetch` → **`safeFetch`** (the wrapper added in #155, which re-validates every redirect hop and passes POST method/body through unchanged). Nothing else in the contributor's logic changed.

## Verification
- `tsc --noEmit` clean
- `immich.test.ts` — **32/32 pass**: the contributor's updated ALBUM + new pagination tests *and* #155's SSRF redirect test all green together
- Full suite — **1283 passing**

## Release
Intended for **v1.9.0** (folded into release PR #160 rather than a separate release). Closes #154.
