### PR TITLE
ci: drop NodeSource apt source before apt-get in Playwright jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,10 @@ jobs:
       - run: npm ci
 
       - name: Install psql (not bundled in Playwright image)
-        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client
+        # Drop the NodeSource apt source first — it periodically 403s and aborts
+        # `apt-get update` (Node is already in the image; we only need psql from
+        # the Ubuntu repos here).
+        run: rm -f /etc/apt/sources.list.d/nodesource* && apt-get update && apt-get install -y --no-install-recommends postgresql-client
 
       - name: Apply base schema
         env:
@@ -239,7 +242,10 @@ jobs:
       - run: npm ci
 
       - name: Install psql + redis-cli (not bundled in Playwright image)
-        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client redis-tools
+        # Drop the NodeSource apt source first — it periodically 403s and aborts
+        # `apt-get update` (Node is already in the image; we only need the
+        # Postgres/Redis clients from the Ubuntu repos here).
+        run: rm -f /etc/apt/sources.list.d/nodesource* && apt-get update && apt-get install -y --no-install-recommends postgresql-client redis-tools
 
       - name: Apply base schema
         env:


### PR DESCRIPTION
The E2E + visual-regression jobs install `postgresql-client`/`redis-tools` via `apt-get update && apt-get install`. NodeSource's apt repo periodically returns **403 Forbidden**, which aborts `apt-get update` (exit 100) **before any test runs** — a persistent flake that failed both jobs on every recent PR (incl. #176 and the v1.10.0 release push).

Node is already present in the Playwright image, so these steps don't need the NodeSource source at all. Remove it before `apt-get update` so only the Ubuntu repos are hit.

This PR's own E2E/visual jobs exercise the fix (checks run the workflow from this branch).