### PR TITLE
feat(photos): bulk W/G/S toggle, below-HD filter, whole-library select all

### DIFF
--- a/src/app/api/photos/bulk-usage/route.ts
+++ b/src/app/api/photos/bulk-usage/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { db } from '@/lib/db/client';
+import { photos } from '@/lib/db/schema';
+import { inArray } from 'drizzle-orm';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { logError } from '@/lib/utils/logError';
+
+const VALID_TAGS = ['wallpaper', 'gallery', 'screensaver'] as const;
+type UsageTag = (typeof VALID_TAGS)[number];
+
+/**
+ * Bulk add/remove a single usage tag (wallpaper | gallery | screensaver) across
+ * many photos at once, preserving each photo's other tags. Used by the photo
+ * library's select mode to toggle W/G/S en masse.
+ *
+ * Body: { ids: string[], tag: UsageTag, action: 'add' | 'remove' }
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const ids: string[] = Array.isArray(body.ids)
+      ? body.ids.filter((x: unknown) => typeof x === 'string')
+      : [];
+    const tag = body.tag as UsageTag;
+    const action = body.action as 'add' | 'remove';
+
+    if (ids.length === 0) {
+      return NextResponse.json({ error: 'No photos selected.' }, { status: 400 });
+    }
+    if (!VALID_TAGS.includes(tag)) {
+      return NextResponse.json({ error: 'Invalid usage tag.' }, { status: 400 });
+    }
+    if (action !== 'add' && action !== 'remove') {
+      return NextResponse.json({ error: 'Invalid action.' }, { status: 400 });
+    }
+
+    const rows = await db
+      .select({ id: photos.id, usage: photos.usage })
+      .from(photos)
+      .where(inArray(photos.id, ids));
+    if (rows.length === 0) {
+      return NextResponse.json({ updated: 0 });
+    }
+
+    // Compute each row's new usage, then batch by resulting value so we issue
+    // one UPDATE per distinct usage string (a handful) rather than one per row.
+    const byNewUsage = new Map<string, string[]>();
+    for (const row of rows) {
+      const tags = new Set(
+        (row.usage ?? '').split(',').filter((t): t is UsageTag =>
+          VALID_TAGS.includes(t as UsageTag),
+        ),
+      );
+      if (action === 'add') tags.add(tag);
+      else tags.delete(tag);
+      // Keep canonical W,G,S order so values dedupe cleanly.
+      const newUsage = VALID_TAGS.filter((t) => tags.has(t)).join(',');
+      if (newUsage === (row.usage ?? '')) continue; // no-op for this row
+      const group = byNewUsage.get(newUsage) ?? [];
+      group.push(row.id);
+      byNewUsage.set(newUsage, group);
+    }
+
+    let updated = 0;
+    for (const [newUsage, groupIds] of byNewUsage) {
+      await db.update(photos).set({ usage: newUsage }).where(inArray(photos.id, groupIds));
+      updated += groupIds.length;
+    }
+
+    if (updated > 0) await invalidateEntity('photos');
+
+    return NextResponse.json({ updated });
+  } catch (error) {
+    logError('Error bulk-updating photo usage:', error);
+    return NextResponse.json({ error: 'Failed to update photos' }, { status: 500 });
+  }
+}

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -37,6 +37,8 @@ export async function GET(request: NextRequest) {
     const usage = searchParams.get('usage');
     const orientation = searchParams.get('orientation');
     const sort = searchParams.get('sort') || 'chronological';
+    const belowHd = searchParams.get('belowHd') === 'true';
+    const idsOnly = searchParams.get('idsOnly') === 'true';
     const limit = parseInt(searchParams.get('limit') || '50', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
 
@@ -48,6 +50,14 @@ export async function GET(request: NextRequest) {
       if (usage) {
         const tag = usage.replace(/_or_all$/, '').replace(/_or_both$/, '');
         conditions.push(like(photos.usage, `%${tag}%`));
+      }
+      // Below-HD: under 1920×1080 (the sub-green resolution dots), plus photos
+      // missing dimensions (treated as low-res). Mirrors getResolutionQuality.
+      if (belowHd) {
+        conditions.push(sql`(
+          ${photos.width} IS NULL OR ${photos.height} IS NULL
+          OR ${photos.width} * ${photos.height} < 2073600
+        )`);
       }
 
       // Cross-source dedup (#57). A photo is suppressed if another photo
@@ -74,6 +84,15 @@ export async function GET(request: NextRequest) {
         )`);
       }
 
+      // ids-only: every matching photo id for the current filter (no
+      // pagination), so the gallery's "Select all" can cover the whole
+      // filtered library rather than just the loaded page.
+      if (idsOnly) {
+        const idQuery = db.select({ id: photos.id }).from(photos);
+        const idRows = conditions.length > 0 ? await idQuery.where(and(...conditions)) : await idQuery;
+        return { ids: idRows.map((r) => r.id), total: idRows.length };
+      }
+
       const orderBy = sort === 'random' ? sql`RANDOM()` : desc(photos.takenAt);
 
       const query = db.select().from(photos).orderBy(orderBy).limit(limit).offset(offset);
@@ -87,11 +106,12 @@ export async function GET(request: NextRequest) {
       return { photos: results, total: Number(totalResult[0]?.count ?? 0) };
     };
 
-    // Skip caching for random sort — the point is to get a different selection each time
-    const result = sort === 'random'
+    // Skip caching for random sort (fresh selection each time) and idsOnly
+    // (different response shape, cheap single-column scan).
+    const result = sort === 'random' || idsOnly
       ? await runQuery()
       : await getCached(
-          `photos:${sourceId ?? 'all'}:${favorite ?? 'any'}:${usage ?? 'all'}:${orientation ?? 'any'}:${sort}:${limit}:${offset}`,
+          `photos:${sourceId ?? 'all'}:${favorite ?? 'any'}:${usage ?? 'all'}:${orientation ?? 'any'}:${belowHd ? 'belowhd' : 'allres'}:${sort}:${limit}:${offset}`,
           runQuery,
           300
         );

--- a/src/app/photos/PhotosView.tsx
+++ b/src/app/photos/PhotosView.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback } from 'react';
 import { ImageIcon, Upload, Star, Play, X, CheckSquare, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { usePhotos, getResolutionQuality } from '@/lib/hooks/usePhotos';
+import { usePhotos } from '@/lib/hooks/usePhotos';
 import type { PhotoOrientation } from '@/lib/hooks/usePhotos';
 import { PhotoGallery } from '@/components/photos/PhotoGallery';
 import { PhotoUpload } from '@/components/photos/PhotoUpload';
@@ -61,6 +61,7 @@ export function PhotosView() {
       sort: 'chronological',
       limit: 50,
       favorite: favoriteFilter,
+      belowHd: belowHdFilter,
     });
 
   // Client-side multi-select filtering
@@ -75,12 +76,10 @@ export function PhotosView() {
         return tags.some((t) => usageFilters.has(t));
       });
     }
-    if (belowHdFilter) {
-      // Everything under the green dot (below 1920×1080) — the low-res photos.
-      filtered = filtered.filter((p) => getResolutionQuality(p.width, p.height) !== 'green');
-    }
+    // belowHd is applied server-side (usePhotos) so it filters the whole
+    // library, not just the loaded page — nothing to do here.
     return filtered;
-  }, [rawPhotos, orientationFilters, usageFilters, belowHdFilter]);
+  }, [rawPhotos, orientationFilters, usageFilters]);
 
   const hasActiveFilters =
     orientationFilters.size > 0 || usageFilters.size > 0 || !!favoriteFilter || belowHdFilter;
@@ -155,6 +154,37 @@ export function PhotosView() {
       setDeleting(false);
     }
   }, [selectedIds, confirm, exitSelectMode, refresh]);
+
+  // Select all — covers the WHOLE filtered library (not just the loaded page)
+  // by asking the server for every matching id. Orientation/usage are filtered
+  // client-side and can't be expressed in that query, so when either is active
+  // we fall back to selecting the currently-loaded photos.
+  const [selectingAll, setSelectingAll] = useState(false);
+  const handleSelectAll = useCallback(async () => {
+    if (selectedIds.size > 0) {
+      setSelectedIds(new Set());
+      return;
+    }
+    if (orientationFilters.size > 0 || usageFilters.size > 0) {
+      setSelectedIds(new Set(photos.map((p) => p.id)));
+      return;
+    }
+    setSelectingAll(true);
+    try {
+      const params = new URLSearchParams();
+      if (favoriteFilter !== undefined) params.set('favorite', String(favoriteFilter));
+      if (belowHdFilter) params.set('belowHd', 'true');
+      params.set('idsOnly', 'true');
+      const res = await fetch(`/api/photos?${params}`);
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      setSelectedIds(new Set<string>(data.ids ?? []));
+    } catch {
+      setSelectedIds(new Set(photos.map((p) => p.id)));
+    } finally {
+      setSelectingAll(false);
+    }
+  }, [selectedIds, orientationFilters, usageFilters, favoriteFilter, belowHdFilter, photos]);
 
   const handleBulkUsage = useCallback(
     async (tag: string, action: 'add' | 'remove') => {
@@ -257,16 +287,14 @@ export function PhotosView() {
               variant="ghost"
               size="sm"
               className="h-8"
-              onClick={() =>
-                setSelectedIds(
-                  selectedIds.size === photos.length
-                    ? new Set()
-                    : new Set(photos.map((p) => p.id)),
-                )
-              }
-              disabled={photos.length === 0}
+              onClick={handleSelectAll}
+              disabled={photos.length === 0 || selectingAll}
             >
-              {selectedIds.size === photos.length ? 'Clear all' : 'Select all'}
+              {selectingAll
+                ? 'Selecting…'
+                : selectedIds.size > 0
+                  ? 'Clear all'
+                  : `Select all${total > photos.length ? ` (${total})` : ''}`}
             </Button>
 
             {/* Bulk-toggle W/G/S across the selection */}

