### PR TITLE
feat(calendar): move calendar management onto the Calendar page

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -29,6 +29,13 @@ export async function GET(request: Request) {
   const integrationsAnchor = '#google-calendars';
   const anchorFor = (section: string) =>
     section === 'integrations' ? integrationsAnchor : '';
+  // Where to send the user after the OAuth round-trip. Calendar management moved
+  // onto the Calendar page (Manage overlay), so a 'calendars' return goes there
+  // and auto-opens the overlay; everything else stays a settings section.
+  const returnUrlFor = (section: string, query: string) =>
+    section === 'calendars'
+      ? `${BASE_URL}/calendar?manage=calendars&${query}`
+      : `${BASE_URL}/settings?section=${section}&${query}${anchorFor(section)}`;
 
   try {
     const { searchParams } = new URL(request.url);
@@ -53,12 +60,12 @@ export async function GET(request: Request) {
     // Check for errors from Google
     if (error) {
       logError('Google OAuth error:', error);
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=google_auth_denied${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'error=google_auth_denied'));
     }
 
     // Ensure we have an authorization code
     if (!code) {
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=missing_code${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'error=missing_code'));
     }
 
     // Re-derive the same request-host redirect URI used at /authorize so the
@@ -126,7 +133,7 @@ export async function GET(request: Request) {
         summary: 'Re-authenticated Google Calendar integration',
       });
 
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_reauth${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'success=google_reauth'));
     }
 
     // Fetch calendars using the plaintext token (before we discard it)
@@ -192,7 +199,7 @@ export async function GET(request: Request) {
     });
 
     // Redirect back to settings with success message
