### PR TITLE
docs(planning): add planning/status index + tidy stale references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@
 3. Run the quality checks (see below)
 4. Submit a pull request
 
+**Not sure what to work on?** The public roadmap is the [Prism Roadmap project](https://github.com/users/sandydargoport/projects/3) (vote with an emoji reaction). Internal planning, the untracked backlog, and the engineering-reference docs are all indexed in [`docs/planning.md`](docs/planning.md).
+
 ## Quality Standards
 
 All pull requests must meet the following Lighthouse score thresholds:

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -28,7 +28,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 | **Meal planning + recipes** | ✅ Built-in (Paprika import, OCR) | ❌ | ❌ | Via module |
 | **Photo screensaver** | ✅ OneDrive sync + slideshow + Ken Burns | ✅ | ✅ | Via module |
 | **Shopping with Kroger / Mariano's push** | ✅ One-click cart push | ❌ | ❌ | ❌ |
-| **Home Assistant integration** | 🚧 [In progress (#81)](https://github.com/sandydargoport/prism/issues/81) | ❌ | Limited | ✅ Native HA card available |
+| **Home Assistant integration** | ✅ [Embed as a panel, REST sensors, + one-click add-on](home-assistant.md) | ❌ | Limited | ✅ Native HA card available |
 | **Voice / Alexa skill** | ✅ Voice API foundation (v1.8) | ❌ | ❌ | Via module |
 | **Vendor lock-in** | None — your data, your DB | High | Medium | None |
 | **You own your data** | ✅ Always | ❌ Hosted by Skylight | ❌ Hosted by Dakboard | ✅ |
@@ -72,7 +72,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 Being fair:
 
 - **Hardware curation.** Skylight ships a beautiful purpose-built display. You have to source your own (a 27" 4K display + a small PC works great, but you have to pick it).
-- **Onboarding friction.** Skylight is plug-and-play. Prism needs Docker + ~15 minutes of setup. We're working on the Home Assistant addon path ([#81](https://github.com/sandydargoport/prism/issues/81)) to close this gap.
+- **Onboarding friction.** Skylight is plug-and-play. Prism needs Docker + ~15 minutes of setup — though Prism now installs as a [Home Assistant add-on](home-assistant.md) for a much simpler path if you already run HA.
 - **Mature ecosystem.** MagicMirror² has a community module for everything. Prism is younger; we're integration-rich but not module-exhaustive.
 
 If those trade-offs are deal-breakers for your household, one of the others is the better fit. If they aren't — Prism is what you've been looking for.

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -1,5 +1,7 @@
 # Prism codebase audit — 2026-07-21
 
+> **Status: ✅ Fully remediated in [v1.9.0](CHANGELOG.md)** (2026-07-24). This report is kept as a historical record — every finding below has been addressed. The remediation-order and "auto-fixes" sections describe the plan that was executed, not open work. See the [planning index](planning.md).
+
 _Full multi-agent audit: 11 finders across security / correctness / housekeeping, each finding adversarially verified before inclusion. 67 findings survived verification (0 critical, 7 high, 23 medium, 37 low)._
 
 ---

--- a/docs/features-index.md
+++ b/docs/features-index.md
@@ -94,7 +94,7 @@ Voice API foundation (v1.8). Ask Alexa "what's on the family calendar today" or 
 
 ## Integrations
 
-Reads from / writes to: **Google Calendar**, **Apple iCloud (CalDAV + CardDAV)**, **Microsoft To Do**, **OneDrive**, **Gmail (bus emails)**, **OpenWeatherMap** / **Open-Meteo**, **Paprika** recipes, **Kroger / Mariano's**, **Home Assistant** (in progress).
+Reads from / writes to: **Google Calendar**, **Apple iCloud (CalDAV + CardDAV)**, **Microsoft To Do**, **OneDrive**, **Gmail (bus emails)**, **OpenWeatherMap** / **Open-Meteo**, **Paprika** recipes, **Kroger / Mariano's**, and **Home Assistant** (embed as a panel, REST sensors, or run Prism as an HA add-on).
 
 → Full docs: [Integrations index](features/KROGER.md)
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -1,0 +1,81 @@
+# Planning &amp; project status
+
+A single map of where Prism's planning lives. The roadmap itself is public and community-voted on GitHub — this page **indexes** the internal planning/reference docs and **gathers the backlog** that isn't yet tracked as an issue, so nothing gets lost.
+
+_Last reviewed: 2026-07-25, after the [v1.9.0](CHANGELOG.md) security release._
+
+---
+
+## Roadmap (live, on GitHub)
+
+The authoritative roadmap is the **[Prism Roadmap project](https://github.com/users/sandydargoport/projects/3)** — every item is a [`roadmap`-labeled issue](https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap+sort%3Areactions-desc), ranked by 👍/❤️/🚀 reaction count. React on an issue to vote for it.
+
+This page **deliberately does not mirror the full list** (a copy would drift). The themed snapshot below is just orientation — GitHub is the source of truth.
+
+**Open roadmap themes (2026-07-25):**
+
+- **Layout / dashboard** — collapsible "expander" widgets ([#121](https://github.com/sandydargoport/prism/issues/121)), freeform pixel-layout mode ([#53](https://github.com/sandydargoport/prism/issues/53)), finish the consolidated Integrations page ([#52](https://github.com/sandydargoport/prism/issues/52) — Phase 1 shipped).
+- **Calendar** — real RRULE recurrence builder ([#59](https://github.com/sandydargoport/prism/issues/59)); the largest single calendar UX gap.
+- **Recipes / meals** — Mealie &amp; Tandoor sync ([#58](https://github.com/sandydargoport/prism/issues/58), gauging interest); due-date-anchored chore recurrence + meal-prep reminders ([#51](https://github.com/sandydargoport/prism/issues/51)).
+- **Photos** — auto-detect favorites from cloud/folder ([#57](https://github.com/sandydargoport/prism/issues/57)); "By Trip" grouping via travel pins ([#54](https://github.com/sandydargoport/prism/issues/54)).
+- **Travel** — globe marker precision at low zoom ([#55](https://github.com/sandydargoport/prism/issues/55), bug).
+- **Voice / Alexa** — remaining intent phases 2c/3/4 ([#56](https://github.com/sandydargoport/prism/issues/56)).
+- **Contacts** — read-only iCloud contacts mirror ([#75](https://github.com/sandydargoport/prism/issues/75), low priority).
+
+---
+
+## Internal planning &amp; reference docs
+
+These live in `docs/` but are kept out of the user-facing nav. What each is, and its current status:
+
+| Doc | What it is | Status |
+|---|---|---|
+| [Architecture review v4](arch-review-v4.md) | April 2026 architecture/security review (meeting notes + graded findings) | **Historical** — its security findings were superseded by the July audit |
+| [Codebase audit 2026-07](audit-2026-07.md) | July 2026 multi-agent security/correctness audit (67 findings) | ✅ **Fully remediated in [v1.9.0](CHANGELOG.md)** — kept as a record |
+| [Decisions &amp; lessons log](decisions-log.md) | Post-mortems of built-but-unmerged spikes | Active (append-only) |
+| [Voice API](voice-api.md) | `/api/v1/voice/*` endpoint reference + Alexa roadmap | Active reference |
+| [Code-review modalities](code-review-modalities.md) | CI review-gate coverage matrix | Active |
+| [Features at a glance](features-index.md) | One-line-per-feature catalog (SEO / AI-summary surface) | Active |
+| [API auth levels](api-auth-levels.md) | Auth-tier reference for API routes | Active reference |
+| [Calendar cards design](calendar-cards-design.md) | Design rationale for the calendar widget cards | Active reference |
+| [Alternatives](alternatives.md) | Prism vs. Skylight / Dakboard / MagicMirror² | Active |
+
+---
+
+## Internal backlog (not yet tracked as issues)
+
+Forward-looking work found in the docs that has **no GitHub issue** — candidates to file if/when prioritized, so they don't get lost in prose.
+
+**Integrations &amp; sync**
+
+- **Resurrect the MCP server** — a working Prism Model Context Protocol server (`.mcp/`, stdio transport, reuses Settings → API Tokens for auth) was built but never merged; re-cut from commit `f870aeb` rather than from scratch. Future direction: a remote/hosted variant (Streamable HTTP + OAuth 2.1). _(`decisions-log.md`)_
+- **Two-way CalDAV calendar write** — Apple / CalDAV calendars are read-only today. _(`features/CALENDAR.md`)_
+
+**Features**
+
+- **Recipe print stylesheet + shareable read-only link** _(`features/RECIPES.md`)_
+- **PWA notification badges** for unapproved chores / unread messages — the badge infra is in place. _(`features/MOBILE.md`)_
+- **Global font-scale override** — listed as planned; verify against the current build before filing. _(`features/MOBILE.md`)_
+- **Weekend Ideas Phase 2+** — POI search, regional map view, weather/season "Suggest" mode, share/collaborate. _(`features/WEEKEND.md`)_
+- **Wishes ↔ Gift-Ideas auto-claim** — marking a gift idea purchased could auto-claim the matching wish item. _(`features/WISHES.md`)_
+- **Global-input-system v2** — camera barcode scanning (zxing + `getUserMedia`), interim-speech chip, voice-language setting, keyboard a11y roles, and more. _(`features/global-input-system.md`)_
+
+**Engineering / tech-debt** (from the April arch review, still open)
+
+- Split the oversized `TravelGlobe.tsx` into hooks (M1); nearby-photos SQL bounding-box + cache + `photos → travel` cross-invalidation (M2); pause auto-rotation on `visibilitychange` (M3); move the traffic workflow to a dedicated branch (M8); weekend a11y tab roles (L1). _(`arch-review-v4.md`)_
+
+---
+
+## Open decisions
+
+Unresolved questions recorded in the review docs:
+
+- **`weekend_visits` table — keep or drop.** It's currently unused (the UI increments a denormalized `visitCount` on the parent row). `arch-review-v4.md` and `features/WEEKEND.md` currently **contradict each other** on whether it's live — resolve, then update both.
+- **Structural guardrail for display-auth on mutation routes** — a `getReadAuth()` / `getWriteAuth()` split vs. a lint rule. The underlying IDOR was fixed in v1.9.0; the guardrail decision is still open. _(`arch-review-v4.md`)_
+- **Traffic bot** — PR vs. direct-push-to-master. _(`arch-review-v4.md`)_
+
+---
+
+## Recently shipped
+
+- **[v1.9.0](CHANGELOG.md)** (2026-07-24) — security-hardening release that closed the entire [2026-07 audit](audit-2026-07.md): item-level authorization sweep, SSRF guards (CalDAV / CardDAV / Immich), session absolute lifetime, OAuth state nonces, service-worker cache fix, path-traversal validation, dependency-advisory bumps, correctness fixes (rate-limit lockout, weather timezone buckets, Google 404 auto-disable, travel-globe deps), and an Immich v3 album-sync fix.

--- a/docs/voice-api.md
+++ b/docs/voice-api.md
@@ -209,4 +209,4 @@ Voice cannot escalate privileges. Specifically:
 
 ## Roadmap
 
-The next phase is the Alexa skill itself, then a HACS-published Home Assistant `custom_component` (see `memory/alexa-voice-api-feature.md`). A later "device-control intents" phase will add a server-sent command bus so voice can drive the running dashboard UI (e.g. *"pull up the lasagna recipe"*).
+The next phase is the Alexa skill itself, then a HACS-published Home Assistant `custom_component` — tracked in [#56](https://github.com/sandydargoport/prism/issues/56). A later "device-control intents" phase will add a server-sent command bus so voice can drive the running dashboard UI (e.g. *"pull up the lasagna recipe"*).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,9 @@ nav:
 #     They stay in the build → sitemap.xml → are crawlable, but don't
 #     appear in the side nav.
 not_in_nav: |
+  /planning.md
   /arch-review-v4.md
+  /audit-2026-07.md
   /calendar-cards-design.md
   /code-review-modalities.md
   /decisions-log.md


### PR DESCRIPTION
Adds **`docs/planning.md`** — one map of where Prism's planning lives — and cleans up the stale references the doc review surfaced.

## `docs/planning.md` (new)
- **Roadmap (live):** points to the [GitHub Roadmap project](https://github.com/users/sandydargoport/projects/3) as the authoritative, community-voted source, with a themed snapshot. Deliberately does **not** mirror the issue list (would drift).
- **Internal planning/reference docs — index:** a table of the `not_in_nav` docs with a one-line status each; `arch-review-v4` and `audit-2026-07` marked **historical**.
- **Internal backlog:** consolidates forward-looking work that has **no GitHub issue** (MCP server resurrection, CalDAV two-way write, arch-review tech-debt, feature 'planned' bits) so it isn't lost in prose — flagged as candidates to file.
- **Open decisions:** the unresolved questions still in the review docs.
- Wired into mkdocs `not_in_nav` (consistent with the other engineering docs) and linked from CONTRIBUTING.

## On merging files
Evaluated per the request — **no whole-file merges are net-positive.** Each doc serves a distinct purpose (competitor matrix, feature catalog, append-only post-mortem log, two dated review records, API reference); merging would conflate genres and break inbound links (e.g. the shipped v1.9.0 PR bodies point at `audit-2026-07.md`). The real consolidation is the index + backlog above.

## Hygiene fixes
- **`audit-2026-07.md`** — banner marking it ✅ fully remediated in v1.9.0 (it read as an open to-do list).
- **`alternatives.md` / `features-index.md`** — Home Assistant is **shipped** (embed as a panel + REST sensors + one-click add-on), not '🚧 in progress (#81)' — #81 is closed.
- **`voice-api.md`** — replaced the dangling `memory/alexa-voice-api-feature.md` reference with the live tracking issue (#56).
- **`mkdocs.yml`** — added the previously-orphaned `audit-2026-07.md` to `not_in_nav`.

## Verification
- All relative doc links resolve (manual check; mkdocs isn't installed locally — CI's `Docs` build runs the strict link-check).

## Follow-up (not here)
`code-review-modalities.md` still labels several CI modalities '(to be added)' that have since landed (reverse-proxy, migration-replay, visual-regression, scan-pii), with scrambled section numbering — needs a proper restructure, not a one-liner.