### PR TITLE
fix(deploy): use 'docker compose' v2 in deploy-local.sh

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -19,7 +19,7 @@ docker exec --user root prism-app sh -c "rm -rf /app/.next/static && mkdir -p /a
 docker cp .next/static/. prism-app:/app/.next/static/
 
 echo "Restarting app..."
-docker-compose restart app
+docker compose restart app
 
 echo "Done. Waiting for health check..."
 sleep 5


### PR DESCRIPTION
The deploy host has no `docker-compose` (v1) binary — only Compose v2 — so `deploy-local.sh`'s restart step failed with `docker-compose: command not found` on every run and had to be finished by hand (`docker compose restart app`). This one-line change makes the script self-complete.

Surfaced during the 1.9.0 deploy. No behavior change beyond the restart now succeeding.