### PR TITLE
feat(community): filter gallery by orientation, share via issue form

### DIFF
--- a/src/components/layout/CommunityGallery.tsx
+++ b/src/components/layout/CommunityGallery.tsx
@@ -14,9 +14,17 @@ import type { WidgetConfig } from '@/lib/hooks/useLayouts';
 interface CommunityGalleryProps {
   mode: 'dashboard' | 'screensaver';
   onApplyLayout: (widgets: WidgetConfig[], name: string) => void;
+  /** Orientation of the dashboard being edited — pre-selects the matching filter. */
+  currentOrientation?: 'landscape' | 'portrait';
 }
 
-const SCREEN_SIZE_OPTIONS = ['1920x1080', '2560x1440', '3840x2160', '2560x1600', '2048x1536', '1366x768'];
+// Layouts stretch to fill whatever screen they're shown on, so the exact
+// resolution no longer matters for browsing — orientation is the axis that
+// does (a portrait layout letterboxes on a landscape screen and vice-versa).
+const ORIENTATION_OPTIONS: Array<{ value: 'landscape' | 'portrait'; label: string }> = [
+  { value: 'landscape', label: '▭ Landscape' },
+  { value: 'portrait', label: '▯ Portrait' },
+];
 
 // Checkered "open space is the wallpaper" field the preview boards float on —
 // theme-agnostic neutral so it reads on both light and dark grounds.
@@ -27,19 +35,19 @@ const PHOTO_FIELD: React.CSSProperties = {
   backgroundSize: '12px 12px',
 };
 
-export function CommunityGallery({ mode, onApplyLayout }: CommunityGalleryProps) {
+export function CommunityGallery({ mode, onApplyLayout, currentOrientation }: CommunityGalleryProps) {
   const [search, setSearch] = useState('');
   const [pendingSearch, setPendingSearch] = useState('');
-  const [screenSize, setScreenSize] = useState<string>('');
+  const [orientation, setOrientation] = useState<'landscape' | 'portrait' | ''>(currentOrientation ?? '');
   const [loading, setLoading] = useState<string | null>(null);
   const [layouts, setLayouts] = useState<CommunityIndexEntry[]>([]);
   const [loadingIndex, setLoadingIndex] = useState(true);
 
   const filters: CommunityFilterOptions = useMemo(() => ({
     mode,
-    ...(screenSize ? { screenSize } : {}),
+    ...(orientation ? { orientation } : {}),
     ...(search ? { search } : {}),
-  }), [mode, screenSize, search]);
+  }), [mode, orientation, search]);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,9 +81,9 @@ export function CommunityGallery({ mode, onApplyLayout }: CommunityGalleryProps)
     }
   }, [onApplyLayout]);
 
-  const hasFilters = Boolean(search || screenSize);
+  const hasFilters = Boolean(search || orientation);
   const clearFilters = useCallback(() => {
-    setPendingSearch(''); setSearch(''); setScreenSize('');
+    setPendingSearch(''); setSearch(''); setOrientation('');
   }, []);
 
   return (
@@ -124,17 +132,17 @@ export function CommunityGallery({ mode, onApplyLayout }: CommunityGalleryProps)
           )}
         </div>
         <div className="flex gap-1 flex-wrap">
