### PR TITLE
feat(calendar): move calendar management onto the Calendar page

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -2,7 +2,18 @@
 
 A single map of where Prism's planning lives. The roadmap itself is public and community-voted on GitHub — this page **indexes** the internal planning/reference docs and **gathers the backlog** that isn't yet tracked as an issue, so nothing gets lost.
 
-_Last reviewed: 2026-07-25, after the [v1.9.0](CHANGELOG.md) security release._
+_Last reviewed: 2026-07-27, after the recipe/meal **sync framework** shipped ([#58](https://github.com/sandydargoport/prism/issues/58))._
+
+## Current focus (2026-07-27)
+
+The reusable review-and-approve **sync framework** just landed (one-way recipes + meal plans, Tandoor & Mealie — [#58](https://github.com/sandydargoport/prism/issues/58)). The active phase extends it and clears two quick wins, then cuts a release:
+
+1. **Weather location via ZIP** ([#170](https://github.com/sandydargoport/prism/issues/170)) — replace the free-text location; small, high-satisfaction. _In progress._
+2. **Write-back / two-way** ([#169](https://github.com/sandydargoport/prism/issues/169)) — push Prism edits back to Tandoor/Mealie.
+3. **Calendar sync on the same framework** ([#171](https://github.com/sandydargoport/prism/issues/171)) — the framework's original motivating case (Google Cal ↔ Prism); review-and-approve + two-way-safe.
+4. **Release** — held until the above land.
+
+Deliberately **deprioritized:** real RRULE recurrence builder ([#59](https://github.com/sandydargoport/prism/issues/59)) — valuable but heavy; revisit much later (note: recurring-event handling in calendar sync is scoped around this).
 
 ---
 
@@ -12,14 +23,16 @@ The authoritative roadmap is the **[Prism Roadmap project](https://github.com/us
 
 This page **deliberately does not mirror the full list** (a copy would drift). The themed snapshot below is just orientation — GitHub is the source of truth.
 
-**Open roadmap themes (2026-07-25):**
+**Open roadmap themes (2026-07-27):**
 
+- **Sync framework** — recipe + meal-plan sync **shipped** for Tandoor & Mealie ([#58](https://github.com/sandydargoport/prism/issues/58)); next: write-back / two-way ([#169](https://github.com/sandydargoport/prism/issues/169)) and **calendar sync** on the same framework ([#171](https://github.com/sandydargoport/prism/issues/171)).
 - **Layout / dashboard** — collapsible "expander" widgets ([#121](https://github.com/sandydargoport/prism/issues/121)), freeform pixel-layout mode ([#53](https://github.com/sandydargoport/prism/issues/53)), finish the consolidated Integrations page ([#52](https://github.com/sandydargoport/prism/issues/52) — Phase 1 shipped).
-- **Calendar** — real RRULE recurrence builder ([#59](https://github.com/sandydargoport/prism/issues/59)); the largest single calendar UX gap.
-- **Recipes / meals** — Mealie &amp; Tandoor sync ([#58](https://github.com/sandydargoport/prism/issues/58), gauging interest); due-date-anchored chore recurrence + meal-prep reminders ([#51](https://github.com/sandydargoport/prism/issues/51)).
+- **Meals / chores** — due-date-anchored chore recurrence + meal-prep reminders ([#51](https://github.com/sandydargoport/prism/issues/51)).
+- **Settings / weather** — replace free-text weather location with a ZIP ([#170](https://github.com/sandydargoport/prism/issues/170)); household timezone setting **shipped**.
+- **Calendar** — sync via the framework (above, [#171](https://github.com/sandydargoport/prism/issues/171)); real RRULE recurrence builder ([#59](https://github.com/sandydargoport/prism/issues/59)) **deprioritized** to later.
 - **Photos** — auto-detect favorites from cloud/folder ([#57](https://github.com/sandydargoport/prism/issues/57)); "By Trip" grouping via travel pins ([#54](https://github.com/sandydargoport/prism/issues/54)).
 - **Travel** — globe marker precision at low zoom ([#55](https://github.com/sandydargoport/prism/issues/55), bug).
-- **Voice / Alexa** — remaining intent phases 2c/3/4 ([#56](https://github.com/sandydargoport/prism/issues/56)).
+- **Voice / Alexa** — remaining intent phases 2c/3/4 ([#56](https://github.com/sandydargoport/prism/issues/56)) — blocked on a remote MCP endpoint.
 - **Contacts** — read-only iCloud contacts mirror ([#75](https://github.com/sandydargoport/prism/issues/75), low priority).
 
 ---
@@ -49,7 +62,7 @@ Forward-looking work found in the docs that has **no GitHub issue** — candidat
 **Integrations &amp; sync**
 
 - **Resurrect the MCP server** — a working Prism Model Context Protocol server (`.mcp/`, stdio transport, reuses Settings → API Tokens for auth) was built but never merged; re-cut from commit `f870aeb` rather than from scratch. Future direction: a remote/hosted variant (Streamable HTTP + OAuth 2.1). _(`decisions-log.md`)_
-- **Two-way CalDAV calendar write** — Apple / CalDAV calendars are read-only today. _(`features/CALENDAR.md`)_
+- **Two-way CalDAV calendar write** — Apple / CalDAV calendars are read-only today. _(`features/CALENDAR.md`)_ → now tracked as part of calendar sync ([#171](https://github.com/sandydargoport/prism/issues/171)).
 
 **Features**
 
@@ -78,4 +91,5 @@ Unresolved questions recorded in the review docs:
 
 ## Recently shipped
 
+- **Recipe & meal-plan sync framework** (2026-07-27, [#58](https://github.com/sandydargoport/prism/issues/58) via [#168](https://github.com/sandydargoport/prism/pull/168)) — reusable review-and-approve sync (entity-agnostic diff → review → apply + provider registry). One-way recipe + meal-plan pull for **Tandoor & Mealie**, with recipe auto-import, images, mass-delete guard, and idempotent re-sync. Also landed a household **timezone setting** and an ingredient **serving-scaling** fix. Not yet in a tagged release.
 - **[v1.9.0](CHANGELOG.md)** (2026-07-24) — security-hardening release that closed the entire [2026-07 audit](audit-2026-07.md): item-level authorization sweep, SSRF guards (CalDAV / CardDAV / Immich), session absolute lifetime, OAuth state nonces, service-worker cache fix, path-traversal validation, dependency-advisory bumps, correctness fixes (rate-limit lockout, weather timezone buckets, Google 404 auto-disable, travel-globe deps), and an Immich v3 album-sync fix.

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -29,6 +29,13 @@ export async function GET(request: Request) {
   const integrationsAnchor = '#google-calendars';
   const anchorFor = (section: string) =>
     section === 'integrations' ? integrationsAnchor : '';
+  // Where to send the user after the OAuth round-trip. Calendar management moved
+  // onto the Calendar page (Manage overlay), so a 'calendars' return goes there
+  // and auto-opens the overlay; everything else stays a settings section.
+  const returnUrlFor = (section: string, query: string) =>
+    section === 'calendars'
+      ? `${BASE_URL}/calendar?manage=calendars&${query}`
+      : `${BASE_URL}/settings?section=${section}&${query}${anchorFor(section)}`;
 
   try {
     const { searchParams } = new URL(request.url);
@@ -53,12 +60,12 @@ export async function GET(request: Request) {
     // Check for errors from Google
     if (error) {
       logError('Google OAuth error:', error);
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=google_auth_denied${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'error=google_auth_denied'));
     }
 
     // Ensure we have an authorization code
     if (!code) {
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&error=missing_code${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'error=missing_code'));
     }
 
     // Re-derive the same request-host redirect URI used at /authorize so the
@@ -126,7 +133,7 @@ export async function GET(request: Request) {
         summary: 'Re-authenticated Google Calendar integration',
       });
 
-      return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_reauth${anchorFor(returnSection)}`);
+      return NextResponse.redirect(returnUrlFor(returnSection, 'success=google_reauth'));
     }
 
     // Fetch calendars using the plaintext token (before we discard it)
@@ -192,7 +199,7 @@ export async function GET(request: Request) {
     });
 
     // Redirect back to settings with success message
-    return NextResponse.redirect(`${BASE_URL}/settings?section=${returnSection}&success=google_connected${anchorFor(returnSection)}`);
+    return NextResponse.redirect(returnUrlFor(returnSection, 'success=google_connected'));
   } catch (error) {
     logError('Google OAuth callback error:', error);
     // The state nonce is single-use and already consumed here, so returnSection

--- a/src/app/api/location-search/route.ts
+++ b/src/app/api/location-search/route.ts
@@ -51,6 +51,17 @@ function shortDisplayName(result: NominatimResult): string {
   return [city, state, country].filter(Boolean).join(', ');
 }
 
+/** Like shortDisplayName but appends the postal code, for ZIP lookups. */
+function postalDisplayName(result: NominatimResult, zip: string): string {
+  const a = result.address;
+  const city = a?.city ?? a?.town ?? a?.village ?? '';
+  const state = a?.state ?? '';
+  const country = a?.country_code?.toUpperCase() ?? a?.country ?? '';
+  const base = [city, state, country].filter(Boolean).join(', ');
+  const code = a?.postcode ?? zip;
+  return base ? `${base} ${code}` : code;
+}
+
 export async function GET(request: NextRequest) {
   const q = new URL(request.url).searchParams.get('q')?.trim();
   if (!q || q.length < 2) {
@@ -60,26 +71,63 @@ export async function GET(request: NextRequest) {
   try {
     const results: LocationCandidate[] = [];
 
-    // For postal codes, try OWM first (more reliable for zip lookup)
+    // Postal-code path. A bare number in a fuzzy free-text search returns noisy
+    // matches (e.g. "60062" also hits a Greek municipality), so resolve postal
+    // codes authoritatively and return them directly:
+    //  1. OWM's zip endpoint when a key is configured, else
+    //  2. a KEYLESS Nominatim *structured* postalcode query (one clean result).
     const zipMatch = q.match(/^(\d{4,10})(?:[,\s]+([A-Za-z]{2}))?$/);
     if (zipMatch) {
+      const zip = zipMatch[1]!;
+      const country = (zipMatch[2] ?? 'US').toUpperCase();
+
       const apiKey = process.env.OPENWEATHER_API_KEY;
       if (apiKey) {
-        const zip = zipMatch[1]!;
-        const country = zipMatch[2] ?? 'US';
         const url = `https://api.openweathermap.org/geo/1.0/zip?zip=${encodeURIComponent(zip)},${country}&appid=${apiKey}`;
         try {
           const res = await fetch(url, { next: { revalidate: 3600 } });
           if (res.ok) {
             const data: OWMZipResult = await res.json();
             results.push({
-              displayName: `${data.name}, ${data.country}`,
+              displayName: `${data.name}, ${data.country} ${zip}`,
               lat: data.lat,
               lon: data.lon,
               country: data.country,
             });
           }
-        } catch { /* fall through to Nominatim */ }
+        } catch { /* fall through */ }
+      }
+
+      if (results.length === 0) {
+        try {
+          const u = new URL('https://nominatim.openstreetmap.org/search');
+          u.searchParams.set('postalcode', zip);
+          u.searchParams.set('countrycodes', country.toLowerCase());
+          u.searchParams.set('format', 'json');
+          u.searchParams.set('addressdetails', '1');
+          u.searchParams.set('limit', '5');
+          const res = await fetch(u.toString(), {
+            headers: { 'User-Agent': 'Prism-Family-Dashboard/1.0' },
+            next: { revalidate: 3600 },
+          });
+          if (res.ok) {
+            const data: NominatimResult[] = await res.json();
+            for (const item of data) {
+              results.push({
+                displayName: postalDisplayName(item, zip),
+                lat: parseFloat(item.lat),
+                lon: parseFloat(item.lon),
+                country: item.address?.country_code?.toUpperCase() ?? country,
+              });
+            }
+          }
+        } catch { /* fall through to free-text search */ }
+      }
+
+      // A postal lookup resolved → return the clean result(s), skipping the
+      // noisy free-text pass below.
+      if (results.length > 0) {
+        return NextResponse.json({ results: results.slice(0, 5) });
       }
     }
 

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addDays, addWeeks, startOfDay } from 'date-fns';
 import {
   DndContext,
@@ -19,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Calendar,
+  CalendarCog,
   Merge,
   Plus,
   Loader2,
@@ -28,6 +30,7 @@ import { contrastText } from '@/lib/utils/color';
 import { useFamily } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import { AddEventModal } from '@/components/modals';
+import { ManageCalendarsModal } from './ManageCalendarsModal';
 import { PageWrapper, SubpageHeader, FilterBar } from '@/components/layout';
 const MonthView = lazy(() => import('@/components/calendar/MonthView').then(m => ({ default: m.MonthView })));
 const WeekView = lazy(() => import('@/components/calendar/WeekView').then(m => ({ default: m.WeekView })));
@@ -214,6 +217,14 @@ export function CalendarView() {
   const [editingChore, setEditingChore] = useState<Chore | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
+  const [showManageCalendars, setShowManageCalendars] = useState(false);
+
+  // Deep link: /calendar?manage=calendars opens the Manage panel (used by the
+  // Integrations settings cards after connecting a Google/CalDAV account).
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    if (searchParams?.get('manage') === 'calendars') setShowManageCalendars(true);
+  }, [searchParams]);
 
   // Live data for the modals. The bucket carries lightweight summaries; the
   // modals need full records (e.g. meal recipe URL, chore startDay), which
@@ -397,6 +408,11 @@ export function CalendarView() {
                 }}
               />
             </div>
+            {!isMobile && (
+              <Button variant="outline" size="sm" onClick={() => setShowManageCalendars(true)} className="h-9" title="Manage calendars">
+                <CalendarCog className="h-4 w-4 mr-1" />Manage
+              </Button>
+            )}
             {!isMobile && (
               <Button size="sm" onClick={handleAddWithAuth}>
                 <Plus className="h-4 w-4 mr-1" />Add Event
@@ -593,6 +609,10 @@ export function CalendarView() {
           } : undefined}
           onEventCreated={() => { refreshEvents(); setShowAddEvent(false); setEditingEvent(null); }}
         />
+
+        {showManageCalendars && (
+          <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} />
+        )}
 
         {editingChore && (
           <ChoreModal

--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+/**
+ * "Manage calendars" overlay — opens from the Calendar page so calendar
+ * configuration lives *with* the calendar (the same "config where the entity
+ * lives" pattern as recipe sync on the Recipes page), instead of buried in
+ * Settings. Reuses the existing CalendarsSection verbatim (connected calendars,
+ * groups, hours, iCal subscriptions).
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { CalendarsSection } from '@/app/settings/sections/CalendarsSection';
+
+export function ManageCalendarsModal({ onClose }: { onClose: () => void }) {
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Manage calendars</DialogTitle>
+        </DialogHeader>
+        <CalendarsSection />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -8,6 +8,7 @@ import {
   Settings,
   Users,
   Palette,
+  SlidersHorizontal,
   Shield,
   Info,
   Home,
@@ -37,6 +38,7 @@ import { AccountSection } from './sections/AccountSection';
 import { FamilySection } from './sections/FamilySection';
 import { CalendarsSection } from './sections/CalendarsSection';
 import { DisplaySection } from './sections/DisplaySection';
+import { GeneralSection } from './sections/GeneralSection';
 import { SecuritySection } from './sections/SecuritySection';
 import { PhotosSettingsSection } from './sections/PhotosSettingsSection';
 // TaskIntegrationsSection, ShoppingIntegrationsSection, WishListIntegrationsSection
@@ -172,6 +174,7 @@ export function SettingsView() {
   const sections = [
     { id: 'account', label: 'Account & Profile', icon: User },
     { id: 'family', label: 'Family Members', icon: Users },
+    { id: 'general', label: 'General', icon: SlidersHorizontal },
     { id: 'integrations', label: 'Integrations', icon: Link2 },
     { id: 'displays', label: 'Displays', icon: Monitor },
     { id: 'display', label: 'Appearance', icon: Palette },
@@ -260,6 +263,7 @@ export function SettingsView() {
               {activeSection === 'photos' && <PhotosSettingsSection />}
               {activeSection === 'bus' && <BusTrackingSection />}
               {activeSection === 'babysitter' && <BabysitterInfoSection />}
+              {activeSection === 'general' && <GeneralSection />}
               {activeSection === 'display' && <DisplaySection />}
               {activeSection === 'input' && <InputSection />}
               {activeSection === 'features' && <FeaturesSection />}

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import {
   Settings,
@@ -148,6 +148,20 @@ function normalizeSection(raw: string | null): string {
 
 export function SettingsView() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Calendar management moved to the Calendar page. Bounce any lingering link
+  // to ?section=calendars (old bookmarks, OAuth returns) to the Manage overlay.
+  const requestedSection = searchParams.get('section');
+  useEffect(() => {
+    if (requestedSection === 'calendars') {
+      const qs = new URLSearchParams(searchParams.toString());
+      qs.delete('section');
+      qs.set('manage', 'calendars');
+      router.replace(`/calendar?${qs.toString()}`);
+    }
+  }, [requestedSection, searchParams, router]);
+
   const initialSection = normalizeSection(searchParams.get('section'));
   const [activeSection, setActiveSection] = useState<string>(initialSection);
 

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -12,7 +12,6 @@ import {
   Shield,
   Info,
   Home,
-  Calendar,
   User,
   ImageIcon,
   ListTodo,
@@ -36,7 +35,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { PageWrapper } from '@/components/layout';
 import { AccountSection } from './sections/AccountSection';
 import { FamilySection } from './sections/FamilySection';
-import { CalendarsSection } from './sections/CalendarsSection';
 import { DisplaySection } from './sections/DisplaySection';
 import { GeneralSection } from './sections/GeneralSection';
 import { SecuritySection } from './sections/SecuritySection';
@@ -176,9 +174,9 @@ export function SettingsView() {
     { id: 'family', label: 'Family Members', icon: Users },
     { id: 'general', label: 'General', icon: SlidersHorizontal },
     { id: 'integrations', label: 'Integrations', icon: Link2 },
+    // Calendar management moved onto the Calendar page (Manage calendars button).
     { id: 'displays', label: 'Displays', icon: Monitor },
     { id: 'display', label: 'Appearance', icon: Palette },
-    { id: 'calendars', label: 'Calendars', icon: Calendar },
     { id: 'photos', label: 'Photos', icon: ImageIcon },
     { id: 'bus', label: 'Bus Tracking', icon: Bus },
     { id: 'input', label: 'Input', icon: KeyboardIcon },
@@ -259,7 +257,6 @@ export function SettingsView() {
               {activeSection === 'family' && <FamilySection />}
               {activeSection === 'integrations' && <IntegrationsSection />}
               {activeSection === 'displays' && <DisplaysSection />}
-              {activeSection === 'calendars' && <CalendarsSection />}
               {activeSection === 'photos' && <PhotosSettingsSection />}
               {activeSection === 'bus' && <BusTrackingSection />}
               {activeSection === 'babysitter' && <BabysitterInfoSection />}

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -15,9 +15,6 @@ import { useCalendarSources } from '@/lib/hooks';
 import { useFamily } from '@/components/providers';
 import { CalendarColorPicker } from '../components/CalendarColorPicker';
 import { useHiddenHours } from '@/lib/hooks/useHiddenHours';
-import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
-import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
-import { listTimezones } from '@/lib/utils/timezone';
 
 export function CalendarsSection() {
   const { confirm, dialogProps: confirmDialogProps } = useConfirmDialog();
@@ -646,52 +643,7 @@ export function CalendarsSection() {
       </div>
 
       <CalendarHoursCard />
-
-      <WeekStartCard />
-
-      <TimezoneCard />
     </div>
-  );
-}
-
-function TimezoneCard() {
-  const { timezone, setTimezone, loading } = useTimezone();
-  const zones = listTimezones();
-  const detected = detectBrowserTimezone();
-  // Make sure the current value is selectable even if it's outside the list.
-  const options = zones.includes(timezone) ? zones : [timezone, ...zones];
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Time Zone</CardTitle>
-        <CardDescription>
-          Used for server-side scheduling and syncs — e.g. placing imported meal-plan times on the
-          right day. On-screen clocks already follow each viewer&apos;s device.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-wrap items-center gap-3">
-          <select
-            value={timezone}
-            disabled={loading}
-            onChange={(e) => setTimezone(e.target.value)}
-            className="h-9 min-w-[16rem] rounded-md border border-border bg-background px-3 text-sm"
-          >
-            {options.map((tz) => (
-              <option key={tz} value={tz}>
-                {tz.replace(/_/g, ' ')}
-              </option>
-            ))}
-          </select>
-          {detected && detected !== timezone && (
-            <Button variant="outline" size="sm" onClick={() => setTimezone(detected)}>
-              Use detected ({detected.replace(/_/g, ' ')})
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
   );
 }
 
@@ -784,47 +736,6 @@ function CalendarHoursCard() {
           ) : (
             <>Auto-fit trims dead hours around your timed events in day/week views with a {settings.bufferHours}-hour buffer.</>
           )}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function WeekStartCard() {
-  const { weekStartsOn, setWeekStartsOn } = useWeekStartsOn();
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Week Starts On</CardTitle>
-        <CardDescription>
-          Controls when weekly goals reset, calendar week boundaries, and meal planning weeks.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setWeekStartsOn(0)}
-            className={cn(
-              'px-4 py-2 rounded-l-md text-sm font-medium border transition-colors',
-              weekStartsOn === 0
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'border-border hover:bg-accent'
-            )}
-          >
-            Sunday
-          </button>
-          <button
-            onClick={() => setWeekStartsOn(1)}
-            className={cn(
-              'px-4 py-2 rounded-r-md text-sm font-medium border border-l-0 transition-colors',
-              weekStartsOn === 1
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'border-border hover:bg-accent'
-            )}
-          >
-            Monday
-          </button>
         </div>
       </CardContent>
     </Card>

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Sun, Moon, Monitor, Search, MapPin, X, Loader2 } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { Sun, Moon, Monitor } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
-import { Input } from '@/components/ui/input';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { useTheme } from '@/components/providers';
 import { useSeasonalTheme } from '@/lib/hooks/useSeasonalTheme';
@@ -182,8 +181,6 @@ export function DisplaySection() {
       <SectionDivider label="Behavior" />
 
       <TimersCard />
-
-      <LocationCard />
 
       <WeatherUnitsCard />
     </div>
@@ -488,158 +485,6 @@ function OrientationCard() {
             </button>
           ))}
         </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-interface LocationValue {
-  lat?: number;
-  lon?: number;
-  displayName?: string;
-  // legacy fields kept for reading existing installs
-  zipCode?: string;
-  city?: string;
-  state?: string;
-}
-
-function legacyDisplayName(loc: LocationValue): string {
-  if (loc.zipCode) return loc.zipCode;
-  return [loc.city, loc.state].filter(Boolean).join(', ');
-}
-
-function LocationCard() {
-  const [query, setQuery] = useState('');
-  const [savedName, setSavedName] = useState<string | null>(null);
-  const [candidates, setCandidates] = useState<{ displayName: string; lat: number; lon: number }[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [open, setOpen] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  // Load current saved location on mount
-  useEffect(() => {
-    fetch('/api/settings')
-      .then(r => r.ok ? r.json() : null)
-      .then(data => {
-        const loc = data?.settings?.location as LocationValue | undefined;
-        if (loc?.displayName) setSavedName(loc.displayName);
-        else if (loc) setSavedName(legacyDisplayName(loc) || null);
-      })
-      .catch(() => {});
-  }, []);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, []);
-
-  // Debounced search
-  useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (query.length < 2) { setCandidates([]); setOpen(false); return; }
-
-    debounceRef.current = setTimeout(async () => {
-      setSearching(true);
-      try {
-        const res = await fetch(`/api/location-search?q=${encodeURIComponent(query)}`);
-        const data = await res.json();
-        setCandidates(data.results ?? []);
-        setOpen((data.results ?? []).length > 0);
-      } catch { /* ignore */ }
-      setSearching(false);
-    }, 350);
-
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  }, [query]);
-
-  const select = useCallback(async (candidate: { displayName: string; lat: number; lon: number }) => {
-    setOpen(false);
-    setQuery('');
-    setSavedName(candidate.displayName);
-    setSaving(true);
-    try {
-      await fetch('/api/settings', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: 'location', value: { lat: candidate.lat, lon: candidate.lon, displayName: candidate.displayName } }),
-      });
-    } catch { /* ignore */ }
-    setSaving(false);
-  }, []);
-
-  const clear = useCallback(async () => {
-    setSavedName(null);
-    setSaving(true);
-    try {
-      await fetch('/api/settings', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: 'location', value: null }),
-      });
-    } catch { /* ignore */ }
-    setSaving(false);
-  }, []);
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Location</CardTitle>
-        <CardDescription>
-          Set your location for weather data. Search by city name or postal code — works worldwide.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {savedName && (
-          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-sm">
-            <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-            <span className="flex-1 truncate">{savedName}</span>
-            <button onClick={clear} disabled={saving} className="text-muted-foreground hover:text-foreground transition-colors">
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
-
-        <div ref={wrapperRef} className="relative">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-            {searching
-              ? <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
-              : null}
-            <Input
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              onFocus={() => candidates.length > 0 && setOpen(true)}
-              placeholder={savedName ? 'Search to change location…' : 'Search city or postal code…'}
-              className="pl-9"
-              autoComplete="off"
-            />
-          </div>
-
-          {open && candidates.length > 0 && (
-            <div className="absolute z-50 top-full mt-1 w-full rounded-md border border-border bg-popover shadow-md overflow-hidden">
-              {candidates.map((c, i) => (
-                <button
-                  key={i}
-                  onMouseDown={e => { e.preventDefault(); select(c); }}
-                  className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-left hover:bg-accent transition-colors"
-                >
-                  <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                  {c.displayName}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {saving && <p className="text-xs text-muted-foreground">Saving…</p>}
       </CardContent>
     </Card>
   );

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+/**
+ * General settings — household / locale basics that aren't tied to one entity:
+ * weather Location, Time zone, and Week-start. Previously scattered under
+ * "Appearance" (Location) and "Calendars" (Time zone, Week starts on).
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Search, MapPin, X, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
+import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
+import { listTimezones } from '@/lib/utils/timezone';
+
+export function GeneralSection() {
+  return (
+    <div className="space-y-6">
+      <LocationCard />
+      <TimezoneCard />
+      <WeekStartCard />
+    </div>
+  );
+}
+
+interface LocationValue {
+  lat?: number;
+  lon?: number;
+  displayName?: string;
+  // legacy fields kept for reading existing installs
+  zipCode?: string;
+  city?: string;
+  state?: string;
+}
+
+function legacyDisplayName(loc: LocationValue): string {
+  if (loc.zipCode) return loc.zipCode;
+  return [loc.city, loc.state].filter(Boolean).join(', ');
+}
+
+function LocationCard() {
+  const [query, setQuery] = useState('');
+  const [savedName, setSavedName] = useState<string | null>(null);
+  const [candidates, setCandidates] = useState<{ displayName: string; lat: number; lon: number }[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [open, setOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Load current saved location on mount
+  useEffect(() => {
+    fetch('/api/settings')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        const loc = data?.settings?.location as LocationValue | undefined;
+        if (loc?.displayName) setSavedName(loc.displayName);
+        else if (loc) setSavedName(legacyDisplayName(loc) || null);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (query.length < 2) { setCandidates([]); setOpen(false); return; }
+
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const res = await fetch(`/api/location-search?q=${encodeURIComponent(query)}`);
+        const data = await res.json();
+        setCandidates(data.results ?? []);
+        setOpen((data.results ?? []).length > 0);
+      } catch { /* ignore */ }
+      setSearching(false);
+    }, 350);
+
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [query]);
+
+  const select = useCallback(async (candidate: { displayName: string; lat: number; lon: number }) => {
+    setOpen(false);
+    setQuery('');
+    setSavedName(candidate.displayName);
+    setSaving(true);
+    try {
+      await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'location', value: { lat: candidate.lat, lon: candidate.lon, displayName: candidate.displayName } }),
+      });
+    } catch { /* ignore */ }
+    setSaving(false);
+  }, []);
+
+  const clear = useCallback(async () => {
+    setSavedName(null);
+    setSaving(true);
+    try {
+      await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'location', value: null }),
+      });
+    } catch { /* ignore */ }
+    setSaving(false);
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Location</CardTitle>
+        <CardDescription>
+          Set your location for weather data. Search by city name or postal code — works worldwide.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {savedName && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-sm">
+            <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="flex-1 truncate">{savedName}</span>
+            <button onClick={clear} disabled={saving} className="text-muted-foreground hover:text-foreground transition-colors">
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+
+        <div ref={wrapperRef} className="relative">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            {searching
+              ? <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+              : null}
+            <Input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              onFocus={() => candidates.length > 0 && setOpen(true)}
+              placeholder={savedName ? 'Search to change location…' : 'Search city or postal code…'}
+              className="pl-9"
+              autoComplete="off"
+            />
+          </div>
+
+          {open && candidates.length > 0 && (
+            <div className="absolute z-50 top-full mt-1 w-full rounded-md border border-border bg-popover shadow-md overflow-hidden">
+              {candidates.map((c, i) => (
+                <button
+                  key={i}
+                  onMouseDown={e => { e.preventDefault(); select(c); }}
+                  className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-left hover:bg-accent transition-colors"
+                >
+                  <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  {c.displayName}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {saving && <p className="text-xs text-muted-foreground">Saving…</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimezoneCard() {
+  const { timezone, setTimezone, loading } = useTimezone();
+  const zones = listTimezones();
+  const detected = detectBrowserTimezone();
+  // Make sure the current value is selectable even if it's outside the list.
+  const options = zones.includes(timezone) ? zones : [timezone, ...zones];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Time Zone</CardTitle>
+        <CardDescription>
+          Used for server-side scheduling and syncs — e.g. placing imported meal-plan times on the
+          right day. On-screen clocks already follow each viewer&apos;s device.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={timezone}
+            disabled={loading}
+            onChange={(e) => setTimezone(e.target.value)}
+            className="h-9 min-w-[16rem] rounded-md border border-border bg-background px-3 text-sm"
+          >
+            {options.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </select>
+          {detected && detected !== timezone && (
+            <Button variant="outline" size="sm" onClick={() => setTimezone(detected)}>
+              Use detected ({detected.replace(/_/g, ' ')})
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function WeekStartCard() {
+  const { weekStartsOn, setWeekStartsOn } = useWeekStartsOn();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Week Starts On</CardTitle>
+        <CardDescription>
+          Controls when weekly goals reset, calendar week boundaries, and meal planning weeks.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setWeekStartsOn(0)}
+            className={cn(
+              'px-4 py-2 rounded-l-md text-sm font-medium border transition-colors',
+              weekStartsOn === 0
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'border-border hover:bg-accent'
+            )}
+          >
+            Sunday
+          </button>
+          <button
+            onClick={() => setWeekStartsOn(1)}
+            className={cn(
+              'px-4 py-2 rounded-r-md text-sm font-medium border border-l-0 transition-colors',
+              weekStartsOn === 1
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'border-border hover:bg-accent'
+            )}
+          >
+            Monday
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/settings/sections/integrations/cards/CalDAVProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/CalDAVProviderCard.tsx
@@ -78,10 +78,10 @@ export function CalDAVProviderCard({ onChange, forceSubSectionOpen }: Props) {
         >
           <div className="text-sm">
             <Link
-              href="/settings?section=calendars"
+              href="/calendar?manage=calendars"
               className="text-primary hover:underline"
             >
-              Open Calendars settings →
+              Manage calendars →
             </Link>
           </div>
         </CollapsibleSubSection>

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -175,10 +175,10 @@ export function GoogleProviderCard({
         >
           <div className="text-sm">
             <Link
-              href="/settings?section=calendars"
+              href="/calendar?manage=calendars"
               className="text-primary hover:underline"
             >
-              Open Calendars settings →
+              Manage calendars →
             </Link>
           </div>
         </CollapsibleSubSection>


### PR DESCRIPTION
(Recreates #173, which auto-closed when its stacked base branch was deleted during the merge of #172.)

Calendar configuration (connected calendars, groups, hours, iCal subscriptions) moved out of **Settings → Calendars** onto the **Calendar page** — a **Manage** button opens a Manage-calendars overlay — so config lives with the entity (same pattern as recipe sync on Recipes). Reuses `CalendarsSection` verbatim.

- Settings → Calendars nav section removed.
- Integrations Google/CalDAV cards → "Manage calendars →" deep-link to `/calendar?manage=calendars` (auto-opens the overlay).
- Google OAuth re-auth callback + SettingsView safety-net route `?section=calendars` returns to the overlay (fixes a dead-page regression).