### PR TITLE
refactor(ui): unify 6 modal backdrops onto shared Dialog

### DIFF
--- a/src/app/chores/ChoreModal.tsx
+++ b/src/app/chores/ChoreModal.tsx
@@ -3,10 +3,16 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { DAYS_SHORT_ARRAY, DAYS_LONG_ARRAY } from '@/lib/constants/days';
-import { X, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { getCategoryEmoji } from '@/app/chores/ChoreItem';
 import type { Chore, FamilyMember } from '@/types';
 
@@ -61,22 +67,11 @@ export function ChoreModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 pb-20 md:pb-0"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
-            {chore ? 'Edit Chore' : 'Add Chore'}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{chore ? 'Edit Chore' : 'Add Chore'}</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -290,7 +285,7 @@ export function ChoreModal({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/settings/components/MemberModal.tsx
+++ b/src/app/settings/components/MemberModal.tsx
@@ -3,11 +3,17 @@
 import { useState, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { toast } from '@/components/ui/use-toast';
-import { X, Upload, Trash2, Smile } from 'lucide-react';
+import { Upload, Trash2, Smile } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { UserAvatar } from '@/components/ui/avatar';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import type { FamilyMember } from './PinEditModal';
 
 const EmojiPicker = dynamic(
@@ -100,22 +106,11 @@ export function MemberModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
-            {member ? 'Edit Member' : 'Add Family Member'}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{member ? 'Edit Member' : 'Add Family Member'}</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Avatar Section */}
@@ -243,7 +238,7 @@ export function MemberModal({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/settings/components/PinEditModal.tsx
+++ b/src/app/settings/components/PinEditModal.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { usePinLength } from '@/lib/hooks/usePinLength';
 import { MAX_PIN_LENGTH } from '@/lib/constants';
 
@@ -71,22 +76,13 @@ export function PinEditModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
             {member.hasPin ? 'Change PIN' : 'Set PIN'} for {member.name}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose}>
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+          </DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {member.hasPin && (
@@ -150,7 +146,7 @@ export function PinEditModal({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/shopping/ItemModal.tsx
+++ b/src/app/shopping/ItemModal.tsx
@@ -2,9 +2,15 @@
 
 import * as React from 'react';
 import { useState } from 'react';
-import { X, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { useShoppingCategories } from '@/lib/hooks/useShoppingCategories';
 import type { ShoppingItem, ShoppingList } from '@/types';
 
@@ -57,22 +63,11 @@ export function ItemModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 pb-20 md:pb-0"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
-            {item ? 'Edit Item' : 'Add Item'}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{item ? 'Edit Item' : 'Add Item'}</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* List selector - only show if multiple lists available */}
@@ -177,7 +172,7 @@ export function ItemModal({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/shopping/ListModal.tsx
+++ b/src/app/shopping/ListModal.tsx
@@ -2,9 +2,15 @@
 
 import * as React from 'react';
 import { useState, useMemo } from 'react';
-import { X, User, Trash2, ShoppingCart, Package, Store, SlidersHorizontal } from 'lucide-react';
+import { User, Trash2, ShoppingCart, Package, Store, SlidersHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { cn } from '@/lib/utils';
@@ -159,22 +165,11 @@ export function ListModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 pb-20 md:pb-0"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
-            {list ? 'Edit List' : 'Create New List'}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{list ? 'Edit List' : 'Create New List'}</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -337,8 +332,8 @@ export function ListModal({
             </div>
           </div>
         </form>
-      </div>
+      </DialogContent>
       <ConfirmDialog {...confirmDialogProps} />
-    </div>
+    </Dialog>
   );
 }

--- a/src/app/tasks/TaskModal.tsx
+++ b/src/app/tasks/TaskModal.tsx
@@ -2,9 +2,14 @@
 
 import * as React from 'react';
 import { useState } from 'react';
-import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import type { Task, FamilyMember } from '@/types';
 
 interface TaskList {
@@ -76,22 +81,11 @@ export function TaskModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 pb-20 md:pb-0"
-      onClick={onClose}
-    >
-      <div
-        className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-lg border border-border max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">
-            {task ? 'Edit Task' : 'Add Task'}
-          </h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{task ? 'Edit Task' : 'Add Task'}</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -225,7 +219,7 @@ export function TaskModal({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
Consistency pass #1 (routed to **Sonnet**, reviewed by me). Converts the 6 modals that hand-rolled an identical `fixed inset-0 bg-black/50…` backdrop onto the shared Radix **`Dialog`** primitive — so they get consistent focus-trap, Escape, scroll-lock, and animation like the rest of the app.

**Files:** shopping `ItemModal`/`ListModal`, `TaskModal`, `ChoreModal`, settings `MemberModal`/`PinEditModal`. Mirrors the established `AddChoreModal`/`RecipeFormModal` pattern (`<Dialog open onOpenChange={onClose}>`, `DialogHeader`/`DialogTitle`, `DialogContent`'s built-in close button). Form fields, validation, and save/delete logic untouched. Net −30 lines.

## Verification
- ✅ type-check clean · ✅ eslint (only pre-existing warnings) · ✅ jest 142 passed
- `ListModal`'s nested `ConfirmDialog` kept as a sibling inside `Dialog` (Radix renders children normally) — intact.
- Mobile bottom-nav clearance: `DialogContent` already ships `mb-16 md:mb-0`, the primitive's equivalent of the old `pb-20 md:pb-0`.

## One nuance worth a click-test before merge
`MemberModal`'s emoji-picker uses a `fixed inset-0` click-catcher. Under Radix's transformed `DialogContent` (which becomes a containing block for fixed descendants), that catcher now scopes to the modal box rather than the full viewport. Net effect: with the picker open, clicking *outside the modal* now closes the whole dialog (Radix overlay) instead of only the picker — which is actually consistent with every other modal. Functionally sound, but worth a 10-second click-test of Settings → edit member → emoji picker if you want full confidence.