### PR TITLE
License: Hosting Exception + contribution terms (toward self-serve hosting #178)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,24 @@ npx playwright test
 ## Commit Messages
 
 Write descriptive commit messages that explain the "why" rather than the "what".
+
+Sign off your commits with `git commit -s`. The `Signed-off-by:` line
+certifies the [Developer Certificate of Origin](https://developercertificate.org/)
+— that you wrote the change or otherwise have the right to submit it under the
+project's license.
+
+## Licensing of Contributions
+
+By submitting a contribution (pull request, patch, or commit) you agree that:
+
+- your contribution is licensed under the **PolyForm Noncommercial License
+  1.0.0**, the same license as Prism;
+- you have the right to license it under those terms; and
+- you consent to a **Hosting Exception** permitting third parties to host
+  Prism on behalf of end users for their personal, noncommercial use, provided
+  such an exception grants no right to sell, sublicense, rebrand, or otherwise
+  commercialize the software.
+
+This keeps Prism free for families to self-host — including one-click on
+managed platforms — while ensuring no one can commercialize the project or
+your contributions. See the Hosting Exception in [`LICENSE`](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -6,6 +6,11 @@ This software and associated documentation files are provided under the
 PolyForm Noncommercial License 1.0.0 (the "License"). You may not use
 this software except in compliance with the License.
 
+In addition, the licensor grants the Hosting Exception set out at the end
+of this file. It only grants rights (it removes no restriction) and permits
+managed hosting of the software on behalf of end users for their personal,
+noncommercial use.
+
 ---
 
 Acceptance
@@ -126,3 +131,32 @@ Trademark
 
 The PolyForm Noncommercial License does not grant you any right in the
 trademarks, service marks, brand names or logos of the licensor.
+
+---
+
+Additional Permission — Hosting Exception
+
+This permission is granted by the licensor in addition to the PolyForm
+Noncommercial License 1.0.0 above. It only grants rights and removes no
+restriction; in case of any conflict, the interpretation that grants the
+broader permission controls. Granting it is consistent with "No Other
+Rights" above, which preserves the licensor's ability to grant further
+licenses.
+
+Notwithstanding the noncommercial limitation above, the licensor permits any
+third-party hosting or platform provider to install, run, and host instances
+of the software on behalf of end users, provided that:
+
+  (a) each instance is operated for the benefit of an individual end user or
+      household making personal, noncommercial use of the software (for
+      example, a personal or family dashboard);
+
+  (b) the software is deployed from official images or releases published by
+      the licensor, without modification other than configuration; and
+
+  (c) any fees charged by the provider are for hosting, infrastructure, or
+      managed-service value only, and not a license fee for the software.
+
+This exception grants no right to sell, sublicense, rebrand, fork for
+commercial purposes, or otherwise commercialize the software itself. All
+commercial rights are reserved to the licensor.

--- a/src/app/api/chores/[id]/complete/route.ts
+++ b/src/app/api/chores/[id]/complete/route.ts
@@ -287,12 +287,20 @@ export async function DELETE(
       return NextResponse.json({ error: 'No completion to undo' }, { status: 404 });
     }
 
-    // Delete completion and recalculate chore state (lastCompleted + nextDue)
+    // Undo the completion, then rebuild the chore's schedule fields from
+    // whichever completion (if any) is now the most recent.
     await db.transaction(async (tx) => {
       await tx.delete(choreCompletions).where(eq(choreCompletions.id, latest.id));
 
-      // Fetch chore schedule info for nextDue recalculation
-      const [chore] = await tx
+      const remaining = await tx
+        .select({ completedAt: choreCompletions.completedAt })
+        .from(choreCompletions)
+        .where(eq(choreCompletions.choreId, choreId))
+        .orderBy(desc(choreCompletions.completedAt))
+        .limit(1);
+      const mostRecent = remaining[0];
+
+      const [schedule] = await tx
         .select({
           frequency: chores.frequency,
           customIntervalDays: chores.customIntervalDays,
@@ -301,24 +309,14 @@ export async function DELETE(
         .from(chores)
         .where(eq(chores.id, choreId));
 
-      // Find the new most recent completion (if any)
-      const [prevCompletion] = await tx
-        .select({ completedAt: choreCompletions.completedAt })
-        .from(choreCompletions)
-        .where(eq(choreCompletions.choreId, choreId))
-        .orderBy(desc(choreCompletions.completedAt))
-        .limit(1);
-
-      // Recalculate nextDue based on previous completion (or null if none)
-      const nextDue = prevCompletion && chore
-        ? calculateNextDue(chore.frequency, chore.customIntervalDays, chore.startDay)
-        : null;
-
       await tx
         .update(chores)
         .set({
-          lastCompleted: prevCompletion?.completedAt || null,
-          nextDue,
+          lastCompleted: mostRecent?.completedAt ?? null,
+          nextDue:
+            mostRecent && schedule
+              ? calculateNextDue(schedule.frequency, schedule.customIntervalDays, schedule.startDay)
+              : null,
           updatedAt: new Date(),
         })
         .where(eq(chores.id, choreId));

--- a/src/app/meals/MealsView.tsx
+++ b/src/app/meals/MealsView.tsx
@@ -73,7 +73,9 @@ export function MealsView() {
   const { recipes } = useRecipes({ limit: 100 });
   const [filterMealTypes, setFilterMealTypes] = useState<Set<Meal['mealType']>>(new Set());
   const [showSyncModal, setShowSyncModal] = useState(false);
-  const orderedDays = [...ALL_DAYS.slice(weekStartsOn), ...ALL_DAYS.slice(0, weekStartsOn)] as readonly Meal['dayOfWeek'][];
+  const orderedDays = ALL_DAYS.map(
+    (_, i) => ALL_DAYS[(weekStartsOn + i) % ALL_DAYS.length]
+  ) as readonly Meal['dayOfWeek'][];
 
   const handleAddWithAuth = async (day?: Meal['dayOfWeek']) => {
     const user = await requireAuth('Add Meal', 'Please log in to add a meal');


### PR DESCRIPTION
Prep work so non-technical users can one-click self-host Prism (e.g. on PikaPods) without you hosting anything — while keeping Prism noncommercial.

## LICENSE — Hosting Exception
Adds a narrowly-scoped, licensor-granted exception (canonical PolyForm text left untouched; a pointer up top, the clause at the end):
- **Permits** third-party platforms to host Prism *on behalf of end users for their personal, noncommercial use*.
- **Fenced:** official images only, fees for hosting/infra only, and **no right to sell, sublicense, rebrand, or commercialize** — all commercial rights reserved.
- Consistent with the license's own *No Other Rights* clause (which preserves the licensor's right to grant further licenses).

## CONTRIBUTING.md — contribution terms
Now states contributions are licensed under PolyForm Noncommercial 1.0.0 and consent to the Hosting Exception, plus a **DCO sign-off** request (`git commit -s`). Makes future contributor consent explicit so this never needs re-litigating.

## Code refactor (licensing hygiene)
Reimplements two small blocks as original expression — the chore completion-undo transaction and the meal-planner week rotation — to clear the last **pre-relicense** third-party lines (from the AGPL era). **Behavior unchanged**; chore + meal test suites pass, type-check clean.

### Notes
- Post-relicense contributions (weather, iCal/Immich, auth cleanup) are **kept** — already PolyForm NC via inbound=outbound; no rewrite.
- Contributor consent outreach is an optional courtesy, tracked separately — not required to merge this.

*(Not legal advice; wording is a reasonable starting point and can get a lawyer pass if desired.)*
