### PR TITLE
feat(calendar): mark meals with a utensils icon on calendar items

### DIFF
--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -8,7 +8,7 @@ import {
   addDays,
   startOfDay,
 } from 'date-fns';
-import { Calendar } from 'lucide-react';
+import { Calendar, UtensilsCrossed } from 'lucide-react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
@@ -345,8 +345,11 @@ function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean
         <div className={cn('text-xs', cards ? 'text-muted-foreground' : 'opacity-80')}>
           {row.timeLabel}
         </div>
-        <div className={cn('text-sm font-medium truncate', cards ? 'text-foreground' : 'text-white', row.muted && 'line-through')}>
-          {row.title}
+        <div className={cn('flex items-center gap-1 text-sm font-medium', cards ? 'text-foreground' : 'text-white', row.muted && 'line-through')}>
+          {row.dragId?.startsWith('meal:') && (
+            <UtensilsCrossed aria-hidden className="h-3 w-3 shrink-0" style={cards ? { color: row.stripeColor } : undefined} />
+          )}
+          <span className="truncate">{row.title}</span>
         </div>
         {row.subtitle && (
           <div className={cn('text-xs truncate', cards ? 'text-muted-foreground' : 'opacity-80')}>

--- a/src/components/calendar/cells/WeekItemCard.tsx
+++ b/src/components/calendar/cells/WeekItemCard.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
+import { UtensilsCrossed } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export type WeekItemVariant = 'event' | 'chore' | 'task' | 'meal';
@@ -129,6 +130,12 @@ export function WeekItemCard({
   const Tag = interactive ? 'button' : 'div';
   const styles = SIZE_STYLES[size];
 
+  // Meals get a small utensils glyph before the title so a meal reads as a meal
+  // at a glance rather than looking like any other colored event. Sized with
+  // the title and tinted to the item's stripe color; hidden on the tiniest
+  // (xs) cells where there isn't room.
+  const showMealIcon = variant === 'meal' && size !== 'xs';
+
   const transformStyle: React.CSSProperties = {
     transform: CSS.Translate.toString(draggable.transform),
     touchAction: dragId ? 'none' : undefined,
@@ -171,8 +178,9 @@ export function WeekItemCard({
             {timeLabel}
           </span>
         )}
-        <span className={cn('flex-1 truncate text-foreground', styles.titleText, styles.titleWeight, muted && 'line-through')}>
-          {title}
+        <span className={cn('flex min-w-0 flex-1 items-center gap-1 text-foreground', styles.titleText, styles.titleWeight, muted && 'line-through')}>
+          {showMealIcon && <UtensilsCrossed aria-hidden className="h-3 w-3 shrink-0" style={{ color: stripeColor }} />}
+          <span className="truncate">{title}</span>
         </span>
         {styles.showSubtitle && subtitle && (
           <span className={cn('shrink-0 truncate text-muted-foreground', styles.metaText)}>
@@ -219,8 +227,9 @@ export function WeekItemCard({
             {timeLabel}
           </span>
         )}
-        <span className={cn('truncate text-foreground', styles.titleText, styles.titleWeight, muted && 'line-through')}>
-          {title}
+        <span className={cn('flex min-w-0 items-center gap-1 text-foreground', styles.titleText, styles.titleWeight, muted && 'line-through')}>
+          {showMealIcon && <UtensilsCrossed aria-hidden className="h-3 w-3 shrink-0" style={{ color: stripeColor }} />}
+          <span className="truncate">{title}</span>
         </span>
         {styles.showSubtitle && subtitle && (
           <span className={cn('truncate text-muted-foreground', styles.metaText)}>


### PR DESCRIPTION
Adds a small utensils glyph before the title on meal-variant calendar items (day/week/month/multi-week via WeekItemCard, plus AgendaView rows), tinted to the item's stripe color — so a meal reads as a meal at a glance, distinct from the diagonal pending-approval texture. Hidden on the tiniest cells.

(The dashboard conform-to-screen fix originally scoped alongside this is deferred to 1.13 — it's a larger core-render change.)