### PR TITLE
feat(calendar): net-change sync counts + calendar fixes (#171 Stage 1)

### DIFF
--- a/src/app/api/birthdays/sync/route.ts
+++ b/src/app/api/birthdays/sync/route.ts
@@ -256,23 +256,29 @@ export async function POST() {
     // "Alex") collapses onto an iCloud contact with FN "Alex Doe"
     // when both share a birth month/day, instead of becoming a separate
     // row. See src/lib/services/birthday-merge.ts.
-    let synced = 0;
+    let added = 0;
+    let updated = 0;
     for (const row of rows) {
       try {
-        await upsertBirthday({
+        const outcome = await upsertBirthday({
           name: row.name,
           birthDate: row.birthDate,
           eventType: row.eventType as 'birthday' | 'anniversary' | 'milestone',
           source: row.googleCalendarSource,
         });
-        synced++;
+        if (outcome === 'inserted') added++;
+        else if (outcome === 'updated') updated++;
       } catch (err) {
         console.error('[BirthdaySync] Failed to upsert:', row.name, row.eventType, err);
         errors.push(`Failed to upsert ${row.name}: ${err}`);
       }
     }
+    // Net changes (added + updated), not the total re-pulled — matches the
+    // calendar-event sync. `synced` kept for back-compat.
     return NextResponse.json({
-      synced,
+      synced: added + updated,
+      added,
+      updated,
       total: allEvents.length,
       errors: errors.length > 0 ? errors : undefined,
     });

--- a/src/app/api/birthdays/sync/route.ts
+++ b/src/app/api/birthdays/sync/route.ts
@@ -18,6 +18,7 @@ import { calendarSources } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { logError } from '@/lib/utils/logError';
 import { upsertBirthday } from '@/lib/services/birthday-merge';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import {
   fetchCalendarEvents,
   refreshAccessToken,
@@ -273,6 +274,9 @@ export async function POST() {
         errors.push(`Failed to upsert ${row.name}: ${err}`);
       }
     }
+    // Refresh cached birthday lists so new/changed ones show immediately.
+    if (added + updated > 0) await invalidateEntity('birthdays');
+
     // Net changes (added + updated), not the total re-pulled — matches the
     // calendar-event sync. `synced` kept for back-compat.
     return NextResponse.json({

--- a/src/app/api/calendars/sync/route.ts
+++ b/src/app/api/calendars/sync/route.ts
@@ -13,6 +13,7 @@ import { logError } from '@/lib/utils/logError';
 import { db } from '@/lib/db/client';
 import { calendarSources } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import {
   syncAllGoogleCalendars,
   syncGoogleCalendarSource,
@@ -121,6 +122,11 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
+
+    // A manual sync writes straight to the DB; invalidate the cached event
+    // lists so the calendar reflects new/removed events immediately (the cron
+    // path does this itself, but this route didn't).
+    await invalidateEntity('events');
 
     // Report NET changes (added / updated / removed), not total re-pulled.
     const changeParts: string[] = [];

--- a/src/app/api/calendars/sync/route.ts
+++ b/src/app/api/calendars/sync/route.ts
@@ -61,7 +61,14 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    let result: { synced?: number; total?: number; errors: string[] };
+    let result: {
+      synced?: number;
+      total?: number;
+      added: number;
+      updated: number;
+      removed: number;
+      errors: string[];
+    };
 
     if (body.calendarId) {
       // Sync specific calendar — dispatch by provider
@@ -80,7 +87,13 @@ export async function POST(request: NextRequest) {
         : source.provider === 'caldav'
           ? await syncCalDAVCalendarSource(body.calendarId, options)
           : await syncGoogleCalendarSource(body.calendarId, options);
-      result = { synced: syncResult.synced, errors: syncResult.errors };
+      result = {
+        synced: syncResult.synced,
+        added: syncResult.added,
+        updated: syncResult.updated,
+        removed: syncResult.removed,
+        errors: syncResult.errors,
+      };
     } else {
       // Sync all calendars across all supported providers
       const [google, ical, caldav] = await Promise.all([
@@ -90,6 +103,9 @@ export async function POST(request: NextRequest) {
       ]);
       result = {
         total: google.total + ical.total + caldav.total,
+        added: google.added + ical.added + caldav.added,
+        updated: google.updated + ical.updated + caldav.updated,
+        removed: google.removed + ical.removed + caldav.removed,
         errors: [...google.errors, ...ical.errors, ...caldav.errors],
       };
     }
@@ -106,11 +122,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Report NET changes (added / updated / removed), not total re-pulled.
+    const changeParts: string[] = [];
+    if (result.added) changeParts.push(`${result.added} added`);
+    if (result.updated) changeParts.push(`${result.updated} updated`);
+    if (result.removed) changeParts.push(`${result.removed} removed`);
+    const changeSummary = changeParts.length ? changeParts.join(', ') : 'no changes';
+
     return NextResponse.json({
       success: true,
-      message: body.calendarId
-        ? `Synced ${result.synced} events`
-        : `Synced ${result.total} events from all calendars`,
+      message: `Calendar sync complete — ${changeSummary}`,
+      added: result.added,
+      updated: result.updated,
+      removed: result.removed,
       synced: result.synced ?? result.total,
       errors: result.errors.length > 0 ? result.errors : undefined,
     });

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -180,7 +180,7 @@ export function CalendarsSection() {
           ? `Sync complete: ${parts.join(', ')}`
           : 'Sync complete — already up to date';
         if (birthdaysSynced > 0) {
-          message += ` · ${birthdaysSynced} celebration${birthdaysSynced === 1 ? '' : 's'} updated`;
+          message += ` · ${birthdaysSynced} milestone${birthdaysSynced === 1 ? '' : 's'} updated`;
         }
         if (data.errors && data.errors.length > 0) {
           message += `\n\nWarnings (${data.errors.length}):\n${data.errors.slice(0, 5).join('\n')}`;

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -172,9 +172,15 @@ export function CalendarsSection() {
       }
 
       if (response.ok) {
-        let message = `Sync complete: ${data.synced ?? data.total ?? 0} events synced`;
+        const parts: string[] = [];
+        if (data.added) parts.push(`${data.added} added`);
+        if (data.updated) parts.push(`${data.updated} updated`);
+        if (data.removed) parts.push(`${data.removed} removed`);
+        let message = parts.length
+          ? `Sync complete: ${parts.join(', ')}`
+          : 'Sync complete — already up to date';
         if (birthdaysSynced > 0) {
-          message += `, ${birthdaysSynced} birthdays synced`;
+          message += ` · ${birthdaysSynced} birthdays synced`;
         }
         if (data.errors && data.errors.length > 0) {
           message += `\n\nWarnings (${data.errors.length}):\n${data.errors.slice(0, 5).join('\n')}`;

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -180,7 +180,7 @@ export function CalendarsSection() {
           ? `Sync complete: ${parts.join(', ')}`
           : 'Sync complete — already up to date';
         if (birthdaysSynced > 0) {
-          message += ` · ${birthdaysSynced} birthdays synced`;
+          message += ` · ${birthdaysSynced} birthday${birthdaysSynced === 1 ? '' : 's'} updated`;
         }
         if (data.errors && data.errors.length > 0) {
           message += `\n\nWarnings (${data.errors.length}):\n${data.errors.slice(0, 5).join('\n')}`;

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -180,7 +180,7 @@ export function CalendarsSection() {
           ? `Sync complete: ${parts.join(', ')}`
           : 'Sync complete — already up to date';
         if (birthdaysSynced > 0) {
-          message += ` · ${birthdaysSynced} birthday${birthdaysSynced === 1 ? '' : 's'} updated`;
+          message += ` · ${birthdaysSynced} celebration${birthdaysSynced === 1 ? '' : 's'} updated`;
         }
         if (data.errors && data.errors.length > 0) {
           message += `\n\nWarnings (${data.errors.length}):\n${data.errors.slice(0, 5).join('\n')}`;

--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -385,8 +385,8 @@ export function AddEventModal({
                 type="date"
                 value={startDate}
                 onChange={(e) => handleStartDateChange(e.target.value)}
+                onClick={(e) => (e.currentTarget as HTMLInputElement).showPicker?.()}
                 className="absolute inset-0 opacity-0 w-full cursor-pointer"
-                tabIndex={-1}
                 required
               />
             </div>
@@ -413,8 +413,8 @@ export function AddEventModal({
                   value={endDate}
                   min={startDate}
                   onChange={(e) => setEndDate(e.target.value)}
+                  onClick={(e) => (e.currentTarget as HTMLInputElement).showPicker?.()}
                   className="absolute inset-0 opacity-0 w-full cursor-pointer"
-                  tabIndex={-1}
                 />
               </div>
             )}
@@ -449,8 +449,8 @@ export function AddEventModal({
                   value={endDate}
                   min={startDate}
                   onChange={(e) => setEndDate(e.target.value)}
+                  onClick={(e) => (e.currentTarget as HTMLInputElement).showPicker?.()}
                   className="absolute inset-0 opacity-0 w-full cursor-pointer"
-                  tabIndex={-1}
                 />
               </div>
             )}

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -69,12 +69,20 @@ export async function upsertBirthday(opts: UpsertOpts): Promise<'inserted' | 'up
   for (const existing of candidates) {
     // Exact match: standard upsert behavior — refresh fields, keep id.
     if (normalize(existing.name) === normalize(name)) {
-      // Already up to date → don't write, and don't count it as a change.
-      if (existing.birthDate === birthDate && (existing.googleCalendarSource ?? null) === (source ?? null)) {
+      // Prefer a known year over the 1904 unknown-year sentinel, so the Google
+      // sync (often has the year) and the CardDAV sync (often 1904) don't
+      // overwrite each other's date on every run.
+      const existingYear = parseYear(existing.birthDate);
+      const keepYear = existingYear !== 1904 ? existingYear : newYear;
+      const mergedDate = `${keepYear}-${mo}-${dy}`;
+      // Only a genuine change to the (year-preferring) date counts. The source
+      // is provenance and legitimately flip-flops between the two birthday
+      // syncs, so a source-only difference must NOT count as an update.
+      if (existing.birthDate === mergedDate) {
         return 'skipped';
       }
       await db.update(birthdays).set({
-        birthDate,
+        birthDate: mergedDate,
         googleCalendarSource: source,
       }).where(eq(birthdays.id, existing.id));
       return 'updated';

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -69,6 +69,10 @@ export async function upsertBirthday(opts: UpsertOpts): Promise<'inserted' | 'up
   for (const existing of candidates) {
     // Exact match: standard upsert behavior — refresh fields, keep id.
     if (normalize(existing.name) === normalize(name)) {
+      // Already up to date → don't write, and don't count it as a change.
+      if (existing.birthDate === birthDate && (existing.googleCalendarSource ?? null) === (source ?? null)) {
+        return 'skipped';
+      }
       await db.update(birthdays).set({
         birthDate,
         googleCalendarSource: source,

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -43,6 +43,77 @@ function tokenNeedsRefresh(expiresAt: Date | null): boolean {
 }
 
 /**
+ * Net-change counts for a sync — what actually changed this run, not the total
+ * number of events re-pulled. `synced` (added + updated) is kept for back-compat
+ * with callers/logging that read a single number.
+ */
+export interface SyncCounts {
+  added: number;
+  updated: number;
+  removed: number;
+  unchanged: number;
+  synced: number;
+  errors: string[];
+}
+
+/** The event fields a change is judged on (identity-independent content). */
+interface EventContent {
+  title: string;
+  description: string | null;
+  location: string | null;
+  startTime: Date | string;
+  endTime: Date | string;
+  allDay: boolean | null;
+  recurring: boolean | null;
+  recurrenceRule: string | null;
+}
+
+/** Seconds since epoch (drops sub-second drift from DB round-trips). */
+const secs = (d: Date | string): number => Math.floor(new Date(d).getTime() / 1000);
+
+/** True when the incoming event differs from the stored row in any shown field. */
+function eventChanged(a: EventContent, b: EventContent): boolean {
+  return (
+    a.title !== b.title ||
+    (a.description ?? '') !== (b.description ?? '') ||
+    (a.location ?? '') !== (b.location ?? '') ||
+    secs(a.startTime) !== secs(b.startTime) ||
+    secs(a.endTime) !== secs(b.endTime) ||
+    Boolean(a.allDay) !== Boolean(b.allDay) ||
+    Boolean(a.recurring) !== Boolean(b.recurring) ||
+    (a.recurrenceRule ?? '') !== (b.recurrenceRule ?? '')
+  );
+}
+
+/** A zero net-change result, optionally carrying errors (for early returns). */
+function emptyCounts(errors: string[] = []): SyncCounts {
+  return { added: 0, updated: 0, removed: 0, unchanged: 0, synced: 0, errors };
+}
+
+/** Build a lookup of a source's existing events by externalEventId (for classify). */
+async function loadExistingByExternalId(sourceId: string): Promise<Map<string, EventContent>> {
+  const rows = await db.query.events.findMany({
+    where: eq(events.calendarSourceId, sourceId),
+    columns: {
+      externalEventId: true,
+      title: true,
+      description: true,
+      location: true,
+      startTime: true,
+      endTime: true,
+      allDay: true,
+      recurring: true,
+      recurrenceRule: true,
+    },
+  });
+  const map = new Map<string, EventContent>();
+  for (const r of rows) {
+    if (r.externalEventId) map.set(r.externalEventId, r);
+  }
+  return map;
+}
+
+/**
  * Sync events from a single Google Calendar source
  */
 export async function syncGoogleCalendarSource(
@@ -51,9 +122,9 @@ export async function syncGoogleCalendarSource(
     timeMin?: Date;
     timeMax?: Date;
   } = {}
-): Promise<{ synced: number; errors: string[] }> {
+): Promise<SyncCounts> {
   const errors: string[] = [];
-  let synced = 0;
+  let added = 0, updated = 0, removed = 0, unchanged = 0;
 
   // Fetch the calendar source
   const source = await db.query.calendarSources.findFirst({
@@ -61,27 +132,27 @@ export async function syncGoogleCalendarSource(
   });
 
   if (!source) {
-    return { synced: 0, errors: ['Calendar source not found'] };
+    return emptyCounts(['Calendar source not found']);
   }
 
   if (source.provider !== 'google') {
-    return { synced: 0, errors: ['Not a Google Calendar source'] };
+    return emptyCounts(['Not a Google Calendar source']);
   }
 
   if (!source.accessToken) {
-    return { synced: 0, errors: ['No access token available'] };
+    return emptyCounts(['No access token available']);
   }
 
   let accessToken: string;
   try {
     accessToken = decrypt(source.accessToken);
   } catch (error) {
-    return { synced: 0, errors: [`Failed to decrypt access token (may need re-authentication): ${error instanceof Error ? error.message : String(error)}`] };
+    return emptyCounts([`Failed to decrypt access token (may need re-authentication): ${error instanceof Error ? error.message : String(error)}`]);
   }
 
   if (tokenNeedsRefresh(source.tokenExpiresAt)) {
     if (!source.refreshToken) {
-      return { synced: 0, errors: ['Token expired and no refresh token available'] };
+      return emptyCounts(['Token expired and no refresh token available']);
     }
 
     try {
@@ -112,9 +183,9 @@ export async function syncGoogleCalendarSource(
             updatedAt: new Date(),
           })
           .where(eq(calendarSources.id, sourceId));
-        return { synced: 0, errors: ['Token expired or revoked. Re-authentication required.'] };
+        return emptyCounts(['Token expired or revoked. Re-authentication required.']);
       }
-      return { synced: 0, errors: [`Failed to refresh token: ${error}`] };
+      return emptyCounts([`Failed to refresh token: ${error}`]);
     }
   }
 
@@ -172,11 +243,12 @@ export async function syncGoogleCalendarSource(
       })
       .where(eq(calendarSources.id, sourceId));
 
-    return { synced: 0, errors: [`Failed to fetch events: ${error}`] };
+    return emptyCounts([`Failed to fetch events: ${error}`]);
   }
 
   // Build set of Google event IDs for deletion cleanup (excluding cancelled)
   const googleEventIds = new Set<string>();
+  const existingByExtId = await loadExistingByExternalId(sourceId);
 
   // Process each event using upsert to prevent duplicates
   for (const googleEvent of googleEvents) {
@@ -219,7 +291,10 @@ export async function syncGoogleCalendarSource(
           },
         });
 
-      synced++;
+      const prevG = existingByExtId.get(internalEvent.externalEventId);
+      if (!prevG) added++;
+      else if (eventChanged(prevG, internalEvent)) updated++;
+      else unchanged++;
     } catch (error) {
       errors.push(`Failed to sync event ${googleEvent.id}: ${error}`);
     }
@@ -242,6 +317,7 @@ export async function syncGoogleCalendarSource(
     // Only delete if it has an external_event_id (was synced) but is no longer in Google
     if (prismEvent.externalEventId && !googleEventIds.has(prismEvent.externalEventId)) {
       await db.delete(events).where(eq(events.id, prismEvent.id));
+      removed++;
     }
   }
 
@@ -256,7 +332,7 @@ export async function syncGoogleCalendarSource(
     })
     .where(eq(calendarSources.id, sourceId));
 
-  return { synced, errors };
+  return { added, updated, removed, unchanged, synced: added + updated, errors };
 }
 
 /**
@@ -267,9 +343,9 @@ export async function syncAllGoogleCalendars(
     timeMin?: Date;
     timeMax?: Date;
   } = {}
-): Promise<{ total: number; errors: string[] }> {
+): Promise<{ total: number; added: number; updated: number; removed: number; errors: string[] }> {
   const allErrors: string[] = [];
-  let total = 0;
+  let total = 0, added = 0, updated = 0, removed = 0;
 
   // Get all enabled Google Calendar sources
   const sources = await db.query.calendarSources.findMany({
@@ -372,6 +448,9 @@ export async function syncAllGoogleCalendars(
     try {
       const result = await syncGoogleCalendarSource(source.id, options);
       total += result.synced;
+      added += result.added;
+      updated += result.updated;
+      removed += result.removed;
       allErrors.push(...result.errors);
     } catch (error) {
       const errorMsg = `Failed to sync calendar "${source.dashboardCalendarName}": ${error instanceof Error ? error.message : String(error)}`;
@@ -380,7 +459,7 @@ export async function syncAllGoogleCalendars(
     }
   }
 
-  return { total, errors: allErrors };
+  return { total, added, updated, removed, errors: allErrors };
 }
 
 const ICAL_DISABLE_THRESHOLD = 3;
@@ -422,22 +501,22 @@ export async function syncIcalCalendarSource(
     timeMin?: Date;
     timeMax?: Date;
   } = {}
-): Promise<{ synced: number; errors: string[] }> {
+): Promise<SyncCounts> {
   const errors: string[] = [];
-  let synced = 0;
+  let added = 0, updated = 0, removed = 0, unchanged = 0;
 
   const source = await db.query.calendarSources.findFirst({
     where: eq(calendarSources.id, sourceId),
   });
 
   if (!source) {
-    return { synced: 0, errors: ['Calendar source not found'] };
+    return emptyCounts(['Calendar source not found']);
   }
   if (source.provider !== 'ical') {
-    return { synced: 0, errors: ['Not an iCal calendar source'] };
+    return emptyCounts(['Not an iCal calendar source']);
   }
   if (!source.icalUrl) {
-    return { synced: 0, errors: ['No iCal URL configured'] };
+    return emptyCounts(['No iCal URL configured']);
   }
 
   const timeMin = options.timeMin || new Date(Date.now() - DEFAULT_TIME_MIN_MS);
@@ -461,7 +540,7 @@ export async function syncIcalCalendarSource(
           updatedAt: new Date(),
         })
         .where(eq(calendarSources.id, sourceId));
-      return { synced: 0, errors: ['iCal URL points at a private or loopback address'] };
+      return emptyCounts(['iCal URL points at a private or loopback address']);
     }
     throw err;
   }
@@ -491,10 +570,11 @@ export async function syncIcalCalendarSource(
       })
       .where(eq(calendarSources.id, sourceId));
 
-    return { synced: 0, errors: [`Failed to fetch iCal feed: ${errorStr}`] };
+    return emptyCounts([`Failed to fetch iCal feed: ${errorStr}`]);
   }
 
   const externalIds = new Set<string>();
+  const existingByExtId = await loadExistingByExternalId(sourceId);
 
   for (const item of Object.values(parsed)) {
     if (!item || item.type !== 'VEVENT') continue;
@@ -597,7 +677,10 @@ export async function syncIcalCalendarSource(
             },
           });
 
-        synced++;
+        const prevI = existingByExtId.get(inst.externalId);
+        if (!prevI) added++;
+        else if (eventChanged(prevI, { title, description, location, startTime: inst.start, endTime: inst.end, allDay, recurring: isRecurring, recurrenceRule })) updated++;
+        else unchanged++;
       }
     } catch (error) {
       errors.push(`Failed to sync VEVENT ${uid}: ${error instanceof Error ? error.message : String(error)}`);
@@ -616,6 +699,7 @@ export async function syncIcalCalendarSource(
   for (const ev of prismEvents) {
     if (ev.externalEventId && !externalIds.has(ev.externalEventId)) {
       await db.delete(events).where(eq(events.id, ev.id));
+      removed++;
     }
   }
 
@@ -629,7 +713,7 @@ export async function syncIcalCalendarSource(
     })
     .where(eq(calendarSources.id, sourceId));
 
-  return { synced, errors };
+  return { added, updated, removed, unchanged, synced: added + updated, errors };
 }
 
 /**
@@ -641,9 +725,9 @@ export async function syncAllIcalCalendars(
     timeMin?: Date;
     timeMax?: Date;
   } = {}
-): Promise<{ total: number; errors: string[] }> {
+): Promise<{ total: number; added: number; updated: number; removed: number; errors: string[] }> {
   const allErrors: string[] = [];
-  let total = 0;
+  let total = 0, added = 0, updated = 0, removed = 0;
 
   const sources = await db.query.calendarSources.findMany({
     where: and(
@@ -656,6 +740,9 @@ export async function syncAllIcalCalendars(
     try {
       const result = await syncIcalCalendarSource(source.id, options);
       total += result.synced;
+      added += result.added;
+      updated += result.updated;
+      removed += result.removed;
       allErrors.push(...result.errors);
     } catch (error) {
       const errorMsg = `Failed to sync iCal calendar "${source.dashboardCalendarName}": ${error instanceof Error ? error.message : String(error)}`;
@@ -664,7 +751,7 @@ export async function syncAllIcalCalendars(
     }
   }
 
-  return { total, errors: allErrors };
+  return { total, added, updated, removed, errors: allErrors };
 }
 
 /**
@@ -716,39 +803,39 @@ export async function getCalendarSourcesWithStatus() {
 export async function syncCalDAVCalendarSource(
   sourceId: string,
   options: { timeMin?: Date; timeMax?: Date } = {}
-): Promise<{ synced: number; errors: string[] }> {
+): Promise<SyncCounts> {
   const errors: string[] = [];
-  let synced = 0;
+  let added = 0, updated = 0, removed = 0, unchanged = 0;
 
   const source = await db.query.calendarSources.findFirst({
     where: eq(calendarSources.id, sourceId),
   });
 
   if (!source || source.provider !== 'caldav') {
-    return { synced: 0, errors: ['Not a CalDAV source'] };
+    return emptyCounts(['Not a CalDAV source']);
   }
 
   if (!source.accessToken) {
-    return { synced: 0, errors: ['No credentials available'] };
+    return emptyCounts(['No credentials available']);
   }
 
   let password: string;
   try {
     password = decrypt(source.accessToken);
   } catch {
-    return { synced: 0, errors: ['Failed to decrypt credentials — may need to reconnect'] };
+    return emptyCounts(['Failed to decrypt credentials — may need to reconnect']);
   }
 
   const config = source.providerConfig as CalDAVConnectionConfig | null;
   if (!config?.serverUrl || !config?.username) {
-    return { synced: 0, errors: ['Missing CalDAV connection config'] };
+    return emptyCounts(['Missing CalDAV connection config']);
   }
 
   // Skip event sync for sources whose discovery flagged them as VTODO-only.
   // (undefined === legacy row from before flags were stored, so default to
   // running the sync — back-compatible.)
   if (config.supportsEvents === false) {
-    return { synced: 0, errors: [] };
+    return emptyCounts([]);
   }
 
   const timeMin = options.timeMin || new Date(Date.now() - DEFAULT_TIME_MIN_MS);
@@ -788,12 +875,12 @@ export async function syncCalDAVCalendarSource(
       };
 
       if (existing) {
+        if (eventChanged(existing, eventData)) updated++; else unchanged++;
         await db.update(events).set(eventData).where(eq(events.id, existing.id));
       } else {
+        added++;
         await db.insert(events).values(eventData);
       }
-
-      synced++;
     }
 
     // Drop events that no longer exist upstream (within the sync window only —
@@ -810,6 +897,7 @@ export async function syncCalDAVCalendarSource(
     for (const local of localEvents) {
       if (local.externalEventId && !upstreamUids.has(local.externalEventId)) {
         await db.delete(events).where(eq(events.id, local.id));
+        removed++;
       }
     }
 
@@ -829,7 +917,7 @@ export async function syncCalDAVCalendarSource(
       .where(eq(calendarSources.id, sourceId));
   }
 
-  return { synced, errors };
+  return { added, updated, removed, unchanged, synced: added + updated, errors };
 }
 
 /**
@@ -837,7 +925,7 @@ export async function syncCalDAVCalendarSource(
  */
 export async function syncCalDAVTasks(
   sourceId: string,
-): Promise<{ synced: number; errors: string[] }> {
+): Promise<SyncCounts> {
   const errors: string[] = [];
   let synced = 0;
 
@@ -846,27 +934,27 @@ export async function syncCalDAVTasks(
   });
 
   if (!source || source.provider !== 'caldav') {
-    return { synced: 0, errors: ['Not a CalDAV source'] };
+    return emptyCounts(['Not a CalDAV source']);
   }
   if (!source.accessToken) {
-    return { synced: 0, errors: ['No credentials available'] };
+    return emptyCounts(['No credentials available']);
   }
 
   let password: string;
   try {
     password = decrypt(source.accessToken);
   } catch {
-    return { synced: 0, errors: ['Failed to decrypt credentials'] };
+    return emptyCounts(['Failed to decrypt credentials']);
   }
 
   const config = source.providerConfig as CalDAVConnectionConfig | null;
   if (!config?.serverUrl || !config?.username) {
-    return { synced: 0, errors: ['Missing CalDAV connection config'] };
+    return emptyCounts(['Missing CalDAV connection config']);
   }
 
   // Skip task sync for sources whose discovery flagged them as VEVENT-only.
   if (config.supportsTasks === false) {
-    return { synced: 0, errors: [] };
+    return emptyCounts([]);
   }
 
   try {
@@ -997,7 +1085,7 @@ export async function syncCalDAVTasks(
     }
   }
 
-  return { synced, errors };
+  return { added: 0, updated: 0, removed: 0, unchanged: 0, synced, errors };
 }
 
 /**
@@ -1005,9 +1093,9 @@ export async function syncCalDAVTasks(
  */
 export async function syncAllCalDAVCalendars(
   options: { timeMin?: Date; timeMax?: Date } = {}
-): Promise<{ total: number; errors: string[] }> {
+): Promise<{ total: number; added: number; updated: number; removed: number; errors: string[] }> {
   const allErrors: string[] = [];
-  let total = 0;
+  let total = 0, added = 0, updated = 0, removed = 0;
 
   const sources = await db.query.calendarSources.findMany({
     where: and(
@@ -1019,6 +1107,9 @@ export async function syncAllCalDAVCalendars(
   for (const source of sources) {
     const eventResult = await syncCalDAVCalendarSource(source.id, options);
     total += eventResult.synced;
+    added += eventResult.added;
+    updated += eventResult.updated;
+    removed += eventResult.removed;
     allErrors.push(...eventResult.errors);
 
     const taskResult = await syncCalDAVTasks(source.id);
@@ -1026,7 +1117,7 @@ export async function syncAllCalDAVCalendars(
     allErrors.push(...taskResult.errors);
   }
 
-  return { total, errors: allErrors };
+  return { total, added, updated, removed, errors: allErrors };
 }
 
 /**


### PR DESCRIPTION
Stacked on #173 (→ #172 → master). First step of #171 (review-and-approve calendar sync): you can't show a review diff without first computing net changes.

## What
- **Net-change sync counts** — per-provider event sync (Google/CalDAV/iCal) now classifies each event as added / updated / unchanged (by content compare) and counts removals, threaded through the aggregators → `/api/calendars/sync` → toast. Reports **"X added, Y updated, Z removed"** or **"already up to date"** instead of the total re-pulled. Back-compat `synced` total kept for the cron/logging.
- **Birthday sync net counts too** — `upsertBirthday` already returned inserted/updated/skipped; count those. Reported as **"N milestones updated"** (covers birthdays + anniversaries + milestones).
- **Birthday churn fix** — people in both Google birthdays *and* iCloud contacts were flip-flopping their `source`/year every run (the phantom "56 milestones"). Prefer a known year over the `1904` sentinel and only count a genuine date change; source-only diffs skip.
- **Cache invalidation on manual sync** — `/api/calendars/sync` + `/api/birthdays/sync` now `invalidateEntity` so a just-synced event/birthday shows on the calendar immediately (previously only the cron did this, so manual syncs sat behind a stale cache).
- **Add-Event date picker fix** — the date fields (hidden `opacity-0` `<input type=date>` over a display button) intercepted the click so `showPicker()` never fired; call it from the input's own `onClick`.

## Test (all confirmed)
- Sync twice → 2nd is "already up to date" (0/0). ✔
- Add/edit a birthday/anniversary → "N milestones updated". ✔
- Add-Event → date is now changeable, not just the time. ✔
- Add an event in Google → syncs and shows on the calendar; delete in Prism → deletes upstream + stays gone. ✔

Per-provider error isolation confirmed: a transient iCloud CalDAV blip doesn't block the Google sync.