### PR TITLE
feat(ui): finish emoji→Twemoji sweep across subpages

### DIFF
--- a/src/app/chores/ChoreItem.tsx
+++ b/src/app/chores/ChoreItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { isPast, isToday, isTomorrow, parseISO, format } from 'date-fns';
+import { Emoji } from '@/components/ui/Emoji';
 import {
   AlertCircle,
   Trash2,
@@ -95,7 +96,7 @@ export function ChoreItem({
       {/* Content */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-base">{categoryEmoji}</span>
+          <span className="text-base"><Emoji e={categoryEmoji} /></span>
           <span className={cn(
             'font-medium',
             isPendingApproval && 'text-amber-700 dark:text-amber-400'

--- a/src/app/goals/GoalsView.tsx
+++ b/src/app/goals/GoalsView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import {
   Trophy,
   Plus,
@@ -290,7 +291,7 @@ export function GoalsView() {
                         </div>
                       )}
 
-                      <span className="text-xl">{goal.emoji || '🎯'}</span>
+                      <span className="text-xl"><Emoji e={goal.emoji || '🎯'} /></span>
 
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
@@ -414,7 +415,7 @@ export function GoalsView() {
                         )}
                         onClick={() => setFormEmoji(e)}
                       >
-                        {e}
+                        <Emoji e={e} />
                       </button>
                     ))}
                   </div>

--- a/src/app/setup/steps/WelcomeStep.tsx
+++ b/src/app/setup/steps/WelcomeStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Emoji } from '@/components/ui/Emoji';
 import { Card, CardContent } from '@/components/ui/card';
 import { PrismIcon } from '@/components/ui/PrismIcon';
 
@@ -31,7 +32,7 @@ export function WelcomeStep({ onNext }: { onNext: () => void }) {
             { icon: '🏠', label: 'Household basics' },
           ].map(({ icon, label }) => (
             <div key={label} className="flex items-center gap-2">
-              <span className="text-lg">{icon}</span>
+              <span className="text-lg"><Emoji e={icon} /></span>
               <span>{label}</span>
             </div>
           ))}

--- a/src/app/shopping/ItemModal.tsx
+++ b/src/app/shopping/ItemModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -149,7 +150,7 @@ export function ItemModal({
                 size="sm"
                 onClick={() => setCategory('other')}
               >
-                🛒 Other
+                <Emoji e="🛒" /> Other
               </Button>
             </div>
           </div>

--- a/src/app/shopping/ManageCategoriesModal.tsx
+++ b/src/app/shopping/ManageCategoriesModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { Plus, Trash2, GripVertical, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -205,7 +206,7 @@ export function ManageCategoriesModal({ open, onOpenChange }: ManageCategoriesMo
                                 )}
                                 onClick={() => handleEmojiSelect(cat.id, emoji)}
                               >
-                                {emoji}
+                                <Emoji e={emoji} />
                               </button>
                             ))}
                           </div>
@@ -241,7 +242,7 @@ export function ManageCategoriesModal({ open, onOpenChange }: ManageCategoriesMo
                     onClick={() => setEmojiPickerFor(emojiPickerFor === '_new' ? null : '_new')}
                     title="Pick emoji"
                   >
-                    {newEmoji || '🛒'}
+                    <Emoji e={newEmoji || '🛒'} />
                   </button>
 
                   {emojiPickerFor === '_new' && (
@@ -263,7 +264,7 @@ export function ManageCategoriesModal({ open, onOpenChange }: ManageCategoriesMo
                               setEmojiPickerFor(null);
                             }}
                           >
-                            {emoji}
+                            <Emoji e={emoji} />
                           </button>
                         ))}
                       </div>

--- a/src/app/shopping/ScanFlowSheet.tsx
+++ b/src/app/shopping/ScanFlowSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Emoji } from '@/components/ui/Emoji';
 import { Spinner } from '@/components/ui/spinner';
 import type { ScanState } from './useShoppingScanFlow';
 import type { ShoppingList } from '@/types';
