### PR TITLE
feat(calendar): delete handling + deletes-only sync review (#171 Stages 2–3)

### DIFF
--- a/drizzle/0015_dismissed_events.sql
+++ b/drizzle/0015_dismissed_events.sql
@@ -1,0 +1,31 @@
+-- 0015_dismissed_events.sql
+--
+-- Tombstones for synced calendar events the user deleted locally. A one-way
+-- pull sync would otherwise re-add them from the source on the next run, so the
+-- sync skips any (calendar_source_id, external_event_id) recorded here.
+-- (Google deletes also propagate upstream; CalDAV/iCal rely on this table.)
+--
+-- Idempotent (safe to re-run).
+
+CREATE TABLE IF NOT EXISTS dismissed_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  calendar_source_id uuid NOT NULL,
+  external_event_id varchar(255) NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+
+-- FK dismissed_events.calendar_source_id -> calendar_sources.id (guarded).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'dismissed_events_calendar_source_id_calendar_sources_id_fk'
+      AND table_name = 'dismissed_events'
+  ) THEN
+    ALTER TABLE dismissed_events
+      ADD CONSTRAINT dismissed_events_calendar_source_id_calendar_sources_id_fk
+      FOREIGN KEY (calendar_source_id) REFERENCES calendar_sources(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_events_source_external_unique
+  ON dismissed_events (calendar_source_id, external_event_id);

--- a/drizzle/0016_event_pending_deletion.sql
+++ b/drizzle/0016_event_pending_deletion.sql
@@ -1,0 +1,12 @@
+-- 0016_event_pending_deletion.sql
+--
+-- Deletes-only review for calendar sync (issue #171, Stage 3). When a synced
+-- event disappears from its source, sync no longer deletes it silently — it
+-- sets events.pending_deletion so the user reviews the removal (Delete / Keep),
+-- protecting against a source glitch or accidental removal wiping the calendar.
+--
+-- Idempotent (safe to re-run).
+
+ALTER TABLE events ADD COLUMN IF NOT EXISTS pending_deletion timestamp;
+
+CREATE INDEX IF NOT EXISTS events_pending_deletion_idx ON events (pending_deletion);

--- a/src/app/api/calendars/pending-deletions/route.ts
+++ b/src/app/api/calendars/pending-deletions/route.ts
@@ -31,15 +31,19 @@ export async function GET() {
         title: events.title,
         startTime: events.startTime,
         allDay: events.allDay,
-        pendingDeletion: events.pendingDeletion,
-        calendarSourceId: events.calendarSourceId,
+        eventColor: events.color,
         provider: calendarSources.provider,
-        sourceCalendarId: calendarSources.sourceCalendarId,
+        displayName: calendarSources.displayName,
+        dashboardName: calendarSources.dashboardCalendarName,
+        calColor: calendarSources.color,
       })
       .from(events)
       .leftJoin(calendarSources, eq(events.calendarSourceId, calendarSources.id))
       .where(isNotNull(events.pendingDeletion))
       .orderBy(events.startTime);
+
+    const providerLabel = (p: string | null) =>
+      p === 'google' ? 'Google' : p === 'caldav' ? 'iCloud/CalDAV' : p === 'ical' ? 'iCal feed' : (p ?? 'source');
 
     return NextResponse.json({
       pending: rows.map((r) => ({
@@ -47,8 +51,10 @@ export async function GET() {
         title: r.title,
         startTime: r.startTime,
         allDay: r.allDay,
-        provider: r.provider,
-        sourceCalendarId: r.sourceCalendarId,
+        // The source calendar this event came from, shown neatly in the splash.
+        sourceCalendar: r.displayName || r.dashboardName || providerLabel(r.provider),
+        provider: providerLabel(r.provider),
+        color: r.calColor || r.eventColor || null,
       })),
       count: rows.length,
     });

--- a/src/app/api/calendars/pending-deletions/route.ts
+++ b/src/app/api/calendars/pending-deletions/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Deletes-only review for calendar sync (#171 Stage 3).
+ *
+ * GET  — list synced events flagged pending-deletion (the source dropped them;
+ *        sync held the delete for review instead of applying it silently).
+ * POST — apply the user's decision for a set of events:
+ *          { eventIds, action: 'delete' }  → remove them (+ tombstone), or
+ *          { eventIds, action: 'keep' }    → detach to a permanent local event
+ *                                            so the next sync won't re-flag it.
+ *
+ * Reviewing/applying requires delete permission — on a shared display the badge
+ * shows but only an authenticated parent can action it.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { events, calendarSources, dismissedEvents } from '@/lib/db/schema';
+import { requireAuth, requireRole, getDisplayAuth } from '@/lib/auth';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { logError } from '@/lib/utils/logError';
+
+export async function GET() {
+  const auth = await getDisplayAuth();
+  if (!auth) return NextResponse.json({ pending: [], count: 0 });
+
+  try {
+    const rows = await db
+      .select({
+        id: events.id,
+        title: events.title,
+        startTime: events.startTime,
+        allDay: events.allDay,
+        pendingDeletion: events.pendingDeletion,
+        calendarSourceId: events.calendarSourceId,
+        provider: calendarSources.provider,
+        sourceCalendarId: calendarSources.sourceCalendarId,
+      })
+      .from(events)
+      .leftJoin(calendarSources, eq(events.calendarSourceId, calendarSources.id))
+      .where(isNotNull(events.pendingDeletion))
+      .orderBy(events.startTime);
+
+    return NextResponse.json({
+      pending: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        startTime: r.startTime,
+        allDay: r.allDay,
+        provider: r.provider,
+        sourceCalendarId: r.sourceCalendarId,
+      })),
+      count: rows.length,
+    });
+  } catch (error) {
+    logError('Error listing pending deletions:', error);
+    return NextResponse.json({ error: 'Failed to load pending deletions' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canDeleteAnyEvent');
+  if (forbidden) return forbidden;
+
+  try {
+    const body = await request.json();
+    const eventIds: string[] = Array.isArray(body.eventIds) ? body.eventIds.filter((x: unknown) => typeof x === 'string') : [];
+    const action = body.action === 'keep' ? 'keep' : body.action === 'delete' ? 'delete' : null;
+
+    if (!action) return NextResponse.json({ error: "action must be 'delete' or 'keep'." }, { status: 400 });
+    if (eventIds.length === 0) return NextResponse.json({ error: 'No events selected.' }, { status: 400 });
+
+    // Only act on events that are actually pending (guard against stale ids).
+    const targets = await db
+      .select({ id: events.id, calendarSourceId: events.calendarSourceId, externalEventId: events.externalEventId })
+      .from(events)
+      .where(and(inArray(events.id, eventIds), isNotNull(events.pendingDeletion)));
+
+    if (action === 'delete') {
+      // Tombstone (so it can't be re-added) then delete.
+      for (const t of targets) {
+        if (t.calendarSourceId && t.externalEventId) {
+          await db
+            .insert(dismissedEvents)
+            .values({ calendarSourceId: t.calendarSourceId, externalEventId: t.externalEventId })
+            .onConflictDoNothing();
+        }
+      }
+      await db.delete(events).where(inArray(events.id, targets.map((t) => t.id)));
+    } else {
+      // Keep: detach from the source (drop externalEventId) so it becomes a
+      // permanent local event the sync never touches again, and clear the flag.
+      await db
+        .update(events)
+        .set({ pendingDeletion: null, externalEventId: null, lastSynced: null })
+        .where(inArray(events.id, targets.map((t) => t.id)));
+    }
+
+    await invalidateEntity('events');
+    return NextResponse.json({ applied: targets.length, action });
+  } catch (error) {
+    logError('Error applying pending deletions:', error);
+    return NextResponse.json({ error: 'Failed to apply.' }, { status: 500 });
+  }
+}

--- a/src/app/api/calendars/sync/route.ts
+++ b/src/app/api/calendars/sync/route.ts
@@ -129,10 +129,11 @@ export async function POST(request: NextRequest) {
     await invalidateEntity('events');
 
     // Report NET changes (added / updated / removed), not total re-pulled.
+    // Removals aren't applied silently anymore — they're flagged for review.
     const changeParts: string[] = [];
     if (result.added) changeParts.push(`${result.added} added`);
     if (result.updated) changeParts.push(`${result.updated} updated`);
-    if (result.removed) changeParts.push(`${result.removed} removed`);
+    if (result.removed) changeParts.push(`${result.removed} flagged for review`);
     const changeSummary = changeParts.length ? changeParts.join(', ') : 'no changes';
 
     return NextResponse.json({

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -17,7 +17,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { db } from '@/lib/db/client';
-import { events, calendarSources } from '@/lib/db/schema';
+import { events, calendarSources, dismissedEvents } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { updateCalendarEvent, deleteCalendarEvent, refreshAccessToken } from '@/lib/integrations/google-calendar';
@@ -520,6 +520,17 @@ export async function DELETE(
           // Continue with local delete even if Google fails
         }
       }
+
+      // Tombstone this synced event so the pull sync doesn't re-add it. Google
+      // deletes propagate upstream above; CalDAV/iCal (and a failed Google
+      // delete) rely on this so the deletion sticks.
+      await db
+        .insert(dismissedEvents)
+        .values({
+          calendarSourceId: existingEvent.calendarSourceId,
+          externalEventId: existingEvent.externalEventId,
+        })
+        .onConflictDoNothing();
     }
 
     // Delete the event locally

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -222,7 +222,7 @@ export function CalendarView() {
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
   const [showManageCalendars, setShowManageCalendars] = useState(false);
   const [showPendingReview, setShowPendingReview] = useState(false);
-  const { pending, count: pendingCount, apply: applyPending } = usePendingDeletions();
+  const { pending, count: pendingCount, apply: applyPending, refresh: refreshPending } = usePendingDeletions();
 
   // Deep link: /calendar?manage=calendars opens the Manage panel (used by the
   // Integrations settings cards after connecting a Google/CalDAV account).
@@ -628,7 +628,10 @@ export function CalendarView() {
         />
 
         {showManageCalendars && (
-          <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} onSynced={refreshAll} />
+          <ManageCalendarsModal
+            onClose={() => setShowManageCalendars(false)}
+            onSynced={() => { refreshAll(); refreshPending(); }}
+          />
         )}
 
         {showPendingReview && (

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -24,6 +24,7 @@ import {
   Merge,
   Plus,
   Loader2,
+  AlertTriangle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { contrastText } from '@/lib/utils/color';
@@ -31,6 +32,8 @@ import { useFamily } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import { AddEventModal } from '@/components/modals';
 import { ManageCalendarsModal } from './ManageCalendarsModal';
+import { PendingDeletionsModal } from './PendingDeletionsModal';
+import { usePendingDeletions } from '@/lib/hooks/usePendingDeletions';
 import { PageWrapper, SubpageHeader, FilterBar } from '@/components/layout';
 const MonthView = lazy(() => import('@/components/calendar/MonthView').then(m => ({ default: m.MonthView })));
 const WeekView = lazy(() => import('@/components/calendar/WeekView').then(m => ({ default: m.WeekView })));
@@ -218,6 +221,8 @@ export function CalendarView() {
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
   const [showManageCalendars, setShowManageCalendars] = useState(false);
+  const [showPendingReview, setShowPendingReview] = useState(false);
+  const { pending, count: pendingCount, apply: applyPending } = usePendingDeletions();
 
   // Deep link: /calendar?manage=calendars opens the Manage panel (used by the
   // Integrations settings cards after connecting a Google/CalDAV account).
@@ -355,6 +360,18 @@ export function CalendarView() {
           icon={!isMobile ? <Calendar className="h-5 w-5 text-primary" /> : undefined}
           title={getDateRangeTitle()}
           actions={<>
+            {pendingCount > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowPendingReview(true)}
+                className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                title="Review calendar removals held for your approval"
+              >
+                <AlertTriangle className="h-4 w-4 mr-1" />
+                Review {pendingCount}
+              </Button>
+            )}
             {isMobile ? null : (
               <>
                 <Button variant="outline" size="sm" onClick={goToToday} className="h-9">Today</Button>
@@ -612,6 +629,18 @@ export function CalendarView() {
 
         {showManageCalendars && (
           <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} onSynced={refreshAll} />
+        )}
+
+        {showPendingReview && (
+          <PendingDeletionsModal
+            pending={pending}
+            onApply={async (ids, action) => {
+              const ok = await applyPending(ids, action);
+              if (ok) refreshAll();
+              return ok;
+            }}
+            onClose={() => setShowPendingReview(false)}
+          />
         )}
 
         {editingChore && (

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -611,7 +611,7 @@ export function CalendarView() {
         />
 
         {showManageCalendars && (
-          <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} />
+          <ManageCalendarsModal onClose={() => setShowManageCalendars(false)} onSynced={refreshAll} />
         )}
 
         {editingChore && (

--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -16,14 +16,21 @@ import {
 } from '@/components/ui/dialog';
 import { CalendarsSection } from '@/app/settings/sections/CalendarsSection';
 
-export function ManageCalendarsModal({ onClose }: { onClose: () => void }) {
+export function ManageCalendarsModal({
+  onClose,
+  onSynced,
+}: {
+  onClose: () => void;
+  /** Called after a manual sync so the calendar page can refetch its events. */
+  onSynced?: () => void;
+}) {
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Manage calendars</DialogTitle>
         </DialogHeader>
-        <CalendarsSection />
+        <CalendarsSection onSynced={onSynced} />
       </DialogContent>
     </Dialog>
   );

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { format, parseISO } from 'date-fns';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, ArrowRight, Home } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -14,9 +14,6 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import type { PendingDeletion } from '@/lib/hooks/usePendingDeletions';
-
-const providerLabel = (p: string | null) =>
-  p === 'google' ? 'Google' : p === 'caldav' ? 'iCloud/CalDAV' : p === 'ical' ? 'iCal feed' : (p ?? 'source');
 
 /**
  * Deletes-only review (#171 Stage 3). Lists events the sync found removed from
@@ -66,9 +63,13 @@ export function PendingDeletionsModal({
 
         <div className="space-y-3 py-1">
           <p className="text-sm text-muted-foreground">
-            {pending.length} event{pending.length === 1 ? ' was' : 's were'} removed from{' '}
-            {pending.length === 1 ? 'its source' : 'their sources'} and held here for review. Delete
-            them from Prism too, or keep them (they become local events).
+            These events were removed from their source calendar and held for review.{' '}
+            <span className="font-medium text-foreground">Delete</span> removes them from Prism too.{' '}
+            <span className="font-medium text-foreground">Keep</span> transfers each one to your{' '}
+            <span className="inline-flex items-center gap-1 font-medium text-foreground">
+              <Home className="h-3 w-3" />local calendar
+            </span>{' '}
+            — it stops syncing and stays put.
           </p>
 
           <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground px-1">
@@ -89,13 +90,25 @@ export function PendingDeletionsModal({
                   className="flex items-start gap-2 rounded px-1 py-1 hover:bg-muted/50 cursor-pointer"
                 >
                   <Checkbox checked={selected.has(p.id)} onCheckedChange={() => toggle(p.id)} className="mt-0.5" />
-                  <span className="text-sm">
+                  <span className="text-sm flex-1 min-w-0">
                     <span className="font-medium">{p.title}</span>
                     <span className="block text-xs text-muted-foreground">
                       {p.allDay
                         ? format(parseISO(p.startTime), 'EEE, MMM d')
-                        : format(parseISO(p.startTime), 'EEE, MMM d · p')}{' '}
-                      · {providerLabel(p.provider)}
+                        : format(parseISO(p.startTime), 'EEE, MMM d · p')}
+                    </span>
+                    <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground flex-wrap">
+                      <span className="inline-flex items-center gap-1 min-w-0">
+                        <span
+                          className="h-2 w-2 rounded-full shrink-0"
+                          style={{ backgroundColor: p.color || 'var(--muted-foreground)' }}
+                        />
+                        <span className="truncate">{p.sourceCalendar}</span>
+                      </span>
+                      <ArrowRight className="h-3 w-3 opacity-60 shrink-0" />
+                      <span className="inline-flex items-center gap-1 shrink-0">
+                        <Home className="h-3 w-3" />Local (if kept)
+                      </span>
                     </span>
                   </span>
                 </label>
@@ -109,7 +122,8 @@ export function PendingDeletionsModal({
             Cancel
           </Button>
           <Button variant="outline" onClick={() => act('keep')} disabled={busy || selected.size === 0}>
-            Keep {selected.size}
+            <Home className="h-4 w-4 mr-1.5" />
+            Keep {selected.size} in Local
           </Button>
           <Button variant="destructive" onClick={() => act('delete')} disabled={busy || selected.size === 0}>
             Delete {selected.size}

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import type { PendingDeletion } from '@/lib/hooks/usePendingDeletions';
+
+const providerLabel = (p: string | null) =>
+  p === 'google' ? 'Google' : p === 'caldav' ? 'iCloud/CalDAV' : p === 'ical' ? 'iCal feed' : (p ?? 'source');
+
+/**
+ * Deletes-only review (#171 Stage 3). Lists events the sync found removed from
+ * their source and held instead of deleting. The user Deletes (remove from
+ * Prism too) or Keeps (retain as a local event) the selected ones.
+ */
+export function PendingDeletionsModal({
+  pending,
+  onApply,
+  onClose,
+}: {
+  pending: PendingDeletion[];
+  onApply: (eventIds: string[], action: 'delete' | 'keep') => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
+  const [busy, setBusy] = useState(false);
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const allSelected = selected.size === pending.length && pending.length > 0;
+  const bulk = useMemo(() => Array.from(selected), [selected]);
+
+  const act = async (action: 'delete' | 'keep') => {
+    if (bulk.length === 0) return;
+    setBusy(true);
+    const ok = await onApply(bulk, action);
+    setBusy(false);
+    if (ok) onClose();
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Review removals
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 py-1">
+          <p className="text-sm text-muted-foreground">
+            {pending.length} event{pending.length === 1 ? ' was' : 's were'} removed from{' '}
+            {pending.length === 1 ? 'its source' : 'their sources'} and held here for review. Delete
+            them from Prism too, or keep them (they become local events).
+          </p>
+
+          <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground px-1">
+            <Checkbox
+              checked={allSelected}
+              onCheckedChange={() =>
+                setSelected(allSelected ? new Set() : new Set(pending.map((p) => p.id)))
+              }
+            />
+            Select all ({selected.size}/{pending.length})
+          </label>
+
+          <ScrollArea className="max-h-[45vh] pr-3">
+            <div className="space-y-1">
+              {pending.map((p) => (
+                <label
+                  key={p.id}
+                  className="flex items-start gap-2 rounded px-1 py-1 hover:bg-muted/50 cursor-pointer"
+                >
+                  <Checkbox checked={selected.has(p.id)} onCheckedChange={() => toggle(p.id)} className="mt-0.5" />
+                  <span className="text-sm">
+                    <span className="font-medium">{p.title}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {p.allDay
+                        ? format(parseISO(p.startTime), 'EEE, MMM d')
+                        : format(parseISO(p.startTime), 'EEE, MMM d · p')}{' '}
+                      · {providerLabel(p.provider)}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={() => act('keep')} disabled={busy || selected.size === 0}>
+            Keep {selected.size}
+          </Button>
+          <Button variant="destructive" onClick={() => act('delete')} disabled={busy || selected.size === 0}>
+            Delete {selected.size}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -16,7 +16,7 @@ import { useFamily } from '@/components/providers';
 import { CalendarColorPicker } from '../components/CalendarColorPicker';
 import { useHiddenHours } from '@/lib/hooks/useHiddenHours';
 
-export function CalendarsSection() {
+export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
   const { confirm, dialogProps: confirmDialogProps } = useConfirmDialog();
   const { members: familyMembers } = useFamily();
   const { calendars, loading: calendarsLoading, refresh: refreshCalendars } = useCalendarSources();
@@ -190,6 +190,9 @@ export function CalendarsSection() {
         }
         toast({ title: message, variant: 'success' });
         refreshCalendars();
+        // Let the host (Calendar page) refetch its events so a manual sync
+        // shows new/removed events immediately, no page refresh needed.
+        onSynced?.();
       } else {
         const hasReauthError = data.errors?.some((e: string) => e.includes('Re-authentication required') || e.includes('Token expired'));
         if (hasReauthError) {

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -175,7 +175,8 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
         const parts: string[] = [];
         if (data.added) parts.push(`${data.added} added`);
         if (data.updated) parts.push(`${data.updated} updated`);
-        if (data.removed) parts.push(`${data.removed} removed`);
+        // Removals are held for review, not applied — reflect that in the toast.
+        if (data.removed) parts.push(`${data.removed} flagged for review`);
         let message = parts.length
           ? `Sync complete: ${parts.join(', ')}`
           : 'Sync complete — already up to date';

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -2598,3 +2598,12 @@ DO $$ BEGIN
   END IF;
 END $$;
 CREATE UNIQUE INDEX IF NOT EXISTS recipes_source_external_unique ON public.recipes (source_id, external_id);
+
+-- Tombstones for locally-deleted synced events (so a pull sync doesn't re-add them).
+CREATE TABLE IF NOT EXISTS public.dismissed_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  calendar_source_id uuid NOT NULL REFERENCES public.calendar_sources(id) ON DELETE CASCADE,
+  external_event_id varchar(255) NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_events_source_external_unique ON public.dismissed_events (calendar_source_id, external_event_id);

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -2607,3 +2607,7 @@ CREATE TABLE IF NOT EXISTS public.dismissed_events (
   created_at timestamp DEFAULT now() NOT NULL
 );
 CREATE UNIQUE INDEX IF NOT EXISTS dismissed_events_source_external_unique ON public.dismissed_events (calendar_source_id, external_event_id);
+
+-- Deletes-only review: flag synced events gone from source instead of deleting (#171).
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS pending_deletion timestamp;
+CREATE INDEX IF NOT EXISTS events_pending_deletion_idx ON public.events (pending_deletion);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -173,6 +173,24 @@ export const events = pgTable('events', {
     .on(table.calendarSourceId, table.externalEventId),
 }));
 
+/**
+ * Tombstones for synced events the user deleted locally. A one-way pull sync
+ * would otherwise re-add them from the source on the next run. The sync skips
+ * any (calendarSourceId, externalEventId) listed here. Cascade-deletes with the
+ * source. (Google deletes propagate upstream too; CalDAV/iCal rely on this.)
+ */
+export const dismissedEvents = pgTable('dismissed_events', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  calendarSourceId: uuid('calendar_source_id')
+    .notNull()
+    .references(() => calendarSources.id, { onDelete: 'cascade' }),
+  externalEventId: varchar('external_event_id', { length: 255 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  dismissedSourceExternalUnique: uniqueIndex('dismissed_events_source_external_unique')
+    .on(table.calendarSourceId, table.externalEventId),
+}));
+
 
 export const taskLists = pgTable('task_lists', {
   id: uuid('id').defaultRandom().primaryKey(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -162,6 +162,11 @@ export const events = pgTable('events', {
 
   lastSynced: timestamp('last_synced'),
 
+  // Set when sync finds this synced event gone from its source. Instead of
+  // deleting silently, it's flagged pending so the user reviews the removal
+  // (deletes-only review). Null = not pending.
+  pendingDeletion: timestamp('pending_deletion'),
+
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({

--- a/src/lib/hooks/usePendingDeletions.ts
+++ b/src/lib/hooks/usePendingDeletions.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+export interface PendingDeletion {
+  id: string;
+  title: string;
+  startTime: string;
+  allDay: boolean;
+  provider: string | null;
+  sourceCalendarId: string | null;
+}
+
+/**
+ * Synced calendar events the sync flagged for removal (the source dropped them),
+ * held for review instead of deleted (#171 Stage 3). Drives the "N to review"
+ * badge on the calendar.
+ */
+export function usePendingDeletions() {
+  const [pending, setPending] = useState<PendingDeletion[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/calendars/pending-deletions');
+      if (res.ok) {
+        const data = await res.json();
+        setPending(data.pending ?? []);
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const apply = useCallback(
+    async (eventIds: string[], action: 'delete' | 'keep') => {
+      const res = await fetch('/api/calendars/pending-deletions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventIds, action }),
+      });
+      await refresh();
+      return res.ok;
+    },
+    [refresh],
+  );
+
+  return { pending, count: pending.length, loading, refresh, apply };
+}

--- a/src/lib/hooks/usePendingDeletions.ts
+++ b/src/lib/hooks/usePendingDeletions.ts
@@ -7,8 +7,10 @@ export interface PendingDeletion {
   title: string;
   startTime: string;
   allDay: boolean;
-  provider: string | null;
-  sourceCalendarId: string | null;
+  /** Neat name of the source calendar the event came from. */
+  sourceCalendar: string;
+  provider: string;
+  color: string | null;
 }
 
 /**

--- a/src/lib/services/__tests__/calendar-sync.test.ts
+++ b/src/lib/services/__tests__/calendar-sync.test.ts
@@ -26,6 +26,10 @@ const mockUpdateSet = jest.fn().mockReturnValue({ where: jest.fn().mockResolvedV
 mockUpdate.mockReturnValue({ set: mockUpdateSet });
 
 const mockDeleteWhere = jest.fn().mockResolvedValue(undefined);
+// db.select(...).from(...).where(...) — used to load dismissed-event tombstones.
+const mockSelect = jest.fn().mockReturnValue({
+  from: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue([]) }),
+});
 mockDelete.mockReturnValue({ where: mockDeleteWhere });
 
 jest.mock('@/lib/db/client', () => ({
@@ -34,6 +38,7 @@ jest.mock('@/lib/db/client', () => ({
       calendarSources: { findFirst: (...args: unknown[]) => mockFindFirst(...args), findMany: (...args: unknown[]) => mockFindMany(...args) },
       events: { findMany: (...args: unknown[]) => mockFindMany(...args) },
     },
+    select: (...args: unknown[]) => mockSelect(...args),
     insert: (...args: unknown[]) => mockInsert(...args),
     update: (...args: unknown[]) => mockUpdate(...args),
     delete: (...args: unknown[]) => mockDelete(...args),
@@ -42,7 +47,8 @@ jest.mock('@/lib/db/client', () => ({
 
 jest.mock('@/lib/db/schema', () => ({
   calendarSources: { id: 'id', provider: 'provider', enabled: 'enabled' },
-  events: { calendarSourceId: 'calendarSourceId', externalEventId: 'externalEventId', startTime: 'startTime', id: 'id' },
+  events: { calendarSourceId: 'calendarSourceId', externalEventId: 'externalEventId', startTime: 'startTime', id: 'id', pendingDeletion: 'pendingDeletion' },
+  dismissedEvents: { calendarSourceId: 'calendarSourceId', externalEventId: 'externalEventId' },
 }));
 
 const mockFetchCalendarEvents = jest.fn();
@@ -248,7 +254,7 @@ describe('syncGoogleCalendarSource', () => {
     expect(result.errors[0]).toContain('event-2');
   });
 
-  it('deletes prism events no longer in Google', async () => {
+  it('flags (pending deletion) events no longer in Google instead of deleting them', async () => {
     mockFindFirst.mockResolvedValue(makeSource());
     // Google only has event-1
     mockFetchCalendarEvents.mockResolvedValue([
@@ -268,8 +274,11 @@ describe('syncGoogleCalendarSource', () => {
 
     await syncGoogleCalendarSource('source-1');
 
-    // Should delete prism-2 (event-2 no longer in Google)
-    expect(mockDelete).toHaveBeenCalled();
+    // Deletes-only review: prism-2 is FLAGGED pending, not hard-deleted.
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ pendingDeletion: expect.any(Date) }),
+    );
   });
 
   it('does not delete local-only events (no externalEventId)', async () => {

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/db/client';
-import { calendarSources, events, tasks, taskLists } from '@/lib/db/schema';
+import { calendarSources, events, tasks, taskLists, dismissedEvents } from '@/lib/db/schema';
 import { eq, and, gte, lte, sql, inArray } from 'drizzle-orm';
 import {
   fetchCalDAVEvents,
@@ -88,6 +88,15 @@ function eventChanged(a: EventContent, b: EventContent): boolean {
 /** A zero net-change result, optionally carrying errors (for early returns). */
 function emptyCounts(errors: string[] = []): SyncCounts {
   return { added: 0, updated: 0, removed: 0, unchanged: 0, synced: 0, errors };
+}
+
+/** External event ids the user deleted locally (tombstones) — skip on re-sync. */
+async function loadDismissedExternalIds(sourceId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({ externalEventId: dismissedEvents.externalEventId })
+    .from(dismissedEvents)
+    .where(eq(dismissedEvents.calendarSourceId, sourceId));
+  return new Set(rows.map((r) => r.externalEventId));
 }
 
 /** Build a lookup of a source's existing events by externalEventId (for classify). */
@@ -249,12 +258,14 @@ export async function syncGoogleCalendarSource(
   // Build set of Google event IDs for deletion cleanup (excluding cancelled)
   const googleEventIds = new Set<string>();
   const existingByExtId = await loadExistingByExternalId(sourceId);
+  const dismissed = await loadDismissedExternalIds(sourceId);
 
   // Process each event using upsert to prevent duplicates
   for (const googleEvent of googleEvents) {
     try {
       // Skip cancelled events (deleted recurring instances)
       if (googleEvent.status === 'cancelled') continue;
+      if (dismissed.has(googleEvent.id)) continue;
 
       googleEventIds.add(googleEvent.id);
       const internalEvent = convertGoogleEventToInternal(googleEvent, sourceId);
@@ -575,6 +586,7 @@ export async function syncIcalCalendarSource(
 
   const externalIds = new Set<string>();
   const existingByExtId = await loadExistingByExternalId(sourceId);
+  const dismissed = await loadDismissedExternalIds(sourceId);
 
   for (const item of Object.values(parsed)) {
     if (!item || item.type !== 'VEVENT') continue;
@@ -645,6 +657,7 @@ export async function syncIcalCalendarSource(
       const location = readIcalString(vevent.location);
 
       for (const inst of instances) {
+        if (dismissed.has(inst.externalId)) continue;
         externalIds.add(inst.externalId);
         await db
           .insert(events)
@@ -851,7 +864,9 @@ export async function syncCalDAVCalendarSource(
       timeMax,
     );
 
+    const dismissed = await loadDismissedExternalIds(sourceId);
     for (const event of caldavEvents) {
+      if (dismissed.has(event.uid)) continue;
       const existing = await db.query.events.findFirst({
         where: and(
           eq(events.calendarSourceId, sourceId),

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db/client';
 import { calendarSources, events, tasks, taskLists, dismissedEvents } from '@/lib/db/schema';
-import { eq, and, gte, lte, sql, inArray } from 'drizzle-orm';
+import { eq, and, gte, lte, sql, inArray, isNotNull } from 'drizzle-orm';
 import {
   fetchCalDAVEvents,
   fetchCalDAVTasks,
@@ -324,11 +324,22 @@ export async function syncGoogleCalendarSource(
     ),
   });
 
+  // Clear the pending-deletion flag on any event that reappeared in the source.
+  if (googleEventIds.size > 0) {
+    await db.update(events).set({ pendingDeletion: null }).where(and(
+      eq(events.calendarSourceId, sourceId),
+      inArray(events.externalEventId, [...googleEventIds]),
+      isNotNull(events.pendingDeletion),
+    ));
+  }
+
   for (const prismEvent of prismEventsToCheck) {
-    // Only delete if it has an external_event_id (was synced) but is no longer in Google
+    // Only flag if it has an external_event_id (was synced) but is no longer in Google
     if (prismEvent.externalEventId && !googleEventIds.has(prismEvent.externalEventId)) {
-      await db.delete(events).where(eq(events.id, prismEvent.id));
-      removed++;
+      if (!prismEvent.pendingDeletion) {
+        await db.update(events).set({ pendingDeletion: new Date() }).where(eq(events.id, prismEvent.id));
+        removed++;
+      }
     }
   }
 
@@ -709,10 +720,19 @@ export async function syncIcalCalendarSource(
       lte(events.startTime, timeMax)
     ),
   });
+  if (externalIds.size > 0) {
+    await db.update(events).set({ pendingDeletion: null }).where(and(
+      eq(events.calendarSourceId, sourceId),
+      inArray(events.externalEventId, [...externalIds]),
+      isNotNull(events.pendingDeletion),
+    ));
+  }
   for (const ev of prismEvents) {
     if (ev.externalEventId && !externalIds.has(ev.externalEventId)) {
-      await db.delete(events).where(eq(events.id, ev.id));
-      removed++;
+      if (!ev.pendingDeletion) {
+        await db.update(events).set({ pendingDeletion: new Date() }).where(eq(events.id, ev.id));
+        removed++;
+      }
     }
   }
 
@@ -909,10 +929,19 @@ export async function syncCalDAVCalendarSource(
       ),
     });
 
+    if (upstreamUids.size > 0) {
+      await db.update(events).set({ pendingDeletion: null }).where(and(
+        eq(events.calendarSourceId, sourceId),
+        inArray(events.externalEventId, [...upstreamUids]),
+        isNotNull(events.pendingDeletion),
+      ));
+    }
     for (const local of localEvents) {
       if (local.externalEventId && !upstreamUids.has(local.externalEventId)) {
-        await db.delete(events).where(eq(events.id, local.id));
-        removed++;
+        if (!local.pendingDeletion) {
+          await db.update(events).set({ pendingDeletion: new Date() }).where(eq(events.id, local.id));
+          removed++;
+        }
       }
     }
 


### PR DESCRIPTION
Makes calendar deletes behave sanely and safely — the sync can no longer silently lose events. Squash-merges as one coherent unit.

## Deletes stick (Stage 2)
Deleting a synced event in Prism no longer reappears on the next pull sync.
- New `dismissed_events` tombstone table (0015 migration, applied). Deleting a synced event records `(calendarSourceId, externalEventId)`; the Google/iCal/CalDAV sync loops skip tombstoned ids.
- Google still deletes upstream; CalDAV/iCal rely on the tombstone (upstream delete-to-iCloud is deferred — needs the CalDAV object href).

## Deletes-only review (Stage 3)
When a *source* drops an event, sync holds it for review instead of deleting silently.
- New `events.pending_deletion` flag (0016 migration, applied). Sync flags removals instead of deleting, and clears the flag if the event reappears. Adds/updates still auto-apply (dashboard stays live).
- An amber **"Review N"** badge on the calendar → a splash listing the held events with their **source calendar → 🏠 Local** and **Delete** / **Keep** (Keep transfers to a permanent local event). Apply is gated on `canDeleteAnyEvent` so a shared display can't action it without a parent.
- Mass-delete protection by design: nothing is removed without review.

## Polish
- Manual sync **refetches the calendar** immediately (no page refresh) and refreshes the review badge.
- Sync toast reports **net changes** honestly: "X added, Y updated, Z flagged for review" (removals aren't silently applied).

## Migrations
`0015_dismissed_events` + `0016_event_pending_deletion` — both idempotent, already applied to the live DB; `init/02-schema.sql` updated for fresh installs.

Validated live end-to-end: delete-in-Prism stays gone; source-side delete → held → Review → Delete/Keep; reappear clears the flag.

Deferred: #2 CalDAV upstream delete (two-way parity with Google).