-    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_connected${anchorFor(returnSection)}`);
+    return NextResponse.redirect(returnUrlFor(returnSection, 'success=google_connected'));
   } catch (error) {
     logError('Google OAuth callback error:', error);
     // The state nonce is single-use and already consumed here, so returnSection

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addDays, addWeeks, startOfDay } from 'date-fns';
 import {
   DndContext,
@@ -19,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Calendar,
+  CalendarCog,
   Merge,
   Plus,
   Loader2,
@@ -28,6 +30,7 @@ import { contrastText } from '@/lib/utils/color';
 import { useFamily } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import { AddEventModal } from '@/components/modals';
+import { ManageCalendarsModal } from './ManageCalendarsModal';
 import { PageWrapper, SubpageHeader, FilterBar } from '@/components/layout';
 const MonthView = lazy(() => import('@/components/calendar/MonthView').then(m => ({ default: m.MonthView })));
 const WeekView = lazy(() => import('@/components/calendar/WeekView').then(m => ({ default: m.WeekView })));
@@ -214,6 +217,14 @@ export function CalendarView() {
   const [editingChore, setEditingChore] = useState<Chore | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
+  const [showManageCalendars, setShowManageCalendars] = useState(false);
+
+  // Deep link: /calendar?manage=calendars opens the Manage panel (used by the
+  // Integrations settings cards after connecting a Google/CalDAV account).
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    if (searchParams?.get('manage') === 'calendars') setShowManageCalendars(true);
+  }, [searchParams]);
 
   // Live data for the modals. The bucket carries lightweight summaries; the
   // modals need full records (e.g. meal recipe URL, chore startDay), which
@@ -397,6 +408,11 @@ export function CalendarView() {
                 }}
               />
             </div>
+            {!isMobile && (
+              <Button variant="outline" size="sm" onClick={() => setShowManageCalendars(true)} className="h-9" title="Manage calendars">
+                <CalendarCog className="h-4 w-4 mr-1" />Manage
+              </Button>
+            )}
             {!isMobile && (
               <Button size="sm" onClick={handleAddWithAuth}>
                 <Plus className="h-4 w-4 mr-1" />Add Event
@@ -593,6 +609,10 @@ export function CalendarView() {
           } : undefined}
           onEventCreated={() => { refreshEvents(); setShowAddEvent(false); setEditingEvent(null); }}
         />
+
+        {showManageCalendars && (
+          <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} />
+        )}
 
         {editingChore && (
           <ChoreModal

--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+/**
+ * "Manage calendars" overlay — opens from the Calendar page so calendar
+ * configuration lives *with* the calendar (the same "config where the entity
+ * lives" pattern as recipe sync on the Recipes page), instead of buried in
+ * Settings. Reuses the existing CalendarsSection verbatim (connected calendars,
+ * groups, hours, iCal subscriptions).
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { CalendarsSection } from '@/app/settings/sections/CalendarsSection';
+
+export function ManageCalendarsModal({ onClose }: { onClose: () => void }) {
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Manage calendars</DialogTitle>
+        </DialogHeader>
+        <CalendarsSection />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import {
   Settings,
@@ -148,6 +148,20 @@ function normalizeSection(raw: string | null): string {
 
 export function SettingsView() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Calendar management moved to the Calendar page. Bounce any lingering link
+  // to ?section=calendars (old bookmarks, OAuth returns) to the Manage overlay.
+  const requestedSection = searchParams.get('section');
+  useEffect(() => {
+    if (requestedSection === 'calendars') {
+      const qs = new URLSearchParams(searchParams.toString());
+      qs.delete('section');
+      qs.set('manage', 'calendars');
+      router.replace(`/calendar?${qs.toString()}`);
+    }
+  }, [requestedSection, searchParams, router]);
+
   const initialSection = normalizeSection(searchParams.get('section'));
   const [activeSection, setActiveSection] = useState<string>(initialSection);
 

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -12,7 +12,6 @@ import {
   Shield,
   Info,
   Home,
-  Calendar,
   User,
   ImageIcon,
   ListTodo,
@@ -36,7 +35,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { PageWrapper } from '@/components/layout';
 import { AccountSection } from './sections/AccountSection';
 import { FamilySection } from './sections/FamilySection';
-import { CalendarsSection } from './sections/CalendarsSection';
 import { DisplaySection } from './sections/DisplaySection';
 import { GeneralSection } from './sections/GeneralSection';
 import { SecuritySection } from './sections/SecuritySection';
@@ -176,9 +174,9 @@ export function SettingsView() {
     { id: 'family', label: 'Family Members', icon: Users },
     { id: 'general', label: 'General', icon: SlidersHorizontal },
     { id: 'integrations', label: 'Integrations', icon: Link2 },
+    // Calendar management moved onto the Calendar page (Manage calendars button).
     { id: 'displays', label: 'Displays', icon: Monitor },
     { id: 'display', label: 'Appearance', icon: Palette },
-    { id: 'calendars', label: 'Calendars', icon: Calendar },
     { id: 'photos', label: 'Photos', icon: ImageIcon },
     { id: 'bus', label: 'Bus Tracking', icon: Bus },
     { id: 'input', label: 'Input', icon: KeyboardIcon },
@@ -259,7 +257,6 @@ export function SettingsView() {
               {activeSection === 'family' && <FamilySection />}
               {activeSection === 'integrations' && <IntegrationsSection />}
               {activeSection === 'displays' && <DisplaysSection />}
-              {activeSection === 'calendars' && <CalendarsSection />}
               {activeSection === 'photos' && <PhotosSettingsSection />}
               {activeSection === 'bus' && <BusTrackingSection />}
               {activeSection === 'babysitter' && <BabysitterInfoSection />}

--- a/src/app/settings/sections/integrations/cards/CalDAVProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/CalDAVProviderCard.tsx
@@ -78,10 +78,10 @@ export function CalDAVProviderCard({ onChange, forceSubSectionOpen }: Props) {
         >
           <div className="text-sm">
             <Link
-              href="/settings?section=calendars"
+              href="/calendar?manage=calendars"
               className="text-primary hover:underline"
             >
-              Open Calendars settings →
+              Manage calendars →
             </Link>
           </div>
         </CollapsibleSubSection>

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -175,10 +175,10 @@ export function GoogleProviderCard({
         >
           <div className="text-sm">
             <Link
-              href="/settings?section=calendars"
+              href="/calendar?manage=calendars"
               className="text-primary hover:underline"
             >
-              Open Calendars settings →
+              Manage calendars →
             </Link>
           </div>
         </CollapsibleSubSection>


### PR DESCRIPTION
Stacked on #172 (interweaves with the General-section change in SettingsView). GitHub will auto-retarget to master when #172 merges.

## What
Calendar configuration (connected calendars, groups, hours, iCal subscriptions) lived buried in **Settings → Calendars**. Move it **onto the Calendar page** — a **Manage** button opens a Manage-calendars overlay — so config lives with the entity (same "config where the entity lives" pattern as recipe sync on Recipes). Reuses `CalendarsSection` verbatim; no logic changes.

- Settings → Calendars nav section removed.
- Integrations Google/CalDAV cards → "Manage calendars →" deep-link to `/calendar?manage=calendars` (auto-opens the overlay).
- Google OAuth re-auth callback + a SettingsView safety-net now route `?section=calendars` returns to the overlay (fixes a dead-page regression).
- Calendar Hours stays in the overlay (the view-gear is shared with the calendar widget, so it can't live there).

## Test
- Calendar → **Manage** → connected calendars / groups / hours / subscriptions.
- Inside the overlay: delete a calendar (confirm), color picker, add iCal subscription (nested-dialog check).
- Re-auth Google from a connected card → lands back on the calendar overlay.