### PR TITLE
fix(dashboard): reveal auto-hidden UI on pointer move (F11 edit toggle, #21)

### DIFF
--- a/src/lib/hooks/useAutoHideUI.ts
+++ b/src/lib/hooks/useAutoHideUI.ts
@@ -46,13 +46,31 @@ export function useAutoHideUI() {
 
     const events = ['mousedown', 'touchstart', 'keydown', 'scroll'] as const;
     const handler = () => resetTimer();
-
     events.forEach(e => window.addEventListener(e, handler, { passive: true }));
+
+    // Also reveal on pointer MOVEMENT (throttled). Without this, the hidden
+    // toolbar can only be un-hidden by a click — but a click on the collapsed
+    // (max-h-0) header lands on the dashboard behind it and never reaches the
+    // control the user aimed for, so the first click just "wakes" the UI and
+    // seems to do nothing (e.g. the F11 kiosk edit-layout button, #21).
+    // Moving toward a control now brings the chrome up before the click.
+    // A still cursor emits no mousemove, so idle auto-hide still engages, and
+    // a touch-only kiosk (no mousemove) is unaffected.
+    let lastMove = 0;
+    const moveHandler = () => {
+      const now = performance.now();
+      if (now - lastMove < 400) return;
+      lastMove = now;
+      resetTimer();
+    };
+    window.addEventListener('mousemove', moveHandler, { passive: true });
+
     // Start the timer immediately
     resetTimer();
 
     return () => {
       events.forEach(e => window.removeEventListener(e, handler));
+      window.removeEventListener('mousemove', moveHandler);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [enabled, resetTimer]);


### PR DESCRIPTION
**Bug (#21):** in F11/kiosk with auto-hide on, the edit-layout button (and other
header controls) appear unresponsive.

**Cause:** the auto-hide toolbar only un-hid on mousedown/touchstart/keydown/
scroll — not mousemove. With the header collapsed to max-h-0, a click aimed at a
header control lands on the dashboard behind it and merely wakes the UI (which
only expands ~200ms later), so the button is never hit.

**Fix:** also reveal on pointer movement (throttled to 400ms), so moving toward a
control brings the chrome up before the click. A still cursor emits no mousemove
(idle auto-hide still engages after 10s), and a touch-only kiosk is unaffected.

tsc clean. Best verified live on the kiosk in F11.