### PR TITLE
chore(license): align license strings + tidy chores/meals internals

### DIFF
--- a/.github/ISSUE_TEMPLATE/layout-submission.yml
+++ b/.github/ISSUE_TEMPLATE/layout-submission.yml
@@ -42,5 +42,5 @@ body:
     attributes:
       label: Terms
       options:
-        - label: I confirm this is my original layout and I agree to share it under the AGPL-3.0 license
+        - label: I confirm this is my original layout and I agree to license it under the PolyForm Noncommercial 1.0.0 license (the same license as Prism), consistent with the project's contribution terms
           required: true

--- a/src/app/api/chores/[id]/complete/route.ts
+++ b/src/app/api/chores/[id]/complete/route.ts
@@ -300,22 +300,15 @@ export async function DELETE(
         .limit(1);
       const mostRecent = remaining[0];
 
-      const [schedule] = await tx
-        .select({
-          frequency: chores.frequency,
-          customIntervalDays: chores.customIntervalDays,
-          startDay: chores.startDay,
-        })
-        .from(chores)
-        .where(eq(chores.id, choreId));
+      const [chore] = await tx.select().from(chores).where(eq(chores.id, choreId));
 
       await tx
         .update(chores)
         .set({
           lastCompleted: mostRecent?.completedAt ?? null,
           nextDue:
-            mostRecent && schedule
-              ? calculateNextDue(schedule.frequency, schedule.customIntervalDays, schedule.startDay)
+            mostRecent && chore
+              ? calculateNextDue(chore.frequency, chore.customIntervalDays, chore.startDay)
               : null,
           updatedAt: new Date(),
         })

--- a/src/app/meals/MealsView.tsx
+++ b/src/app/meals/MealsView.tsx
@@ -43,6 +43,7 @@ import { useMealsViewData } from './useMealsViewData';
 import { useRecipes, type Recipe } from '@/lib/hooks/useRecipes';
 import { useAuth } from '@/components/providers';
 import type { Meal } from '@/types';
+import { DAYS_OF_WEEK as ALL_DAYS } from '@/lib/constants/days';
 
 function getMealTypeEmoji(mealType: string): string {
   switch (mealType) {
@@ -54,13 +55,10 @@ function getMealTypeEmoji(mealType: string): string {
   }
 }
 
-import { DAYS_OF_WEEK as ALL_DAYS } from '@/lib/constants/days';
-
 export function MealsView() {
   const { requireAuth } = useAuth();
   const {
-    weekStartsOn,
-    today, currentWeek, weekOfString, loading,
+    weekStartsOn, today, currentWeek, weekOfString, loading,
     showAddModal, setShowAddModal,
     selectedDay, setSelectedDay,
     editingMeal, setEditingMeal,
@@ -164,8 +162,8 @@ export function MealsView() {
             <PageLoader />
           ) : (
             <div className="max-w-6xl mx-auto space-y-3">
-              {orderedDays.map((day, index) => {
-                const dayDate = addDays(currentWeek, index);
+              {orderedDays.map((day, offset) => {
+                const dayDate = addDays(currentWeek, offset);
                 const allDayMeals = mealsByDay[day] || [];
                 const dayMeals = filterMealTypes.size > 0 ? allDayMeals.filter(m => filterMealTypes.has(m.mealType)) : allDayMeals;
                 const isDayToday = format(dayDate, 'yyyy-MM-dd') === format(today, 'yyyy-MM-dd');
@@ -182,14 +180,24 @@ export function MealsView() {
         </div>
 
         {showAddModal && (
-          <MealModal weekOf={weekOfString} defaultDay={selectedDay || orderedDays[0]} dayOptions={orderedDays} recipes={recipes}
+          <MealModal
+            weekOf={weekOfString}
+            defaultDay={selectedDay || orderedDays[0]}
+            dayOptions={orderedDays}
+            recipes={recipes}
             onClose={() => { setShowAddModal(false); setSelectedDay(null); }}
-            onSave={(meal) => { addMeal(meal); setShowAddModal(false); setSelectedDay(null); }} />
+            onSave={(meal) => { addMeal(meal); setShowAddModal(false); setSelectedDay(null); }}
+          />
         )}
         {editingMeal && (
-          <MealModal weekOf={weekOfString} meal={editingMeal} dayOptions={orderedDays} recipes={recipes}
+          <MealModal
+            weekOf={weekOfString}
+            meal={editingMeal}
+            dayOptions={orderedDays}
+            recipes={recipes}
             onClose={() => setEditingMeal(null)}
-            onSave={(updates) => { editMeal(editingMeal.id, updates); setEditingMeal(null); }} />
+            onSave={(updates) => { editMeal(editingMeal.id, updates); setEditingMeal(null); }}
+          />
         )}
         {showSyncModal && (
           <RecipeSyncModal entity="meals" onClose={() => setShowSyncModal(false)} onSynced={refresh} />
@@ -342,12 +350,18 @@ function MealCard({ meal, onMarkCooked, onUnmarkCooked, onEdit, onDelete, onDrop
 
 
 export function MealModal({ weekOf, meal, defaultDay, dayOptions, recipes, onClose, onSave }: {
-  weekOf: string; meal?: Meal; defaultDay?: Meal['dayOfWeek']; dayOptions: readonly Meal['dayOfWeek'][]; recipes: Recipe[];
-  onClose: () => void; onSave: (meal: Record<string, unknown>) => void;
+  weekOf: string;
+  meal?: Meal;
+  defaultDay?: Meal['dayOfWeek'];
+  dayOptions: readonly Meal['dayOfWeek'][];
+  recipes: Recipe[];
+  onClose: () => void;
+  onSave: (meal: Record<string, unknown>) => void;
 }) {
   const [name, setName] = useState(meal?.name || '');
   const [description, setDescription] = useState(meal?.description || '');
-  const [dayOfWeek, setDayOfWeek] = useState<Meal['dayOfWeek']>(meal?.dayOfWeek || defaultDay || dayOptions[0] || 'sunday');
+  const initialDay: Meal['dayOfWeek'] = meal?.dayOfWeek || defaultDay || dayOptions[0] || 'sunday';
+  const [dayOfWeek, setDayOfWeek] = useState<Meal['dayOfWeek']>(initialDay);
   const [mealType, setMealType] = useState<Meal['mealType']>(meal?.mealType || 'dinner');
   const [mealTime, setMealTime] = useState<string>(meal?.mealTime || '');
   const [prepTime, setPrepTime] = useState(meal?.prepTime?.toString() || '');
@@ -477,13 +491,13 @@ export function MealModal({ weekOf, meal, defaultDay, dayOptions, recipes, onClo
           <div><label className="text-sm font-medium">Name</label><Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Meal name..." autoFocus={recipes.length === 0} /></div>
           <div><label className="text-sm font-medium">Description (optional)</label><Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Any details..." /></div>
           <div>
-              <label className="text-sm font-medium">Day</label>
-              <div className="grid grid-cols-4 gap-2 mt-1">
-              {dayOptions.map((d) => (
-                <Button key={d} type="button" variant={dayOfWeek === d ? 'default' : 'outline'} size="sm" onClick={() => setDayOfWeek(d)} className="capitalize text-xs">{d.slice(0, 3)}</Button>
+            <label className="text-sm font-medium">Day</label>
+            <div className="grid grid-cols-4 gap-2 mt-1">
+              {dayOptions.map((option) => (
+                <Button key={option} type="button" variant={dayOfWeek === option ? 'default' : 'outline'} size="sm" onClick={() => setDayOfWeek(option)} className="capitalize text-xs">{option.slice(0, 3)}</Button>
               ))}
-              </div>
             </div>
+          </div>
           <div>
             <label className="text-sm font-medium">Meal Type</label>
             <div className="flex gap-2 mt-1 flex-wrap">

--- a/src/app/meals/useMealsViewData.ts
+++ b/src/app/meals/useMealsViewData.ts
@@ -148,8 +148,7 @@ export function useMealsViewData() {
   const cookedMeals = meals.filter((m) => m.cookedAt).length;
 
   return {
-    weekStartsOn,
-    today, currentWeek, weekOfString, loading,
+    weekStartsOn, today, currentWeek, weekOfString, loading,
     showAddModal, setShowAddModal,
     selectedDay, setSelectedDay,
     editingMeal, setEditingMeal,

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -297,7 +297,8 @@ export function SettingsView() {
                             your calendars, tasks, and photos from the services you already use.
                           </p>
                           <p>
-                            Prism is free and open-source under the AGPL-3.0 license. If you find it useful,
+                            Prism is source-available under the PolyForm Noncommercial 1.0.0 license — free for
+                            personal and non-commercial use. If you find it useful,
                             please star the repo and share it with others who might benefit.
                           </p>
                           <div className="space-y-1 pt-2">


### PR DESCRIPTION
## License-string consistency + internal tidy

Aligns the codebase with the project's current **PolyForm Noncommercial** license and does a small behavior-preserving cleanup.

### License strings
Two user-facing strings still referenced the old AGPL-3.0 license:
- **Settings → About** text.
- The **layout-submission issue template** — so inbound community layout contributions are now offered under the correct PolyForm Noncommercial license, consistent with `CONTRIBUTING.md`.

No `AGPL` references remain in the tree.

### Internal tidy (no behavior change)
- **chores** (`complete/route.ts`) — simplify the completion-undo schedule lookup to a full-row fetch.
- **meals** (`MealsView.tsx`, `useMealsViewData.ts`) — formatting/readability of the day-ordering wiring: destructure/prop/type reflow, clearer loop-variable names, import hoist.

### Verification
Type-check clean; full suite green (1321 passing). Behavior-preserving throughout.