### PR TITLE
UI audit rig: responsive/display-scale sweep + blue-tape board (toward #178)

### DIFF
--- a/e2e/helpers/ui-detectors.ts
+++ b/e2e/helpers/ui-detectors.ts
@@ -1,0 +1,116 @@
+/**
+ * In-page layout detectors for the UI audit rig (e2e/ui-audit.spec.ts).
+ *
+ * `layoutProbe` is intentionally SELF-CONTAINED — it is serialized and run
+ * inside the browser via `page.evaluate`, so it may reference only browser
+ * globals and its single argument (no imports, no closures). It measures the
+ * *rendered* layout, so it sees the effect of the display-scale `zoom` wrapper
+ * exactly as a user would.
+ */
+
+export interface Overflower {
+  desc: string;
+  right: number;
+  overflow: number;
+  w: number;
+  h: number;
+}
+
+export interface LayoutProbeResult {
+  viewportW: number;
+  viewportH: number;
+  /** Horizontal pixels the document scrolls beyond the viewport (0 = none). */
+  pageOverflowX: number;
+  /** Elements pushed off the right edge, worst first (max 8). */
+  overflowers: Overflower[];
+  /** True when the fixed side/portrait nav is clipped or spills the viewport. */
+  navClipped: boolean;
+  navDetail: string | null;
+}
+
+/** Runs in the browser. `tolerance` is the px slack before flagging. */
+export function layoutProbe(tolerance: number): LayoutProbeResult {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const doc = document.documentElement;
+  const pageOverflowX = Math.max(0, doc.scrollWidth - vw);
+
+  const describe = (el: Element): string => {
+    const e = el as HTMLElement;
+    const id = e.id ? `#${e.id}` : '';
+    const cls =
+      typeof e.className === 'string'
+        ? e.className
+            .split(/\s+/)
+            .filter(Boolean)
+            .slice(0, 3)
+            .map((c) => `.${c}`)
+            .join('')
+        : '';
+    const widget = e.getAttribute('data-widget');
+    return `${el.tagName.toLowerCase()}${id}${cls}${widget ? `[data-widget="${widget}"]` : ''}`;
+  };
+
+  const overflowers: Overflower[] = [];
+  for (const el of Array.from(document.body.querySelectorAll('*')) as HTMLElement[]) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) continue;
+    const over = r.right - vw;
+    // Flag elements pushed partly off the right edge — but skip giant
+    // containers wider than the viewport (they scroll internally by design);
+    // we want the element that actually overhangs.
+    if (over > tolerance && r.width <= vw + tolerance) {
+      overflowers.push({
+        desc: describe(el),
+        right: Math.round(r.right),
+        overflow: Math.round(over),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+      });
+    }
+  }
+  overflowers.sort((a, b) => b.overflow - a.overflow);
+
+  let navClipped = false;
+  let navDetail: string | null = null;
+  const aside = document.querySelector('aside');
+  if (aside) {
+    const scroller = aside.querySelector('nav');
+    if (scroller && scroller.scrollHeight - scroller.clientHeight > tolerance) {
+      navClipped = true;
+      navDetail = `side-nav list clipped: ${scroller.scrollHeight}px of items in a ${scroller.clientHeight}px rail`;
+    }
+    const r = aside.getBoundingClientRect();
+    if (r.bottom - vh > tolerance || r.right - vw > tolerance) {
+      navClipped = true;
+      navDetail =
+        (navDetail ? navDetail + '; ' : '') +
+        `nav spills viewport (bottom ${Math.round(r.bottom)}/${vh}, right ${Math.round(r.right)}/${vw})`;
+    }
+  }
+
+  return {
+    viewportW: vw,
+    viewportH: vh,
+    pageOverflowX: Math.round(pageOverflowX),
+    overflowers: overflowers.slice(0, 8),
+    navClipped,
+    navDetail,
+  };
+}
+
+export type Severity = 'high' | 'medium' | 'ok';
+
+/** Collapse a probe result into a single severity + human summary. */
+export function gradeProbe(p: LayoutProbeResult): { severity: Severity; summary: string } {
+  if (p.navClipped) return { severity: 'high', summary: p.navDetail || 'navigation clipped' };
+  if (p.pageOverflowX > 4)
+    return { severity: 'high', summary: `page scrolls horizontally by ${p.pageOverflowX}px` };
+  const worst = p.overflowers[0];
+  if (worst)
+    return {
+      severity: 'medium',
+      summary: `${p.overflowers.length} element(s) overhang the right edge (worst: ${worst.desc} by ${worst.overflow}px)`,
+    };
+  return { severity: 'ok', summary: 'no layout overflow detected' };
+}

