### PR TITLE
feat(recipes): import from Tandoor (#58) + LAN internal-hosts allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,17 @@ PIN_ENCRYPTION_KEY=generate_another_random_32_character_string
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ENCRYPTION_KEY=generate_a_64_hex_character_string_here
 
+# --- Self-hosted integrations on your LAN (SSRF allowlist) ---
+# To prevent Prism from being used to probe your internal network, it blocks
+# outbound integration requests to private/loopback addresses by default. If you
+# run an integration on your own LAN — Tandoor, Nextcloud/CalDAV, Immich, etc. —
+# on a private IP, list its host(s) here to allow it. Entries may be separated
+# by spaces, commas, or newlines, and can be hostnames, IPs, or CIDR ranges.
+# Leave empty (the default) to keep the strict block. Requires a restart.
+# Example: PRISM_ALLOWED_INTERNAL_HOSTS="192.168.x.x tandoor.local"
+# (entries may be hostnames, IP addresses, or CIDR ranges like 10.x.x.x/8)
+PRISM_ALLOWED_INTERNAL_HOSTS=
+
 # --- Google Calendar ---
 # Get credentials at: https://console.cloud.google.com
 # Enable "Google Calendar API", create OAuth 2.0 Client ID

--- a/scripts/scan-hostnames.sh
+++ b/scripts/scan-hostnames.sh
@@ -94,6 +94,9 @@ ALLOWLIST=(
   "caldav.icloud.com"
   "contacts.icloud.com"
   "appleid.apple.com"
+  # Self-hosted recipe managers referenced by the recipe integrations
+  "tandoor.dev"
+  "mealie.io"
   # Common public-suffix anchors that show up via vendor doc URLs
   "google.com"
   "microsoft.com"

--- a/src/app/api/recipes/import-tandoor/route.ts
+++ b/src/app/api/recipes/import-tandoor/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { recipes } from '@/lib/db/schema';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { rateLimitGuard } from '@/lib/cache/rateLimit';
+import { saveRecipeImage } from '@/lib/services/recipe-image-storage';
+import { logError } from '@/lib/utils/logError';
+import {
+  testTandoorConnection,
+  fetchTandoorRecipes,
+  fetchTandoorImage,
+  UnsafeUrlError,
+} from '@/lib/integrations/tandoor';
+
+/**
+ * POST /api/recipes/import-tandoor
+ *
+ * One-shot import of every recipe from a Tandoor server into Prism, mirroring
+ * the URL / Paprika import paths. Body: `{ serverUrl, token, preview? }`.
+ * `preview: true` only verifies connectivity and returns the recipe count.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  // Connecting to an external server with a credential is integration
+  // management, not ordinary recipe editing — gate on canManageIntegrations
+  // (parent-only), matching the photo/calendar source connect flows.
+  const forbidden = requireRole(auth, 'canManageIntegrations');
+  if (forbidden) return forbidden;
+
+  const limited = await rateLimitGuard(auth.userId, 'recipe-import-tandoor', 5, 60);
+  if (limited) return limited;
+
+  try {
+    const body = await request.json();
+    const serverUrl = typeof body.serverUrl === 'string' ? body.serverUrl.trim() : '';
+    const token = typeof body.token === 'string' ? body.token.trim() : '';
+
+    if (!serverUrl || !token) {
+      return NextResponse.json(
+        { error: 'Tandoor server URL and API token are both required.' },
+        { status: 400 },
+      );
+    }
+
+    // Preview: verify the server + token, report how many recipes are there.
+    if (body.preview) {
+      const { count } = await testTandoorConnection(serverUrl, token);
+      return NextResponse.json({ preview: true, count });
+    }
+
+    const { recipes: items, total } = await fetchTandoorRecipes(serverUrl, token);
+
+    let imported = 0;
+    for (const item of items) {
+      const [row] = await db
+        .insert(recipes)
+        .values({
+          name: item.name,
+          description: item.description,
+          url: item.url,
+          sourceType: 'tandoor_import',
+          ingredients: item.ingredients,
+          instructions: item.instructions,
+          prepTime: item.prepTime,
+          cookTime: item.cookTime,
+          servings: item.servings,
+          tags: item.tags,
+          imageUrl: null,
+          createdBy: auth.userId,
+        })
+        .returning({ id: recipes.id });
+
+      // Best-effort image: download server-side with the token (Tandoor media
+      // can sit behind auth / on an internal host), store locally, point the
+      // row at the proxy path. A missing image never fails the import.
+      if (row && item.remoteImageUrl) {
+        const buffer = await fetchTandoorImage(item.remoteImageUrl, token);
+        if (buffer) {
+          try {
+            await saveRecipeImage(buffer, row.id);
+            await db
+              .update(recipes)
+              .set({ imageUrl: `/api/recipes/${row.id}/image` })
+              .where(eq(recipes.id, row.id));
+          } catch (imgErr) {
+            logError('Tandoor import: failed to store recipe image', imgErr);
+          }
+        }
+      }
+      imported += 1;
+    }
+
+    await invalidateEntity('recipes');
+    return NextResponse.json({ imported, total }, { status: 201 });
+  } catch (error) {
+    // The SSRF-allowlist message is actionable (names the host + the env var);
+    // surface it straight to the user so they know exactly what to do.
+    if (error instanceof UnsafeUrlError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    logError('Error importing recipes from Tandoor:', error);
+    // Connection / auth failures carry a user-useful message; pass it through.
+    if (error instanceof Error && /Tandoor|token|reach|list Tandoor recipes/i.test(error.message)) {
+      return NextResponse.json({ error: error.message }, { status: 502 });
+    }
+    return NextResponse.json({ error: 'Failed to import recipes from Tandoor.' }, { status: 500 });
+  }
+}

--- a/src/app/recipes/ImportTandoorModal.tsx
+++ b/src/app/recipes/ImportTandoorModal.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+
+export interface ImportTandoorModalProps {
+  onClose: () => void;
+  /** Called after a successful import so the recipe list can refresh. */
+  onImported: () => void;
+}
+
+export function ImportTandoorModal({ onClose, onImported }: ImportTandoorModalProps) {
+  const [serverUrl, setServerUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+
+  const canSubmit = Boolean(serverUrl.trim() && token.trim()) && !importing;
+
+  const handleImport = async () => {
+    if (!canSubmit) return;
+    setImporting(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch('/api/recipes/import-tandoor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ serverUrl: serverUrl.trim(), token: token.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Import failed.');
+        return;
+      }
+      setResult(
+        `Imported ${data.imported} of ${data.total} recipe${data.total === 1 ? '' : 's'}.`,
+      );
+      onImported();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import Recipes from Tandoor</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <p className="text-sm text-muted-foreground">
+            Pull your recipes from a{' '}
+            <a
+              href="https://tandoor.dev"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              Tandoor
+            </a>{' '}
+            server. In Tandoor, create a read-only API token (Settings &rarr; API Token,
+            scope <code>read</code>) and paste it below. Imported recipes link back to
+            Tandoor and can be edited there.
+          </p>
+
+          <div className="space-y-2">
+            <Label htmlFor="tandoor-url">Tandoor server URL</Label>
+            <Input
+              id="tandoor-url"
+              value={serverUrl}
+              onChange={(e) => setServerUrl(e.target.value)}
+              placeholder="https://tandoor.example.com"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="tandoor-token">API token</Label>
+            <Input
+              id="tandoor-token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="tda_…"
+              autoComplete="off"
+            />
+          </div>
+
+          {/* whitespace-pre-wrap so the actionable "add host to allowlist"
+              message from the SSRF guard displays in full. */}
+          {error && <p className="text-sm text-destructive whitespace-pre-wrap">{error}</p>}
+          {result && (
+            <p className="text-sm text-green-600 dark:text-green-400">{result}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {result ? 'Done' : 'Cancel'}
+          </Button>
+          <Button onClick={handleImport} disabled={!canSubmit}>
+            {importing ? 'Importing…' : 'Import Recipes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/recipes/RecipesView.tsx
+++ b/src/app/recipes/RecipesView.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { toast } from '@/components/ui/use-toast';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
-import { ChefHat, Plus, Search, Heart, X, Link2, FileUp, PenLine, ChevronDown, ClipboardPaste } from 'lucide-react';
+import { ChefHat, Plus, Search, Heart, X, Link2, FileUp, PenLine, ChevronDown, ClipboardPaste, Soup } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -26,6 +26,7 @@ import { RecipeFormModal } from './RecipeFormModal';
 import { ImportUrlModal } from './ImportUrlModal';
 import { ImportPaprikaModal } from './ImportPaprikaModal';
 import { ImportTextModal } from './ImportTextModal';
+import { ImportTandoorModal } from './ImportTandoorModal';
 import type { ParsedRecipeText } from '@/lib/utils/recipeTextParser';
 
 type ViewMode = 'all' | 'favorites';
@@ -41,11 +42,12 @@ export function RecipesView() {
   const [showImportUrlModal, setShowImportUrlModal] = useState(false);
   const [showImportPaprikaModal, setShowImportPaprikaModal] = useState(false);
   const [showImportTextModal, setShowImportTextModal] = useState(false);
+  const [showImportTandoorModal, setShowImportTandoorModal] = useState(false);
   const [textPrefill, setTextPrefill] = useState<ParsedRecipeText | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [paramHandled, setParamHandled] = useState(false);
 
-  const { recipes, loading, error, deleteRecipe, toggleFavorite, importFromUrl, importFromPaprika, createRecipe, updateRecipe } = useRecipes({
+  const { recipes, loading, error, deleteRecipe, toggleFavorite, importFromUrl, importFromPaprika, createRecipe, updateRecipe, refresh } = useRecipes({
     favorite: viewMode === 'favorites' ? true : undefined,
   });
 
@@ -106,6 +108,11 @@ export function RecipesView() {
     setShowImportTextModal(true);
   };
 
+  const handleImportTandoorWithAuth = async () => {
+    if (!await requireAuth('Import Recipes', 'Please log in to import recipes')) return;
+    setShowImportTandoorModal(true);
+  };
+
   return (
     <PageWrapper>
       <div className="h-screen flex flex-col">
@@ -132,6 +139,10 @@ export function RecipesView() {
                 <DropdownMenuItem onClick={handleImportTextWithAuth}>
                   <ClipboardPaste className="h-4 w-4 mr-2 text-muted-foreground" />
                   Paste recipe text
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleImportTandoorWithAuth}>
+                  <Soup className="h-4 w-4 mr-2 text-muted-foreground" />
+                  Import from Tandoor
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleAddWithAuth}>
                   <PenLine className="h-4 w-4 mr-2 text-muted-foreground" />
@@ -262,6 +273,9 @@ export function RecipesView() {
 
       {showImportPaprikaModal && (
         <ImportPaprikaModal onClose={() => setShowImportPaprikaModal(false)} onImport={importFromPaprika} />
+      )}
+      {showImportTandoorModal && (
+        <ImportTandoorModal onClose={() => setShowImportTandoorModal(false)} onImported={refresh} />
       )}
 
       <ConfirmDialog {...confirmDialogProps} />

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -507,7 +507,7 @@ export const recipes = pgTable('recipes', {
 
   // Where did this recipe come from?
   sourceType: varchar('source_type', { length: 50 }).default('manual').notNull()
-    .$type<'manual' | 'url_import' | 'paprika_import'>(),
+    .$type<'manual' | 'url_import' | 'paprika_import' | 'tandoor_import'>(),
 
   // Structured ingredients (JSON array of {name, amount, unit, notes})
   ingredients: jsonb('ingredients').default([]).notNull(),

--- a/src/lib/hooks/useRecipes.ts
+++ b/src/lib/hooks/useRecipes.ts
@@ -25,7 +25,7 @@ export interface Recipe {
   name: string;
   description?: string | null;
   url?: string | null;
-  sourceType: 'manual' | 'url_import' | 'paprika_import';
+  sourceType: 'manual' | 'url_import' | 'paprika_import' | 'tandoor_import';
   ingredients: RecipeIngredient[];
   instructions?: string | null;
   prepTime?: number | null;

--- a/src/lib/integrations/__tests__/tandoor.test.ts
+++ b/src/lib/integrations/__tests__/tandoor.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the Tandoor recipe import client. The fixture mirrors the real
+ * shape observed from a live Tandoor v1 instance: steps carry ingredients with
+ * `original_text` + structured food/unit/amount, `working_time`/`waiting_time`,
+ * keywords, and an `image` reported on Tandoor's own origin.
+ */
+
+import {
+  normalizeTandoorRecipe,
+  testTandoorConnection,
+  fetchTandoorImage,
+  UnsafeUrlError,
+  type TandoorRecipeDetail,
+} from '../tandoor';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const DETAIL: TandoorRecipeDetail = {
+  id: 2,
+  name: '16 Bean Pasta e Fagioli',
+  description: 'From Barefoot Contessa.',
+  image: 'http://localhost:8082/media/recipes/abc_2.jpg',
+  keywords: [{ name: 'ina garten' }, { name: 'lunch' }],
+  working_time: 0,
+  waiting_time: 30,
+  servings: 6,
+  steps: [
+    {
+      name: 'Ingredients',
+      instruction: 'Soak the beans overnight.',
+      ingredients: [
+        { food: { name: 'Section' }, is_header: true, note: 'For the soup' },
+        {
+          food: { name: 'olive oil' },
+          unit: { name: 'tablespoons' },
+          amount: 2,
+          note: 'plus extra',
+          original_text: '2 tablespoons good olive oil, plus extra for serving',
+        },
+        { food: { name: 'pancetta' }, unit: { name: 'ounces' }, amount: 6, note: 'diced' },
+        { food: { name: 'salt' }, no_amount: true, note: 'to taste' },
+      ],
+    },
+    { instruction: 'Simmer for 30 minutes.', ingredients: [] },
+  ],
+};
+
+describe('normalizeTandoorRecipe', () => {
+  it('maps core fields and re-anchors the image onto the connected serverUrl', () => {
+    const r = normalizeTandoorRecipe(DETAIL, 'https://tandoor.example.com/');
+    expect(r.name).toBe('16 Bean Pasta e Fagioli');
+    expect(r.description).toBe('From Barefoot Contessa.');
+    expect(r.url).toBe('https://tandoor.example.com/view/recipe/2');
+    expect(r.prepTime).toBeNull(); // working_time 0 → null
+    expect(r.cookTime).toBe(30);
+    expect(r.servings).toBe(6);
+    expect(r.tags).toEqual(['ina garten', 'lunch']);
+    // Image host swapped from Tandoor's localhost:8082 to the server we connected to.
+    expect(r.remoteImageUrl).toBe('https://tandoor.example.com/media/recipes/abc_2.jpg');
+  });
+
+  it('prefers original_text, composes structured lines otherwise, and keeps headers', () => {
+    const r = normalizeTandoorRecipe(DETAIL, 'https://tandoor.example.com');
+    expect(r.ingredients).toEqual([
+      { heading: 'For the soup' },
+      { text: '2 tablespoons good olive oil, plus extra for serving' }, // original_text
+      { text: '6 ounces pancetta (diced)' }, // composed from structured fields
+      { text: 'salt (to taste)' }, // no_amount → no leading amount
+    ]);
+  });
+
+  it('joins step instructions into a single block', () => {
+    const r = normalizeTandoorRecipe(DETAIL, 'https://tandoor.example.com');
+    expect(r.instructions).toBe(
+      'Ingredients\nSoak the beans overnight.\n\nSimmer for 30 minutes.',
+    );
+  });
+});
+
+describe('testTandoorConnection', () => {
+  it('returns the recipe count on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: () => Promise.resolve({ count: 3, results: [] }),
+    }) as unknown as typeof fetch;
+
+    const res = await testTandoorConnection('https://tandoor.example.com', 'tok');
+    expect(res.count).toBe(3);
+  });
+
+  it('throws a clear error when the token is rejected (401)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+    }) as unknown as typeof fetch;
+
+    await expect(testTandoorConnection('https://tandoor.example.com', 'bad')).rejects.toThrow(/token/i);
+  });
+
+  it('rejects a private serverUrl (SSRF) before making any request', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(testTandoorConnection('http://10.0.0.5', 'tok')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchTandoorImage', () => {
+  it('returns a Buffer for a successful download', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff, 0xd8]).buffer),
+    }) as unknown as typeof fetch;
+
+    const buf = await fetchTandoorImage('https://tandoor.example.com/media/x.jpg', 'tok');
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(buf?.length).toBe(2);
+  });
+
+  it('returns null on a failed download (never throws)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+    }) as unknown as typeof fetch;
+
+    expect(await fetchTandoorImage('https://tandoor.example.com/media/missing.jpg', 'tok')).toBeNull();
+  });
+});

--- a/src/lib/integrations/tandoor.ts
+++ b/src/lib/integrations/tandoor.ts
@@ -1,0 +1,255 @@
+/**
+ * Tandoor (tandoor.dev) recipe import client.
+ *
+ * One-way, read-only: pulls recipes FROM a Tandoor server into Prism as a
+ * one-shot import (mirrors the URL / Paprika import paths). The Tandoor API
+ * is DRF-based; a personal API token (scope `read`) is passed as a Bearer
+ * token. Every outbound call goes through safeFetch/validatePublicUrl so a
+ * user-supplied serverUrl can't be used to probe the internal network (SSRF).
+ */
+
+import { validatePublicUrl, safeFetch, UnsafeUrlError } from '@/lib/utils/safeFetch';
+
+/** A recipe normalized into Prism's insert shape (minus createdBy/sourceType). */
+export interface NormalizedTandoorRecipe {
+  name: string;
+  description: string | null;
+  /** Deep link back to the recipe in Tandoor (for the "Open in source" link). */
+  url: string;
+  ingredients: Array<{ text?: string; heading?: string }>;
+  instructions: string | null;
+  prepTime: number | null;
+  cookTime: number | null;
+  servings: number | null;
+  tags: string[];
+  /** Absolute remote image URL to download, or null. */
+  remoteImageUrl: string | null;
+}
+
+// --- Partial shapes of the Tandoor API responses we read ---
+interface TandoorListResponse {
+  count: number;
+  next: string | null;
+  results: Array<{ id: number }>;
+}
+interface TandoorNamed { name?: string | null }
+interface TandoorIngredient {
+  food?: TandoorNamed | null;
+  unit?: TandoorNamed | null;
+  amount?: number | string | null;
+  note?: string | null;
+  is_header?: boolean;
+  no_amount?: boolean;
+  original_text?: string | null;
+}
+interface TandoorStep {
+  name?: string | null;
+  instruction?: string | null;
+  ingredients?: TandoorIngredient[];
+}
+export interface TandoorRecipeDetail {
+  id: number;
+  name: string;
+  description?: string | null;
+  image?: string | null;
+  keywords?: TandoorNamed[];
+  steps?: TandoorStep[];
+  working_time?: number | null;
+  waiting_time?: number | null;
+  servings?: number | null;
+  source_url?: string | null;
+}
+
+const PAGE_SIZE = 50;
+const MAX_RECIPES = 1000; // hard cap so a huge library can't run unbounded
+
+function baseUrl(serverUrl: string): string {
+  return serverUrl.trim().replace(/\/+$/, '');
+}
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, Accept: 'application/json' };
+}
+
+/**
+ * Verify the server is reachable and the token authenticates. Returns the
+ * total recipe count Tandoor reports. Throws UnsafeUrlError for a private
+ * serverUrl, or a descriptive Error otherwise.
+ */
+export async function testTandoorConnection(
+  serverUrl: string,
+  token: string,
+): Promise<{ count: number }> {
+  validatePublicUrl(serverUrl);
+  const res = await safeFetch(`${baseUrl(serverUrl)}/api/recipe/?page_size=1`, {
+    headers: authHeaders(token),
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('Tandoor rejected the API token — check the token and that its scope includes `read`.');
+  }
+  if (!res.ok) {
+    throw new Error(`Could not reach Tandoor: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as TandoorListResponse;
+  return { count: data.count ?? 0 };
+}
+
+/** Page through /api/recipe/ collecting recipe ids (bounded). */
+async function listRecipeIds(base: string, token: string): Promise<number[]> {
+  const ids: number[] = [];
+  let next: string | null = `${base}/api/recipe/?page_size=${PAGE_SIZE}`;
+  let guard = 0;
+  while (next && ids.length < MAX_RECIPES && guard < 200) {
+    guard += 1;
+    // safeFetch re-validates the URL each hop — important because `next` is a
+    // server-supplied absolute URL, not something we constructed.
+    const res: Response = await safeFetch(next, { headers: authHeaders(token) });
+    if (!res.ok) {
+      throw new Error(`Failed to list Tandoor recipes: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as TandoorListResponse;
+    for (const r of data.results ?? []) {
+      if (typeof r.id === 'number') ids.push(r.id);
+    }
+    next = data.next;
+  }
+  return ids.slice(0, MAX_RECIPES);
+}
+
+async function fetchRecipeDetail(base: string, token: string, id: number): Promise<TandoorRecipeDetail> {
+  const res = await safeFetch(`${base}/api/recipe/${id}/`, { headers: authHeaders(token) });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Tandoor recipe ${id}: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as TandoorRecipeDetail;
+}
+
+/** Format a Tandoor numeric amount, dropping zeros/blanks and trailing zeros. */
+function formatAmount(n: number | string | null | undefined): string {
+  if (n == null) return '';
+  const num = typeof n === 'string' ? parseFloat(n) : n;
+  if (!Number.isFinite(num) || num === 0) return '';
+  return String(Number(num.toFixed(3)));
+}
+
+/**
+ * Flatten Tandoor's steps[].ingredients[] into Prism's ingredient lines.
+ * Prism renders `{text}` and `{heading}` only, so structured amount/unit/food
+ * is composed into a single display string per line.
+ */
+function normalizeIngredients(steps: TandoorStep[]): Array<{ text?: string; heading?: string }> {
+  const out: Array<{ text?: string; heading?: string }> = [];
+  for (const step of steps) {
+    for (const ing of step.ingredients ?? []) {
+      if (ing.is_header) {
+        const heading = (ing.note || ing.food?.name || '').trim();
+        if (heading) out.push({ heading });
+        continue;
+      }
+      // Prefer the user's original typed line when Tandoor kept it.
+      if (ing.original_text && ing.original_text.trim()) {
+        out.push({ text: ing.original_text.trim() });
+        continue;
+      }
+      const amount = ing.no_amount ? '' : formatAmount(ing.amount);
+      const unit = (ing.unit?.name || '').trim();
+      const food = (ing.food?.name || '').trim();
+      const note = (ing.note || '').trim();
+      const main = [amount, unit, food].filter(Boolean).join(' ').trim();
+      const text = note ? (main ? `${main} (${note})` : note) : main;
+      if (text) out.push({ text });
+    }
+  }
+  return out;
+}
+
+/** Join Tandoor steps into one plain-text instructions block. */
+function normalizeInstructions(steps: TandoorStep[]): string | null {
+  const parts: string[] = [];
+  for (const step of steps) {
+    const instruction = (step.instruction || '').trim();
+    if (!instruction) continue;
+    const name = (step.name || '').trim();
+    parts.push(name ? `${name}\n${instruction}` : instruction);
+  }
+  return parts.length ? parts.join('\n\n') : null;
+}
+
+/** Map a full Tandoor recipe detail into Prism's insert shape. */
+export function normalizeTandoorRecipe(
+  detail: TandoorRecipeDetail,
+  serverUrl: string,
+): NormalizedTandoorRecipe {
+  const base = baseUrl(serverUrl);
+  const steps = detail.steps ?? [];
+  let remoteImageUrl: string | null = null;
+  if (detail.image) {
+    // Tandoor reports the image with its own configured origin (e.g.
+    // http://localhost:8082/media/...), which the Prism server can't reach.
+    // Re-anchor the media path onto the serverUrl the user connected with.
+    let imagePath = detail.image;
+    if (/^https?:\/\//i.test(imagePath)) {
+      try {
+        const u = new URL(imagePath);
+        imagePath = u.pathname + u.search;
+      } catch {
+        /* fall through with the raw value */
+      }
+    }
+    remoteImageUrl = `${base}${imagePath.startsWith('/') ? '' : '/'}${imagePath}`;
+  }
+  const positive = (n: number | null | undefined) => (typeof n === 'number' && n > 0 ? n : null);
+  return {
+    name: detail.name,
+    description: (detail.description || '').trim() || null,
+    url: `${base}/view/recipe/${detail.id}`,
+    ingredients: normalizeIngredients(steps),
+    instructions: normalizeInstructions(steps),
+    prepTime: positive(detail.working_time),
+    cookTime: positive(detail.waiting_time),
+    servings: positive(detail.servings),
+    tags: (detail.keywords ?? []).map((k) => (k.name || '').trim()).filter(Boolean),
+    remoteImageUrl,
+  };
+}
+
+/**
+ * Fetch and normalize every recipe from a Tandoor server (bounded to
+ * MAX_RECIPES). Individual recipe failures are skipped, not fatal.
+ */
+export async function fetchTandoorRecipes(
+  serverUrl: string,
+  token: string,
+): Promise<{ recipes: NormalizedTandoorRecipe[]; total: number }> {
+  validatePublicUrl(serverUrl);
+  const base = baseUrl(serverUrl);
+  const ids = await listRecipeIds(base, token);
+  const recipes: NormalizedTandoorRecipe[] = [];
+  for (const id of ids) {
+    try {
+      const detail = await fetchRecipeDetail(base, token, id);
+      if (detail && detail.name) recipes.push(normalizeTandoorRecipe(detail, base));
+    } catch (err) {
+      console.error(`[tandoor] skipping recipe ${id}:`, err instanceof Error ? err.message : err);
+    }
+  }
+  return { recipes, total: ids.length };
+}
+
+/**
+ * Best-effort download of a Tandoor recipe image (Tandoor media may sit behind
+ * auth or on an internal host, so we fetch server-side with the token rather
+ * than storing a remote URL the browser couldn't load). Returns null on any
+ * failure — a missing image never fails an import.
+ */
+export async function fetchTandoorImage(imageUrl: string, token: string): Promise<Buffer | null> {
+  try {
+    const res = await safeFetch(imageUrl, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    return buf.length ? buf : null;
+  } catch {
+    return null;
+  }
+}
+
+export { UnsafeUrlError };

--- a/src/lib/utils/__tests__/safeFetch.test.ts
+++ b/src/lib/utils/__tests__/safeFetch.test.ts
@@ -8,7 +8,7 @@
 
 export {};
 
-import { validatePublicUrl, safeFetch, UnsafeUrlError } from '../safeFetch';
+import { validatePublicUrl, safeFetch, parseAllowedInternalHosts, UnsafeUrlError } from '../safeFetch';
 
 describe('validatePublicUrl', () => {
   it('accepts a public https URL', () => {
@@ -130,6 +130,94 @@ describe('validatePublicUrl', () => {
       expect(() => validatePublicUrl('http://10.0.0.1/', { isProduction: false }))
         .toThrow(UnsafeUrlError);
     });
+  });
+});
+
+describe('validatePublicUrl — PRISM_ALLOWED_INTERNAL_HOSTS allowlist', () => {
+  it('permits an allowlisted private IP in production', () => {
+    const url = validatePublicUrl('http://192.168.50.60:8082/api/recipe/', {
+      isProduction: true,
+      allowedInternalHosts: ['192.168.50.60'],
+    });
+    expect(url.hostname).toBe('192.168.50.60');
+  });
+
+  it('permits an allowlisted bare hostname in production', () => {
+    const url = validatePublicUrl('http://docker-host:8082/api', {
+      isProduction: true,
+      allowedInternalHosts: ['docker-host'],
+    });
+    expect(url.hostname).toBe('docker-host');
+  });
+
+  it('permits a private IP inside an allowlisted CIDR range', () => {
+    const url = validatePublicUrl('http://10.1.2.3/x', {
+      isProduction: true,
+      allowedInternalHosts: ['10.0.0.0/8'],
+    });
+    expect(url.hostname).toBe('10.1.2.3');
+  });
+
+  it('permits an allowlisted IPv6 loopback (bracket-insensitive)', () => {
+    const url = validatePublicUrl('http://[::1]:8082/', {
+      isProduction: true,
+      allowedInternalHosts: ['::1'],
+    });
+    expect(url.hostname).toBe('[::1]');
+  });
+
+  it('still rejects a private host that is NOT on the allowlist', () => {
+    expect(() =>
+      validatePublicUrl('http://192.168.1.99/', {
+        isProduction: true,
+        allowedInternalHosts: ['192.168.50.60'],
+      }),
+    ).toThrow(UnsafeUrlError);
+  });
+
+  it('rejects an out-of-range IP even when a CIDR is allowlisted', () => {
+    expect(() =>
+      validatePublicUrl('http://172.16.5.5/', {
+        isProduction: true,
+        allowedInternalHosts: ['192.168.0.0/16'],
+      }),
+    ).toThrow(UnsafeUrlError);
+  });
+
+  it('the block error is actionable — names the host and the env var', () => {
+    try {
+      validatePublicUrl('http://192.168.1.99/', { isProduction: true, allowedInternalHosts: [] });
+      throw new Error('expected validatePublicUrl to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnsafeUrlError);
+      expect((e as Error).message).toContain('192.168.1.99');
+      expect((e as Error).message).toContain('PRISM_ALLOWED_INTERNAL_HOSTS');
+      expect((e as Error).message).toMatch(/\.env/);
+    }
+  });
+
+  it('empty allowlist preserves strict behavior', () => {
+    expect(() =>
+      validatePublicUrl('http://10.0.0.1/', { isProduction: true, allowedInternalHosts: [] }),
+    ).toThrow(UnsafeUrlError);
+  });
+});
+
+describe('parseAllowedInternalHosts', () => {
+  const expected = ['192.168.50.60', 'docker-host', '10.0.0.0/8'];
+  it('accepts comma-separated entries', () => {
+    expect(parseAllowedInternalHosts(' 192.168.50.60, docker-host ,10.0.0.0/8 ')).toEqual(expected);
+  });
+  it('accepts space-separated entries', () => {
+    expect(parseAllowedInternalHosts('192.168.50.60 docker-host 10.0.0.0/8')).toEqual(expected);
+  });
+  it('accepts newline-separated entries (multiline .env value)', () => {
+    expect(parseAllowedInternalHosts('192.168.50.60\ndocker-host\n10.0.0.0/8')).toEqual(expected);
+  });
+  it('returns an empty list for empty / undefined input', () => {
+    expect(parseAllowedInternalHosts(undefined)).toEqual([]);
+    expect(parseAllowedInternalHosts('')).toEqual([]);
+    expect(parseAllowedInternalHosts('  ,  ')).toEqual([]);
   });
 });
 

--- a/src/lib/utils/safeFetch.ts
+++ b/src/lib/utils/safeFetch.ts
@@ -89,9 +89,75 @@ function isLocalhostName(host: string): boolean {
   return lower === 'localhost' || lower.endsWith('.localhost');
 }
 
+/** Strip surrounding brackets from a bracketed IPv6 literal. */
+function unbracket(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
+/**
+ * Parse PRISM_ALLOWED_INTERNAL_HOSTS into a list of allowlist entries.
+ * Entries may be separated by commas, spaces, or newlines — whichever reads
+ * best in your .env. Each entry is a hostname, IP literal, or IPv4 CIDR range.
+ */
+export function parseAllowedInternalHosts(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+}
+
+function ipv4ToInt(s: string): number | null {
+  const m = s.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return null;
+  const parts = m.slice(1, 5).map(Number);
+  if (parts.some((p) => p > 255)) return null;
+  return ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0;
+}
+
+/** True if dotted-quad `ip` is inside an `a.b.c.d/n` IPv4 CIDR. */
+function ipv4InCidr(ip: string, cidr: string): boolean {
+  const [range, bitsStr] = cidr.split('/');
+  const bits = Number(bitsStr);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return false;
+  const ipInt = ipv4ToInt(ip);
+  const rangeInt = ipv4ToInt(range ?? '');
+  if (ipInt === null || rangeInt === null) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ipInt & mask) === (rangeInt & mask);
+}
+
+/** Whether a host literal is explicitly allowlisted by the operator. */
+function hostAllowed(host: string, allowlist: string[]): boolean {
+  if (allowlist.length === 0) return false;
+  const bare = unbracket(host).toLowerCase();
+  for (const entry of allowlist) {
+    if (entry.includes('/')) {
+      if (ipv4InCidr(bare, entry)) return true;
+    } else if (unbracket(entry).toLowerCase() === bare) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Actionable message naming the blocked host and exactly how to allow it. */
+function blockedMessage(host: string): string {
+  return (
+    `Address "${host}" is a private or internal network address, which Prism blocks ` +
+    `by default to prevent server-side request forgery (SSRF). If this is your own ` +
+    `self-hosted service, add "${host}" to PRISM_ALLOWED_INTERNAL_HOSTS in your Prism ` +
+    `.env (comma-separated — hostnames, IPs, or CIDR ranges) and restart Prism.`
+  );
+}
+
 export interface ValidatePublicUrlOptions {
   /** Override the production check; defaults to NODE_ENV === 'production'. */
   isProduction?: boolean;
+  /**
+   * Hosts the operator has explicitly allowlisted — their own self-hosted
+   * services on a private network. Defaults to parsing
+   * PRISM_ALLOWED_INTERNAL_HOSTS. Entries are hostnames, IP literals, or IPv4
+   * CIDR ranges; a matching host bypasses the private-range checks below.
+   */
+  allowedInternalHosts?: string[];
 }
 
 /**
@@ -102,7 +168,8 @@ export interface ValidatePublicUrlOptions {
  * Rejected: non-http(s) protocols, loopback, RFC1918 private ranges,
  * link-local, cloud metadata IP, IPv6 loopback / ULA / link-local.
  * In non-production, localhost and 127.x are permitted to keep dev
- * flows working.
+ * flows working. Hosts on PRISM_ALLOWED_INTERNAL_HOSTS are always
+ * permitted (how a LAN self-hosted integration is allowed).
  */
 export function validatePublicUrl(
   rawUrl: string,
@@ -124,13 +191,21 @@ export function validatePublicUrl(
   }
 
   const isProd = options.isProduction ?? process.env.NODE_ENV === 'production';
+  const allowlist =
+    options.allowedInternalHosts ??
+    parseAllowedInternalHosts(process.env.PRISM_ALLOWED_INTERNAL_HOSTS);
   const host = parsed.hostname;
+
+  // Operator-allowlisted internal hosts bypass the private-range checks
+  // (protocol is still enforced above). This is how self-hosted integrations
+  // on a LAN — Tandoor, Nextcloud/CalDAV, Immich — are permitted in production.
+  if (hostAllowed(host, allowlist)) return parsed;
 
   // IPv6 literals come bracketed in URL.hostname on some runtimes and
   // unbracketed on others, so isPrivateIPv6 handles both shapes.
   if (host.includes(':') || (host.startsWith('[') && host.endsWith(']'))) {
     if (isPrivateIPv6(host)) {
-      throw new UnsafeUrlError('URL points at a private or loopback IPv6 address');
+      throw new UnsafeUrlError(blockedMessage(host));
     }
     return parsed;
   }
@@ -138,12 +213,12 @@ export function validatePublicUrl(
   if (isPrivateIPv4(host)) {
     // Loopback / 127.x is allowed in non-production for local dev.
     if (!isProd && /^127\./.test(host)) return parsed;
-    throw new UnsafeUrlError('URL points at a private or loopback IPv4 address');
+    throw new UnsafeUrlError(blockedMessage(host));
   }
 
   if (isLocalhostName(host)) {
     if (!isProd) return parsed;
-    throw new UnsafeUrlError('URL points at localhost');
+    throw new UnsafeUrlError(blockedMessage(host));
   }
 
   return parsed;


### PR DESCRIPTION
Implements the top-voted recipes roadmap item (**[#58](https://github.com/sandydargoport/prism/issues/58)**), **Tandoor first**, as a one-shot import — plus the SSRF-allowlist that lets self-hosted LAN integrations work at all. Validated end-to-end against a live Tandoor instance.

## Recipe import (Tandoor)
- **`src/lib/integrations/tandoor.ts`** — read-only client (Bearer API token, scope `read`) over `safeFetch`/`validatePublicUrl`. Lists `/api/recipe/` (paginated, bounded to 1000) and fetches each detail; a normalizer maps Tandoor → Prism:
  - `steps[].ingredients[]` → Prism's `{text}`/`{heading}` lines, **preferring Tandoor's `original_text`** so ingredients read exactly as entered ("6 ounces pancetta, ¼-inch-diced").
  - step instructions joined; `working_time`/`waiting_time` → prep/cook (0 → null); `keywords` → tags; **image re-anchored** onto the connected serverUrl (Tandoor reports it on its own origin).
- **`POST /api/recipes/import-tandoor`** — parent-only (`canManageIntegrations`), rate-limited. Bulk-inserts with `sourceType: 'tandoor_import'` and `url` = the Tandoor view link (so the existing **"Open in source →"** link works for free); downloads images server-side with the token → `saveRecipeImage`. `preview: true` returns the recipe count.
- **`ImportTandoorModal`** + an "Import from Tandoor" item in the Recipes add-menu.
- Widened `recipes.sourceType` union (+ `useRecipes`) to `'tandoor_import'` — `varchar(50)`, **no migration**.

## SSRF allowlist — `PRISM_ALLOWED_INTERNAL_HOSTS`
Self-hosted integrations (Tandoor, Nextcloud/CalDAV, Immich) usually live on a **private LAN address**, which the #155 SSRF guard rejects in production. New opt-in allowlist:
- `validatePublicUrl` permits operator-listed hosts (hostnames, IPs, or IPv4 CIDRs; comma/space/newline separated) even in production. **Empty by default** — strict behavior preserved. Applies to CalDAV & Immich too (**repairs the LAN-CalDAV regression #155 introduced**).
- **Actionable error:** a blocked host now yields a message naming the exact host and telling the user to add it to `PRISM_ALLOWED_INTERNAL_HOSTS` in `.env` and restart — surfaced straight through the import UI.
- **Kept operator-controlled (env, not app-editable)** on purpose: an app-editable allowlist would let a logged-in user self-authorize internal probing — the exact SSRF threat the guard exists to stop.
- Documented in `.env.example`; `tandoor.dev`/`mealie.io` added to the hostname-scan allowlist.

## Verification
- Type-check clean; `mkdocs` N/A. Full suite **1303 passing**.
- **Live-validated** against a real Tandoor: 3 recipes fetched + normalized correctly (ingredients via `original_text`, tags, servings, instructions, image, view links).
- Tests: normalizer mapping, connection/401/SSRF rejection; allowlist (IP/hostname/CIDR/IPv6, actionable error, strict default) + the tolerant parser.

## Follow-up (agreed): meal-plan sync
Prism's `meals` table already has `source`/`sourceId`/`recipeId`; Tandoor exposes `/api/meal-plan/`. A **phase-2 PR** will sync Tandoor meal plans → Prism meal plans (referencing the imported recipes).
