### PR TITLE
feat(calendar): propagate CalDAV event deletes upstream to the source

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Deleting a synced Apple/CalDAV event in Prism now removes it from the source too.** Previously only Google deletes propagated upstream — a CalDAV event you deleted in Prism was tombstoned locally but lingered on iCloud/Nextcloud/etc. Prism now captures each event's server address at sync time and sends the delete back to the source. Single (non-recurring) events only; recurring series still delete locally without touching the source (they need proper recurrence editing first). Ships one additive database migration, applied automatically on start.
+
 ## [1.10.0] – 2026-07-27
 
 A feature release: recipe & meal-plan sync with Tandoor and Mealie, a calendar-sync overhaul that stops the sync from ever silently losing events, and a settings reshuffle so household basics live where you'd expect. Ships three database migrations (recipe sources, deleted-event tombstones, and a pending-deletion flag) — all applied automatically on start.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -11,8 +11,9 @@ _Last reviewed: 2026-07-27, after the recipe/meal **sync framework** shipped ([#
 **Top of the backlog — revisit next:**
 
 1. ⭐ **Easy self-serve hosting** ([#178](https://github.com/sandydargoport/prism/issues/178)) — let non-technical users (no Docker / HA) spin up their *own* cloud instance via a one-click deploy, so the maintainer hosts nothing (not a multi-tenant SaaS). The standout strategic item; not yet scoped.
-2. **Write-back / two-way** ([#169](https://github.com/sandydargoport/prism/issues/169)) — push Prism edits back to Tandoor/Mealie (recipe/meal sync phase 2b).
-3. **CalDAV upstream delete** ([#171](https://github.com/sandydargoport/prism/issues/171)) — deleting in Prism also removes it from iCloud (two-way parity with Google; deferred from the Stage 2/3 work).
+2. **Write-back / two-way** ([#169](https://github.com/sandydargoport/prism/issues/169)) — push Prism edits back to Tandoor/Mealie (recipe/meal sync phase 2b). Low priority.
+
+**Recently closed from this list:** **CalDAV upstream delete** ([#171](https://github.com/sandydargoport/prism/issues/171) Stage 4) — deleting a synced Apple/CalDAV event in Prism now propagates to the source (parity with Google), single-event scope; validated live against iCloud. Awaiting the next release.
 
 Deliberately **deprioritized:** real RRULE recurrence builder ([#59](https://github.com/sandydargoport/prism/issues/59)) — valuable but heavy; revisit much later.
 

--- a/drizzle/0017_event_caldav_href.sql
+++ b/drizzle/0017_event_caldav_href.sql
@@ -1,0 +1,16 @@
+-- 0017_event_caldav_href.sql
+--
+-- CalDAV upstream delete (issue #171, single-event scope). Deleting a synced
+-- CalDAV event in Prism should also remove it from the source server (parity
+-- with Google, which already propagates deletes). A CalDAV DELETE targets the
+-- calendar object by its href (path on the server), not by UID, so we persist
+-- the per-event href — plus the ETag for a conflict-safe delete — at sync time.
+--
+-- Recurring events are intentionally out of scope: their instances share one
+-- parent object, so an href-based delete would remove the whole series. The
+-- delete path skips write-back for recurring rows.
+--
+-- Idempotent (safe to re-run).
+
+ALTER TABLE events ADD COLUMN IF NOT EXISTS caldav_href varchar(1024);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS caldav_etag varchar(255);

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -21,6 +21,7 @@ import { events, calendarSources, dismissedEvents } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { updateCalendarEvent, deleteCalendarEvent, refreshAccessToken } from '@/lib/integrations/google-calendar';
+import { pushCalDAVEventDelete } from '@/lib/services/calendar-sync';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
@@ -459,6 +460,9 @@ export async function DELETE(
         title: events.title,
         externalEventId: events.externalEventId,
         calendarSourceId: events.calendarSourceId,
+        recurring: events.recurring,
+        caldavHref: events.caldavHref,
+        caldavEtag: events.caldavEtag,
       })
       .from(events)
       .where(eq(events.id, id));
@@ -518,6 +522,37 @@ export async function DELETE(
         } catch (error) {
           logError('Failed to delete event from Google Calendar:', error);
           // Continue with local delete even if Google fails
+        }
+      }
+
+      // Propagate the delete to a CalDAV source too (parity with Google). The
+      // server addresses objects by href, so we use the href + ETag captured at
+      // sync time. Single-event scope only: recurring events share one parent
+      // object, and an href-based delete would drop the whole series — for those
+      // we skip write-back and just tombstone + delete locally (matches the
+      // documented CalDAV write scope, issue #59 for recurrence).
+      if (calendarSource?.provider === 'caldav') {
+        if (existingEvent.recurring) {
+          logError(
+            'Skipping CalDAV upstream delete for recurring event (single-event scope only):',
+            existingEvent.id
+          );
+        } else if (!existingEvent.caldavHref) {
+          logError(
+            'Skipping CalDAV upstream delete: no stored href (event predates href capture; re-sync to populate):',
+            existingEvent.id
+          );
+        } else {
+          const result = await pushCalDAVEventDelete(
+            calendarSource.id,
+            existingEvent.caldavHref,
+            existingEvent.caldavEtag ?? undefined
+          );
+          if (!result.ok) {
+            // Continue with local delete even if the server rejects it; the
+            // tombstone below still prevents the event from being re-pulled.
+            logError('Failed to delete event from CalDAV server:', result.error);
+          }
         }
       }
 

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -301,6 +301,9 @@ CREATE TABLE IF NOT EXISTS public.events (
     color character varying(7),
     reminder_minutes integer,
     last_synced timestamp without time zone,
+    pending_deletion timestamp without time zone,
+    caldav_href character varying(1024),
+    caldav_etag character varying(255),
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -167,6 +167,13 @@ export const events = pgTable('events', {
   // (deletes-only review). Null = not pending.
   pendingDeletion: timestamp('pending_deletion'),
 
+  // CalDAV calendar-object href + ETag, captured at sync time. A CalDAV DELETE
+  // targets the object by href (not UID), so we need it to propagate a local
+  // delete upstream to the source server (single-event scope; recurring events
+  // share one parent object and are excluded from write-back).
+  caldavHref: varchar('caldav_href', { length: 1024 }),
+  caldavEtag: varchar('caldav_etag', { length: 255 }),
+
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({

--- a/src/lib/integrations/caldav.ts
+++ b/src/lib/integrations/caldav.ts
@@ -48,6 +48,12 @@ export interface CalDAVEvent {
   color: string | null;
   recurring: boolean;
   recurrenceRule: string | null;
+  /** href (path) of the CalDAV object this event was parsed from, plus its
+   *  ETag. Needed to propagate a delete/update back to the server, which
+   *  addresses objects by href, not UID. Recurring instances share the parent
+   *  object's href — write-back is single-event-only, so that's acceptable. */
+  href: string | null;
+  etag: string | null;
 }
 
 export interface CalDAVTask {
@@ -244,6 +250,12 @@ function parseICalObject(
   const vevents = comp.getAllSubcomponents('vevent');
   const events: CalDAVEvent[] = [];
 
+  // Object identity on the server: the href addresses the .ics resource and
+  // the ETag guards a conflict-safe delete/update. Both come from the DAV
+  // object, not the iCal body.
+  const href = obj.url || null;
+  const etag = obj.etag || null;
+
   for (const vevent of vevents) {
     const event = new ICAL.Event(vevent);
 
@@ -277,6 +289,8 @@ function parseICalObject(
               color: null,
               recurring: true,
               recurrenceRule: vevent.getFirstPropertyValue('rrule')?.toString() || null,
+              href,
+              etag,
             });
           }
 
@@ -285,17 +299,22 @@ function parseICalObject(
         }
       } catch {
         // If recurrence expansion fails, add the base event
-        events.push(makeEvent(event, vevent));
+        events.push(makeEvent(event, vevent, href, etag));
       }
     } else {
-      events.push(makeEvent(event, vevent));
+      events.push(makeEvent(event, vevent, href, etag));
     }
   }
 
   return events;
 }
 
-function makeEvent(event: ICAL.Event, vevent: ICAL.Component): CalDAVEvent {
+function makeEvent(
+  event: ICAL.Event,
+  vevent: ICAL.Component,
+  href: string | null,
+  etag: string | null,
+): CalDAVEvent {
   return {
     uid: event.uid,
     title: event.summary,
@@ -307,6 +326,8 @@ function makeEvent(event: ICAL.Event, vevent: ICAL.Component): CalDAVEvent {
     color: null,
     recurring: false,
     recurrenceRule: null,
+    href,
+    etag,
   };
 }
 

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -906,6 +906,12 @@ export async function syncCalDAVCalendarSource(
         recurrenceRule: event.recurrenceRule,
         calendarSourceId: sourceId,
         externalEventId: event.uid,
+        // Persist the object href + ETag so a local delete can propagate
+        // upstream (CalDAV addresses objects by href, not UID). Refreshed on
+        // every sync even when the event is otherwise unchanged, keeping the
+        // ETag current for a conflict-safe delete.
+        caldavHref: event.href,
+        caldavEtag: event.etag,
         updatedAt: new Date(),
       };
 


### PR DESCRIPTION
## What

Deleting a synced **Apple/CalDAV** event in Prism now removes it from the source server too — parity with Google, which already propagated deletes. Previously such a delete was only tombstoned locally, so the event lingered on iCloud/Nextcloud/etc. (the exact gap hit while click-testing the #171 work).

## How

CalDAV addresses calendar objects by **href**, not UID, so:
- the read path (`caldav.ts`) now carries each object's `href` + `ETag` onto every parsed `CalDAVEvent`;
- the sync writer persists them on the `events` row — new `caldav_href` / `caldav_etag` columns (**migration 0017**, additive + idempotent), refreshed on every sync so the ETag stays current;
- the `DELETE /api/events/[id]` route sends a conflict-safe delete back through the existing `pushCalDAVEventDelete` helper, mirroring the Google branch right above it.

## Scope & safety

- **Single (non-recurring) events only.** Recurring instances share one parent object, so an href-based delete would drop the whole series — those still delete locally without touching the source (proper recurrence editing is #59). The route logs and skips write-back for `recurring` rows.
- **Graceful fallback.** A row with no stored href (synced before this change) or a server that rejects the delete falls back to local delete + tombstone, so the deletion still sticks locally and the event is repopulated with an href on the next sync.

## Validation

- `type-check`, `lint`, and the calendar-sync unit suite (29/29) pass.
- **Live end-to-end against iCloud**, non-destructively: confirmed href/ETag capture on sync, then `create → sync → upstream delete → confirmed gone from the server`, with the account's other events left untouched.

Closes #171 (Stage 4).