--- a/src/app/photos/PhotosView.tsx
+++ b/src/app/photos/PhotosView.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback } from 'react';
 import { ImageIcon, Upload, Star, Play, X, CheckSquare, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { usePhotos } from '@/lib/hooks/usePhotos';
+import { usePhotos, getResolutionQuality } from '@/lib/hooks/usePhotos';
 import type { PhotoOrientation } from '@/lib/hooks/usePhotos';
 import { PhotoGallery } from '@/components/photos/PhotoGallery';
 import { PhotoUpload } from '@/components/photos/PhotoUpload';
@@ -54,6 +54,7 @@ export function PhotosView() {
   const [orientationFilters, setOrientationFilters] = useState<Set<string>>(new Set());
   const [usageFilters, setUsageFilters] = useState<Set<string>>(new Set());
   const [favoriteFilter, setFavoriteFilter] = useState<boolean | undefined>(undefined);
+  const [belowHdFilter, setBelowHdFilter] = useState(false);
 
   const { photos: rawPhotos, loading, error, total, refresh, loadMore, updateUsage } =
     usePhotos({
@@ -74,15 +75,30 @@ export function PhotosView() {
         return tags.some((t) => usageFilters.has(t));
       });
     }
+    if (belowHdFilter) {
+      // Everything under the green dot (below 1920×1080) — the low-res photos.
+      filtered = filtered.filter((p) => getResolutionQuality(p.width, p.height) !== 'green');
+    }
     return filtered;
-  }, [rawPhotos, orientationFilters, usageFilters]);
+  }, [rawPhotos, orientationFilters, usageFilters, belowHdFilter]);
 
