### PR TITLE
docs(links): fix two dangling in-page anchors

### DIFF
--- a/docs/features/ICLOUD.md
+++ b/docs/features/ICLOUD.md
@@ -10,7 +10,7 @@ If you have an Apple household and want Prism to surface family data living in i
 
 | iCloud surface | Supported? | How / why not |
 |---|---|---|
-| **Calendars** | ✅ Yes, two-way | CalDAV (`caldav.icloud.com`). See [Calendar setup](CALENDAR.md#apple-icloud-caldav--private-calendars--reminders--alpha). |
+| **Calendars** | ✅ Yes, two-way | CalDAV (`caldav.icloud.com`). See [Calendar setup](CALENDAR.md#apple-icloud-caldav-private-calendars-reminders-alpha). |
 | **Contacts** (incl. birthdays) | ✅ Yes, read-only | CardDAV (`contacts.icloud.com`). Used by the planned [family contacts page](https://github.com/sandydargoport/prism/issues/75). |
 | **Reminders / Tasks** | ❌ No | Apple migrated Reminders off CalDAV-VTODO years ago; iCloud Reminders are CloudKit-only with no public web API. |
 | **Notes** | ❌ No | iCloud-synced Notes have always been CloudKit-only. No IMAP-style or web API. |

--- a/docs/features/global-input-system.md
+++ b/docs/features/global-input-system.md
@@ -17,7 +17,7 @@
 9. [Physical Keyboard Auto-Dismiss](#9-physical-keyboard-auto-dismiss)
 10. [Settings](#10-settings)
 11. [File Manifest](#11-file-manifest)
-12. [Open Questions / Deferred Items](#12-open-questions--deferred-items)
+12. [Open Questions / Deferred](#12-open-questions-deferred)
 
 ---
 


### PR DESCRIPTION
Fixes the two `INFO`-level dangling anchors surfaced by `mkdocs build --strict`:

- **`features/ICLOUD.md`** — the "See Calendar setup" link pointed at a stale double-hyphen slug (`…caldav--private-calendars--reminders--alpha`); corrected to the real anchor (`…caldav-private-calendars-reminders-alpha`). This is the old iCloud/CalDAV investigation section.
- **`features/global-input-system.md`** — the table-of-contents link to the "§12 Open Questions / Deferred" heading used a stale slug (`#12-open-questions--deferred-items`); corrected to match the heading (`#12-open-questions-deferred`).

Verified with `mkdocs build --strict` locally — **zero notices** (previously two).

> Note: the companion CI change (strict-build docs on PRs) is coming as a separate PR — pushing `.github/workflows/` needs the `workflow` token scope, which the current session token lacks.