@@ -93,7 +94,7 @@ export function ScanFlowSheet({
                   variant={cat.id === product.suggestedCategory ? 'default' : 'outline'}
                   className="w-full justify-start text-base py-3 gap-2"
                   onClick={() => onDoAdd(cat.id)}>
-                  <span>{getCategoryEmoji(cat.id)}</span>
+                  <span><Emoji e={getCategoryEmoji(cat.id)} /></span>
                   <span>{cat.name}</span>
                   {cat.id === product.suggestedCategory && <span className="ml-auto text-xs opacity-60">suggested</span>}
                 </Button>

--- a/src/app/shopping/ShoppingCategoryCard.tsx
+++ b/src/app/shopping/ShoppingCategoryCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Plus, GripVertical, ChevronsDown } from 'lucide-react';
+import { Emoji } from '@/components/ui/Emoji';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -87,7 +88,7 @@ export function ShoppingCategoryCard({
         style={{ backgroundColor: categoryColor + '20' }}
       >
         <GripVertical className="h-4 w-4 text-muted-foreground/50 shrink-0 hidden md:block" />
-        <span className="text-xl">{categoryEmoji}</span>
+        <span className="text-xl"><Emoji e={categoryEmoji} /></span>
         <h3
           className="text-base font-bold capitalize"
           style={{ color: categoryColor }}

--- a/src/app/shopping/ShoppingView.tsx
+++ b/src/app/shopping/ShoppingView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { toast } from '@/components/ui/use-toast';
 import { ShoppingCart, Plus, Settings, Maximize2, Minimize2, Tags, Send, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -371,7 +372,7 @@ export function ShoppingView() {
                   {otherItems.map(([category, items]) => (
                     <div key={category} className="border rounded-lg p-3 bg-card/90 backdrop-blur-sm">
                       <h4 className="text-base font-semibold text-muted-foreground mb-2 capitalize flex items-center gap-2">
-                        <span>{getDynCategoryEmoji(category)}</span><span>{category}</span>
+                        <span><Emoji e={getDynCategoryEmoji(category)} /></span><span>{category}</span>
                       </h4>
                       <div className="space-y-1">
                         {(items as ShoppingItem[]).map((item) => (

--- a/src/app/travel/components/InlineChildAdd.tsx
+++ b/src/app/travel/components/InlineChildAdd.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { Search, Loader2, Plus, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -167,7 +168,7 @@ export function InlineChildAdd({ childType, onAdd }: InlineChildAddProps) {
               onClick={() => handleSelectParkWithGeocode(u.name)}
               className="w-full text-left px-2.5 py-1.5 text-xs hover:bg-accent transition-colors border-b border-border last:border-0 flex items-center gap-1.5"
             >
-              🌲 <span className="font-medium">{u.name}</span>
+              <Emoji e="🌲" /> <span className="font-medium">{u.name}</span>
               <span className="text-muted-foreground text-[10px] ml-auto">{u.type}</span>
             </button>
           )) : (

--- a/src/app/travel/components/PinForm.tsx
+++ b/src/app/travel/components/PinForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { Search, X, Loader2, Star, MapPin, Plus, TreePine, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -432,7 +433,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                   <div className="flex flex-wrap gap-1">
                     {childPins.filter(c => c.pinType === 'stop').map((s) => (
                       <Badge key={s.id} variant="secondary" className="text-violet-700 bg-violet-50 dark:bg-violet-900/20 text-xs">
-                        📍 {s.name}
+                        <Emoji e="📍" /> {s.name}
                       </Badge>
                     ))}
                   </div>
@@ -470,7 +471,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                       <Badge key={s.name} variant="secondary"
                         className="gap-1 pr-1 text-violet-700 bg-violet-50 dark:bg-violet-900/20"
                       >
-                        📍 {s.name}
+                        <Emoji e="📍" /> {s.name}
                         {s.latitude === 0 && s.longitude === 0 && (
                           <span className="text-[10px] text-amber-500 ml-0.5">no location</span>
                         )}
@@ -512,7 +513,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                 {childPins.filter(c => c.pinType === 'national_park').length > 0 && (
                   <div className="p-2 border-b border-border flex flex-wrap gap-1">
                     {childPins.filter(c => c.pinType === 'national_park').map((p) => (
-                      <Badge key={p.id} className="bg-emerald-700 text-white text-xs">🌲 {p.name}</Badge>
+                      <Badge key={p.id} className="bg-emerald-700 text-white text-xs"><Emoji e="🌲" /> {p.name}</Badge>
                     ))}
                   </div>
                 )}
@@ -551,7 +552,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
               <div className="flex flex-wrap gap-1">
                 {pendingParks.map((p) => (
                   <Badge key={p.name} className="bg-emerald-700 text-white gap-1 pr-1 text-xs">
-                    🌲 {p.name}
+                    <Emoji e="🌲" /> {p.name}
                     {p.latitude === 0 && p.longitude === 0 && (
                       <span className="text-[10px] text-emerald-200 ml-0.5">locating…</span>
                     )}

--- a/src/app/travel/components/PinList.tsx
+++ b/src/app/travel/components/PinList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { format, parseISO } from 'date-fns';
+import { Emoji } from '@/components/ui/Emoji';
 import { Plus, MapPin, Star, Search, Globe as GlobeIcon, Calendar, TreePine, Route } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -228,7 +229,7 @@ export function PinList({
                               <span className="font-medium text-sm truncate">{pin.name}</span>
                               {pin.isBucketList && <Star className="h-3 w-3 fill-amber-500 text-amber-500 shrink-0" />}
                               {(photoCounts[pin.id] ?? 0) > 0 && (
-                                <span className="text-[10px] text-muted-foreground shrink-0">📷 {photoCounts[pin.id]}</span>
+                                <span className="text-[10px] text-muted-foreground shrink-0"><Emoji e="📷" /> {photoCounts[pin.id]}</span>
                               )}
                             </div>
                             <div className="flex items-center gap-2 mt-0.5 flex-wrap">

--- a/src/app/travel/components/TripForm.tsx
+++ b/src/app/travel/components/TripForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -117,7 +118,7 @@ export function TripForm({ initialData, hideHeader, onSave, onCancel }: TripForm
                     : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
                 )}
               >
-                {s === 'been_there' ? '✓ Been There' : '📍 Want to Go'}
+                {s === 'been_there' ? '✓ Been There' : <><Emoji e="📍" /> Want to Go</>}
               </button>
             ))}
           </div>

--- a/src/app/weekend/components/WeekendPlaceForm.tsx
+++ b/src/app/weekend/components/WeekendPlaceForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -144,7 +145,7 @@ export function WeekendPlaceForm({ initial, onSave, onCancel, hideHeader }: Week
                 : 'border-transparent bg-muted text-muted-foreground hover:bg-accent'
             }`}
           >
-            ⭐ {isFavorite ? 'Favorite' : 'Mark as favorite'}
+            <Emoji e="⭐" /> {isFavorite ? 'Favorite' : 'Mark as favorite'}
           </button>
         </div>
 

--- a/src/app/weekend/components/WeekendPlaceGrid.tsx
+++ b/src/app/weekend/components/WeekendPlaceGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Compass } from 'lucide-react';
+import { Emoji } from '@/components/ui/Emoji';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { WeekendPlaceCard } from './WeekendPlaceCard';
@@ -74,7 +75,7 @@ export function WeekendPlaceGrid({ places, selectedId, onSelect, hasUnfilteredPl
       {groups.map(group => (
         <div key={group.key}>
           <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-1.5">
-            <span>{group.emoji}</span>
+            <span><Emoji e={group.emoji} /></span>
             <span>{group.label}</span>
             <span className="text-muted-foreground/50 font-normal normal-case tracking-normal">({group.places.length})</span>
           </h3>

--- a/src/components/modals/AddChoreModal.tsx
+++ b/src/components/modals/AddChoreModal.tsx
@@ -15,6 +15,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { useState, useEffect } from 'react';
 import { DAYS_SHORT_ARRAY, DAYS_LONG_ARRAY } from '@/lib/constants/days';
 import { Loader2 } from 'lucide-react';
@@ -265,7 +266,7 @@ export function AddChoreModal({
                   onClick={() => setCategory(cat)}
                   className="capitalize"
                 >
-                  {getCategoryEmoji(cat)} {cat}
+                  <Emoji e={getCategoryEmoji(cat)} /> {cat}
                 </Button>
               ))}
             </div>

--- a/src/components/modals/AddShoppingItemModal.tsx
+++ b/src/components/modals/AddShoppingItemModal.tsx
@@ -16,6 +16,7 @@
 'use client';
 
 import * as React from 'react';
+import { Emoji } from '@/components/ui/Emoji';
 import { useState, useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
 import {
@@ -309,7 +310,7 @@ export function AddShoppingItemModal({
                   onClick={() => setCategory(cat)}
                   className="capitalize"
                 >
-                  {getCategoryEmoji(cat)} {cat}
+                  <Emoji e={getCategoryEmoji(cat)} /> {cat}
                 </Button>
               ))}
             </div>


### PR DESCRIPTION
Wraps the remaining color-emoji render sites with <Emoji> so they show on the
thin-client kiosk (which can't render color-emoji webfonts). 16 files: shopping
(category cards, add/scan flows, manage-categories + goal emoji pickers), chores,
travel (pins/trips), weekend, goals, and the setup welcome step.

Only JSX render sites are wrapped — helper return values, state defaults, and
emoji data arrays stay raw. Monochrome symbols (✓ ★ keyboard arrows) are left as
text (they render fine everywhere). Known small gap: the VirtualKeyboard mic (🎤)
stays raw since it lives in react-simple-keyboard's string display map.

tsc clean; full unit suite green (1349 passing); no UTF-8 mojibake.