-          {SCREEN_SIZE_OPTIONS.map(size => (
+          {ORIENTATION_OPTIONS.map(opt => (
             <button
-              key={size}
-              onClick={() => setScreenSize(prev => prev === size ? '' : size)}
-              className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
-                screenSize === size
+              key={opt.value}
+              onClick={() => setOrientation(prev => prev === opt.value ? '' : opt.value)}
+              className={`px-2.5 py-0.5 text-xs rounded-full border transition-colors ${
+                orientation === opt.value
                   ? 'bg-primary text-primary-foreground border-primary'
                   : 'bg-muted/60 border-border text-muted-foreground hover:bg-accent hover:text-foreground'
               }`}
             >
-              {size}
+              {opt.label}
             </button>
           ))}
         </div>
@@ -232,13 +240,11 @@ function CommunityLayoutCard({
           <span className="opacity-40">·</span>
           <span className="shrink-0 tabular-nums">{entry.widgetCount}w</span>
         </div>
-        {entry.screenSizes.length > 0 && (
-          <div className="mt-1.5 flex flex-wrap gap-1">
-            {entry.screenSizes.map(s => (
-              <span key={s} className="rounded-full border border-border/70 bg-muted/50 px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground">
-                {s}
-              </span>
-            ))}
+        {entry.orientation && (
+          <div className="mt-1.5">
+            <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-muted/50 px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
+              {entry.orientation === 'portrait' ? '▯' : '▭'} {entry.orientation}
+            </span>
           </div>
         )}
       </div>

--- a/src/components/layout/LayoutEditorShareDialog.tsx
+++ b/src/components/layout/LayoutEditorShareDialog.tsx
@@ -48,7 +48,6 @@ export function LayoutEditorShareDialog({
     name: layoutName || '',
     description: '',
     author: '',
-    screenSizes: [] as string[],
     orientation: 'landscape' as 'landscape' | 'portrait',
     tags: '',
   });
@@ -61,7 +60,6 @@ export function LayoutEditorShareDialog({
         name: layoutName || '',
         description: '',
         author: '',
-        screenSizes: [],
         orientation: 'landscape',
         tags: '',
       });
@@ -109,7 +107,6 @@ export function LayoutEditorShareDialog({
       name: shareForm.name,
       description: shareForm.description,
       author: shareForm.author,
-      screenSizes: shareForm.screenSizes,
       orientation: shareForm.orientation,
       tags: shareForm.tags.split(',').map(t => t.trim()).filter(Boolean),
     };
@@ -120,19 +117,18 @@ export function LayoutEditorShareDialog({
       return;
     }
 
-    const title = encodeURIComponent(`Community Layout: ${shareForm.name}`);
-    const body = encodeURIComponent(
-      '```json\n' + JSON.stringify(submissionData, null, 2) + '\n```\n\n' +
-      `**Author:** ${shareForm.author}\n` +
-      `**Screen Sizes:** ${shareForm.screenSizes.join(', ')}\n` +
-      `**Orientation:** ${shareForm.orientation}\n`
-    );
-    const url = `https://github.com/sandydargoport/prism/issues/new?labels=layout-submission&title=${title}&body=${body}`;
-    window.open(url, '_blank');
+    // Route to the "Community Layout Submission" issue FORM and prefill its
+    // fields by id — forms ignore ?body=. Field ids come from
+    // .github/ISSUE_TEMPLATE/layout-submission.yml.
+    const params = new URLSearchParams({
+      template: 'layout-submission.yml',
+      title: `Community Layout: ${shareForm.name}`,
+      'layout-json': JSON.stringify(submissionData, null, 2),
+      'author-name': shareForm.author,
+    });
+    window.open(`https://github.com/sandydargoport/prism/issues/new?${params.toString()}`, '_blank');
     onClose();
   };
-
-  const presetSizes = ['1920x1080', '2560x1440', '3840x2160', '2560x1600', '2048x1536', '1366x768'];
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" onClick={onClose}>
@@ -173,56 +169,6 @@ export function LayoutEditorShareDialog({
           />
         </div>
         <div className="flex items-center gap-4">
-          <div>
-            <label className="text-xs text-muted-foreground block mb-1">Target Resolutions *</label>
-            <div className="flex gap-1 flex-wrap items-center">
-              {presetSizes.map(size => (
-                <button
-                  key={size}
-                  onClick={() => setShareForm(f => ({
-                    ...f,
-                    screenSizes: f.screenSizes.includes(size)
-                      ? f.screenSizes.filter(s => s !== size)
-                      : [...f.screenSizes, size],
-                  }))}
-                  className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
-                    shareForm.screenSizes.includes(size)
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-muted border-border hover:bg-accent'
-                  }`}
-                >
-                  {size}
-                </button>
-              ))}
-              <input
-                type="text"
-                placeholder="Custom (e.g. 2736x1824)"
-                className="px-2 py-0.5 text-xs bg-muted border border-border rounded-full w-[155px] focus:outline-none focus:ring-1 focus:ring-primary"
-                onKeyDown={e => {
-                  if (e.key === 'Enter') {
-                    const val = (e.target as HTMLInputElement).value.trim();
-                    if (/^\d{3,5}x\d{3,5}$/.test(val) && !shareForm.screenSizes.includes(val)) {
-                      setShareForm(f => ({ ...f, screenSizes: [...f.screenSizes, val] }));
-                      (e.target as HTMLInputElement).value = '';
-                    }
-                  }
-                }}
-              />
-            </div>
-            {shareForm.screenSizes.filter(s => !presetSizes.includes(s)).length > 0 && (
-              <div className="flex gap-1 flex-wrap mt-1">
-                {shareForm.screenSizes.filter(s => !presetSizes.includes(s)).map(size => (
-                  <button
-                    key={size}
-                    onClick={() => setShareForm(f => ({ ...f, screenSizes: f.screenSizes.filter(s => s !== size) }))}
-                    className="px-2 py-0.5 text-xs rounded-full border bg-primary text-primary-foreground border-primary transition-colors"
-                  >
-                    {size} &times;
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
           <div>
             <label className="text-xs text-muted-foreground block mb-1">Orientation *</label>
             <div className="flex gap-1">

--- a/src/components/layout/LayoutEditorToolbarLeft.tsx
+++ b/src/components/layout/LayoutEditorToolbarLeft.tsx
@@ -201,7 +201,7 @@ export function LayoutEditorToolbarLeft({
         width={640}
       >
         <div className="p-3 max-h-[60vh] overflow-auto">
-          <CommunityGallery mode={mode} onApplyLayout={onApplyCommunityLayout} />
+          <CommunityGallery mode={mode} onApplyLayout={onApplyCommunityLayout} currentOrientation={screenGuideOrientation} />
         </div>
       </PopoverButton>
 

--- a/src/lib/community/__tests__/validateLayout.test.ts
+++ b/src/lib/community/__tests__/validateLayout.test.ts
@@ -290,9 +290,9 @@ describe('validateCommunityLayout', () => {
       expect(result.valid).toBe(false);
     });
 
-    it('requires at least one screenSize for community submission', () => {
+    it('no longer requires a screenSize for community submission (layouts stretch to any screen)', () => {
       const result = validateCommunityLayout(makeLayout({ screenSizes: [] }), { communitySubmission: true });
-      expect(result.valid).toBe(false);
+      expect(result.valid).toBe(true);
     });
 
     it('requires orientation for community submission', () => {

--- a/src/lib/community/validateLayout.ts
+++ b/src/lib/community/validateLayout.ts
@@ -288,7 +288,6 @@ export function validateCommunityLayout(
     const name = typeof obj.name === 'string' ? obj.name : '';
     const description = typeof obj.description === 'string' ? obj.description : '';
     const author = typeof obj.author === 'string' ? obj.author : '';
-    const screenSizes = Array.isArray(obj.screenSizes) ? obj.screenSizes : [];
     const orientation = obj.orientation;
 
     if (name.length === 0 || name.length > 100) {
@@ -300,9 +299,8 @@ export function validateCommunityLayout(
     if (author.length === 0 || author.length > 50) {
       errors.push('Community submission requires an author (1-50 characters).');
     }
-    if (screenSizes.length === 0) {
-      errors.push('Community submission requires at least one screen size.');
-    }
+    // Layouts stretch to fill any screen, so a specific screen-size / resolution
+    // is no longer required — orientation is the meaningful axis.
     if (orientation !== 'landscape' && orientation !== 'portrait') {
       errors.push('Community submission requires orientation ("landscape" or "portrait").');
     }


### PR DESCRIPTION
Community-gallery + share-flow improvements.

## Gallery
- Filter by **Landscape / Portrait** (chips + a card badge) instead of screen resolution. Layouts stretch to fill any screen, so exact resolution is moot — **orientation** is the axis that matters (a portrait layout letterboxes on a landscape screen). The filter **defaults to the dashboard you're editing**.

## Share dialog
- Removes **"Target Resolutions"** (kept Orientation).
- Fixes a real mismatch: the repo has an issue **form** (`layout-submission.yml`, `blank_issues_enabled: false`), but the Share link used a `?body=` URL that issue forms ignore. It now routes to `?template=layout-submission.yml` and prefills the form fields by id (`layout-json`, `author-name`) — so GitHub applies the **Community Layout Submission** template.
- `validateCommunityLayout` no longer requires a screen size (orientation still required); test updated. The submission-processing workflow already tolerates empty `screenSizes`.

## Verification
- `tsc --noEmit`: clean · `jest` community validator: 42/42 · production build: clean.