### PR TITLE
chore(release): 1.13.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.13.1] – 2026-08-02
+
+### Dashboard
+- **Fixed the bottom row clipping on some kiosks.** On touch displays where the top toolbar renders a little taller, the bottom row of widgets could be clipped while the toolbar was showing. The layout now measures the real toolbar height and fits cleanly whether the toolbar is shown or hidden.
+- **Weather no longer cuts a forecast day in half.** The daily forecast shows only the whole day rows that fit, instead of clipping the last one mid-row.
+
+### Screensaver
+- **Screensaver scales to fit any screen.** It shrinks to fit the display so nothing runs off the bottom edge, on any monitor size.
+
 ## [1.13.0] – 2026-08-02
 
 ### Dashboard

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.13.0"
+version: "1.13.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/src/components/layout/grid/CssGridDisplay.tsx
+++ b/src/components/layout/grid/CssGridDisplay.tsx
@@ -100,8 +100,15 @@ export function CssGridDisplay({
   // chrome is present absorbs any residual slop — better a hair of bottom gap
   // than a clipped row.
   const chromeTop = headerOffset <= 0 ? 0 : Math.max(top, headerOffset);
-  const bottomSafety = chromeTop > 0 ? margin : 0;
-  const availH = Math.max(120, viewportHeight - chromeTop - bottomOffset - bottomSafety);
+  // Some kiosk browsers over-report window.innerHeight vs the actually-visible
+  // area (a device/browser bottom bar), which let the bottom row clip on a real
+  // touch display even when the math looked right. Prefer the visual-viewport
+  // height whenever it's smaller.
+  const visualH = (typeof window !== 'undefined' && window.visualViewport)
+    ? Math.min(viewportHeight, window.visualViewport.height)
+    : viewportHeight;
+  const bottomSafety = chromeTop > 0 ? Math.round(margin * 1.5) : 0;
+  const availH = Math.max(120, visualH - chromeTop - bottomOffset - bottomSafety);
 
   // Contain (letterbox) mode: largest square cell that fits the WHOLE content
   // canvas within the available box on both axes.

--- a/src/components/layout/grid/useSquareCells.ts
+++ b/src/components/layout/grid/useSquareCells.ts
@@ -61,8 +61,13 @@ export function useSquareCells(
       // taller touch-device header) that would otherwise leave `top` stale and
       // the grid mis-sized (bottom-row clip on a real kiosk).
       requestAnimationFrame(compute);
+      // Multiple settle passes: the header height can change after first paint
+      // (web fonts, async toolbar toggles/badges, a taller touch-device header),
+      // which would otherwise leave `top` stale and clip the bottom row.
       setTimeout(compute, 200);
       setTimeout(compute, 600);
+      setTimeout(compute, 1200);
+      setTimeout(compute, 2500);
       const ro = new ResizeObserver(compute);
       ro.observe(node);
       roRef.current = ro;


### PR DESCRIPTION
Patch release — kiosk clipping fixes (#201): dashboard bottom row (toolbar present), weather whole day rows, screensaver scale-to-fit. Already live on prod. No schema changes.