-  const hasActiveFilters = orientationFilters.size > 0 || usageFilters.size > 0 || !!favoriteFilter;
+  const hasActiveFilters =
+    orientationFilters.size > 0 || usageFilters.size > 0 || !!favoriteFilter || belowHdFilter;
+
+  // Currently-selected photos (for bulk usage toggles' aggregate state)
+  const selectedPhotos = React.useMemo(
+    () => photos.filter((p) => selectedIds.has(p.id)),
+    [photos, selectedIds],
+  );
+  const allSelectedHaveTag = (tag: string) =>
+    selectedPhotos.length > 0 &&
+    selectedPhotos.every((p) => p.usage.split(',').includes(tag));
 
   const clearFilters = () => {
     setOrientationFilters(new Set());
     setUsageFilters(new Set());
     setFavoriteFilter(undefined);
+    setBelowHdFilter(false);
   };
 
   const handleDelete = useCallback(async (photoId: string) => {
@@ -140,6 +156,26 @@ export function PhotosView() {
     }
   }, [selectedIds, confirm, exitSelectMode, refresh]);
 
+  const handleBulkUsage = useCallback(
+    async (tag: string, action: 'add' | 'remove') => {
+      const ids = Array.from(selectedIds);
+      if (ids.length === 0) return;
+      try {
+        const res = await fetch('/api/photos/bulk-usage', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids, tag, action }),
+        });
+        if (!res.ok) throw new Error('Request failed');
+        refresh();
+      } catch (err) {
+        console.error('Error updating usage:', err);
+        toast({ title: 'Failed to update photos', variant: 'destructive' });
+      }
+    },
+    [selectedIds, refresh],
+  );
+
   return (
     <PageWrapper>
       <div className="h-screen flex flex-col">
@@ -194,6 +230,16 @@ export function PhotosView() {
             <Star className="h-3.5 w-3.5" />
             Favorites
           </Button>
+          <Button
+            variant={belowHdFilter ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={() => setBelowHdFilter((v) => !v)}
+            className="h-8 gap-1.5 shrink-0"
+            title="Show only photos below 1920×1080 (yellow/red dots) — low-res for HD wallpaper"
+          >
+            <span className="w-2.5 h-2.5 rounded-full bg-yellow-500 ring-1 ring-black/30" />
+            Below HD
+          </Button>
           {hasActiveFilters && (
             <Button variant="ghost" size="sm" onClick={clearFilters} className="shrink-0 text-muted-foreground h-8">
               <X className="h-3 w-3 mr-1" />
@@ -222,6 +268,28 @@ export function PhotosView() {
             >
               {selectedIds.size === photos.length ? 'Clear all' : 'Select all'}
             </Button>
+
+            {/* Bulk-toggle W/G/S across the selection */}
+            <div className="flex items-center gap-1 border-l pl-2 ml-1">
+              <span className="text-xs text-muted-foreground mr-0.5">Show in:</span>
+              {USAGE_OPTIONS.map((opt) => {
+                const active = allSelectedHaveTag(opt.value);
+                return (
+                  <Button
+                    key={opt.value}
+                    variant={active ? 'secondary' : 'outline'}
+                    size="sm"
+                    className="h-8"
+                    disabled={selectedIds.size === 0}
+                    onClick={() => handleBulkUsage(opt.value, active ? 'remove' : 'add')}
+                    title={`${active ? 'Remove selected from' : 'Add selected to'} ${opt.label}`}
+                  >
+                    {opt.label}
+                  </Button>
+                );
+              })}
+            </div>
+
             <div className="ml-auto">
               <Button
                 variant="destructive"

--- a/src/lib/hooks/usePhotos.ts
+++ b/src/lib/hooks/usePhotos.ts
@@ -60,6 +60,7 @@ interface UsePhotosOptions {
   favorite?: boolean;
   usage?: string; // single tag to filter by (e.g., 'wallpaper'), matched against comma-separated field
   orientation?: PhotoOrientation;
+  belowHd?: boolean; // only photos under 1920×1080 (sub-green resolution)
   sort?: 'random' | 'chronological';
   limit?: number;
   refreshInterval?: number;
@@ -82,6 +83,7 @@ export function usePhotos(options: UsePhotosOptions = {}): UsePhotosResult {
     favorite,
     usage,
     orientation,
+    belowHd,
     sort = 'chronological',
     limit = 50,
     refreshInterval = 0,
@@ -94,11 +96,12 @@ export function usePhotos(options: UsePhotosOptions = {}): UsePhotosResult {
     if (favorite !== undefined) params.set('favorite', String(favorite));
     if (usage) params.set('usage', usage);
     if (orientation) params.set('orientation', orientation);
+    if (belowHd) params.set('belowHd', 'true');
     params.set('sort', sort);
     params.set('limit', String(limit));
     params.set('offset', '0');
     return `/api/photos?${params}`;
-  }, [sourceId, favorite, usage, orientation, sort, limit]);
+  }, [sourceId, favorite, usage, orientation, belowHd, sort, limit]);
 
   const cached = navCacheGet<{ photos: Photo[]; total: number }>(cacheKey);
   const [photos, setPhotos] = useState<Photo[]>(() => cached?.photos ?? []);
@@ -117,6 +120,7 @@ export function usePhotos(options: UsePhotosOptions = {}): UsePhotosResult {
       if (favorite !== undefined) params.set('favorite', String(favorite));
       if (usage) params.set('usage', usage);
       if (orientation) params.set('orientation', orientation);
+      if (belowHd) params.set('belowHd', 'true');
       params.set('sort', sort);
       params.set('limit', String(limit));
       params.set('offset', String(requestOffset));
@@ -137,7 +141,7 @@ export function usePhotos(options: UsePhotosOptions = {}): UsePhotosResult {
     } finally {
       setLoading(false);
     }
-  }, [sourceId, favorite, usage, orientation, sort, limit, cacheKey]);
+  }, [sourceId, favorite, usage, orientation, belowHd, sort, limit, cacheKey]);
 
   const loadMore = useCallback(() => {
     const newOffset = offsetRef.current + limit;


### PR DESCRIPTION
Follow-on photo-library curation tools (all deployed + verified on prod):

- **Bulk W/G/S usage toggle** in select mode — 'Show in: Wallpaper / Gallery /
  Screensaver' toggles each usage tag across the whole selection at once, via
  POST /api/photos/bulk-usage (preserves each photo's other tags, batches writes
  by resulting value). Button reflects aggregate state of the loaded selection.
- **Below-HD filter (server-side)** — GET /api/photos?belowHd=true narrows the
  entire library to sub-1920×1080 photos, so total/Load-More reflect the full
  low-res set (not just the loaded page).
- **Whole-library Select all** — new idsOnly mode returns every matching id
  across all pages; falls back to loaded page when a client-side orientation/
  usage filter is active. Makes 'filter low-res → Select all → Remove' two clicks.

tsc clean; full unit suite green (1349 passing).