### PR TITLE
fix(wallpaper): never blank — orientation + missing-pin fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ transcript*.json
 
 # Lighthouse reports
 lighthouse-*
+/public/twemoji/

--- a/drizzle/0021_excluded_photos.sql
+++ b/drizzle/0021_excluded_photos.sql
@@ -1,0 +1,33 @@
+-- 0021_excluded_photos.sql
+--
+-- Tombstones for synced photos the user removed from Prism. Photo sources are a
+-- one-way pull sync, so a plain delete would re-download the photo on the next
+-- run. The sync skips any (source_id, external_id) recorded here, so
+-- "remove from Prism" stays removed without ever touching OneDrive/Immich.
+-- Only synced photos (with an external_id) are tombstoned; local uploads have
+-- no remote to boomerang from.
+--
+-- Idempotent (safe to re-run).
+
+CREATE TABLE IF NOT EXISTS excluded_photos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  source_id uuid NOT NULL,
+  external_id varchar(255) NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+
+-- FK excluded_photos.source_id -> photo_sources.id (guarded).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'excluded_photos_source_id_photo_sources_id_fk'
+      AND table_name = 'excluded_photos'
+  ) THEN
+    ALTER TABLE excluded_photos
+      ADD CONSTRAINT excluded_photos_source_id_photo_sources_id_fk
+      FOREIGN KEY (source_id) REFERENCES photo_sources(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS excluded_photos_source_external_unique
+  ON excluded_photos (source_id, external_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism",
-  "version": "1.9.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism",
-      "version": "1.9.0",
+      "version": "1.13.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -65,6 +65,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@discordapp/twemoji": "^16.0.1",
         "@eslint/eslintrc": "^3.2.0",
         "@next/bundle-analyzer": "^15.5.21",
         "@playwright/test": "^1.58.2",
@@ -1949,6 +1950,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@discordapp/twemoji": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@discordapp/twemoji/-/twemoji-16.0.1.tgz",
+      "integrity": "sha512-figLiBWzjS5cyrAjLaGjM8AAaowO3qvK8rg5bA2dElB4qsaPMvBVlFDMO2d3x+nC1igt7kgWH4dvNmvvUHUF8w==",
+      "dev": true,
+      "license": "MIT AND CC-BY-4.0",
+      "dependencies": {
+        "@twemoji/parser": "16.0.0",
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "node_modules/@discordapp/twemoji/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@discordapp/twemoji/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@discordapp/twemoji/node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@discordapp/twemoji/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6294,6 +6356,13 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@twemoji/parser": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@twemoji/parser/-/parser-16.0.0.tgz",
+      "integrity": "sha512-jmuIjkp3OIaEemwMy3sArBwZSuZkRqmueGwRe2Zk4cFzbUJISFBJSZLDUUBNIgq3c+nY49ideYN2OiII6JUqwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
     "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prebuild": "node scripts/copy-emoji-assets.mjs",
+    "predev": "node scripts/copy-emoji-assets.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -117,6 +119,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@discordapp/twemoji": "^16.0.1",
     "@eslint/eslintrc": "^3.2.0",
     "@next/bundle-analyzer": "^15.5.21",
     "@playwright/test": "^1.58.2",

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -71,9 +71,16 @@ if [ -n "$RCLONE_REMOTE" ] && command -v rclone >/dev/null 2>&1; then
   # live under data/ (see src/lib/config/runtime.ts), NOT uploads/. The photo
   # cache (data/photos/cache) is regenerable on demand, so it is excluded.
   DATA_REMOTE="${RCLONE_REMOTE%/*}/data"
+  # NON-DESTRUCTIVE: user photos/avatars are irreplaceable, so a local loss must
+  # NOT wipe the off-site copy. --backup-dir moves any file that would be deleted
+  # or overwritten into a timestamped folder instead of removing it, so a
+  # deleted-locally photo is preserved off-site and recoverable. (A plain
+  # `rclone sync` mirrors deletions — which is exactly how a local photo loss
+  # once propagated to the backup and destroyed the safety net.)
+  DATA_ARCHIVE="${RCLONE_REMOTE%/*}/data-deleted/${TIMESTAMP}"
   if [ -d "/data" ] && [ "$(ls -A /data 2>/dev/null)" ]; then
-    echo "[$(date)] Syncing data directory to off-site storage: $DATA_REMOTE..."
-    if rclone sync /data "$DATA_REMOTE" --exclude 'photos/cache/**' --progress; then
+    echo "[$(date)] Syncing data directory to off-site storage: $DATA_REMOTE (preserving deletions to $DATA_ARCHIVE)..."
+    if rclone sync /data "$DATA_REMOTE" --exclude 'photos/cache/**' --backup-dir "$DATA_ARCHIVE" --progress; then
       echo "[$(date)] Data sync completed successfully"
     else
       echo "[$(date)] WARNING: Data off-site sync failed!"

--- a/scripts/copy-emoji-assets.mjs
+++ b/scripts/copy-emoji-assets.mjs
@@ -1,0 +1,26 @@
+// Copies the self-hosted Twemoji SVG set from @discordapp/twemoji (a devDep)
+// into public/twemoji at build time. We render emoji as <img> (see
+// components/ui/Emoji.tsx) so they display on ANY browser — including the
+// thin-client / kiosk Chromium builds that can't render a color-emoji webfont.
+// The assets are NOT committed (gitignored); this runs on prebuild/predev.
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const src = path.join(root, 'node_modules/@discordapp/twemoji/dist/svg');
+const dest = path.join(root, 'public/twemoji');
+
+if (!existsSync(src)) {
+  console.warn('[copy-emoji-assets] twemoji SVG assets not found — skipping (emoji fall back to text).');
+  process.exit(0);
+}
+
+// Skip if already populated (fast no-op on repeated builds).
+if (existsSync(dest) && readdirSync(dest).length > 1000) {
+  process.exit(0);
+}
+
+mkdirSync(dest, { recursive: true });
+cpSync(src, dest, { recursive: true });
+console.log(`[copy-emoji-assets] copied Twemoji SVGs → ${path.relative(root, dest)}`);

--- a/src/app/api/photos/bulk-delete/route.ts
+++ b/src/app/api/photos/bulk-delete/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { db } from '@/lib/db/client';
+import { photos, excludedPhotos } from '@/lib/db/schema';
+import { inArray } from 'drizzle-orm';
+import { deletePhoto } from '@/lib/services/photo-storage';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { logError } from '@/lib/utils/logError';
+
+/**
+ * Bulk "remove from Prism" for photos. Deletes the Prism records + their local
+ * files, and — for synced photos (those with an externalId) — records an
+ * excludedPhotos tombstone so a future pull sync won't re-download them. This
+ * NEVER touches the photo in OneDrive/Immich; it only removes it from Prism.
+ *
+ * Body: { ids: string[] }
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const ids: string[] = Array.isArray(body.ids)
+      ? body.ids.filter((x: unknown) => typeof x === 'string')
+      : [];
+    if (ids.length === 0) {
+      return NextResponse.json({ error: 'No photos selected.' }, { status: 400 });
+    }
+
+    const targets = await db.select().from(photos).where(inArray(photos.id, ids));
+    if (targets.length === 0) {
+      return NextResponse.json({ deleted: 0, excluded: 0 });
+    }
+
+    // Tombstone synced photos so the next sync skips re-adding them. Local
+    // uploads (no externalId) have no remote to boomerang from, so no tombstone.
+    const tombstones = targets
+      .filter((p): p is typeof p & { externalId: string } => !!p.externalId)
+      .map((p) => ({ sourceId: p.sourceId, externalId: p.externalId }));
+    if (tombstones.length > 0) {
+      await db.insert(excludedPhotos).values(tombstones).onConflictDoNothing();
+    }
+
+    // Remove local files (missing files are ignored) — never the remote source.
+    for (const p of targets) {
+      await deletePhoto(p.filename, p.thumbnailPath);
+    }
+
+    await db.delete(photos).where(
+      inArray(
+        photos.id,
+        targets.map((t) => t.id),
+      ),
+    );
+    await invalidateEntity('photos');
+
+    return NextResponse.json({
+      deleted: targets.length,
+      excluded: tombstones.length,
+    });
+  } catch (error) {
+    logError('Error bulk-deleting photos:', error);
+    return NextResponse.json({ error: 'Failed to delete photos' }, { status: 500 });
+  }
+}

--- a/src/app/photos/PhotosView.tsx
+++ b/src/app/photos/PhotosView.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useState, useCallback } from 'react';
-import { ImageIcon, Upload, Star, Play, X } from 'lucide-react';
+import { ImageIcon, Upload, Star, Play, X, CheckSquare, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { usePhotos } from '@/lib/hooks/usePhotos';
@@ -15,6 +15,9 @@ import { PageWrapper, SubpageHeader, FilterBar, FilterDropdown } from '@/compone
 import { useAutoOrientationSetting } from '@/components/layout/WallpaperBackground';
 import { useAuth } from '@/components/providers';
 import { EmptyState } from '@/components/ui/empty-state';
+import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { toast } from '@/components/ui/use-toast';
 
 const ORIENTATION_OPTIONS = [
   { value: 'landscape', label: 'Landscape' },
@@ -34,6 +37,12 @@ export function PhotosView() {
   const [showUpload, setShowUpload] = useState(false);
   const [galleryMode, setGalleryMode] = useState(false);
   const { enabled: autoOrientationEnabled } = useAutoOrientationSetting();
+  const { confirm, dialogProps } = useConfirmDialog();
+
+  // Multi-select "remove from Prism" mode
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = useState(false);
 
   const handleUploadWithAuth = async () => {
     const user = await requireAuth('Upload Photo', 'Please log in to upload photos');
@@ -85,6 +94,52 @@ export function PhotosView() {
     }
   }, [refresh]);
 
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const handleBulkDelete = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    const ok = await confirm(
+      `Remove ${ids.length} photo${ids.length === 1 ? '' : 's'} from Prism?`,
+      'This removes them from Prism only — your OneDrive/source photos are never touched, and synced photos stay removed instead of re-downloading.',
+      { confirmLabel: 'Remove from Prism' },
+    );
+    if (!ok) return;
+    setDeleting(true);
+    try {
+      const res = await fetch('/api/photos/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      toast({
+        title: `Removed ${data.deleted ?? ids.length} photo${(data.deleted ?? ids.length) === 1 ? '' : 's'} from Prism`,
+        variant: 'success',
+      });
+      exitSelectMode();
+      refresh();
+    } catch (err) {
+      console.error('Error removing photos:', err);
+      toast({ title: 'Failed to remove photos', variant: 'destructive' });
+    } finally {
+      setDeleting(false);
+    }
+  }, [selectedIds, confirm, exitSelectMode, refresh]);
+
   return (
     <PageWrapper>
       <div className="h-screen flex flex-col">
@@ -92,16 +147,27 @@ export function PhotosView() {
           icon={<ImageIcon className="h-5 w-5 text-primary" />}
           title="Photos"
           badge={total > 0 ? <Badge variant="secondary">{total}</Badge> : undefined}
-          actions={<>
-            <Button variant="outline" size="sm" onClick={() => setGalleryMode(true)} disabled={photos.length === 0}>
-              <Play className="h-4 w-4 mr-1" />
-              Gallery
+          actions={selectMode ? (
+            <Button variant="ghost" size="sm" onClick={exitSelectMode}>
+              <X className="h-4 w-4 mr-1" />
+              Cancel
             </Button>
-            <Button size="sm" onClick={handleUploadWithAuth}>
-              <Upload className="h-4 w-4 mr-1" />
-              Upload
-            </Button>
-          </>}
+          ) : (
+            <>
+              <Button variant="outline" size="sm" onClick={() => setSelectMode(true)} disabled={photos.length === 0}>
+                <CheckSquare className="h-4 w-4 mr-1" />
+                Select
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setGalleryMode(true)} disabled={photos.length === 0}>
+                <Play className="h-4 w-4 mr-1" />
+                Gallery
+              </Button>
+              <Button size="sm" onClick={handleUploadWithAuth}>
+                <Upload className="h-4 w-4 mr-1" />
+                Upload
+              </Button>
+            </>
+          )}
         />
 
         <FilterBar>
@@ -136,6 +202,41 @@ export function PhotosView() {
           )}
         </FilterBar>
 
+        {selectMode && (
+          <div className="flex items-center gap-2 border-b bg-muted/40 px-4 py-2">
+            <span className="text-sm font-medium">
+              {selectedIds.size} selected
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8"
+              onClick={() =>
+                setSelectedIds(
+                  selectedIds.size === photos.length
+                    ? new Set()
+                    : new Set(photos.map((p) => p.id)),
+                )
+              }
+              disabled={photos.length === 0}
+            >
+              {selectedIds.size === photos.length ? 'Clear all' : 'Select all'}
+            </Button>
+            <div className="ml-auto">
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-8"
+                onClick={handleBulkDelete}
+                disabled={selectedIds.size === 0 || deleting}
+              >
+                <Trash2 className="h-4 w-4 mr-1" />
+                {deleting ? 'Removing…' : 'Remove from Prism'}
+              </Button>
+            </div>
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
           {showUpload && (
             <PhotoUpload onUploadComplete={() => { refresh(); setShowUpload(false); }} />
@@ -160,6 +261,9 @@ export function PhotosView() {
               onPhotoClick={(i) => setLightboxIndex(i)}
               onLoadMore={loadMore}
               hasMore={photos.length < total}
+              selectMode={selectMode}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
             />
           )}
         </div>
@@ -185,6 +289,8 @@ export function PhotosView() {
           autoOrientationEnabled={autoOrientationEnabled}
         />
       )}
+
+      <ConfirmDialog {...dialogProps} />
     </PageWrapper>
   );
 }

--- a/src/app/settings/sections/integrations/cards/MicrosoftCredentialsForm.tsx
+++ b/src/app/settings/sections/integrations/cards/MicrosoftCredentialsForm.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+
+/**
+ * Admin form to set/rotate the Microsoft (Azure AD) OAuth *app* credentials —
+ * Client ID, Client Secret, Redirect URI. Saved encrypted to the DB (settings
+ * key 'credentials.microsoft'), which takes precedence over .env, so this is
+ * the self-serve way to update an expired client secret without SSH-ing into
+ * the env file. Write-only: the stored secret is never read back to the UI.
+ */
+export function MicrosoftCredentialsForm({ onSaved }: { onSaved?: () => void }) {
+  const [clientId, setClientId] = React.useState('');
+  const [clientSecret, setClientSecret] = React.useState('');
+  const defaultRedirect =
+    typeof window !== 'undefined' ? `${window.location.origin}/api/auth/microsoft/callback` : '';
+  const [redirectUri, setRedirectUri] = React.useState(defaultRedirect);
+  const [saving, setSaving] = React.useState(false);
+
+  const canSave = clientId.trim() && clientSecret.trim() && redirectUri.trim() && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const tasksRedirectUri =
+        typeof window !== 'undefined'
+          ? `${window.location.origin}/api/auth/microsoft-tasks/callback`
+          : redirectUri;
+      const res = await fetch('/api/setup/credentials/microsoft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clientId: clientId.trim(),
+          clientSecret: clientSecret.trim(),
+          redirectUri: redirectUri.trim(),
+          tasksRedirectUri,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to save credentials');
+      }
+      toast({ title: 'Microsoft credentials saved', description: 'You can now connect Microsoft / OneDrive.' });
+      setClientSecret('');
+      onSaved?.();
+    } catch (err) {
+      toast({
+        title: 'Could not save credentials',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    'h-9 w-full rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Paste your Azure AD app registration values. In the Azure portal, create a{' '}
+        <span className="font-medium">Client secret</span> under{' '}
+        <span className="font-medium">Certificates &amp; secrets</span> and copy its{' '}
+        <span className="font-medium">Value</span>. Client secrets expire — set a long
+        expiry (e.g. 24 months). Add the Redirect URI below to the app&apos;s{' '}
+        <span className="font-medium">Authentication → Redirect URIs</span>.
+      </p>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client ID</span>
+        <input
+          className={inputClass}
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="00000000-0000-0000-0000-000000000000"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client secret (value)</span>
+        <input
+          className={inputClass}
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          placeholder="Paste the new secret value"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Redirect URI</span>
+        <input
+          className={inputClass}
+          value={redirectUri}
+          onChange={(e) => setRedirectUri(e.target.value)}
+          spellCheck={false}
+        />
+      </label>
+
+      <Button size="sm" onClick={handleSave} disabled={!canSave}>
+        {saving ? 'Saving…' : 'Save credentials'}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/settings/sections/integrations/cards/MicrosoftCredentialsForm.tsx
+++ b/src/app/settings/sections/integrations/cards/MicrosoftCredentialsForm.tsx
@@ -68,7 +68,10 @@ export function MicrosoftCredentialsForm({ onSaved }: { onSaved?: () => void }) 
         <span className="font-medium">Certificates &amp; secrets</span> and copy its{' '}
         <span className="font-medium">Value</span>. Client secrets expire — set a long
         expiry (e.g. 24 months). Add the Redirect URI below to the app&apos;s{' '}
-        <span className="font-medium">Authentication → Redirect URIs</span>.
+        <span className="font-medium">Authentication → Redirect URIs</span>. The app must
+        allow <span className="font-medium">personal Microsoft accounts</span> (Supported
+        account types) — otherwise sign-in fails with{' '}
+        <span className="font-medium">&ldquo;not enabled for consumers&rdquo;</span>.
       </p>
 
       <label className="block space-y-1">
@@ -81,6 +84,10 @@ export function MicrosoftCredentialsForm({ onSaved }: { onSaved?: () => void }) 
           autoComplete="off"
           spellCheck={false}
         />
+        <span className="text-[11px] text-muted-foreground">
+          The app&apos;s <span className="font-medium">Application (client) ID</span> from its
+          Overview page.
+        </span>
       </label>
 
       <label className="block space-y-1">
@@ -94,6 +101,11 @@ export function MicrosoftCredentialsForm({ onSaved }: { onSaved?: () => void }) 
           autoComplete="off"
           spellCheck={false}
         />
+        <span className="text-[11px] text-muted-foreground">
+          Copy the secret&apos;s <span className="font-medium">Value</span> column — not the{' '}
+          <span className="font-medium">Secret ID</span>. Azure hides the Value once you
+          leave the page.
+        </span>
       </label>
 
       <label className="block space-y-1">

--- a/src/app/settings/sections/integrations/cards/MicrosoftProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/MicrosoftProviderCard.tsx
@@ -11,6 +11,7 @@ import { ProviderCardShell } from '../shared/ProviderCardShell';
 import { CollapsibleSubSection } from '../shared/CollapsibleSubSection';
 import type { IntegrationStatus } from '../shared/useIntegrationStatus';
 import type { ConnectionStatus } from '../shared/ConnectionStatusBadge';
+import { MicrosoftCredentialsForm } from './MicrosoftCredentialsForm';
 import { connectedAsLabel } from '../shared/connectedAs';
 import { useOAuthConfigStatus } from '../shared/useOAuthConfigStatus';
 import { TaskIntegrationsSection } from '../../TaskIntegrationsSection';
@@ -170,17 +171,19 @@ export function MicrosoftProviderCard({
           <CollapsibleSubSection
             id="microsoft-setup"
             label="One-time admin setup"
-            summary="Requires an Azure AD app registration"
+            summary="Enter your Azure AD app credentials"
             defaultOpen
           >
-            <p className="text-sm text-muted-foreground">
-              An admin needs to register an Azure AD app and set{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">MICROSOFT_CLIENT_ID</code>,{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">MICROSOFT_CLIENT_SECRET</code>, and{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">MICROSOFT_REDIRECT_URI</code> in{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">.env</code> (see{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">.env.example</code>).
-            </p>
+            <MicrosoftCredentialsForm onSaved={() => window.location.reload()} />
+          </CollapsibleSubSection>
+        )}
+        {configured && (
+          <CollapsibleSubSection
+            id="microsoft-credentials"
+            label="App credentials (advanced)"
+            summary="Update the Azure client ID / secret / redirect — e.g. after a secret expires"
+          >
+            <MicrosoftCredentialsForm onSaved={() => window.location.reload()} />
           </CollapsibleSubSection>
         )}
         {connected && (

--- a/src/components/layout/MobileFab.tsx
+++ b/src/components/layout/MobileFab.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Emoji } from '@/components/ui/Emoji';
 
 import { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
@@ -151,7 +152,7 @@ export function MobileFab({ user, onLogin, onLogout, uiHidden }: MobileFabProps)
           style={{ backgroundColor: user.color || '#6B7280' }}
         >
           {user.avatarUrl?.startsWith('emoji:') ? (
-            <span className="text-sm">{user.avatarUrl.slice(6)}</span>
+            <span className="text-sm"><Emoji e={user.avatarUrl.slice(6)} /></span>
           ) : user.avatarUrl ? (
             <Image src={user.avatarUrl} alt={user.name} fill unoptimized className="rounded-full object-cover" />
           ) : (

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -7,6 +7,7 @@
  */
 
 'use client';
+import { Emoji } from '@/components/ui/Emoji';
 
 import * as React from 'react';
 import { useState } from 'react';
@@ -160,7 +161,7 @@ export function MobileNav({ user, onLogin, onLogout, uiHidden }: MobileNavProps)
                     style={{ backgroundColor: user.color || '#6B7280' }}
                   >
                     {user.avatarUrl?.startsWith('emoji:') ? (
-                      <span className="text-sm">{user.avatarUrl.slice(6)}</span>
+                      <span className="text-sm"><Emoji e={user.avatarUrl.slice(6)} /></span>
                     ) : user.avatarUrl ? (
                       <Image
                         src={user.avatarUrl}

--- a/src/components/layout/PortraitNav.tsx
+++ b/src/components/layout/PortraitNav.tsx
@@ -6,6 +6,7 @@
  */
 
 'use client';
+import { Emoji } from '@/components/ui/Emoji';
 
 import * as React from 'react';
 import Image from 'next/image';
@@ -79,7 +80,7 @@ export function PortraitNav({ user, onLogin, onLogout, uiHidden }: PortraitNavPr
                 style={{ backgroundColor: user.color || '#6B7280' }}
               >
                 {user.avatarUrl?.startsWith('emoji:') ? (
-                  <span className="text-base">{user.avatarUrl.slice(6)}</span>
+                  <span className="text-base"><Emoji e={user.avatarUrl.slice(6)} /></span>
                 ) : user.avatarUrl ? (
                   <Image
                     src={user.avatarUrl}

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -21,6 +21,7 @@
  */
 
 'use client';
+import { Emoji } from '@/components/ui/Emoji';
 
 import * as React from 'react';
 import Image from 'next/image';
@@ -211,7 +212,7 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
                   style={{ backgroundColor: user.color || '#6B7280' }}
                 >
                   {user.avatarUrl?.startsWith('emoji:') ? (
-                    <span className="text-lg">{user.avatarUrl.slice(6)}</span>
+                    <span className="text-lg"><Emoji e={user.avatarUrl.slice(6)} /></span>
                   ) : user.avatarUrl ? (
                     <Image
                       src={user.avatarUrl}

--- a/src/components/layout/WallpaperBackground.tsx
+++ b/src/components/layout/WallpaperBackground.tsx
@@ -154,45 +154,52 @@ export function WallpaperBackground() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [fadingOut, setFadingOut] = useState(false);
 
-  // A pinned photo that was later deleted 404s and would leave the screen blank —
-  // detect that (via the img onError below) and fall back to the rotation.
-  const [pinnedBroken, setPinnedBroken] = useState(false);
-  useEffect(() => { setPinnedBroken(false); }, [pinnedId]);
-  const usePinned = !!pinnedId && !pinnedBroken;
+  // Track photos whose file is missing/deleted (the image 404s) so we skip past
+  // them instead of showing a blank background. A broken pinned photo falls back
+  // to the rotation; a broken rotation photo is dropped from the pool so the next
+  // render lands on a good one. Resets on reload (so restored files reappear).
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+  const markBroken = useCallback((id: string) => {
+    setBrokenIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  const usePinned = !!pinnedId && !brokenIds.has(pinnedId);
+  const pool = photos.filter((p) => !brokenIds.has(p.id));
 
   // Rotate photos (only if no pinned photo and interval is not "never")
   useEffect(() => {
-    if (!enabled || photos.length <= 1 || usePinned || interval === 0) return;
+    if (!enabled || pool.length <= 1 || usePinned || interval === 0) return;
     const timer = window.setInterval(() => {
       setFadingOut(true);
       // After fade out, switch image and fade back in
       setTimeout(() => {
-        setCurrentIndex((i) => (i + 1) % photos.length);
+        setCurrentIndex((i) => i + 1);
         setFadingOut(false);
       }, 1000);
     }, interval * 1000);
     return () => window.clearInterval(timer);
-  }, [enabled, photos.length, interval, usePinned]);
+  }, [enabled, pool.length, interval, usePinned]);
 
   if (!enabled) return null;
 
-  // Use pinned photo if set (and not broken), otherwise the rotating photos.
-  const safeIndex = photos.length > 0 ? currentIndex % photos.length : 0;
-  const src = usePinned
-    ? `/api/photos/${pinnedId}/file`
-    : photos[safeIndex]
-      ? `/api/photos/${photos[safeIndex]!.id}/file`
-      : null;
+  // Pinned photo (if set and not broken), else the next non-broken rotation photo.
+  const rotationPhoto = pool.length > 0 ? pool[currentIndex % pool.length] : undefined;
+  const activeId = usePinned ? pinnedId : (rotationPhoto?.id ?? null);
+  const src = activeId ? `/api/photos/${activeId}/file` : null;
 
   if (!src) return null;
 
   return (
     <div className="fixed inset-0 z-0 pointer-events-none">
-      {/* Validate a pinned photo — if it 404s (deleted), fall back to rotation. */}
-      {usePinned && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={src} alt="" className="hidden" onError={() => setPinnedBroken(true)} />
-      )}
+      {/* Validator — if this photo's file 404s, mark it broken and skip it. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        key={activeId ?? 'none'}
+        src={src}
+        alt=""
+        className="hidden"
+        onError={() => activeId && markBroken(activeId)}
+      />
       {/* Photo */}
       <div
         className="absolute inset-0 bg-cover bg-center transition-opacity duration-1000"

--- a/src/components/layout/WallpaperBackground.tsx
+++ b/src/components/layout/WallpaperBackground.tsx
@@ -138,18 +138,31 @@ export function WallpaperBackground() {
   const screenOrientation = useScreenOrientation();
   const orientationOverride = useOrientationOverride();
   const effectiveOrientation = orientationOverride === 'auto' ? screenOrientation : orientationOverride;
-  const { photos } = usePhotos({
+  // Fetch all wallpaper photos, then PREFER the ones matching this screen's
+  // orientation — but fall back to any photo when none match, so a display whose
+  // orientation has no photos still shows a wallpaper instead of going blank.
+  const { photos: allPhotos } = usePhotos({
     sort: 'random',
-    limit: 30,
+    limit: 40,
     usage: 'wallpaper',
-    orientation: autoOrientation ? effectiveOrientation : undefined,
   });
+  const orientedPhotos = autoOrientation
+    ? allPhotos.filter((p) => p.orientation === effectiveOrientation)
+    : allPhotos;
+  const photos = orientedPhotos.length > 0 ? orientedPhotos : allPhotos;
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [fadingOut, setFadingOut] = useState(false);
 
+  // A pinned photo that was later deleted 404s and would leave the screen blank —
+  // detect that (via the img onError below) and fall back to the rotation.
+  const [pinnedBroken, setPinnedBroken] = useState(false);
+  useEffect(() => { setPinnedBroken(false); }, [pinnedId]);
+  const usePinned = !!pinnedId && !pinnedBroken;
+
   // Rotate photos (only if no pinned photo and interval is not "never")
   useEffect(() => {
-    if (!enabled || photos.length <= 1 || pinnedId || interval === 0) return;
+    if (!enabled || photos.length <= 1 || usePinned || interval === 0) return;
     const timer = window.setInterval(() => {
       setFadingOut(true);
       // After fade out, switch image and fade back in
@@ -159,21 +172,27 @@ export function WallpaperBackground() {
       }, 1000);
     }, interval * 1000);
     return () => window.clearInterval(timer);
-  }, [enabled, photos.length, interval, pinnedId]);
+  }, [enabled, photos.length, interval, usePinned]);
 
   if (!enabled) return null;
 
-  // Use pinned photo if set, otherwise use rotating photos
-  const src = pinnedId
+  // Use pinned photo if set (and not broken), otherwise the rotating photos.
+  const safeIndex = photos.length > 0 ? currentIndex % photos.length : 0;
+  const src = usePinned
     ? `/api/photos/${pinnedId}/file`
-    : photos[currentIndex]
-      ? `/api/photos/${photos[currentIndex]!.id}/file`
+    : photos[safeIndex]
+      ? `/api/photos/${photos[safeIndex]!.id}/file`
       : null;
 
   if (!src) return null;
 
   return (
     <div className="fixed inset-0 z-0 pointer-events-none">
+      {/* Validate a pinned photo — if it 404s (deleted), fall back to rotation. */}
+      {usePinned && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt="" className="hidden" onError={() => setPinnedBroken(true)} />
+      )}
       {/* Photo */}
       <div
         className="absolute inset-0 bg-cover bg-center transition-opacity duration-1000"

--- a/src/components/photos/PhotoGallery.tsx
+++ b/src/components/photos/PhotoGallery.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import * as React from 'react';
+import { Check } from 'lucide-react';
 import type { Photo } from '@/lib/hooks/usePhotos';
 import { getResolutionQuality } from '@/lib/hooks/usePhotos';
+import { cn } from '@/lib/utils';
 import { PageLoader } from '@/components/ui/spinner';
 
 interface PhotoGalleryProps {
@@ -11,6 +13,10 @@ interface PhotoGalleryProps {
   onPhotoClick: (index: number) => void;
   onLoadMore?: () => void;
   hasMore?: boolean;
+  /** When true, tiles toggle selection instead of opening the lightbox. */
+  selectMode?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
 }
 
 function usageBadge(usage: Photo['usage']): string {
@@ -42,23 +48,49 @@ export function PhotoGallery({
   onPhotoClick,
   onLoadMore,
   hasMore,
+  selectMode = false,
+  selectedIds,
+  onToggleSelect,
 }: PhotoGalleryProps) {
   return (
     <div>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2">
-        {photos.map((photo, index) => (
+        {photos.map((photo, index) => {
+          const selected = !!selectedIds?.has(photo.id);
+          return (
           <div
             key={photo.id}
-            className="group relative aspect-square cursor-pointer overflow-hidden rounded-lg bg-muted"
-            onClick={() => onPhotoClick(index)}
+            className={cn(
+              'group relative aspect-square cursor-pointer overflow-hidden rounded-lg bg-muted',
+              selectMode && selected && 'ring-2 ring-primary ring-offset-2 ring-offset-background',
+            )}
+            onClick={() =>
+              selectMode ? onToggleSelect?.(photo.id) : onPhotoClick(index)
+            }
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={`/api/photos/${photo.id}/file?thumb=true`}
               alt={photo.originalFilename}
-              className="h-full w-full object-cover transition-transform group-hover:scale-105"
+              className={cn(
+                'h-full w-full object-cover transition-transform group-hover:scale-105',
+                selectMode && selected && 'opacity-80',
+              )}
               loading="lazy"
             />
+            {/* Selection checkbox (select mode only) */}
+            {selectMode && (
+              <span
+                className={cn(
+                  'absolute top-1.5 left-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors',
+                  selected
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-white/80 bg-black/30',
+                )}
+              >
+                {selected && <Check className="h-4 w-4" />}
+              </span>
+            )}
             {/* Resolution quality dot */}
             <span className={`absolute top-1.5 right-1.5 w-2.5 h-2.5 rounded-full ${qualityColors[getResolutionQuality(photo.width, photo.height)]} ring-1 ring-black/30`} />
             {/* Usage badge */}
@@ -70,7 +102,8 @@ export function PhotoGallery({
               {orientationBadge(photo.width, photo.height)}
             </span>
           </div>
-        ))}
+          );
+        })}
       </div>
 
       {loading && <PageLoader className="py-8" />}

--- a/src/components/ui/Emoji.tsx
+++ b/src/components/ui/Emoji.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+// Convert an emoji string to its Twemoji codepoint filename (e.g. "🐼" →
+// "1f43c", "👩‍💻" → "1f469-200d-1f4bb"). Mirrors twemoji's toCodePoint: strip the
+// FE0F variation selector unless the sequence contains a ZWJ (U+200D).
+const U200D = '‍';
+const VS16 = /️/g;
+function toCodePoint(str: string): string {
+  const clean = str.indexOf(U200D) < 0 ? str.replace(VS16, '') : str;
+  const out: string[] = [];
+  let hi = 0;
+  for (let i = 0; i < clean.length; i++) {
+    const c = clean.charCodeAt(i);
+    if (hi) {
+      out.push((0x10000 + ((hi - 0xd800) << 10) + (c - 0xdc00)).toString(16));
+      hi = 0;
+    } else if (c >= 0xd800 && c <= 0xdbff) {
+      hi = c;
+    } else {
+      out.push(c.toString(16));
+    }
+  }
+  return out.join('-');
+}
+
+interface EmojiProps {
+  /** The emoji character(s), e.g. "🎂" */
+  e: string;
+  /** Accessible label (defaults to the raw emoji). */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Renders an emoji as a self-hosted Twemoji <img> so it displays on ANY browser,
+ * including thin-client / kiosk Chromium builds that can't render a color-emoji
+ * font. Sized 1em square inline by default (override via className). Falls back
+ * to the raw emoji text if the SVG is missing or fails to load.
+ */
+export function Emoji({ e, label, className }: EmojiProps) {
+  const [broken, setBroken] = React.useState(false);
+  const cp = e ? toCodePoint(e) : '';
+
+  if (!cp || broken) {
+    return (
+      <span role="img" aria-label={label ?? e} className={className}>
+        {e}
+      </span>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`/twemoji/${cp}.svg`}
+      alt={label ?? e}
+      draggable={false}
+      onError={() => setBroken(true)}
+      className={cn('inline-block h-[1em] w-[1em] align-[-0.125em]', className)}
+    />
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -31,6 +31,7 @@
 import * as React from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import { cn } from '@/lib/utils';
+import { Emoji } from '@/components/ui/Emoji';
 
 
 /**
@@ -188,7 +189,7 @@ export function UserAvatar({
         )}
         style={color ? { backgroundColor: color } : { backgroundColor: 'hsl(var(--muted))' }}
       >
-        <span className="leading-none">{emoji}</span>
+        <span className="leading-none"><Emoji e={emoji} label={name} /></span>
       </div>
     );
   }

--- a/src/components/widgets/BirthdaysWidget.tsx
+++ b/src/components/widgets/BirthdaysWidget.tsx
@@ -55,6 +55,26 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
 }: BirthdaysWidgetProps) {
   const items = birthdays.slice(0, maxItems);
 
+  // Show only the whole rows that fit (no scrollbar, no half-cut last row) —
+  // measure the list area and cap the visible count, like the weather widget.
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const [maxRows, setMaxRows] = React.useState(maxItems);
+  React.useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const HEADER_PX = 26; // table header row
+    const ROW_PX = 34; // one birthday row (py-1.5 + text), slightly generous
+    const measure = () => {
+      const h = el.clientHeight;
+      if (h > 0) setMaxRows(Math.max(1, Math.floor((h - HEADER_PX) / ROW_PX)));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const visible = items.slice(0, maxRows);
+
   return (
     <WidgetContainer
       title="Upcoming Birthdays & Milestones"
@@ -69,7 +89,7 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
           message="No upcoming birthdays or events"
         />
       ) : (
-        <div className="overflow-auto h-full">
+        <div ref={listRef} className="overflow-hidden h-full">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-xs text-muted-foreground">
@@ -81,7 +101,7 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
               </tr>
             </thead>
             <tbody>
-              {items.map((item) => (
+              {visible.map((item) => (
                 <tr
                   key={item.id}
                   className={cn(

--- a/src/components/widgets/BirthdaysWidget.tsx
+++ b/src/components/widgets/BirthdaysWidget.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { cn } from '@/lib/utils';
 import { WidgetContainer, WidgetEmpty } from './WidgetContainer';
 import type { Birthday } from '@/lib/hooks/useBirthdays';
@@ -78,14 +79,14 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
   return (
     <WidgetContainer
       title="Upcoming Birthdays & Milestones"
-      icon={<span>🎂</span>}
+      icon={<Emoji e="🎂" />}
       loading={loading}
       error={error}
       titleHref={titleHref}
     >
       {items.length === 0 ? (
         <WidgetEmpty
-          icon={<span>🎂</span>}
+          icon={<Emoji e="🎂" />}
           message="No upcoming birthdays or events"
         />
       ) : (
@@ -118,7 +119,7 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
                     )}
                   </td>
                   <td className="py-1.5 px-1 text-center">
-                    {TYPE_ICONS[item.eventType] || '⭐'}
+                    <Emoji e={TYPE_ICONS[item.eventType] || '⭐'} />
                   </td>
                   <td className="py-1.5 px-1 text-right text-muted-foreground tabular-nums">
                     {item.age != null ? item.age : ''}

--- a/src/components/widgets/ChoresWidget.tsx
+++ b/src/components/widgets/ChoresWidget.tsx
@@ -25,6 +25,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { useState, useMemo, useCallback } from 'react';
 import { format, isToday, isTomorrow, isPast, parseISO } from 'date-fns';
 import { ClipboardList, Plus, AlertCircle, CheckCircle, Clock, Hourglass } from 'lucide-react';
@@ -267,7 +268,7 @@ function ChoreItem({
       >
         <div className="flex items-center gap-2">
           {/* Category emoji */}
-          <span className="text-base">{categoryEmoji}</span>
+          <span className="text-base"><Emoji e={categoryEmoji} /></span>
 
           {/* Title */}
           <span className={cn(

--- a/src/components/widgets/MealsWidget.tsx
+++ b/src/components/widgets/MealsWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { DAYS_OF_WEEK_MON_FIRST, DAYS_OF_WEEK, type DayOfWeek } from '@/lib/constants/days';
 import { useState, useMemo, useCallback } from 'react';
 import { format, startOfWeek, addDays, parseISO } from 'date-fns';
@@ -226,7 +227,7 @@ function MealItem({
   const isCooked = !!meal.cookedAt;
   return (
     <div className={cn('flex items-start gap-2 p-2 rounded-md', 'hover:bg-accent/50 transition-colors group', isCooked && 'opacity-60')}>
-      <span className="text-base shrink-0">{getMealTypeEmoji(meal.mealType)}</span>
+      <span className="text-base shrink-0"><Emoji e={getMealTypeEmoji(meal.mealType)} /></span>
       {/* Meal content — clickable surface that opens the edit modal. */}
       <div
         className={cn('flex-1 min-w-0', onClick && 'cursor-pointer')}

--- a/src/components/widgets/PointsWidget.tsx
+++ b/src/components/widgets/PointsWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { cn } from '@/lib/utils';
 import { WidgetContainer, WidgetEmpty } from './WidgetContainer';
 import { Check } from 'lucide-react';
@@ -26,7 +27,7 @@ export const PointsWidget = React.memo(function PointsWidget({
   return (
     <WidgetContainer
       title="Points"
-      icon={<span className="text-sm">🏆</span>}
+      icon={<span className="text-sm"><Emoji e="🏆" /></span>}
       loading={loading}
       error={error}
       titleHref={titleHref}
@@ -60,7 +61,7 @@ export const PointsWidget = React.memo(function PointsWidget({
                 {goal.fullyAchieved && (
                   <Check className="h-3.5 w-3.5 text-green-500 shrink-0" />
                 )}
-                <span>{goal.emoji || '🎯'}</span>
+                <span><Emoji e={goal.emoji || '🎯'} /></span>
                 <span className="font-medium truncate">{goal.name}</span>
                 <span className="ml-auto text-xs text-muted-foreground tabular-nums shrink-0">
                   {goal.pointCost}pts

--- a/src/components/widgets/ShoppingWidget.tsx
+++ b/src/components/widgets/ShoppingWidget.tsx
@@ -23,6 +23,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { useState, useMemo, useCallback } from 'react';
 import { ShoppingCart, Plus, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -266,7 +267,7 @@ function ShoppingItemRow({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           {/* Category emoji */}
-          {categoryEmoji && <span className="text-sm">{categoryEmoji}</span>}
+          {categoryEmoji && <span className="text-sm"><Emoji e={categoryEmoji} /></span>}
 
           {/* Name */}
           <span

--- a/src/components/widgets/WidgetContainer.tsx
+++ b/src/components/widgets/WidgetContainer.tsx
@@ -34,6 +34,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui';
@@ -405,7 +406,7 @@ function WidgetLoading() {
 function WidgetError({ message }: { message: string }) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center text-center p-4">
-      <div className="text-destructive text-4xl mb-2">⚠️</div>
+      <div className="text-destructive text-4xl mb-2"><Emoji e="⚠️" /></div>
       <p className="text-sm text-muted-foreground">{message}</p>
     </div>
   );

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -2623,3 +2623,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS dismissed_events_source_external_unique ON pub
 -- Deletes-only review: flag synced events gone from source instead of deleting (#171).
 ALTER TABLE public.events ADD COLUMN IF NOT EXISTS pending_deletion timestamp;
 CREATE INDEX IF NOT EXISTS events_pending_deletion_idx ON public.events (pending_deletion);
+
+-- Tombstones for synced photos removed from Prism (so a pull sync doesn't re-add them).
+CREATE TABLE IF NOT EXISTS public.excluded_photos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  source_id uuid NOT NULL REFERENCES public.photo_sources(id) ON DELETE CASCADE,
+  external_id varchar(255) NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS excluded_photos_source_external_unique ON public.excluded_photos (source_id, external_id);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1259,6 +1259,27 @@ export const photos = pgTable('photos', {
 }));
 
 
+/**
+ * Tombstones for synced photos the user removed from Prism. Photo sources are a
+ * one-way pull sync, so a plain delete would re-download the photo on the next
+ * run. The sync skips any (sourceId, externalId) recorded here, so "remove from
+ * Prism" stays removed without ever touching the photo in OneDrive/Immich.
+ * Cascade-deletes with the source. Only synced photos (those with an externalId)
+ * are tombstoned; local uploads have no remote to boomerang from.
+ */
+export const excludedPhotos = pgTable('excluded_photos', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  sourceId: uuid('source_id')
+    .notNull()
+    .references(() => photoSources.id, { onDelete: 'cascade' }),
+  externalId: varchar('external_id', { length: 255 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  excludedSourceExternalUnique: uniqueIndex('excluded_photos_source_external_unique')
+    .on(table.sourceId, table.externalId),
+}));
+
+
 export const photoSourcesRelations = relations(photoSources, ({ many }) => ({
   photos: many(photos),
 }));

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -37,6 +37,7 @@ import type {
 } from '@/components/widgets/WeatherWidget';
 import type { LocationParam, WeatherOptions } from './weather';
 import { getMoonData } from './moon';
+import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 
 function defaultImperialUnits(): WeatherUnits {
   return { temperature: 'F', windSpeed: 'mph', precipitation: 'in' };
@@ -175,7 +176,6 @@ function zonedTimeToUtc(localIso: string, timeZone: string): Date {
 // Main fetch function
 // ---------------------------------------------------------------------------
 
-const DAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 export async function fetchWeatherData(
   location?: LocationParam,
@@ -283,7 +283,7 @@ export async function fetchWeatherData(
         : new Date(dateStr);
       return {
         date,
-        dayName: DAYS_SHORT[date.getUTCDay()] ?? 'Day',
+        dayName: DAYS_SHORT_ARRAY[date.getUTCDay()] ?? 'Day',
         high: Math.round(daily.temperature_2m_max[i] ?? 0),
         low: Math.round(daily.temperature_2m_min[i] ?? 0),
         condition: mapWmoCode(daily.weather_code[i] ?? 0),

--- a/src/lib/services/__tests__/photo-sync.test.ts
+++ b/src/lib/services/__tests__/photo-sync.test.ts
@@ -29,6 +29,7 @@ jest.mock('@/lib/db/client', () => ({
 jest.mock('@/lib/db/schema', () => ({
   photos: { id: 'id', sourceId: 'sourceId', filename: 'filename', externalId: 'externalId' },
   photoSources: { id: 'id', type: 'type' },
+  excludedPhotos: { id: 'id', sourceId: 'sourceId', externalId: 'externalId' },
 }));
 
 jest.mock('drizzle-orm', () => ({

--- a/src/lib/services/photo-sync.ts
+++ b/src/lib/services/photo-sync.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/db/client';
-import { photos, photoSources } from '@/lib/db/schema';
+import { photos, photoSources, excludedPhotos } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import {
   listPhotosInFolder,
@@ -100,9 +100,21 @@ export async function syncOneDriveSource(sourceId: string) {
   const existingExternalIds = new Set(existingPhotos.map((p) => p.externalId));
   const remoteIds = new Set(remotePhotos.map((p) => p.id));
 
+  // Photos the user removed from Prism — skip re-adding them (they stay in
+  // OneDrive, just not pulled back into Prism). See excludedPhotos tombstones.
+  const excludedIds = new Set(
+    (
+      await db
+        .select({ externalId: excludedPhotos.externalId })
+        .from(excludedPhotos)
+        .where(eq(excludedPhotos.sourceId, sourceId))
+    ).map((r) => r.externalId),
+  );
+
   // Download new photos (or record metadata-only if OneDrive already has GPS)
   for (const remotePhoto of remotePhotos) {
     if (existingExternalIds.has(remotePhoto.id)) continue;
+    if (excludedIds.has(remotePhoto.id)) continue;
 
     try {
       const facetLat = remotePhoto.location?.latitude;
@@ -284,10 +296,22 @@ export async function syncImmichSource(sourceId: string) {
     existingPhotos.map((p) => p.externalId).filter((x): x is string => !!x),
   );
 
+  // Photos the user removed from Prism — skip re-adding them (they stay in
+  // Immich, just not pulled back into Prism). See excludedPhotos tombstones.
+  const excludedIds = new Set(
+    (
+      await db
+        .select({ externalId: excludedPhotos.externalId })
+        .from(excludedPhotos)
+        .where(eq(excludedPhotos.sourceId, sourceId))
+    ).map((r) => r.externalId),
+  );
+
   // Insert new assets as external metadata-only records (proxy serves bytes
   // on demand, with the local cache absorbing repeat requests).
   for (const asset of remoteImages) {
     if (existingExternalIds.has(asset.id)) continue;
+    if (excludedIds.has(asset.id)) continue;
 
     const takenAt = asset.fileCreatedAt ? new Date(asset.fileCreatedAt) : null;
 


### PR DESCRIPTION
The wallpaper could render nothing on a given display in two cases:
- **Auto-orientation on + no photos for that display's orientation** → empty set → blank (this is the likely cause of the wallpaper showing on the 22" but not the touch screen).
- **A pinned photo that was later deleted** → its `/api/photos/<id>/file` 404s → blank.

Now it prefers orientation-matched photos but falls back to any wallpaper photo when none match, and falls back from a broken pinned photo to the rotation. So as long as wallpaper is enabled and any photos exist, a background always shows.

Already deployed to prod for live verification (note: wallpaper enable/pin/auto-orientation are per-device localStorage, so also confirm it's toggled on for the touch screen).