--- a/e2e/ui-audit.spec.ts
+++ b/e2e/ui-audit.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * UI audit rig.
+ *
+ * Sweeps the app across routes × viewports × display-scales, runs the
+ * `layoutProbe` detectors at each stop, screenshots it, and writes a punch-list
+ * to e2e/ui-audit-artifacts/report.json (render into a board with
+ * `node scripts/ui-audit-board.mjs`).
+ *
+ * This is a DIAGNOSTIC, not a gate — it collects findings and never fails the
+ * build on a layout issue (so it can run in CI and upload the board as an
+ * artifact). Assertions are limited to "the sweep ran".
+ *
+ * TEST-ENVIRONMENT DEPENDENCY (same as visual-regression.spec.ts):
+ * - Requires a fresh, synthetic-seed DB. Gated on E2E_HAS_TEST_DB=1; without
+ *   it the sweep is skipped by design (login PINs are unknown on a live
+ *   deployment, and resetAll would wipe real data). NEVER run against a live
+ *   instance.
+ *
+ * Display scale note: the setting is `layouts.font_scale`, applied as CSS
+ * `zoom` on a server-rendered wrapper (src/app/page.tsx). It is read from the
+ * DB at SSR time, so the rig sets it via a DB UPDATE before navigating — a
+ * client-side localStorage tweak would not take effect.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { execSync } from 'child_process';
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+import { loginViaAPI } from './helpers/auth';
+import { resetAll } from './helpers/reset';
+import { ALL_NAV_ITEMS } from '../src/lib/constants/navItems';
+import { layoutProbe, gradeProbe, type LayoutProbeResult, type Severity } from './helpers/ui-detectors';
+
+const HAS_TEST_DB = process.env.E2E_HAS_TEST_DB === '1';
+const TOLERANCE = 2; // px slack before flagging overflow
+const OUT_DIR = path.join('e2e', 'ui-audit-artifacts');
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 414, height: 896 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'laptop', width: 1024, height: 768 },
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'wall', width: 1920, height: 1080 },
+] as const;
+
+// Display-scale is only applied on the dashboard/display wrapper, so the scale
+// sweep targets '/' (the reported "navbar cut off at 75%" repro).
+const SCALES = [75, 125, 150] as const; // 100 covered by the viewport sweep
+
+interface Finding {
+  route: string;
+  viewport: string;
+  width: number;
+  height: number;
+  scale: number;
+  severity: Severity;
+  summary: string;
+  probe: LayoutProbeResult;
+  screenshot: string;
+}
+
+/** Run a DB statement through the same channel resetAll/getSeededParentName use. */
+function execDb(sql: string): void {
+  const cmd = process.env.DATABASE_URL
+    ? `psql "${process.env.DATABASE_URL}" -c "${sql}"`
+    : `docker exec prism-db psql -U prism -d ${process.env.E2E_DB_NAME || 'prism'} -c "${sql}"`;
+  execSync(cmd, { encoding: 'utf-8' });
+}
+
+function getSeededParentName(): string {
+  const sel = "SELECT name FROM users WHERE role = 'parent' ORDER BY created_at LIMIT 1";
+  const cmd = process.env.DATABASE_URL
+    ? `psql "${process.env.DATABASE_URL}" -At -c "${sel}"`
+    : `docker exec prism-db psql -U prism -d ${process.env.E2E_DB_NAME || 'prism'} -At -c "${sel}"`;
+  const out = execSync(cmd, { encoding: 'utf-8' }).trim();
+  if (!out) throw new Error('No seeded parent in DB — did seeds run?');
+  return out;
+}
+
+function setDefaultFontScale(scale: number | null): void {
+  execDb(`UPDATE layouts SET font_scale = ${scale === null ? 'NULL' : scale} WHERE is_default = true`);
+}
+
+function slug(route: string): string {
+  return route === '/' ? 'dashboard' : route.replace(/^\//, '').replace(/\//g, '-');
+}
+
+async function probeRoute(
+  page: Page,
+  route: string,
+  viewport: { name: string; width: number; height: number },
+  scale: number,
+): Promise<Finding> {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(route);
+  await page.waitForLoadState('networkidle').catch(() => {});
+  await page.waitForTimeout(500);
+
+  const probe = await page.evaluate(layoutProbe, TOLERANCE);
+  const { severity, summary } = gradeProbe(probe);
+
+  const name = `${slug(route)}__${viewport.name}__s${scale}.png`;
+  await page.screenshot({ path: path.join(OUT_DIR, name), fullPage: false, animations: 'disabled' });
+
+  return {
+    route,
+    viewport: viewport.name,
+    width: viewport.width,
+    height: viewport.height,
+    scale,
+    severity,
+    summary,
+    probe,
+    screenshot: name,
+  };
+}
+
+test.describe('UI audit sweep', () => {
+  let parentName: string;
+
+  test.beforeAll(() => {
+    if (HAS_TEST_DB) {
+      resetAll();
+      parentName = getSeededParentName();
+      mkdirSync(OUT_DIR, { recursive: true });
+    }
+  });
+
+  test.afterAll(() => {
+    if (HAS_TEST_DB) setDefaultFontScale(null); // restore default zoom
+  });
+
+  test('sweep routes × viewports × scale', async ({ page }) => {
+    test.skip(!HAS_TEST_DB, 'Set E2E_HAS_TEST_DB=1 against a fresh-seeded DB');
+    test.setTimeout(10 * 60 * 1000);
+
+    await page.addInitScript(() => {
+      localStorage.setItem('prism-theme', 'light');
+      localStorage.setItem('prism:auto-hide-ui', 'false');
+    });
+    await loginViaAPI(page, parentName);
+
+    const findings: Finding[] = [];
+    const routes = ALL_NAV_ITEMS.map((n) => n.href);
+
+    // 1) Every route across every viewport at default scale (100%).
+    for (const route of routes) {
+      for (const vp of VIEWPORTS) {
+        findings.push(await probeRoute(page, route, vp, 100));
+      }
+    }
+
+    // 2) Display-scale sweep on the dashboard (where the zoom wrapper applies).
+    for (const scale of SCALES) {
+      setDefaultFontScale(scale);
+      for (const vp of [VIEWPORTS[3], VIEWPORTS[4]]) {
+        // laptop + wall
+        findings.push(await probeRoute(page, '/', vp, scale));
+      }
+    }
+    setDefaultFontScale(null);
+
+    const summary = {
+      generatedAtNote: 'timestamp added by scripts/ui-audit-board.mjs at render time',
+      totals: {
+        checks: findings.length,
+        high: findings.filter((f) => f.severity === 'high').length,
+        medium: findings.filter((f) => f.severity === 'medium').length,
+        ok: findings.filter((f) => f.severity === 'ok').length,
+      },
+      findings: findings.sort((a, b) => severityRank(b.severity) - severityRank(a.severity)),
+    };
+    writeFileSync(path.join(OUT_DIR, 'report.json'), JSON.stringify(summary, null, 2));
+
+    // Surface a console summary; do not fail the build (diagnostic only).
+    console.log(
+      `[ui-audit] ${summary.totals.checks} checks — ` +
+        `${summary.totals.high} high, ${summary.totals.medium} medium, ${summary.totals.ok} ok`,
+    );
+    for (const f of summary.findings.filter((x) => x.severity !== 'ok')) {
+      console.log(`  [${f.severity}] ${f.route} @ ${f.viewport} ×${f.scale}% — ${f.summary}`);
+    }
+
+    expect(summary.totals.checks).toBeGreaterThan(0);
+  });
+});
+
+function severityRank(s: Severity): number {
+  return s === 'high' ? 2 : s === 'medium' ? 1 : 0;
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:visual": "playwright test e2e/visual-regression.spec.ts",
     "test:visual:update": "playwright test e2e/visual-regression.spec.ts --update-snapshots",
+    "test:ui-audit": "playwright test e2e/ui-audit.spec.ts && node scripts/ui-audit-board.mjs",
     "test:migration-replay": "bash scripts/test-migration-replay.sh",
     "scan:pii": "bash scripts/scan-pii.sh",
     "scan:pii:install-hook": "echo '#!/usr/bin/env bash\\nbash scripts/scan-pii.sh' > .git/hooks/pre-push && chmod +x .git/hooks/pre-push && echo 'Pre-push PII hook installed at .git/hooks/pre-push'",

--- a/scripts/ui-audit-board.mjs
+++ b/scripts/ui-audit-board.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Render the UI audit punch-list (e2e/ui-audit-artifacts/report.json) into a
+ * self-contained HTML "blue-tape board" — one card per finding, screenshot
+ * embedded as a data URI so the page has no external dependencies and can be
+ * published directly as an Artifact.
+ *
+ * Usage:  node scripts/ui-audit-board.mjs
+ * Output: e2e/ui-audit-artifacts/board.html
+ */
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const DIR = path.join('e2e', 'ui-audit-artifacts');
+const REPORT = path.join(DIR, 'report.json');
+const OUT = path.join(DIR, 'board.html');
+
+if (!existsSync(REPORT)) {
+  console.error(`No report at ${REPORT}. Run the sweep first: npm run test:ui-audit`);
+  process.exit(1);
+}
+
+const report = JSON.parse(readFileSync(REPORT, 'utf-8'));
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+
+function dataUri(file) {
+  const p = path.join(DIR, file);
+  if (!existsSync(p)) return '';
+  return `data:image/png;base64,${readFileSync(p).toString('base64')}`;
+}
+
+const BADGE = { high: '#dc2626', medium: '#d97706', ok: '#16a34a' };
+
+function card(f) {
+  const uri = dataUri(f.screenshot);
+  const overflowers = (f.probe?.overflowers || [])
+    .map((o) => `<li><code>${esc(o.desc)}</code> — overhang ${o.overflow}px (w ${o.w})</li>`)
+    .join('');
+  return `
+  <article class="card sev-${f.severity}">
+    <header>
+      <span class="badge" style="background:${BADGE[f.severity]}">${f.severity.toUpperCase()}</span>
+      <strong>${esc(f.route)}</strong>
+      <span class="meta">${esc(f.viewport)} · ${f.width}×${f.height} · scale ${f.scale}%</span>
+    </header>
+    <p class="summary">${esc(f.summary)}</p>
+    ${overflowers ? `<details><summary>overhanging elements</summary><ul>${overflowers}</ul></details>` : ''}
+    ${uri ? `<a href="${uri}" target="_blank"><img loading="lazy" src="${uri}" alt="${esc(f.route)} ${esc(f.viewport)}"></a>` : '<p class="noshot">(no screenshot)</p>'}
+  </article>`;
+}
+
+const t = report.totals || { checks: 0, high: 0, medium: 0, ok: 0 };
+const flagged = (report.findings || []).filter((f) => f.severity !== 'ok');
+const okCount = t.ok;
+
+const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Prism UI Audit — blue-tape board</title>
+<style>
+  :root { color-scheme: light dark; --bg:#fff; --fg:#111; --card:#f6f7f9; --line:#e3e6ea; --muted:#667; }
+  @media (prefers-color-scheme: dark){ :root{ --bg:#0f1115; --fg:#e8eaed; --card:#181b21; --line:#282d36; --muted:#99a; } }
+  *{box-sizing:border-box} body{margin:0;font:15px/1.5 system-ui,sans-serif;background:var(--bg);color:var(--fg)}
+  header.top{padding:24px;border-bottom:1px solid var(--line)}
+  h1{margin:0 0 6px;font-size:20px} .tallies{display:flex;gap:14px;flex-wrap:wrap;color:var(--muted)}
+  .tally b{font-size:20px;color:var(--fg)}
+  main{padding:20px;display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:16px}
+  .card{background:var(--card);border:1px solid var(--line);border-left-width:4px;border-radius:10px;padding:12px;overflow:hidden}
+  .card.sev-high{border-left-color:${BADGE.high}} .card.sev-medium{border-left-color:${BADGE.medium}} .card.sev-ok{border-left-color:${BADGE.ok}}
+  .card header{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:6px}
+  .badge{color:#fff;font-size:11px;font-weight:700;padding:2px 7px;border-radius:5px}
+  .meta{color:var(--muted);font-size:12px} .summary{margin:4px 0 8px}
+  code{font-size:12px;background:rgba(127,127,127,.15);padding:1px 4px;border-radius:4px}
+  details{margin:0 0 8px;font-size:13px} details ul{margin:6px 0 0;padding-left:18px}
+  img{width:100%;height:auto;border:1px solid var(--line);border-radius:6px;display:block}
+  .noshot{color:var(--muted);font-size:13px} section h2{padding:0 20px;margin:18px 0 0;font-size:15px;color:var(--muted)}
+</style></head>
+<body>
+<header class="top">
+  <h1>🩹 Prism UI Audit — blue-tape board</h1>
+  <div class="tallies">
+    <span class="tally"><b>${t.checks}</b> checks</span>
+    <span class="tally" style="color:${BADGE.high}"><b>${t.high}</b> high</span>
+    <span class="tally" style="color:${BADGE.medium}"><b>${t.medium}</b> medium</span>
+    <span class="tally" style="color:${BADGE.ok}"><b>${okCount}</b> clean</span>
+  </div>
+</header>
+${flagged.length ? `<section><h2>Flagged (${flagged.length})</h2></section><main>${flagged.map(card).join('')}</main>` : '<section><h2>No layout issues flagged 🎉</h2></section>'}
+</body></html>`;
+
+writeFileSync(OUT, html);
+console.log(`Board written to ${OUT} (${flagged.length} flagged of ${t.checks} checks)`);


### PR DESCRIPTION
A Playwright-driven **diagnostic** that systematically catches the hard-to-eyeball layout bugs (like the navbar cutoff at 75% display scale) instead of hoping to notice them.

## What it does
- **`e2e/ui-audit.spec.ts`** — sweeps every nav route × 5 viewports (414→1920) × display-scales (75/125/150% on the dashboard, where the `font_scale` `zoom` wrapper applies). Sets scale via DB before navigating (SSR-read, so a client tweak won't take).
- **`e2e/helpers/ui-detectors.ts`** — in-page detectors: horizontal page overflow, elements overhanging the right edge, and clipped/spilled fixed navigation (the `SideNav`/`PortraitNav` scale-fragile case).
- **`scripts/ui-audit-board.mjs`** — renders the punch-list into a self-contained **blue-tape board** (screenshots embedded as data URIs → publishable as an Artifact).
- `npm run test:ui-audit` runs both.

## Safety
Diagnostic only — **never fails the build**. Gated on `E2E_HAS_TEST_DB=1`, so it runs only against a fresh synthetic-seed DB (login PIN `1234`, `resetAll` reseed) — **never a live instance**. Same guard model as the visual-regression suite.

## Next step
Wire a `workflow_dispatch` CI job that runs the sweep against the ephemeral seeded DB and uploads `board.html` as an artifact — so we get a real board without any local prod risk.

Toward #178 (pre-hosting UI polish).