### PR TITLE
ci(docs): run mkdocs build --strict on pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,18 +8,22 @@ on:
       - 'mkdocs.yml'
       - 'requirements-docs.txt'
       - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+# Least privilege by default; the deploy job elevates for itself.
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
+  # Builds the site with --strict on every push AND pull request so broken
+  # links / nav are caught before merge. Only master pushes upload the Pages
+  # artifact for the deploy job; pull requests validate without publishing.
   build:
     runs-on: ubuntu-latest
     steps:
@@ -38,12 +42,21 @@ jobs:
       - run: mkdocs build --strict
 
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request'
         with:
           path: site
 
+  # Publishes to GitHub Pages — never on pull requests.
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Closes the CI gap found while validating #163: the **Docs** workflow only ran `mkdocs build --strict` on **push to master**, so doc PRs merged **unvalidated** — a broken link only surfaced *after* merge, where it also blocks the Pages deploy.

## Change
- Add a **`pull_request`** trigger (same `paths` filter) so docs are strict-built **before** merge.
- **PRs validate without publishing:** the Pages artifact upload + the `deploy` job are gated to `github.event_name != 'pull_request'` (i.e. master pushes only).
- **Least privilege:** workflow-level `permissions: contents: read`; only the `deploy` job elevates to `pages: write` / `id-token: write`.
- Moved the `concurrency: group: pages` lock onto the `deploy` job so PR builds don't queue behind a live Pages deploy.

## Note
This PR touches `.github/workflows/`, so it should be the first to exercise the new trigger — expect a **Docs** check to appear on it (build-only, no deploy). Validated `mkdocs build --strict` locally: clean.