### PR TITLE
fix(dashboard): kiosk clipping — dashboard bottom row, weather day rows, screensaver fit

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -427,7 +427,7 @@ export function Dashboard({
                 renderWidget={renderDashboardWidget}
                 widgetConstraints={dashboardConstraints}
                 margin={8}
-                headerOffset={layout.isEditing ? 140 : uiHidden ? 0 : 50}
+                headerOffset={layout.isEditing ? 140 : uiHidden ? 0 : 56}
                 bottomOffset={bottomOffset}
                 screenGuideOrientation={screenGuideOrientation}
                 enabledSizes={enabledSizes}

--- a/src/components/layout/grid/CssGridDisplay.tsx
+++ b/src/components/layout/grid/CssGridDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { WidgetBgOverrideProvider } from '@/components/widgets/WidgetContainer';
 import { getWidgetStyle, getWidgetContentStyle, getTextColorClass } from './gridWidgetStyles';
 import { useSquareCells } from './useSquareCells';
@@ -24,10 +24,16 @@ export function CssGridDisplay({
   minVisibleRows = 0,
   targetRows,
   designOrientation,
+  containMode = false,
   className,
 }: CssGridDisplayProps) {
-  const { containerRef, cellSize: widthCellSize, width, top } = useSquareCells(cols, containerPadding, margin, fillHeight);
+  const { containerRef, cellSize: widthCellSize, width, top, remeasure } = useSquareCells(cols, containerPadding, margin, fillHeight);
   const { width: viewportWidth, height: viewportHeight } = useViewportSize();
+
+  // Re-read the grid's real top whenever the chrome offset changes (a toolbar
+  // show/hide is a position change the ResizeObserver never sees), so the fill
+  // math tracks the actual header height instead of a stale value.
+  useEffect(() => { remeasure(); }, [headerOffset, bottomOffset, remeasure]);
 
   const visibleWidgets = useMemo(
     () => layout.filter(w => w.visible !== false),
@@ -60,7 +66,7 @@ export function CssGridDisplay({
     return { fitCols: maxCol, fitRows: maxRow };
   }, [visibleWidgets]);
 
-  const fit = !!targetRows && !fillHeight;
+  const fit = (!!targetRows || containMode) && !fillHeight;
   // Decide stretch-vs-letterbox from the CONTENT'S OWN SHAPE, not a stored
   // orientation label (which can drift from the actual widgets — e.g. a layout
   // saved as "portrait" but laid out landscape). A wide design on a wide screen
@@ -73,8 +79,11 @@ export function CssGridDisplay({
     : (designOrientation ? designOrientation === 'landscape' : true);
   const screenWide = viewportWidth >= viewportHeight;
   const sameOrientation = designWide === screenWide;
-  const stretch = fit && sameOrientation;
-  const contain = fit && !sameOrientation;
+  // containMode always scales-to-fit (screensaver — sparse ambient layout that
+  // should fit any screen without clipping); otherwise stretch when orientation
+  // matches and letterbox only on a genuine mismatch.
+  const stretch = fit && sameOrientation && !containMode;
+  const contain = fit && (!sameOrientation || containMode);
 
   // Available box below the real chrome. Uses the measured grid top when we have
   // it (real header height) and the reactive viewport height so F11/fullscreen,
@@ -85,8 +94,14 @@ export function CssGridDisplay({
   // re-reads on resize (a chrome hide is a position change, not a size change),
   // so it stays stale at ~56px and leaves ~1-2 empty rows at the bottom. When the
   // caller says the chrome is gone, the top is 0.
-  const chromeTop = headerOffset <= 0 ? 0 : (top > 0 ? top : headerOffset);
-  const availH = Math.max(120, viewportHeight - chromeTop - bottomOffset);
+  // Take the LARGER of the measured grid-top and the caller's offset so we never
+  // under-estimate the header (a taller touch-device header, or a not-yet-settled
+  // measurement, used to let the bottom row clip). A small safety margin when
+  // chrome is present absorbs any residual slop — better a hair of bottom gap
+  // than a clipped row.
+  const chromeTop = headerOffset <= 0 ? 0 : Math.max(top, headerOffset);
+  const bottomSafety = chromeTop > 0 ? margin : 0;
+  const availH = Math.max(120, viewportHeight - chromeTop - bottomOffset - bottomSafety);
 
   // Contain (letterbox) mode: largest square cell that fits the WHOLE content
   // canvas within the available box on both axes.

--- a/src/components/layout/grid/gridEditorTypes.ts
+++ b/src/components/layout/grid/gridEditorTypes.ts
@@ -52,6 +52,13 @@ export interface CssGridDisplayProps {
    * Falls back to inferring from the canvas shape when omitted.
    */
   designOrientation?: 'landscape' | 'portrait';
+  /**
+   * Force contain/scale-to-fit (never stretch, never fixed-cell fill). The
+   * content bounding box is scaled with square cells to fit the viewport and
+   * centered — used for the screensaver, where a sparse ambient layout should
+   * scale to fit any screen without clipping or distortion.
+   */
+  containMode?: boolean;
   className?: string;
 }
 

--- a/src/components/layout/grid/useSquareCells.ts
+++ b/src/components/layout/grid/useSquareCells.ts
@@ -56,8 +56,13 @@ export function useSquareCells(
       // Re-measure after layout settles: the ResizeObserver fires on the
       // container's SIZE, but its top offset (header/nav chrome above it) only
       // becomes accurate once the surrounding chrome has laid out — a position
-      // change the observer never sees. rAF catches that settled position.
+      // change the observer never sees. rAF catches the first settled frame;
+      // the delayed passes catch late layout (fonts, async header content, a
+      // taller touch-device header) that would otherwise leave `top` stale and
+      // the grid mis-sized (bottom-row clip on a real kiosk).
       requestAnimationFrame(compute);
+      setTimeout(compute, 200);
+      setTimeout(compute, 600);
       const ro = new ResizeObserver(compute);
       ro.observe(node);
       roRef.current = ro;
@@ -78,5 +83,5 @@ export function useSquareCells(
     return () => roRef.current?.disconnect();
   }, []);
 
-  return { containerRef, cellSize, width, top, mounted };
+  return { containerRef, cellSize, width, top, mounted, remeasure: compute };
 }

--- a/src/components/screensaver/Screensaver.tsx
+++ b/src/components/screensaver/Screensaver.tsx
@@ -159,7 +159,8 @@ function ScreensaverGrid() {
       margin={4}
       containerPadding={12}
       cols={GRID_COLS}
-      fillHeight
+      containMode
+      headerOffset={0}
       className="w-full h-full"
     />
   );

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -313,6 +313,25 @@ export const WeatherWidget = React.memo(function WeatherWidget({
   const resolvedDays = Math.max(0, forecastDays ?? autoDays);
   const showHourly = showForecast && gridH >= 9;
 
+  // The daily forecast is a vertical list of fixed-height rows. Measure the space
+  // it actually has and render only WHOLE rows, so a day is never cut in half at
+  // the bottom (which looks broken on a kiosk). Falls back to showing all days
+  // when unmeasured (SSR/tests, where clientHeight is 0).
+  const dayListRef = React.useRef<HTMLDivElement>(null);
+  const [maxDayRows, setMaxDayRows] = React.useState(7);
+  React.useEffect(() => {
+    const el = dayListRef.current;
+    if (!el) return;
+    const measure = () => {
+      const h = el.clientHeight;
+      if (h > 0) setMaxDayRows(Math.max(1, Math.floor(h / 44)));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [showForecast, resolvedDays, gridH]);
+
   // Pre-filter to today-or-future so the label count matches what renders.
   // Provider stores forecast.date as UTC-midnight of the location's calendar
   // day (see openmeteo.ts comment), so read via getUTC* to compare against
@@ -324,6 +343,8 @@ export const WeatherWidget = React.memo(function WeatherWidget({
     const s = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
     return s >= todayLocalStr;
   });
+  // Only the days that fit as whole rows (see maxDayRows above).
+  const shownForecast = visibleForecast.slice(0, maxDayRows);
 
   const hasDays = weatherData.forecast.length > 0;
 
@@ -365,15 +386,18 @@ export const WeatherWidget = React.memo(function WeatherWidget({
         {showForecast && hasDays && resolvedDays > 0 && (
           <div className="border-t border-border pt-3 flex-1 min-h-0 flex flex-col gap-3">
 
-            {/* Multi-day summary */}
-            <div>
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {visibleForecast.length}-Day Forecast
+            {/* Multi-day summary — the day list fills the remaining space and
+                clips to WHOLE rows (maxDayRows) so a day is never half-cut. */}
+            <div className="flex-1 min-h-0 flex flex-col">
+              <span className="flex-shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {shownForecast.length}-Day Forecast
               </span>
-              <DayHeader
-                days={visibleForecast}
-                units={units}
-              />
+              <div ref={dayListRef} className="flex-1 min-h-0 overflow-hidden">
+                <DayHeader
+                  days={shownForecast}
+                  units={units}
+                />
+              </div>
             </div>
 
             {/* Sun + moon arc — replaced by precip chart when rain is imminent.
@@ -381,7 +405,7 @@ export const WeatherWidget = React.memo(function WeatherWidget({
                 row (CurrentConditions), so the arc renders without a
                 duplicate label strip. */}
             {showSunArc && (
-              <div className="flex flex-col gap-1">
+              <div className="flex-shrink-0 flex flex-col gap-1">
                 <SunriseSunsetArc
                   sunrise={weatherData.sunrise!}
                   sunset={weatherData.sunset!}
@@ -396,7 +420,7 @@ export const WeatherWidget = React.memo(function WeatherWidget({
 
             {/* Precipitation chart — replaces sunrise/sunset arc when rain is coming in the next hour */}
             {showPrecipChart && (
-              <div className="flex flex-col gap-1">
+              <div className="flex-shrink-0 flex flex-col gap-1">
                 <PrecipitationChart minutely={weatherData.minutely!} />
               </div>
             )}


### PR DESCRIPTION
Three kiosk-display clipping fixes found after the 1.13 deploy (all verified headlessly on the demo — no clipping):

- **Dashboard bottom-row clip when toolbar present** — re-measure the real grid-top after layout settles + on chrome toggle, never under-estimate the (taller, on touch) header, small bottom safety margin, offset bumped 50→56.
- **Weather day cut mid-row** — measure the day-list height and render only whole day rows.
- **Screensaver clips at bottom** — new `containMode` scales the content to fit the screen (centered, square cells), so a sparse layout fits any display without clipping.

Already deployed to prod for live verification on the touch display.