### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.13.0] – 2026-08-02
+
 ### Dashboard
 - **Your layout now fills any screen.** Design your dashboard once — on your kiosk or in a laptop browser — and it stretches to fit whatever screen it's shown on, edge to edge, without clipping or stopping awkwardly short of the bottom. It re-fits live when you resize the window, go full-screen, or zoom, and when the toolbars auto-hide the layout grows to fill the space they leave. A design whose orientation doesn't match the screen (a portrait layout on a landscape display) is neatly letterboxed rather than stretched out of shape.
 - **Preview shows exactly what the wall will show.** Full-screen preview now renders the real, stretched dashboard, and a new **device gallery** shows how your one design looks on a 27″ display, an iPad, a Fire tablet and a phone — so you can check the fit before you deploy. The old per-resolution "screen zone" controls are retired in favor of this simpler model.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.12.0"
+version: "1.13.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Version bump to 1.13.0 — dashboard & screensaver scale-to-fit (#199). No schema changes.