### PR TITLE
docs(community): sharing flow + orientation filter, and remove em-dashes across Help + mkdocs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,22 +5,22 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Dashboard
-- **The built-in templates were rebuilt around real composition principles.** Each board now leads with one hero (usually the calendar), sizes every widget to its natural shape — birthdays runs tall rather than wide, the clock stays small, weather gets room for its sun/moon detail — and arranges them into a couple of balanced zones instead of an even grid packed with too many panels. The new lineup is **Family Central, Calendar Focus, Command Center, Meal Planner, School Mornings**, and a photo-forward **Ambient** whose glassy clock and weather float over your wallpaper.
+- **The built-in templates were rebuilt around real composition principles.** Each board now leads with one hero (usually the calendar), sizes every widget to its natural shape (birthdays runs tall rather than wide, the clock stays small, weather gets room for its sun/moon detail) and arranges them into a couple of balanced zones instead of an even grid packed with too many panels. The new lineup is **Family Central, Calendar Focus, Command Center, Meal Planner, School Mornings**, and a photo-forward **Ambient** whose glassy clock and weather float over your wallpaper.
 
 ### Screensaver
-- **Refreshed screensaver templates.** The calendar (or tonight's meals) is the hero; the clock, weather and messages are small, aligned accents floating over one clean photo region — calmer and less cluttered, with everything sitting fully on-screen.
+- **Refreshed screensaver templates.** The calendar (or tonight's meals) is the hero; the clock, weather and messages are small, aligned accents floating over one clean photo region, calmer and less cluttered, with everything sitting fully on-screen.
 
 ### Weather
 - **Sunrise, sunset, moonrise and moonset now show their times** along the sun/moon arc. The arc and the hourly timeline appear only when the widget is tall enough to draw them cleanly, so a short widget no longer clips them.
 
 ### Community layouts
-- **Redesigned the community-layouts gallery.** The preview boards now float on a wallpaper-style field with cleaner cards, a header with a live count, calmer search and size filters, and a clear **Apply layout** button — so browsing and applying a shared layout is easier to scan. The bundled community layouts were also regenerated to the current grid so they apply correctly.
+- **Redesigned the community-layouts gallery.** The preview boards now float on a wallpaper-style field with cleaner cards, a header with a live count, calmer search and size filters, and a clear **Apply layout** button, so browsing and applying a shared layout is easier to scan. The bundled community layouts were also regenerated to the current grid so they apply correctly.
 
 ### Layout editor
-- **"Save As" confirmations are no longer trapped** behind the editor overlay — when a dashboard name already exists you can now see and act on the confirm/cancel prompt.
+- **"Save As" confirmations are no longer trapped** behind the editor overlay, when a dashboard name already exists you can now see and act on the confirm/cancel prompt.
 
 ### Photos
-- **Bulk photo management on desktop.** Select several photos at once — or **Select all** across your whole library — then act on the selection in one go: **remove them from Prism** (this only drops them from Prism, it does not delete the originals in OneDrive/Immich), or flip their **Wallpaper / Gallery / Screensaver** usage toggles together.
+- **Bulk photo management on desktop.** Select several photos at once, or **Select all** across your whole library, then act on the selection in one go: **remove them from Prism** (this only drops them from Prism, it does not delete the originals in OneDrive/Immich), or flip their **Wallpaper / Gallery / Screensaver** usage toggles together.
 - **Below-HD filter and resolution indicators.** Each thumbnail carries a small resolution dot, and a **Below-HD** filter surfaces low-resolution images so you can keep them out of wallpaper and screensaver rotation.
 - **Sturdier wallpaper handling and OneDrive recovery.** Wallpaper selection is more robust, and a OneDrive photo source that stopped syncing can be recovered without losing already-imported photos.
 
@@ -36,24 +36,24 @@ All notable changes to Prism are documented in this file.
 ## [1.13.0] – 2026-08-02
 
 ### Dashboard
-- **Your layout now fills any screen.** Design your dashboard once — on your kiosk or in a laptop browser — and it stretches to fit whatever screen it's shown on, edge to edge, without clipping or stopping awkwardly short of the bottom. It re-fits live when you resize the window, go full-screen, or zoom, and when the toolbars auto-hide the layout grows to fill the space they leave. A design whose orientation doesn't match the screen (a portrait layout on a landscape display) is neatly letterboxed rather than stretched out of shape.
-- **Preview shows exactly what the wall will show.** Full-screen preview now renders the real, stretched dashboard, and a new **device gallery** shows how your one design looks on a 27″ display, an iPad, a Fire tablet and a phone — so you can check the fit before you deploy. The old per-resolution "screen zone" controls are retired in favor of this simpler model.
+- **Your layout now fills any screen.** Design your dashboard once (on your kiosk or in a laptop browser) and it stretches to fit whatever screen it's shown on, edge to edge, without clipping or stopping awkwardly short of the bottom. It re-fits live when you resize the window, go full-screen, or zoom, and when the toolbars auto-hide the layout grows to fill the space they leave. A design whose orientation doesn't match the screen (a portrait layout on a landscape display) is neatly letterboxed rather than stretched out of shape.
+- **Preview shows exactly what the wall will show.** Full-screen preview now renders the real, stretched dashboard, and a new **device gallery** shows how your one design looks on a 27″ display, an iPad, a Fire tablet and a phone, so you can check the fit before you deploy. The old per-resolution "screen zone" controls are retired in favor of this simpler model.
 - **Better starting templates and widget sizes.** The built-in layout templates were rebuilt to fit the screen properly (several used to run off the page), the **weather** panel now has room to breathe, and a freshly-added widget arrives at a sensible size instead of nearly filling the screen.
-- **The weather widget fits its space.** It shows as much as fits — current conditions, an hourly timeline, and up to a 7-day forecast — revealing more as you make it bigger, so it's never cut off.
+- **The weather widget fits its space.** It shows as much as fits: current conditions, an hourly timeline, and up to a 7-day forecast, revealing more as you make it bigger, so it's never cut off.
 
 ### Screensaver
-- **Refreshed, legible screensaver templates.** The built-in screensaver layouts were rebuilt to sit fully on-screen (some used to run off the bottom) and kept clean and minimal, and screensaver text is now light and readable over the wallpaper — no more dark-on-dark widgets.
+- **Refreshed, legible screensaver templates.** The built-in screensaver layouts were rebuilt to sit fully on-screen (some used to run off the bottom) and kept clean and minimal, and screensaver text is now light and readable over the wallpaper. No more dark-on-dark widgets.
 
 ## [1.12.0] – 2026-08-01
 
 ### Setup & first-run
-- **A slimmer, keyless setup.** First run is now just **Welcome → Family → Household → Done** — no API keys or accounts required to finish. Location uses a ZIP lookup with automatic time zone; calendars and other integrations connect later from their own pages. You can no longer accidentally finish setup with **no family members** (which used to lock you out of login with no way back), and a brand-new dashboard shows your calendar without anyone needing to sign in.
+- **A slimmer, keyless setup.** First run is now just **Welcome → Family → Household → Done**: no API keys or accounts required to finish. Location uses a ZIP lookup with automatic time zone; calendars and other integrations connect later from their own pages. You can no longer accidentally finish setup with **no family members** (which used to lock you out of login with no way back), and a brand-new dashboard shows your calendar without anyone needing to sign in.
 
 ### Calendar
-- **Assign events to a person with zero integrations.** Every family member automatically gets their own personal calendar (plus a shared **Family** one), so an event you add is assigned to someone and color-coded on the dashboard — no third-party setup. The old anonymous "Local only" bucket is gone; existing installs pick the calendars up automatically. Connected accounts (Google) still layer on top, clearly marked as two-way syncing.
+- **Assign events to a person with zero integrations.** Every family member automatically gets their own personal calendar (plus a shared **Family** one), so an event you add is assigned to someone and color-coded on the dashboard: no third-party setup. The old anonymous "Local only" bucket is gone; existing installs pick the calendars up automatically. Connected accounts (Google) still layer on top, clearly marked as two-way syncing.
 - **Meals on the calendar are marked with a utensils icon**, so a meal is instantly distinct from an ordinary event.
-- **Calendars refresh on their own after a sync** — no manual page reload after adding a subscription or hitting "Sync Now".
-- **Clearer calendar connect** — the dialog shows exactly where to find a Google Calendar's private iCal link, and rejects a Google *web* link (which used to sync nothing) with a helpful message.
+- **Calendars refresh on their own after a sync**, no manual page reload after adding a subscription or hitting "Sync Now".
+- **Clearer calendar connect**: the dialog shows exactly where to find a Google Calendar's private iCal link, and rejects a Google *web* link (which used to sync nothing) with a helpful message.
 
 ### Meals
 - **Correct weekday labels, and meal plans no longer vanish** when you change "Week starts on." Meals now anchor to their real calendar date, so toggling the setting simply re-windows the week. Ships one automatic, additive database migration; existing meals keep their dates.
@@ -61,248 +61,248 @@ All notable changes to Prism are documented in this file.
 ## [1.11.0] – 2026-07-31
 
 ### Calendar
-- **Deleting a synced Apple/CalDAV event in Prism now removes it from the source too.** Previously only Google deletes propagated upstream — a CalDAV event you deleted in Prism was tombstoned locally but lingered on iCloud/Nextcloud/etc. Prism now captures each event's server address at sync time and sends the delete back to the source. Single (non-recurring) events only; recurring series still delete locally without touching the source (they need proper recurrence editing first). Ships one additive database migration, applied automatically on start.
+- **Deleting a synced Apple/CalDAV event in Prism now removes it from the source too.** Previously only Google deletes propagated upstream. A CalDAV event you deleted in Prism was tombstoned locally but lingered on iCloud/Nextcloud/etc. Prism now captures each event's server address at sync time and sends the delete back to the source. Single (non-recurring) events only; recurring series still delete locally without touching the source (they need proper recurrence editing first). Ships one additive database migration, applied automatically on start.
 
 ### Setup & first-run
 - **A much smoother first run for non-technical users.** The setup wizard now lets you **edit or remove** family members as you go (fix a typo, change a color), **remembers them if you step back or refresh**, and no longer drops you on a **blank screen** when you finish. Setup dialogs fit the screen, member **names must be unique**, "Add member" no longer looks disabled, and Prism now **starts in light mode**.
 
 ### Security
-- **Per-member PIN length.** Each family member can pick their own **4- or 6-digit** PIN, and every PIN pad now asks for exactly *that* member's length — so a longer PIN can no longer lock someone out (fixes login for 5/6-digit PINs). The confusing family-wide "default PIN length" setting is gone. Ships one additive, automatic database migration; existing PINs keep working. The admin/settings gate now correctly lists parents only.
+- **Per-member PIN length.** Each family member can pick their own **4- or 6-digit** PIN, and every PIN pad now asks for exactly *that* member's length, so a longer PIN can no longer lock someone out (fixes login for 5/6-digit PINs). The confusing family-wide "default PIN length" setting is gone. Ships one additive, automatic database migration; existing PINs keep working. The admin/settings gate now correctly lists parents only.
 
 ### Interface
-- **Leaner one-screen default dashboard** (weather-forward, no off-screen overflow — existing custom layouts are untouched), **consistent empty & loading states** across every page each with a clear "Add your first…" button, list pages that **start ungrouped**, and a **Wishes** view that matches the rest of the app (person filter + group-by). Plus dozens of small first-impression fixes.
+- **Leaner one-screen default dashboard** (weather-forward, no off-screen overflow; existing custom layouts are untouched), **consistent empty & loading states** across every page each with a clear "Add your first…" button, list pages that **start ungrouped**, and a **Wishes** view that matches the rest of the app (person filter + group-by). Plus dozens of small first-impression fixes.
 
 ## [1.10.0] – 2026-07-27
 
-A feature release: recipe & meal-plan sync with Tandoor and Mealie, a calendar-sync overhaul that stops the sync from ever silently losing events, and a settings reshuffle so household basics live where you'd expect. Ships three database migrations (recipe sources, deleted-event tombstones, and a pending-deletion flag) — all applied automatically on start.
+A feature release: recipe & meal-plan sync with Tandoor and Mealie, a calendar-sync overhaul that stops the sync from ever silently losing events, and a settings reshuffle so household basics live where you'd expect. Ships three database migrations (recipe sources, deleted-event tombstones, and a pending-deletion flag), all applied automatically on start.
 
 ### Recipes & meals
-- **Sync recipes and meal plans from Tandoor and Mealie.** Connect a server once (read-only API token) and pull recipes — ingredients, steps, times, tags, and photos — and your meal plan into Prism, from **Recipes → Add ▾ → "Sync recipes…"** and **Meals → Add ▾ → "Sync meal plan…"**. It's review-and-approve: every sync shows exactly what would change and you pick what to apply — adds and updates are pre-selected, removals are opt-in, and a mass-delete guard keeps a source glitch from wiping your library. A planned meal automatically brings its recipe along if you haven't imported it yet. Re-syncing is idempotent (unchanged items show "up to date"). Both apps ride one reusable framework, so more integrations are straightforward from here.
+- **Sync recipes and meal plans from Tandoor and Mealie.** Connect a server once (read-only API token) and pull recipes (ingredients, steps, times, tags, and photos) and your meal plan into Prism, from **Recipes → Add ▾ → "Sync recipes…"** and **Meals → Add ▾ → "Sync meal plan…"**. It's review-and-approve: every sync shows exactly what would change and you pick what to apply: adds and updates are pre-selected, removals are opt-in, and a mass-delete guard keeps a source glitch from wiping your library. A planned meal automatically brings its recipe along if you haven't imported it yet. Re-syncing is idempotent (unchanged items show "up to date"). Both apps ride one reusable framework, so more integrations are straightforward from here.
 - **Fixed ingredient scaling.** Scaling a recipe's servings multiplied *every* number in an ingredient line, so "1 8 oz can" doubled to "2 16 oz can". It now scales only the leading quantity (handling fractions and mixed numbers) and leaves pack/size numbers alone.
 
 ### Calendar
-- **Sync never silently deletes anymore.** When an event disappears from its source calendar, Prism no longer removes it on the next pull — it *holds* it and shows a "**Review N**" badge on the calendar. You review each removal and choose **Delete** (remove it) or **Keep** (turn it into a permanent local event). Adds and updates still apply automatically, so the dashboard stays current; only removals wait for you. Applying requires delete permission, so a shared display shows the badge but can't act on it without a parent.
+- **Sync never silently deletes anymore.** When an event disappears from its source calendar, Prism no longer removes it on the next pull. It *holds* it and shows a "**Review N**" badge on the calendar. You review each removal and choose **Delete** (remove it) or **Keep** (turn it into a permanent local event). Adds and updates still apply automatically, so the dashboard stays current; only removals wait for you. Applying requires delete permission, so a shared display shows the badge but can't act on it without a parent.
 - **Deleting an event in Prism now sticks.** Previously a synced event you deleted could reappear on the next sync; a tombstone now keeps it gone (and Google deletes also propagate back to Google).
 - **Calendar management moved onto the Calendar page.** Connected calendars, groups, hours, and iCal subscriptions now live behind a **Manage** button on the calendar itself instead of buried in Settings.
 - **Honest sync counts + a smoother sync.** The sync toast reports what actually changed ("2 added, 1 updated, 3 flagged for review") instead of the total re-pulled, a manual sync refreshes the calendar immediately (no page reload), and the Add-Event date field is now clickable to change the date, not just the time.
 
 ### Settings
 - **New "General" section** groups the household basics that were scattered before: **Location**, **Time zone**, and **Week starts on**.
-- **Household time zone setting** — server-side scheduling and syncs (e.g. placing imported meal-plan times) now anchor to your zone; defaults to your browser's.
+- **Household time zone setting**: server-side scheduling and syncs (e.g. placing imported meal-plan times) now anchor to your zone; defaults to your browser's.
 - **Set your weather location by ZIP / postal code** with a clean, single-result lookup (no API key required), instead of fiddly free text.
 
 ## [1.9.0] – 2026-07-24
 
-Security-hardening release from a full codebase audit. It closes a cluster of access-control gaps on the API, adds server-side-request-forgery guards to the calendar/photo integrations, hardens sessions and OAuth, and updates dependencies carrying published advisories. No changes to how Prism behaves for you day-to-day, and no database migration — but if you run Prism on a network-exposed Home Assistant ingress, this is a recommended upgrade.
+Security-hardening release from a full codebase audit. It closes a cluster of access-control gaps on the API, adds server-side-request-forgery guards to the calendar/photo integrations, hardens sessions and OAuth, and updates dependencies carrying published advisories. No changes to how Prism behaves for you day-to-day, and no database migration. But if you run Prism on a network-exposed Home Assistant ingress, this is a recommended upgrade.
 
-### Security — Access control
-- **Item-level edit/delete on events, chores, calendars, and photo sources now enforce the same permissions as the rest of the app.** Several `PATCH`/`DELETE` endpoints checked only that you were signed in, not *which* role you had — so a child, guest, or a narrowly-scoped API token could edit or delete family data (and, for calendars/photo sources, cascade-delete the linked source and its on-disk originals) by addressing it directly by id. Every one of these now applies the owner-or-role check the collection routes already used. Chore completion is now anchored to the signed-in caller, closing an approval bypass where a child could self-approve by supplying a parent's id.
+### Security: Access control
+- **Item-level edit/delete on events, chores, calendars, and photo sources now enforce the same permissions as the rest of the app.** Several `PATCH`/`DELETE` endpoints checked only that you were signed in, not *which* role you had, so a child, guest, or a narrowly-scoped API token could edit or delete family data (and, for calendars/photo sources, cascade-delete the linked source and its on-disk originals) by addressing it directly by id. Every one of these now applies the owner-or-role check the collection routes already used. Chore completion is now anchored to the signed-in caller, closing an approval bypass where a child could self-approve by supplying a parent's id.
 - **API-token scopes are enforced on the admin routes.** Bearer tokens were treated as full parent on the database and backup routes regardless of their scope; a `voice`-scoped token could truncate/seed the database or download/restore/delete backups. Scopes are now honored.
 - **Kiosk PIN lockout can no longer be brute-forced** (the lockout counter is keyed on the resolved user, so failed attempts actually accumulate).
 
-### Security — Server-side request forgery (SSRF)
+### Security: Server-side request forgery (SSRF)
 - **CalDAV, CardDAV, and Immich outbound fetches now validate the target address.** A signed-in parent could previously point one of these at a loopback / private / cloud-metadata address and use Prism to probe the internal network. All three now reject private targets before connecting, the CalDAV *test* endpoint no longer leaks whether an internal host exists, and Immich no longer follows a redirect to an internal host.
 
-### Security — Sessions, OAuth & storage
+### Security: Sessions, OAuth & storage
 - **Sessions now have an absolute lifetime** (parent 30 days / child 7 / guest 1 hour) on top of the existing sliding window, so a stolen session cookie can't be kept alive indefinitely.
-- **Google and Microsoft OAuth now verify a single-use state nonce**, matching the Kroger flow — closing a window where a valid `code` could bind an attacker's account (or an attacker-chosen owner) to the dashboard. The Microsoft photo-source callback, previously unauthenticated, now requires a signed-in parent.
-- **The service worker no longer caches authenticated `/api` responses to disk** — previously messages, family, tokens, and other per-session data were written into on-disk Cache Storage and outlived the session on a shared kiosk.
+- **Google and Microsoft OAuth now verify a single-use state nonce**, matching the Kroger flow, closing a window where a valid `code` could bind an attacker's account (or an attacker-chosen owner) to the dashboard. The Microsoft photo-source callback, previously unauthenticated, now requires a signed-in parent.
+- **The service worker no longer caches authenticated `/api` responses to disk**: previously messages, family, tokens, and other per-session data were written into on-disk Cache Storage and outlived the session on a shared kiosk.
 - **Avatar and recipe-image URLs validate the id** before reading from disk, rejecting path-traversal payloads.
 
-### Security — Dependencies
+### Security: Dependencies
 - Updated dependencies carrying published advisories: **Next.js** (`15.5.21`), **drizzle-orm** (`0.45.2`), **node-ical** (`0.27.1`, which also drops a vulnerable bundled `axios`), **undici** (`6.27.0`), and **dompurify** (`3.4.x`), plus dev tooling (postcss, next-tooling alignment). The abandoned `next-pwa`/Workbox build chain is a known remaining item slated for a separate migration.
 
-### Fixed — Correctness
+### Fixed: Correctness
 - **The API rate limiter can no longer permanently lock you out.** If Redis dropped the window's expiry (e.g. a crash at the wrong moment), the counter never reset and you'd stay blocked; the window now self-heals.
-- **Weather "Morning / Afternoon / Evening" temperatures now bucket by the forecast location's timezone**, not the server's UTC clock — so day-parts land on the right hours and don't roll to the wrong day.
-- **A Google calendar is only auto-disabled after 3 *consecutive* 404s**, not three assorted failures — transient network/5xx blips no longer count toward disabling a calendar that still exists.
+- **Weather "Morning / Afternoon / Evening" temperatures now bucket by the forecast location's timezone**, not the server's UTC clock, so day-parts land on the right hours and don't roll to the wrong day.
+- **A Google calendar is only auto-disabled after 3 *consecutive* 404s**, not three assorted failures. Transient network/5xx blips no longer count toward disabling a calendar that still exists.
 - **The travel globe re-highlights trip stops correctly** when you select or deselect a trip.
 
-### Fixed — Photos
+### Fixed: Photos
 - **Immich album photo sources now sync on Immich v3.** An album-backed source synced **zero photos** on Immich v3: the old `GET /api/albums/{id}` listing returns an empty asset array over a share key, so the sync finished without error and added nothing. Prism now lists album assets via the paginated `POST /api/search/metadata` endpoint (requesting EXIF so photo GPS still reaches the Travel Map); thumbnail and original downloads were already fine and are unchanged. Thanks @guylenical for the report and the suggested fix (verified against a live v3 instance). Closes [#154](https://github.com/sandydargoport/prism/pull/154).
 
 ## [1.8.14] – 2026-06-29
 
-### Fixed — Display
-- **Emoji now render on devices without a system emoji font.** Prism uses Unicode emoji throughout the UI (Goals 🎯, Birthdays 🎂, shopping categories 🛒, Points 🏆, the avatar picker, …); these render in the *viewing browser* using the device's emoji font, so on a minimal client with none installed — e.g. a bare Raspberry Pi OS / Chromium kiosk — they showed as empty "tofu" boxes (□). Prism now bundles the Noto Color Emoji webfont and adds it to the font stack after the system emoji fonts, so it serves the glyphs itself and emoji render on any client regardless of installed fonts. The font is subsetted by Unicode range, so a browser only downloads the small chunks for the emoji actually on screen. Devices that already have a native emoji font keep using it (no extra download). Thanks @theg00se1030 for the report. Closes [#145](https://github.com/sandydargoport/prism/issues/145).
+### Fixed: Display
+- **Emoji now render on devices without a system emoji font.** Prism uses Unicode emoji throughout the UI (Goals 🎯, Birthdays 🎂, shopping categories 🛒, Points 🏆, the avatar picker, …); these render in the *viewing browser* using the device's emoji font, so on a minimal client with none installed (e.g. a bare Raspberry Pi OS / Chromium kiosk) they showed as empty "tofu" boxes (□). Prism now bundles the Noto Color Emoji webfont and adds it to the font stack after the system emoji fonts, so it serves the glyphs itself and emoji render on any client regardless of installed fonts. The font is subsetted by Unicode range, so a browser only downloads the small chunks for the emoji actually on screen. Devices that already have a native emoji font keep using it (no extra download). Thanks @theg00se1030 for the report. Closes [#145](https://github.com/sandydargoport/prism/issues/145).
 
 ## [1.8.13] – 2026-06-29
 
-### Added — Integrations
-- **Each Integrations card now shows which account it's connected to — "Connected as `you@example.com`".** Previously the cards showed *that* a provider was connected but not *which account*, so anyone running split accounts under one provider (e.g. a personal Google for calendars plus a family Gmail for school-bus emails) couldn't tell from the card which account each feature used. Prism now captures the account's email during the OAuth login (Google, Microsoft, and Gmail) and shows it on the provider card and its Account sub-section; split-account setups show the primary plus a "+N more". **Existing connections show no email until you click Re-authenticate on the card** — the email is only captured on a fresh login, and there's intentionally no backfill of stored tokens. The new login adds read-only identity scopes (Google `openid email`, Microsoft `User.Read`); Gmail reuses its existing scope. Closes [#100](https://github.com/sandydargoport/prism/issues/100).
+### Added: Integrations
+- **Each Integrations card now shows which account it's connected to: "Connected as `you@example.com`".** Previously the cards showed *that* a provider was connected but not *which account*, so anyone running split accounts under one provider (e.g. a personal Google for calendars plus a family Gmail for school-bus emails) couldn't tell from the card which account each feature used. Prism now captures the account's email during the OAuth login (Google, Microsoft, and Gmail) and shows it on the provider card and its Account sub-section; split-account setups show the primary plus a "+N more". **Existing connections show no email until you click Re-authenticate on the card**: the email is only captured on a fresh login, and there's intentionally no backfill of stored tokens. The new login adds read-only identity scopes (Google `openid email`, Microsoft `User.Read`); Gmail reuses its existing scope. Closes [#100](https://github.com/sandydargoport/prism/issues/100).
 
 ## [1.8.12] – 2026-06-28
 
-### Fixed — Integrations
-- **Google & Microsoft OAuth redirect URIs are now derived from the request, fixing `redirect_uri_mismatch`.** Previously the redirect URI came from a static `*_REDIRECT_URI` env var (defaulting to `localhost`), so anyone whose env var didn't byte-match what they'd registered in the provider console hit `Error 400: redirect_uri_mismatch` on Connect. All Google (Calendar, Gmail/Bus, Tasks) and Microsoft (OneDrive, Tasks) flows now build the redirect URI from the incoming request's host/proto (honoring `X-Forwarded-Host`/`-Proto` behind a reverse proxy), the same approach Kroger already uses — so the URI always matches the host you started from, and `/authorize` and `/token` stay in lockstep. The env vars still work as a fallback. Existing connections are unaffected (token refresh doesn't use the redirect URI). Closes [#124](https://github.com/sandydargoport/prism/issues/124).
+### Fixed: Integrations
+- **Google & Microsoft OAuth redirect URIs are now derived from the request, fixing `redirect_uri_mismatch`.** Previously the redirect URI came from a static `*_REDIRECT_URI` env var (defaulting to `localhost`), so anyone whose env var didn't byte-match what they'd registered in the provider console hit `Error 400: redirect_uri_mismatch` on Connect. All Google (Calendar, Gmail/Bus, Tasks) and Microsoft (OneDrive, Tasks) flows now build the redirect URI from the incoming request's host/proto (honoring `X-Forwarded-Host`/`-Proto` behind a reverse proxy), the same approach Kroger already uses, so the URI always matches the host you started from, and `/authorize` and `/token` stay in lockstep. The env vars still work as a fallback. Existing connections are unaffected (token refresh doesn't use the redirect URI). Closes [#124](https://github.com/sandydargoport/prism/issues/124).
 
 ## [1.8.11] – 2026-06-27
 
-### Fixed — Home Assistant addon
-- **The bundled-database addon now actually starts — and survives restarts.** With `bundled_db: true` (the default), the addon failed to boot at all: Alpine's Postgres defaults its Unix socket to `/run/postgresql`, which doesn't exist in the container, so `pg_ctl` died with `could not create lock file "…/.s.PGSQL.5432.lock": No such file or directory` and the dashboard never came up. A second bug then crash-looped the addon on its first restart/update — the base schema (a full `pg_dump`) was re-applied on every boot, and its `ADD CONSTRAINT` statements aren't idempotent (`relation "…" already exists`). The entrypoint now creates the socket directory on every start, and applies the base schema only when the database is empty (mirroring the standalone deploy, where Postgres' init dir runs it once), letting the idempotent migration step handle every later boot. It also dumps the Postgres log on a startup failure instead of swallowing it behind `pg_ctl`'s "Examine the log output". Thanks @joe-cole1 for the report and logs. Closes [#81](https://github.com/sandydargoport/prism/issues/81).
+### Fixed: Home Assistant addon
+- **The bundled-database addon now actually starts: and survives restarts.** With `bundled_db: true` (the default), the addon failed to boot at all: Alpine's Postgres defaults its Unix socket to `/run/postgresql`, which doesn't exist in the container, so `pg_ctl` died with `could not create lock file "…/.s.PGSQL.5432.lock": No such file or directory` and the dashboard never came up. A second bug then crash-looped the addon on its first restart/update: the base schema (a full `pg_dump`) was re-applied on every boot, and its `ADD CONSTRAINT` statements aren't idempotent (`relation "…" already exists`). The entrypoint now creates the socket directory on every start, and applies the base schema only when the database is empty (mirroring the standalone deploy, where Postgres' init dir runs it once), letting the idempotent migration step handle every later boot. It also dumps the Postgres log on a startup failure instead of swallowing it behind `pg_ctl`'s "Examine the log output". Thanks @joe-cole1 for the report and logs. Closes [#81](https://github.com/sandydargoport/prism/issues/81).
 
-### Changed — Backups
+### Changed: Backups
 - **Off-site sync and the dead-man healthcheck are now opt-in via `.env`.** `RCLONE_REMOTE` and `HC_URL` were previously hardcoded in `docker-compose.yml`, so every deployment shared one set of endpoints. They now default to empty: set your own `RCLONE_REMOTE` (an rclone remote for off-site copies) and `HC_URL` (your own healthchecks.io check) in `.env` to enable them, or leave them blank to keep backups local-only. The backup tunables (`BACKUP_HOUR`, `RETENTION_DAYS`, `RCLONE_RETENTION_DAYS`) are overridable the same way. See the new Backups section in `.env.example`.
 
-### Fixed — Integrations
-- **Clicking "Connect" before configuring OAuth now shows a setup prompt instead of a raw JSON error.** If you skipped OAuth setup during onboarding and then hit Connect on the Google / Gmail / Microsoft cards, the browser landed on a bare `{"error":"Failed to initiate … authentication"}` page. The init routes now detect the not-configured case and redirect back to the Integrations page with a clear banner — pointing to the Setup Wizard (where you enter your OAuth credentials) and naming the required env vars — instead of a dead JSON page. Thanks @joe-cole1 for the report and the "make this clearer for dummies who skipped onboarding" nudge. Closes [#108](https://github.com/sandydargoport/prism/issues/108).
+### Fixed: Integrations
+- **Clicking "Connect" before configuring OAuth now shows a setup prompt instead of a raw JSON error.** If you skipped OAuth setup during onboarding and then hit Connect on the Google / Gmail / Microsoft cards, the browser landed on a bare `{"error":"Failed to initiate … authentication"}` page. The init routes now detect the not-configured case and redirect back to the Integrations page with a clear banner, pointing to the Setup Wizard (where you enter your OAuth credentials) and naming the required env vars, instead of a dead JSON page. Thanks @joe-cole1 for the report and the "make this clearer for dummies who skipped onboarding" nudge. Closes [#108](https://github.com/sandydargoport/prism/issues/108).
 
 ## [1.8.10] – 2026-06-19
 
-### Fixed — Tasks
-- **Newly-added tasks no longer vanish once a household has 100+ tasks.** The Tasks list fetches a capped number of rows (100) ordered by due date; with many tasks — especially ones without a due date, which sort last — the newest tasks fell past the row limit and were silently dropped from the fetch. They saved to the database fine but never appeared in any view (touch display or PWA). The fetch now orders **incomplete tasks first** with a newest-first tiebreaker, so active tasks are never truncated out. Display order is unchanged (the client still sorts the visible list).
+### Fixed: Tasks
+- **Newly-added tasks no longer vanish once a household has 100+ tasks.** The Tasks list fetches a capped number of rows (100) ordered by due date; with many tasks (especially ones without a due date, which sort last) the newest tasks fell past the row limit and were silently dropped from the fetch. They saved to the database fine but never appeared in any view (touch display or PWA). The fetch now orders **incomplete tasks first** with a newest-first tiebreaker, so active tasks are never truncated out. Display order is unchanged (the client still sorts the visible list).
 
-### Fixed — Touch keyboard
-- **On-screen keyboard no longer dismisses itself when you tap Shift.** On touch displays (e.g. Raspberry Pi kiosks), tapping Shift (or a symbol key) blurred the focused input, so the global focusout handler hid the keyboard. The keyboard container now keeps the input focused on tap — a `mousedown` preventDefault, since simple-keyboard swallows the pointerdown the existing handler relied on. Thanks @theg00se1030 for the precise root-cause analysis. Closes [#125](https://github.com/sandydargoport/prism/issues/125).
+### Fixed: Touch keyboard
+- **On-screen keyboard no longer dismisses itself when you tap Shift.** On touch displays (e.g. Raspberry Pi kiosks), tapping Shift (or a symbol key) blurred the focused input, so the global focusout handler hid the keyboard. The keyboard container now keeps the input focused on tap: a `mousedown` preventDefault, since simple-keyboard swallows the pointerdown the existing handler relied on. Thanks @theg00se1030 for the precise root-cause analysis. Closes [#125](https://github.com/sandydargoport/prism/issues/125).
 
 ## [1.8.9] – 2026-06-16
 
-### Fixed — Security / Login
-- **5–6 digit PINs can now actually be used.** PIN length is now a uniform family-wide setting (4–6 digits, like an iPhone passcode) — chosen in the setup wizard and changeable in Settings → Security. Previously PIN *creation* allowed up to 6 digits while every login/unlock pad was hard-coded to 4 and auto-submitted at 4, so any 5–6 digit PIN could never be entered and the member was locked out. All five PIN surfaces (login, settings gate, quick-switch, away-exit, babysitter-exit), `PinEditModal`, and the family API now read and enforce the configured length. Added `scripts/reset-pin.js` for offline recovery of a locked-out member. Closes [#123](https://github.com/sandydargoport/prism/issues/123).
+### Fixed: Security / Login
+- **5–6 digit PINs can now actually be used.** PIN length is now a uniform family-wide setting (4–6 digits, like an iPhone passcode), chosen in the setup wizard and changeable in Settings → Security. Previously PIN *creation* allowed up to 6 digits while every login/unlock pad was hard-coded to 4 and auto-submitted at 4, so any 5–6 digit PIN could never be entered and the member was locked out. All five PIN surfaces (login, settings gate, quick-switch, away-exit, babysitter-exit), `PinEditModal`, and the family API now read and enforce the configured length. Added `scripts/reset-pin.js` for offline recovery of a locked-out member. Closes [#123](https://github.com/sandydargoport/prism/issues/123).
 
 ## [1.8.8] – 2026-06-16
 
-### Changed — Mobile
-- **Per-person list views become a swipeable carousel on phones**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all switch to a CSS scroll-snap carousel when viewed on mobile with more than one group — each profile takes the full viewport width and the user swipes left/right between people while still scrolling vertically inside the active profile's list. Desktop / tablet behavior unchanged (min-width columns + horizontal scroll). Cleaner than the previous "1.5 profiles visible at 220 px each" feel on phones.
+### Changed: Mobile
+- **Per-person list views become a swipeable carousel on phones**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all switch to a CSS scroll-snap carousel when viewed on mobile with more than one group: each profile takes the full viewport width and the user swipes left/right between people while still scrolling vertically inside the active profile's list. Desktop / tablet behavior unchanged (min-width columns + horizontal scroll). Cleaner than the previous "1.5 profiles visible at 220 px each" feel on phones.
 
-### Fixed — List views
+### Fixed: List views
 - **Chores person filter now actually filters the rendered columns**: `ChoresView`'s `choresByUser` memo iterated every family member when building columns, so selecting a single-person filter under Group:Person still showed empty columns for everyone else. Tasks and Wishes already filtered correctly; Chores now matches. Unassigned column also hides when a person filter is active (the user explicitly asked to see only those people).
-- **Per-person grids no longer squeeze when the family is large**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all used `grid-cols-2 md:grid-cols-3` which crammed 7 people (5 kids + 2 adults) into 3 narrow columns × 3 rows on a portrait tablet. Switched all five views to `gridTemplateColumns: repeat(N, minmax(220px, 1fr))` + `overflow-x-auto`. Each column gets at least 220px; if the viewport can't fit every column comfortably, the grid scrolls horizontally — same shape across all list views. Closes [#105](https://github.com/sandydargoport/prism/issues/105).
-- **Desktop carousel reveal**: per-person carousels on Chores, Tasks (flat + nested), Wishes, and Gift Ideas now render left/right chevron buttons over the column area when more profiles exist than fit on screen — mouse users were otherwise stuck with no obvious affordance (touch users already had the snap-swipe gesture). New `CarouselArrows` component scrolls 85 % of the visible width per click and fades at the edges.
+- **Per-person grids no longer squeeze when the family is large**: Chores, Tasks (flat + nested), Wishes, and Gift Ideas all used `grid-cols-2 md:grid-cols-3` which crammed 7 people (5 kids + 2 adults) into 3 narrow columns × 3 rows on a portrait tablet. Switched all five views to `gridTemplateColumns: repeat(N, minmax(220px, 1fr))` + `overflow-x-auto`. Each column gets at least 220px; if the viewport can't fit every column comfortably, the grid scrolls horizontally, same shape across all list views. Closes [#105](https://github.com/sandydargoport/prism/issues/105).
+- **Desktop carousel reveal**: per-person carousels on Chores, Tasks (flat + nested), Wishes, and Gift Ideas now render left/right chevron buttons over the column area when more profiles exist than fit on screen. Mouse users were otherwise stuck with no obvious affordance (touch users already had the snap-swipe gesture). New `CarouselArrows` component scrolls 85 % of the visible width per click and fades at the edges.
 - **Tasks PersonFilter now hides unselected columns**: under Group:Person, picking a subset in the filter chip-bar dropped the unselected people's empty columns (and the Unassigned bucket) entirely, matching Chores/Wishes. `useTaskGrouping` takes a new `filterPerson` param and the column list is filtered before the grid renders.
 - **Gift Ideas intermittent "Something went wrong" on refresh**: `useRef` for the carousel scroll container was placed after three conditional early returns (`!activeUser` / `loading` / `error`), so the hook count changed between renders depending on data state and React threw on roughly half of mounts. Moved the ref to the top of the component.
 - **Wishes per-member cards now fill row height**: `WishesView` was missing the `h-screen flex flex-col` wrapper that Chores/Tasks/Shopping use, so `flex-1` on the content area never engaged and the columns collapsed to natural content height. Wrapper added and `MemberWishCard` root now stretches with `h-full` so the inner body's `flex-1 overflow-y-auto` engages.
 - **Gift Ideas tab shares the PersonFilter with Wishes**: the filter chip-bar now also renders on the Ideas tab and the selection drives which member columns appear there. Previously Ideas always showed every member regardless of filter.
 
-### Changed — Shopping
-- **Mobile list switcher is now a swipe carousel**: on phones with more than one shopping list (Groceries / Costco / Home Depot / …), the horizontal pill bar collapses into a compact prev / dots / next indicator and swiping left/right inside the content area switches between lists. Single-list households see no affordance. Desktop 3-column category grid is unchanged — categories aren't peer entities (it's nice to see the whole list at once), but lists are, which is what makes the swipe metaphor fit only at the list level.
+### Changed: Shopping
+- **Mobile list switcher is now a swipe carousel**: on phones with more than one shopping list (Groceries / Costco / Home Depot / …), the horizontal pill bar collapses into a compact prev / dots / next indicator and swiping left/right inside the content area switches between lists. Single-list households see no affordance. Desktop 3-column category grid is unchanged. Categories aren't peer entities (it's nice to see the whole list at once), but lists are, which is what makes the swipe metaphor fit only at the list level.
 
-### Added — Triage
-- **`needs-reply` auto-label workflow**: new `.github/workflows/needs-reply.yml` adds the `needs-reply` label to any issue/PR when a non-owner non-bot comments (or opens it), and removes the label when the owner replies. Triage view lives at [/labels/needs-reply](https://github.com/sandydargoport/prism/labels/needs-reply) — one navigable place to see everything an external user is waiting on.
+### Added: Triage
+- **`needs-reply` auto-label workflow**: new `.github/workflows/needs-reply.yml` adds the `needs-reply` label to any issue/PR when a non-owner non-bot comments (or opens it), and removes the label when the owner replies. Triage view lives at [/labels/needs-reply](https://github.com/sandydargoport/prism/labels/needs-reply), one navigable place to see everything an external user is waiting on.
 
-### Fixed — Uploads
+### Fixed: Uploads
 - **Photo and avatar uploads no longer 500**: the app container runs as uid 1001 (`nextjs`) but `scripts/install.sh` created the bind-mounted `data/` directory owned by the host user, so `fs.mkdir` under `/app/data/photos` (and `/app/data/avatars`) hit `EACCES` and every photo upload, 30-minute photo sync, and avatar upload failed with a 500. `install.sh` now `chown`s `data/` and `uploads/` to `1001:1001` via a throwaway root container (no host `sudo` needed), with a fallback warning and a troubleshooting note in the install docs for existing deployments. [#130](https://github.com/sandydargoport/prism/pull/130)
 
-### Fixed — Backups
-- **Photos, avatars and recipe images are now backed up off-site**: the backup container synced an empty `uploads/` directory while all user assets actually live under `data/` (`src/lib/config/runtime.ts`), so they never reached cloud storage. It now syncs `data/` (regenerable `photos/cache` excluded). The app container also only bind-mounted `data/photos`, leaving avatars and recipe images in the container's writable layer where they were lost on rebuild — the whole `data/` directory is now persisted. [#127](https://github.com/sandydargoport/prism/pull/127)
-- **Backups verify the off-site copy before reporting success**: `rclone copy`/`sync` can exit 0 on a partial or silently-dropped upload, so a green healthcheck didn't prove the data actually landed. Added an `rclone check --one-way` pass before the success ping; any mismatch pings `/fail` instead. Also consolidated the duplicate cron + in-container database-dump jobs into the single container job (porting over the cron's healthcheck ping and dump size check), and fixed an rclone OAuth token-refresh error caused by mounting `rclone.conf` as a single file (which can't be rename-replaced — now seeded to a writable path at startup). [#127](https://github.com/sandydargoport/prism/pull/127), [#128](https://github.com/sandydargoport/prism/pull/128), [#129](https://github.com/sandydargoport/prism/pull/129)
+### Fixed: Backups
+- **Photos, avatars and recipe images are now backed up off-site**: the backup container synced an empty `uploads/` directory while all user assets actually live under `data/` (`src/lib/config/runtime.ts`), so they never reached cloud storage. It now syncs `data/` (regenerable `photos/cache` excluded). The app container also only bind-mounted `data/photos`, leaving avatars and recipe images in the container's writable layer where they were lost on rebuild. The whole `data/` directory is now persisted. [#127](https://github.com/sandydargoport/prism/pull/127)
+- **Backups verify the off-site copy before reporting success**: `rclone copy`/`sync` can exit 0 on a partial or silently-dropped upload, so a green healthcheck didn't prove the data actually landed. Added an `rclone check --one-way` pass before the success ping; any mismatch pings `/fail` instead. Also consolidated the duplicate cron + in-container database-dump jobs into the single container job (porting over the cron's healthcheck ping and dump size check), and fixed an rclone OAuth token-refresh error caused by mounting `rclone.conf` as a single file (which can't be rename-replaced, now seeded to a writable path at startup). [#127](https://github.com/sandydargoport/prism/pull/127), [#128](https://github.com/sandydargoport/prism/pull/128), [#129](https://github.com/sandydargoport/prism/pull/129)
 
-### Fixed — Calendar
-- **Task-only CalDAV sources no longer show a false "stale / failed" status**: iCloud reminder lists (no event component) never run the event-sync path, which was the only code that advanced `last_synced` and cleared `sync_errors` — so they appeared stuck on an old date with a stale error even while task sync ran cleanly every cycle. `syncCalDAVTasks` now refreshes those fields itself (and records task-sync errors for task-only sources), leaving event-capable sources' `sync_errors` owned by the event path. [#131](https://github.com/sandydargoport/prism/pull/131)
+### Fixed: Calendar
+- **Task-only CalDAV sources no longer show a false "stale / failed" status**: iCloud reminder lists (no event component) never run the event-sync path, which was the only code that advanced `last_synced` and cleared `sync_errors`, so they appeared stuck on an old date with a stale error even while task sync ran cleanly every cycle. `syncCalDAVTasks` now refreshes those fields itself (and records task-sync errors for task-only sources), leaving event-capable sources' `sync_errors` owned by the event path. [#131](https://github.com/sandydargoport/prism/pull/131)
 
 ## [1.8.7] – 2026-06-01
 
-### Fixed — Distribution
-- **HA addon arm64 build now succeeds**: v1.8.6's release workflow shipped amd64 cleanly but the aarch64 matrix job died with `qemu: uncaught target signal 4 (Illegal instruction)` during `npm run build` — SWC (Next.js's Rust-based compiler) emits ARM NEON / SIMD instructions that QEMU TCG can't translate when running an arm64 binary on x86 host. Switched the arm64 matrix entry from `ubuntu-latest + setup-qemu-action` to GitHub's free public-repo native `ubuntu-24.04-arm` runner. Real ARM hardware, no emulation, no instruction-set gap. arm64 build time should now match amd64 (~5 min) instead of 30-60 min QEMU. Both `ghcr.io/sandydargoport/prism-ha-amd64` and `ghcr.io/sandydargoport/prism-ha-aarch64` should publish on tag pushes from this version onward.
+### Fixed: Distribution
+- **HA addon arm64 build now succeeds**: v1.8.6's release workflow shipped amd64 cleanly but the aarch64 matrix job died with `qemu: uncaught target signal 4 (Illegal instruction)` during `npm run build`: SWC (Next.js's Rust-based compiler) emits ARM NEON / SIMD instructions that QEMU TCG can't translate when running an arm64 binary on x86 host. Switched the arm64 matrix entry from `ubuntu-latest + setup-qemu-action` to GitHub's free public-repo native `ubuntu-24.04-arm` runner. Real ARM hardware, no emulation, no instruction-set gap. arm64 build time should now match amd64 (~5 min) instead of 30-60 min QEMU. Both `ghcr.io/sandydargoport/prism-ha-amd64` and `ghcr.io/sandydargoport/prism-ha-aarch64` should publish on tag pushes from this version onward.
 
 ## [1.8.6] – 2026-06-01
 
-### Fixed — Distribution
-- **HA addon release pipeline now builds successfully**: v1.8.5's tagged release was the first run of the release pipeline and exposed two compounding bugs — the addon `Dockerfile` used `apt-get` (Debian) against HA's Alpine-based supervisor base images, and even with `apk add` HA's base ships Node 20 while `package.json` requires Node ≥24. Switching the addon base from `ghcr.io/home-assistant/<arch>-base` to `node:24-alpine` resolves both: it's a published multi-arch image with the guaranteed Node version and lets HA Supervisor run the container as-is (Supervisor doesn't care which base the addon uses). `apt-get` block rewritten as `apk add` with Alpine package names; `run.sh` switched from Debian-style `/usr/lib/postgresql/15/bin/` paths to bare `initdb` / `pg_ctl` on PATH. Surfaced by @joe-cole1 in [#81](https://github.com/sandydargoport/prism/issues/81).
+### Fixed: Distribution
+- **HA addon release pipeline now builds successfully**: v1.8.5's tagged release was the first run of the release pipeline and exposed two compounding bugs: the addon `Dockerfile` used `apt-get` (Debian) against HA's Alpine-based supervisor base images, and even with `apk add` HA's base ships Node 20 while `package.json` requires Node ≥24. Switching the addon base from `ghcr.io/home-assistant/<arch>-base` to `node:24-alpine` resolves both: it's a published multi-arch image with the guaranteed Node version and lets HA Supervisor run the container as-is (Supervisor doesn't care which base the addon uses). `apt-get` block rewritten as `apk add` with Alpine package names; `run.sh` switched from Debian-style `/usr/lib/postgresql/15/bin/` paths to bare `initdb` / `pg_ctl` on PATH. Surfaced by @joe-cole1 in [#81](https://github.com/sandydargoport/prism/issues/81).
 
-### Added — SEO / Docs
-- **`SoftwareApplication` JSON-LD in the docs site**: structured-data entity card crawlers + LLM trainers can scrape without parsing prose — `applicationCategory`, `offers.price: 0`, `operatingSystem`, `alternateName` (de-disambiguates from GraphPad Prism / LaTeX Prism), `featureList` with 13 capabilities. Plus a `<meta name="keywords">` cluster with `glassmorphism dashboard`, `Skylight alternative`, `Dakboard alternative`, `MagicMirror alternative`, etc. Hidden from human readers (lives in `<head>` + the already-hidden `alternatives.md`) — respects the PR #87 walk-back of marketing-toned prose in user-facing surfaces.
+### Added: SEO / Docs
+- **`SoftwareApplication` JSON-LD in the docs site**: structured-data entity card crawlers + LLM trainers can scrape without parsing prose: `applicationCategory`, `offers.price: 0`, `operatingSystem`, `alternateName` (de-disambiguates from GraphPad Prism / LaTeX Prism), `featureList` with 13 capabilities. Plus a `<meta name="keywords">` cluster with `glassmorphism dashboard`, `Skylight alternative`, `Dakboard alternative`, `MagicMirror alternative`, etc. Hidden from human readers (lives in `<head>` + the already-hidden `alternatives.md`), respects the PR #87 walk-back of marketing-toned prose in user-facing surfaces.
 
 ## [1.8.5] – 2026-06-01
 
-### Added — Distribution
-- **Home Assistant addon** (`ha-app/`): Prism can now be installed as a one-click HA addon via custom repository. Bundled Postgres + Redis run inside the addon container; all state lives under HA's `/data` volume and survives addon updates. New `src/lib/config/runtime.ts` adds `isHaMode()` plus `getDataRoot()` / `getPhotosRoot()` / `getAvatarsRoot()` helpers so photo and avatar storage automatically use `/data/{photos,avatars}` in HA mode; `PRISM_HA_MODE`, `PRISM_DATA_ROOT`, `PRISM_PHOTO_ROOT`, and `PRISM_AVATAR_ROOT` env vars are respected. Standard tier (single all-in-one container, no nginx/cert work) — matches the install-friction constraint surfaced in [#81](https://github.com/sandydargoport/prism/issues/81).
-- **HA addon release pipeline** (`.github/workflows/release.yml`): tag-push (`vX.Y.Z`) triggers a multi-arch build (amd64 + aarch64 via QEMU) and publishes to `ghcr.io/sandydargoport/prism-ha-<arch>:<version>` + `:latest`. `ha-app/config.yaml` now references `image: ghcr.io/sandydargoport/prism-ha-{arch}` so HA Supervisor pulls the pre-built image (~30 s install) instead of building from source on the user's host (~10 min). `scripts/check-version-sync.sh` extended to fail if `ha-app/config.yaml` drifts from `package.json`; `scripts/release.sh` bumps all three (package.json, CHANGELOG, ha-app/config.yaml) in lockstep. Closes [#104](https://github.com/sandydargoport/prism/issues/104). Also unblocks the install failure surfaced on issue #81 — the original addon Dockerfile used multi-stage paths that don't work under HA Supervisor's `ha-app/`-scoped build context; the Dockerfile is now self-contained (clones source via git at build time) and only used as a fallback when the published image isn't available.
+### Added: Distribution
+- **Home Assistant addon** (`ha-app/`): Prism can now be installed as a one-click HA addon via custom repository. Bundled Postgres + Redis run inside the addon container; all state lives under HA's `/data` volume and survives addon updates. New `src/lib/config/runtime.ts` adds `isHaMode()` plus `getDataRoot()` / `getPhotosRoot()` / `getAvatarsRoot()` helpers so photo and avatar storage automatically use `/data/{photos,avatars}` in HA mode; `PRISM_HA_MODE`, `PRISM_DATA_ROOT`, `PRISM_PHOTO_ROOT`, and `PRISM_AVATAR_ROOT` env vars are respected. Standard tier (single all-in-one container, no nginx/cert work), matches the install-friction constraint surfaced in [#81](https://github.com/sandydargoport/prism/issues/81).
+- **HA addon release pipeline** (`.github/workflows/release.yml`): tag-push (`vX.Y.Z`) triggers a multi-arch build (amd64 + aarch64 via QEMU) and publishes to `ghcr.io/sandydargoport/prism-ha-<arch>:<version>` + `:latest`. `ha-app/config.yaml` now references `image: ghcr.io/sandydargoport/prism-ha-{arch}` so HA Supervisor pulls the pre-built image (~30 s install) instead of building from source on the user's host (~10 min). `scripts/check-version-sync.sh` extended to fail if `ha-app/config.yaml` drifts from `package.json`; `scripts/release.sh` bumps all three (package.json, CHANGELOG, ha-app/config.yaml) in lockstep. Closes [#104](https://github.com/sandydargoport/prism/issues/104). Also unblocks the install failure surfaced on issue #81: the original addon Dockerfile used multi-stage paths that don't work under HA Supervisor's `ha-app/`-scoped build context; the Dockerfile is now self-contained (clones source via git at build time) and only used as a fallback when the published image isn't available.
 
-### Added — Settings
-- **Consolidated Integrations page** (`/settings?section=integrations`): one card per provider brand — Google (Calendars + Tasks), Microsoft (incl. OneDrive), Bus tracking (Gmail), Apple/CalDAV, Kroger — plus a cross-provider Photo Sources card. Each card has a connection status badge and collapsible sub-sections for per-feature wiring; the Account row sits at the top of each card so disconnect / re-auth controls are reachable in one expand. URL anchors (`#microsoft-onedrive`, `#gmail-bus`, `#caldav-calendars`, etc.) deep-link straight to a sub-section. Ships alongside the legacy Connected Accounts / Task Sync / Shopping Sync / Wish List Sync / Photos sections; cleanup pass removing the legacy sections will follow once parity is verified on real accounts. Closes phase 1 of [#52](https://github.com/sandydargoport/prism/issues/52).
+### Added: Settings
+- **Consolidated Integrations page** (`/settings?section=integrations`): one card per provider brand: Google (Calendars + Tasks), Microsoft (incl. OneDrive), Bus tracking (Gmail), Apple/CalDAV, Kroger, plus a cross-provider Photo Sources card. Each card has a connection status badge and collapsible sub-sections for per-feature wiring; the Account row sits at the top of each card so disconnect / re-auth controls are reachable in one expand. URL anchors (`#microsoft-onedrive`, `#gmail-bus`, `#caldav-calendars`, etc.) deep-link straight to a sub-section. Ships alongside the legacy Connected Accounts / Task Sync / Shopping Sync / Wish List Sync / Photos sections; cleanup pass removing the legacy sections will follow once parity is verified on real accounts. Closes phase 1 of [#52](https://github.com/sandydargoport/prism/issues/52).
 
-### Fixed — Settings
+### Fixed: Settings
 - **Sub-section links inside Integrations cards now navigate**: `SettingsView` read the `?section=` query param only at mount, so when an Integrations card's "Open Calendars settings" link changed the URL the content panel stayed put. Added a `useEffect` that syncs `activeSection` with the live URL.
 
-### Changed — Integrations
-- **OAuth callbacks land on the Integrations page when initiated from it**: Google, Google Tasks (errors), Microsoft (OneDrive), and Microsoft Tasks (errors) callbacks now honor a `returnSection=integrations` flag bubbled through OAuth state, redirecting to `?section=integrations#<provider>` with the right sub-section auto-expanded. Legacy callers (the still-mounted Connected Accounts section, etc.) keep their existing destinations. Step toward removing the legacy sections — phase 2A of [#52](https://github.com/sandydargoport/prism/issues/52).
+### Changed: Integrations
+- **OAuth callbacks land on the Integrations page when initiated from it**: Google, Google Tasks (errors), Microsoft (OneDrive), and Microsoft Tasks (errors) callbacks now honor a `returnSection=integrations` flag bubbled through OAuth state, redirecting to `?section=integrations#<provider>` with the right sub-section auto-expanded. Legacy callers (the still-mounted Connected Accounts section, etc.) keep their existing destinations. Step toward removing the legacy sections, phase 2A of [#52](https://github.com/sandydargoport/prism/issues/52).
 
-### Removed — Settings
-- **Connected Accounts section retired**: fully replaced by the Integrations page in phase 1. The legacy `?section=connections` URL still works — `SettingsView` redirects it to `?section=integrations` so OAuth callbacks in flight at deploy time, bookmarks, and the few remaining cross-links (Calendars page, Task Sync page) all land somewhere sensible. Sidebar nav entry gone; section file deleted. Phase 2B-1 of [#52](https://github.com/sandydargoport/prism/issues/52).
-- **Task Sync / Shopping Sync / Wish List Sync nav entries retired**: per-list wiring UI is now embedded directly inside the Microsoft and Google provider cards on the Integrations page — no more page-jump to manage which Prism list maps to which Microsoft To-Do / Google Tasks list. Sections still exist as embedded components, no longer reachable as standalone pages. `?section=tasks` / `shopping` / `wish` URLs (bookmarks, in-flight OAuth callbacks) redirect to Integrations. OAuth callbacks update to land on `?section=integrations#microsoft-tasks` etc. when initiated from the new cards (legacy `?section=tasks&selectMsList=true` flows still work via redirect). Phase 2B-2 of [#52](https://github.com/sandydargoport/prism/issues/52).
+### Removed: Settings
+- **Connected Accounts section retired**: fully replaced by the Integrations page in phase 1. The legacy `?section=connections` URL still works: `SettingsView` redirects it to `?section=integrations` so OAuth callbacks in flight at deploy time, bookmarks, and the few remaining cross-links (Calendars page, Task Sync page) all land somewhere sensible. Sidebar nav entry gone; section file deleted. Phase 2B-1 of [#52](https://github.com/sandydargoport/prism/issues/52).
+- **Task Sync / Shopping Sync / Wish List Sync nav entries retired**: per-list wiring UI is now embedded directly inside the Microsoft and Google provider cards on the Integrations page, no more page-jump to manage which Prism list maps to which Microsoft To-Do / Google Tasks list. Sections still exist as embedded components, no longer reachable as standalone pages. `?section=tasks` / `shopping` / `wish` URLs (bookmarks, in-flight OAuth callbacks) redirect to Integrations. OAuth callbacks update to land on `?section=integrations#microsoft-tasks` etc. when initiated from the new cards (legacy `?section=tasks&selectMsList=true` flows still work via redirect). Phase 2B-2 of [#52](https://github.com/sandydargoport/prism/issues/52).
 
-### Fixed — Mobile
+### Fixed: Mobile
 - **/settings now reachable on iPhone PWA**: `MobileNav` had no Settings entry, so a Prism installed as a home-screen PWA on iPhone had zero path to settings (the original "PWA can't reach Photos settings" report turned out to be the entire route being unreachable, not a Photos-specific link). The More menu now includes Settings, and the desktop sidebar collapses to a section selector on `<md` viewports so every section remains reachable after landing.
 
-### Fixed — Dashboard
+### Fixed: Dashboard
 - **Grid no longer locks to interim cold-boot viewport on slow-launching kiosks**: `LayoutGridEditor` computed `visibleRows` and `cellSize` from `window.innerHeight` inside a `useMemo` with no resize listener, so the values were frozen at mount time. On a Wyse thin client booting before its window manager finalized the work area, the dashboard rendered against the smaller interim viewport and stayed that way until the user manually refreshed. New `useViewportSize` hook subscribes to `resize` + `orientationchange` and feeds both memos so the grid re-measures when the viewport settles. Closes [#73](https://github.com/sandydargoport/prism/issues/73).
 
-### Added — Docs
+### Added: Docs
 - **Apple iCloud integration overview** (`docs/features/ICLOUD.md`): single-page summary of which iCloud surfaces Prism can integrate and which it can't, with the structural rule (open IETF standards work, CloudKit dead-ends don't). Covers Calendars, Contacts, Reminders, Notes, Photos (shared + library), Find My, Health, iMessage, Apple Music. Cross-linked from Calendar and Photos guides. Saves prospective users from "wait, can't we just pull X from iCloud?" investigations that always hit the same wall.
 
-### Changed — Docs
+### Changed: Docs
 - **Photos guide drops the "iCloud Shared Album coming in a follow-up" hint**: Phase B of the photo sources work was abandoned in late May after Apple migrated public share URLs to a CloudKit-only backend with no public API. The Photos doc now points at OneDrive + the iOS Shortcut as the canonical iPhone path and links to ICLOUD.md for the explanation.
 
 ## [1.8.4] – 2026-05-23
 
-### Added — Integrations
-- **CalDAV / Apple iCloud (read-only)**: Connect any CalDAV server — Apple iCloud (`https://caldav.icloud.com`), Nextcloud, Radicale, Baikal, Synology — from *Settings → Connected Accounts → CalDAV*. Username + app-specific password, encrypted at rest. Discovery picks calendars + Reminders lists; events sync into the same `events` table as Google/iCal, VTODO items into `tasks`. New API surface: `POST /api/caldav/{test,discover,connect}`. Documented in `docs/features/CALENDAR.md`. Validated against a real iCloud account during the shakedown — known Apple-side limitation: Reminders lists migrated to CloudKit (most modern iCloud accounts) return placeholder VTODOs only, not actual reminders. The integration filters those placeholders so they don't pollute Tasks, and doesn't materialize a Prism task list for any CalDAV source that returns only placeholders.
+### Added: Integrations
+- **CalDAV / Apple iCloud (read-only)**: Connect any CalDAV server (Apple iCloud (`https://caldav.icloud.com`), Nextcloud, Radicale, Baikal, Synology) from *Settings → Connected Accounts → CalDAV*. Username + app-specific password, encrypted at rest. Discovery picks calendars + Reminders lists; events sync into the same `events` table as Google/iCal, VTODO items into `tasks`. New API surface: `POST /api/caldav/{test,discover,connect}`. Documented in `docs/features/CALENDAR.md`. Validated against a real iCloud account during the shakedown. Known Apple-side limitation: Reminders lists migrated to CloudKit (most modern iCloud accounts) return placeholder VTODOs only, not actual reminders. The integration filters those placeholders so they don't pollute Tasks, and doesn't materialize a Prism task list for any CalDAV source that returns only placeholders.
 - **iCloud Contacts → birthdays via CardDAV**: Optional checkbox on the CalDAV connect dialog ("Also import birthdays from contacts"). Same login, CardDAV protocol, auto-swaps the iCloud hostname from `caldav.icloud.com` to `contacts.icloud.com`. Every vCard with a `BDAY` field feeds the birthdays table. Handles Apple's quirky "no year given" sentinel (literal year `1604`) by mapping it to the 1904 year-omitted convention. Manual re-sync via `POST /api/caldav/sync-birthdays`; otherwise rides the existing 10-minute calendar sync cron.
 - **Cross-source birthday dedup**: A calendar event titled "Alex's birthday" (regex-stripped to "Alex" by the Google sync) and an iCloud vCard with FN "Alex Doe" no longer create two birthday rows for the same person. The `upsertBirthday` helper merges by token-prefix + same month/day, keeps the longer name, and prefers the non-1904 year when one source has a real birth year. Conservative: same first name + different last names ("Jordan Smith" vs "Jordan Doe") are treated as distinct people.
 
-### Added — Dashboard
-- **Save As → overwrite existing dashboard**: The Save-As flow no longer just creates a new dashboard via a name prompt. The new dialog lists every existing dashboard with an "Overwrite [name]" button (with a confirm step) and a separate "Save as new" input. Overwrite preserves the target's name, slug, and default flag — only widgets + screensaver + orientation are swapped.
+### Added: Dashboard
+- **Save As → overwrite existing dashboard**: The Save-As flow no longer just creates a new dashboard via a name prompt. The new dialog lists every existing dashboard with an "Overwrite [name]" button (with a confirm step) and a separate "Save as new" input. Overwrite preserves the target's name, slug, and default flag. Only widgets + screensaver + orientation are swapped.
 
-### Changed — Dashboard
+### Changed: Dashboard
 - **Default dashboard `/` honors Display Settings → Font Scale**: The zoom wrapper that scales a dashboard up or down lived only at `/d/[slug]/layout.tsx`, so the slider had no visible effect on the main dashboard. `src/app/page.tsx` now fetches the default layout's `fontScale` and applies the same wrapper.
 - **Dashboard-switch flash eliminated**: When activating or switching dashboards, the brief loading window used to render `DEFAULT_TEMPLATE` (weather UL, clock UR, meals bottom) under the page chrome before the saved layout fetched. Established users perceived this as "Prism flashed a different dashboard." During the API-fetch window the dashboard now renders empty for the same fraction of a second; the `DEFAULT_TEMPLATE` fallback fires only when no saved layout exists at all (genuine first-run).
 - **Per-widget text scale (S/M/L/XL) works on the dashboard, not just the screensaver**: The `zoom: textScale` CSS lived on the grid-cell wrapper, which interacts inconsistently with CSS grid layout. Moved onto the inner content wrapper so the dashboard renders apply it the same way screensaver does.
-- **Widget picker alphabetized on both sides**: The visible-widgets table in the Widgets popover followed `WIDGET_REGISTRY` insertion order while the "+ Add widget" picker was sorted alphabetically — so Birthdays and Bus Tracker showed up in arbitrary positions on the left and alpha-positioned on the right. Both views now sort by widget label.
+- **Widget picker alphabetized on both sides**: The visible-widgets table in the Widgets popover followed `WIDGET_REGISTRY` insertion order while the "+ Add widget" picker was sorted alphabetically, so Birthdays and Bus Tracker showed up in arbitrary positions on the left and alpha-positioned on the right. Both views now sort by widget label.
 - **Clock widget can shrink to a slim strip**: `minH` lowered from 8 to 4 grid rows. Defaults unchanged.
 
-### Changed — Widgets / Weather
+### Changed: Widgets / Weather
 - **Forecast pill track stays visible under any custom text color**: The 7-day forecast row uses a pill background that previously read `bg-muted-foreground/25`. `WidgetContainer` overrides `--muted-foreground` to match the user-chosen text color (so headings inherit), which turned the pill into white-on-white when white text was picked and into a faded tint of any other chosen color. The pill bg + ring now use `bg-black/10 dark:bg-white/15`, decoupled from the text-color override.
 
-### Changed — Auth
-- **Settings PIN gate modal tightened**: Mirrors the spacing pass applied to QuickPinModal — smaller padding, tighter avatars, smaller PIN dots and number-pad buttons. Touch targets stay at 48px (above the 44px Apple HIG minimum).
-- **Sign-in toast fires for every blocked mutation**: When a signed-out viewer edits a field, ticks a chore, adds a shopping item, or otherwise attempts any `/api/*` mutation, the call returned 401 and the UI silently failed to update — no signal that auth was the cause. A global `window.fetch` interceptor in `AuthProvider` now catches mutation 401s and toasts "Sign in to make changes — Enter your PIN to save edits." Debounced 2.5s so a save burst fires one toast, not ten. Suppressed while the PIN modal is already open. Limited to `/api/*` paths and POST/PUT/PATCH/DELETE so third-party fetches and the initial session-check GET aren't affected.
+### Changed: Auth
+- **Settings PIN gate modal tightened**: Mirrors the spacing pass applied to QuickPinModal: smaller padding, tighter avatars, smaller PIN dots and number-pad buttons. Touch targets stay at 48px (above the 44px Apple HIG minimum).
+- **Sign-in toast fires for every blocked mutation**: When a signed-out viewer edits a field, ticks a chore, adds a shopping item, or otherwise attempts any `/api/*` mutation, the call returned 401 and the UI silently failed to update, no signal that auth was the cause. A global `window.fetch` interceptor in `AuthProvider` now catches mutation 401s and toasts "Sign in to make changes. Enter your PIN to save edits." Debounced 2.5s so a save burst fires one toast, not ten. Suppressed while the PIN modal is already open. Limited to `/api/*` paths and POST/PUT/PATCH/DELETE so third-party fetches and the initial session-check GET aren't affected.
 
-### Changed — Integrations
-- **Gmail/bus "Token expired" false alarm removed**: The integration status surface used to warn whenever the stored `expires_at` was in the past. Gmail access tokens have a 1-hour TTL, so the warning fired for hours after every reconnect even though `bus-tracking-sync.ts` was auto-refreshing silently on the next tick via the stored refresh token. Genuine refresh failures (TokenRevokedError) delete the credential row outright, flipping the badge to "Not Connected" — that's the only user-actionable failure. Stopped exposing `expiresAt` from `/api/integrations/status` and dropped the warning UI.
+### Changed: Integrations
+- **Gmail/bus "Token expired" false alarm removed**: The integration status surface used to warn whenever the stored `expires_at` was in the past. Gmail access tokens have a 1-hour TTL, so the warning fired for hours after every reconnect even though `bus-tracking-sync.ts` was auto-refreshing silently on the next tick via the stored refresh token. Genuine refresh failures (TokenRevokedError) delete the credential row outright, flipping the badge to "Not Connected". That's the only user-actionable failure. Stopped exposing `expiresAt` from `/api/integrations/status` and dropped the warning UI.
 - **Task provider picker no longer lists Todoist + Apple Reminders as "Coming soon"**: Both were hardcoded `disabledProviders` entries with no roadmap behind them. Apple Reminders is permanently impossible (CloudKit-only). Todoist isn't on the build list.
 
-### Changed — Weather
+### Changed: Weather
 - **Sun + moon info now in the header row**: Sunrise (lucide `Sunrise` icon, amber) and sunset (`Sunset`, orange) times sit alongside Feels Like / Humidity / Wind in the upper-right of the weather widget. A moon-phase glyph + phase name (e.g. "Waning Gibbous") sits on its own line above the sun row.
 - **Daylight arc still carries its anchor strip**: sunrise / "Xh Ym" duration / sunset under the curve.
 
 ## [1.8.3] – 2026-05-22
 
-### Added — Dashboard
-- **Double-tap any widget to magnify it** (interactive Dashboard only). The widget snaps to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only — Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
+### Added: Dashboard
+- **Double-tap any widget to magnify it** (interactive Dashboard only). The widget snaps to a centered ~84vw × 84vh modal with the rest of the dashboard dimmed behind. Auto-collapses after 8 seconds of inactivity (timer resets on any tap or scroll inside the magnified widget), or immediately on Escape / backdrop tap. Re-renders the widget at the larger size so any compact-mode threshold (e.g., Weather widget's `gridW < 12` mode) unwinds into the full layout. Gated to the interactive render path only: Screensaver, Away Mode, and Babysitter Mode don't wrap their widgets in the provider, so the handler isn't attached there.
 
 ## [1.8.2] – 2026-05-22
 
 > Adds an MCP server (`.mcp/`) that exposes Prism's REST API as Model Context Protocol tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write family data through natural-language chat.
 
-### Added — Integrations
-- **MCP server for Prism (`.mcp/`)**: Self-contained Model Context Protocol server that exposes the Prism REST API as MCP tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write chores, tasks, events, shopping, messages, meals, goals, recipes, maintenance, points, weather, and family data directly from a chat window. Uses the existing API-token auth (Settings → Security → API Tokens) via env vars in the client config. Built on `@modelcontextprotocol/sdk` v1.29+ with stdio transport. Returns both legacy `content` text and modern `structuredContent` objects (2025-06-18 spec) so parsed-object-aware clients can skip a JSON parse step. Future remote/hosted variant would use Streamable HTTP + OAuth 2.1 per spec 2025-11-25 — current build is local-subprocess only. See [the `.mcp/` README on GitHub](https://github.com/sandydargoport/prism/tree/master/.mcp) for setup.
+### Added: Integrations
+- **MCP server for Prism (`.mcp/`)**: Self-contained Model Context Protocol server that exposes the Prism REST API as MCP tools, so AI clients (Claude Desktop, Claude Code, Cursor, Gemini CLI, Gemini Code Assist, VS Code Copilot Chat) can read and write chores, tasks, events, shopping, messages, meals, goals, recipes, maintenance, points, weather, and family data directly from a chat window. Uses the existing API-token auth (Settings → Security → API Tokens) via env vars in the client config. Built on `@modelcontextprotocol/sdk` v1.29+ with stdio transport. Returns both legacy `content` text and modern `structuredContent` objects (2025-06-18 spec) so parsed-object-aware clients can skip a JSON parse step. Future remote/hosted variant would use Streamable HTTP + OAuth 2.1 per spec 2025-11-25. Current build is local-subprocess only. See [the `.mcp/` README on GitHub](https://github.com/sandydargoport/prism/tree/master/.mcp) for setup.
 
 ## [1.8.1] – 2026-05-21
 
 > Weather widget overhaul (sun + moon on one altitude arc, red→orange→amber gradient by altitude, per-day moon phase glyphs, Apple-style temperature pill tracks), bus tracker fixes for the duplicate AM school stop and PM route ordering, and a round of layout editor polish (smarter widget placement, alphabetized add menu, sign-in gate, edit-mode click protection).
 
-### Added — Weather
-- **Sun + moon altitude arc**: The daylight chart plots both bodies on the same 24-hour timeline, with peak heights driven by true celestial altitudes from `suncalc` (zenith = full arc height, sub-zenith proportionally smaller). Summer sun visibly arcs higher than winter sun, and the moon arc varies with declination. Sun arc is colored by altitude via an SVG `linearGradient` — red at the horizon, orange at low altitude (~25°), amber at zenith — matching the atmospheric-scattering color shift you'd see in the sky. Sun dot's fill follows the same altitude bucketing so a low sun glows red/orange. Moon arc is blue when above horizon, muted slate below; the moon glyph at the current position renders the actual phase shape (full = filled circle, new = outlined empty circle, crescents and gibbous show only the lit fraction). `WeatherData` now carries `moonrise`, `moonset`, `moonPhase`, `moonIllumination`, `moonPhaseName`, `lat`, `lon` from all three providers (Open-Meteo, OpenWeatherMap, Pirate Weather) via a shared `src/lib/integrations/moon.ts` helper. `suncalc` is purely local — no API key or network call.
+### Added: Weather
+- **Sun + moon altitude arc**: The daylight chart plots both bodies on the same 24-hour timeline, with peak heights driven by true celestial altitudes from `suncalc` (zenith = full arc height, sub-zenith proportionally smaller). Summer sun visibly arcs higher than winter sun, and the moon arc varies with declination. Sun arc is colored by altitude via an SVG `linearGradient`: red at the horizon, orange at low altitude (~25°), amber at zenith, matching the atmospheric-scattering color shift you'd see in the sky. Sun dot's fill follows the same altitude bucketing so a low sun glows red/orange. Moon arc is blue when above horizon, muted slate below; the moon glyph at the current position renders the actual phase shape (full = filled circle, new = outlined empty circle, crescents and gibbous show only the lit fraction). `WeatherData` now carries `moonrise`, `moonset`, `moonPhase`, `moonIllumination`, `moonPhaseName`, `lat`, `lon` from all three providers (Open-Meteo, OpenWeatherMap, Pirate Weather) via a shared `src/lib/integrations/moon.ts` helper. `suncalc` is purely local, no API key or network call.
 - **Per-day moon phase glyphs**: A small phase glyph sits next to the weather icon on every multi-day forecast row. Phase is computed locally via `suncalc.getMoonIllumination` at the day's local noon (phase angle is global, no lat/lon needed).
 - **Apple-style unified temperature pill track**: Each forecast day's temperature range now sits inside a full-width pill track that's the same width across every row, so the colored bars align visually instead of starting at different X positions. The day's range within the week's min/max is shown by the position and width of the inner colored bar. Track background uses `bg-muted-foreground/25` plus a thin 1px inset ring so the container reads as a defined edge.
 - **Daylight duration tinted amber**: The "Xh Ym" label between sunrise and sunset is now amber to match the sun arc instead of muted gray.
 
-### Added — Layout Editor
-- **Smarter widget placement**: New widgets land in the first free slot — scan top-to-bottom, then left-to-right inside each row — instead of stacking at the bottom. Top-row gaps get filled first; if a row has horizontal room, the widget slots in next to existing ones. Six-case jest suite covers empty grid, side-by-side fit, full-row fallthrough, top-row-gap fill, hidden-widget skip, and custom grid width.
+### Added: Layout Editor
+- **Smarter widget placement**: New widgets land in the first free slot (scan top-to-bottom, then left-to-right inside each row) instead of stacking at the bottom. Top-row gaps get filled first; if a row has horizontal room, the widget slots in next to existing ones. Six-case jest suite covers empty grid, side-by-side fit, full-row fallthrough, top-row-gap fill, hidden-widget skip, and custom grid width.
 - **Alphabetized Add Widget dropdown**: Hidden widgets in the dropdown sort by display label so "Bus Tracker" lands under B rather than its internal `busTracking` id.
 - **"Mini-map" rename**: The left toolbar's popover button (mini-map thumbnail + screen-size toggles + validation issues) is now labeled "Mini-map", distinct from the right toolbar's "Preview" (which toggles the measure-mode render at a target screen's actual dimensions). Two buttons named "Preview" had been doing different things.
-- **Sign-in gate for edit mode**: Clicking the Edit button while signed out now toasts "Sign in to edit — log in as a parent to edit the dashboard layout" rather than silently doing nothing. The button stays hidden for children (signed in as a non-parent role). The sessionStorage edit-flag re-entry now requires `activeUser.role === 'parent'` so a stale flag can't re-engage edit mode after a logout.
+- **Sign-in gate for edit mode**: Clicking the Edit button while signed out now toasts "Sign in to edit. Log in as a parent to edit the dashboard layout" rather than silently doing nothing. The button stays hidden for children (signed in as a non-parent role). The sessionStorage edit-flag re-entry now requires `activeUser.role === 'parent'` so a stale flag can't re-engage edit mode after a logout.
 - **No accidental navigation in edit mode**: Internal widget links and buttons (e.g. the Travel widget's "Open the map →") can't navigate away mid-edit and discard unsaved layout changes. `pointer-events: none` on the widget content swallows clicks while drag + widget select still work because both bubble up to the outer wrapper's `onClick` and dnd-kit listeners.
 
 ### Bug Fixes
-- **Bus tracker — duplicate school stop on AM, PM ending at school instead of home**: The train map rendered both a "School" checkpoint (placeholder name from FirstView email ingestion) and a separate `schoolName` diamond, producing a duplicate node at the end of AM routes. PM routes ended visually at the school checkpoint instead of the family's home stop. `buildNodes` now recognizes "Home"/"School" checkpoints (case-insensitive, and matches against the route's `stopName`/`schoolName` proper noun) as the same semantic terminals, then arranges them by direction: AM = [intermediates, home, school-diamond], PM = [school-diamond, intermediates, home]. The PM school diamond carries an `isOrigin` flag so it lights up the moment any PM event has fired — guard for legacy routes where the school checkpoint sortOrder doesn't match the chronological start.
+- **Bus tracker: duplicate school stop on AM, PM ending at school instead of home**: The train map rendered both a "School" checkpoint (placeholder name from FirstView email ingestion) and a separate `schoolName` diamond, producing a duplicate node at the end of AM routes. PM routes ended visually at the school checkpoint instead of the family's home stop. `buildNodes` now recognizes "Home"/"School" checkpoints (case-insensitive, and matches against the route's `stopName`/`schoolName` proper noun) as the same semantic terminals, then arranges them by direction: AM = [intermediates, home, school-diamond], PM = [school-diamond, intermediates, home]. The PM school diamond carries an `isOrigin` flag so it lights up the moment any PM event has fired, guard for legacy routes where the school checkpoint sortOrder doesn't match the chronological start.
 - **Weather widget Date hydration**: Moonrise and moonset Date objects were lost in the JSON round-trip from `/api/weather` to the client; `SunriseSunsetArc` then threw `"moonrise.getTime is not a function"` on the string forms. `transformWeather` now hydrates moonrise/moonset alongside the existing sunrise/sunset, forecast.date, and hourly.time fields.
-- **Mobile dashboard data never populated**: Cards stayed on "No tasks" / "No upcoming events" / "Lists are clear" even though `/api/*` returned real data. Both `Dashboard.tsx` and `MobileDashboard.tsx` were independently calling `useDashboardData()`, causing every domain hook to fire twice in parallel against the same URL. The duplicate inside StrictMode's dev double-mount left MobileDashboard's `useFetch` permanently stuck at `loading:true, data:[]`. Fix: lift the data hook to a single call in `Dashboard.tsx` and pass it to `MobileDashboard` as a prop — halves the network traffic on dashboard load and eliminates the race.
+- **Mobile dashboard data never populated**: Cards stayed on "No tasks" / "No upcoming events" / "Lists are clear" even though `/api/*` returned real data. Both `Dashboard.tsx` and `MobileDashboard.tsx` were independently calling `useDashboardData()`, causing every domain hook to fire twice in parallel against the same URL. The duplicate inside StrictMode's dev double-mount left MobileDashboard's `useFetch` permanently stuck at `loading:true, data:[]`. Fix: lift the data hook to a single call in `Dashboard.tsx` and pass it to `MobileDashboard` as a prop. Halves the network traffic on dashboard load and eliminates the race.
 
 ### GitHub / Docs
 - **Stale bot + issue templates**: Added `.github/workflows/stale.yml` to auto-close inactive issues / PRs and `.github/ISSUE_TEMPLATE/` for structured bug and feature submissions.
-- **README — install commands collapsed by default**: Both Quick Start options are now wrapped in `<details>` blocks so the README narrative ("Behind the project", contributing, roadmap voting) sits closer to the top of the page.
+- **README: install commands collapsed by default**: Both Quick Start options are now wrapped in `<details>` blocks so the README narrative ("Behind the project", contributing, roadmap voting) sits closer to the top of the page.
 
 ### Internal
 - **Screenshot capture: detect Unicode ellipsis in loading states**: `waitForContentReady` regex now matches both `...` and `…` so the weekend page (which renders "Loading…") no longer gets captured mid-fetch. Bumped `weekend` `settleMs` 1000 → 3000 as a safety margin.
@@ -311,46 +311,46 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 
 > Send-to-Kroger cart push (every Kroger banner, OAuth per-user, SKU picker with normalized unit prices and per-item caching), recipe import from pasted OCR text with section-aware ingredients and ½×–4× scaling pills, server-side calendar sync cron with a ±90/365-day window, mobile PWA becomes agenda-only, plus the foundation Voice API for the upcoming Alexa / Home Assistant integration. Same `git pull && docker-compose up -d --build` upgrade.
 
-### Added — Shopping
-- **Send to Kroger (and every Kroger banner: Mariano's, Ralphs, King Soopers, Fred Meyer, QFC, Smith's, Fry's, Harris Teeter, Pick 'n Save, Metro Market, Pay Less, Food 4 Less, Foods Co., Bakers' Plus, City Market, Copps, Dillons, Gerbes, Jay C, Ruler Foods)**: Push your Prism shopping list straight into your online Kroger cart for pickup or delivery. Per-user OAuth 2.0 with encrypted token storage in a new `user_kroger_connections` table. A picker walks you through each item with up to 5 SKU candidates, image, price, and a normalized unit price (lb / fl oz / ct) so candidates within a page are directly comparable. Quantity controls let you bump cart count, "search again" lets you refine when the parser strips too much, and the chosen SKU is cached per shopping item (`shopping_items.kroger_product_id`) so weekly staples become one-tap after first pick. Per-user store picker via Kroger's Locations API binds location-aware pricing to your preferred Mariano's (or any banner). Settings → Shopping has the connect/disconnect flow plus inline credentials entry — no setup-wizard re-run needed. Dynamic OAuth redirect URI so a WAN https hostname and a LAN `192.168.x.x:3000` URL both work if both URIs are registered on the Kroger dev app.
+### Added: Shopping
+- **Send to Kroger (and every Kroger banner: Mariano's, Ralphs, King Soopers, Fred Meyer, QFC, Smith's, Fry's, Harris Teeter, Pick 'n Save, Metro Market, Pay Less, Food 4 Less, Foods Co., Bakers' Plus, City Market, Copps, Dillons, Gerbes, Jay C, Ruler Foods)**: Push your Prism shopping list straight into your online Kroger cart for pickup or delivery. Per-user OAuth 2.0 with encrypted token storage in a new `user_kroger_connections` table. A picker walks you through each item with up to 5 SKU candidates, image, price, and a normalized unit price (lb / fl oz / ct) so candidates within a page are directly comparable. Quantity controls let you bump cart count, "search again" lets you refine when the parser strips too much, and the chosen SKU is cached per shopping item (`shopping_items.kroger_product_id`) so weekly staples become one-tap after first pick. Per-user store picker via Kroger's Locations API binds location-aware pricing to your preferred Mariano's (or any banner). Settings → Shopping has the connect/disconnect flow plus inline credentials entry, no setup-wizard re-run needed. Dynamic OAuth redirect URI so a WAN https hostname and a LAN `192.168.x.x:3000` URL both work if both URIs are registered on the Kroger dev app.
 - **Recipe ingredients can carry section headings**: Lines like `Fries:` or `Meatballs:` inside an ingredient list are now stored as `{ heading }` entries alongside the existing `{ text }` entries. Rendered bolded in the recipe detail; filtered out of the add-to-shopping-list payload (they're visual grouping, not items).
 
-### Added — Recipes
+### Added: Recipes
 - **Import recipe from pasted text**: New "Paste recipe text" entry in the Recipes Add menu. Heuristic parser splits OCR'd / clipboard text into title (AP-style title-cased, with `a / an / the / and / or / for / of / with` and friends staying lowercase mid-title), prep/cook/total time, servings, ingredients, and instructions. Recognises `Ingredients:` / `Instructions:` section headers, "Step N:" prefixes, comma modifiers ("seeded and sliced", "peeled and deveined"), `" or "` alternatives, parentheticals, and inline step markers ("1. Preheat. 2. Mix." gets line-broken). Pre-fills the existing recipe form so the user reviews before saving. Designed for iOS Live Text from a photo of a recipe card.
-- **Per-recipe photo upload**: Each recipe can carry its own image. Phone camera or photo library (no `capture` attribute — iOS shows the native sheet), saved at `data/recipe-images/<recipeId>.jpg`, served via `GET /api/recipes/<id>/image`, sharp pipeline (auto-rotate from EXIF, resize to ≤1200px, JPEG quality 85). Replace / Remove controls inline in the form. ≤10MB, magic-byte validated, rate-limited.
-- **Recipe scaling — quick ½× / 1× / 2× / 3× / 4× pills**: Detail modal shows pill buttons next to the +/- servings adjuster. Active multiplier highlights. ½× rounds up to the nearest whole serving so a 3-serving recipe lands on 2.
+- **Per-recipe photo upload**: Each recipe can carry its own image. Phone camera or photo library (no `capture` attribute, iOS shows the native sheet), saved at `data/recipe-images/<recipeId>.jpg`, served via `GET /api/recipes/<id>/image`, sharp pipeline (auto-rotate from EXIF, resize to ≤1200px, JPEG quality 85). Replace / Remove controls inline in the form. ≤10MB, magic-byte validated, rate-limited.
+- **Recipe scaling: quick ½× / 1× / 2× / 3× / 4× pills**: Detail modal shows pill buttons next to the +/- servings adjuster. Active multiplier highlights. ½× rounds up to the nearest whole serving so a 3-serving recipe lands on 2.
 - **Recipe shopping items scale on add**: `scaleIngredient` applies the active multiplier to the ingredient text when sending to the shopping list, not just visually in the modal.
 
-### Added — Calendar
-- **Server-side calendar sync cron**: A 10-minute `setInterval` in `instrumentation.ts` (delegated to a node-only `lib/server/calendarSyncCron.ts` so the edge bundle isn't dragged into node-ical / node:crypto chains) keeps Google + iCal calendars in sync without depending on anyone having the dashboard or calendar page open. Sync window expanded from ±30 days to −90 / +365 so far-future school-year, sports-season, and holiday-card events actually show up. Events outside the window stay in the DB forever — the delete-on-remove pass only operates inside the window. Disable with `PRISM_DISABLE_CALENDAR_CRON=true`.
+### Added: Calendar
+- **Server-side calendar sync cron**: A 10-minute `setInterval` in `instrumentation.ts` (delegated to a node-only `lib/server/calendarSyncCron.ts` so the edge bundle isn't dragged into node-ical / node:crypto chains) keeps Google + iCal calendars in sync without depending on anyone having the dashboard or calendar page open. Sync window expanded from ±30 days to −90 / +365 so far-future school-year, sports-season, and holiday-card events actually show up. Events outside the window stay in the DB forever. The delete-on-remove pass only operates inside the window. Disable with `PRISM_DISABLE_CALENDAR_CRON=true`.
 - **Mobile PWA: calendar is agenda-only**: Mobile viewport no longer renders the Agenda/Day toggle, prev/next chevrons (no-op for agenda), or Today button. Header reads "Upcoming Events". useEffect forces agenda on mobile.
 
-### Added — Voice / API tokens (carried from earlier work in this Unreleased block)
-- **Voice API foundation (`/api/v1/voice/*`)**: New versioned, token-authenticated API surface for voice and home-automation integrations. First endpoint: `GET /api/v1/voice/calendar/today` returns today's events with a pre-formatted natural-language `spoken` field (`"Today you have Soccer Practice at 4 PM."`) so callers don't need their own templating. Reuses the existing `apiTokens` Bearer-token system; per-token rate-limited at 60 req/min. Documented in `docs/voice-api.md`. Phase 1 of the Alexa + HA distribution plan — additional intents (shopping/add, chore/complete, calendar/upcoming, etc.) coming in follow-ups.
+### Added: Voice / API tokens (carried from earlier work in this Unreleased block)
+- **Voice API foundation (`/api/v1/voice/*`)**: New versioned, token-authenticated API surface for voice and home-automation integrations. First endpoint: `GET /api/v1/voice/calendar/today` returns today's events with a pre-formatted natural-language `spoken` field (`"Today you have Soccer Practice at 4 PM."`) so callers don't need their own templating. Reuses the existing `apiTokens` Bearer-token system; per-token rate-limited at 60 req/min. Documented in `docs/voice-api.md`. Phase 1 of the Alexa + HA distribution plan, additional intents (shopping/add, chore/complete, calendar/upcoming, etc.) coming in follow-ups.
 - **Voice token scope (`voice`)**: `withAuth` now supports a `tokenScope` option that rejects session-cookie callers and requires an API token whose scopes include either the named scope or `*`. The Voice API uses `tokenScope: 'voice'` so a leaked browser session cannot reach it, and Voice tokens issued with `scopes: ['voice']` are confined to `/api/v1/voice/*` (vs. the legacy `['*']` default which grants full account access). Token-creation validator now restricts scopes to the known set `['*', 'voice']`.
-- **Voice API endpoints**: Six new endpoints filling out the `/api/v1/voice/*` surface — `GET /family`, `GET /calendar/upcoming`, `GET /tasks/today`, `POST /shopping/add`, `POST /chore/complete`, `POST /message/post`. Each returns the shared `{ ok, spoken, data }` shape. `chore/complete` enforces the documented security rules: completions inherit the chore's `assignedTo`, voice cannot bypass `requiresApproval` (pending completions stay pending until a parent approves in-app), and ambiguous chore names (e.g. both children have "Feed the dog") return an `ok:false` disambiguation prompt with `data.candidates` for the caller to resend with `assignee`. Phrase-builder tests grew from 7 to 18 cases covering the new spoken templates.
-- **Six more voice endpoints (Alexa Phase 2)**: A further round rounds out the read surface — `GET /weather/today`, `GET /bus/status`, `GET /birthdays/upcoming`, `GET /meals/today`, `GET /chores/today`, and `GET /message/recent` — each returning the same `{ ok, spoken, data }` shape with a pre-formatted `spoken` line. All are documented in `docs/voice-api.md`.
-- **API token scope picker in Settings**: The Security section's token issuer now shows a scope dropdown ("Voice API only (recommended)" / "Full access (legacy)") and the issued-token list shows each token's scopes as a colored badge (Voice = blue, `*` = amber). Voice is the default — picking the smallest scope that works means a leaked token can't reach data outside its surface.
+- **Voice API endpoints**: Six new endpoints filling out the `/api/v1/voice/*` surface: `GET /family`, `GET /calendar/upcoming`, `GET /tasks/today`, `POST /shopping/add`, `POST /chore/complete`, `POST /message/post`. Each returns the shared `{ ok, spoken, data }` shape. `chore/complete` enforces the documented security rules: completions inherit the chore's `assignedTo`, voice cannot bypass `requiresApproval` (pending completions stay pending until a parent approves in-app), and ambiguous chore names (e.g. both children have "Feed the dog") return an `ok:false` disambiguation prompt with `data.candidates` for the caller to resend with `assignee`. Phrase-builder tests grew from 7 to 18 cases covering the new spoken templates.
+- **Six more voice endpoints (Alexa Phase 2)**: A further round rounds out the read surface: `GET /weather/today`, `GET /bus/status`, `GET /birthdays/upcoming`, `GET /meals/today`, `GET /chores/today`, and `GET /message/recent`, each returning the same `{ ok, spoken, data }` shape with a pre-formatted `spoken` line. All are documented in `docs/voice-api.md`.
+- **API token scope picker in Settings**: The Security section's token issuer now shows a scope dropdown ("Voice API only (recommended)" / "Full access (legacy)") and the issued-token list shows each token's scopes as a colored badge (Voice = blue, `*` = amber). Voice is the default: picking the smallest scope that works means a leaked token can't reach data outside its surface.
 
 ### Bug Fixes
-- **Shopping items — rate limit raised 30/min → 120/min**: Recipe imports add ingredients one-by-one in a sequential loop; long lists were hitting the cap with "Failed to add item: too many requests". Proper fix (a batch endpoint) is a follow-up.
+- **Shopping items: rate limit raised 30/min → 120/min**: Recipe imports add ingredients one-by-one in a sequential loop; long lists were hitting the cap with "Failed to add item: too many requests". Proper fix (a batch endpoint) is a follow-up.
 - **Mobile calendar header overflow**: Picker modal now fits an iPhone in portrait by trimming dialog padding, gap, image size, and price-column fixed width. Product names wrap to 2 lines instead of truncating. Review-screen items break-words.
-- **Calendar — recipe form / shopping list error visibility**: "Failed to save recipe" / "Failed to add ingredients" / "Failed to remove photo" now propagate the actual server error so a stuck user can self-diagnose.
-- **Shopping list — assigning to a family member**: Members whose `id` wasn't exposed (unauthenticated `/api/family` returns `id=''`) are filtered out of the assign-to picker so selecting them can't silently set `assignedTo=''` and fail validation.
-- **Recipe photo — iOS file input**: Removed `capture="environment"` so iOS shows Photo Library / Take Photo / Files instead of forcing the back camera.
+- **Calendar: recipe form / shopping list error visibility**: "Failed to save recipe" / "Failed to add ingredients" / "Failed to remove photo" now propagate the actual server error so a stuck user can self-diagnose.
+- **Shopping list: assigning to a family member**: Members whose `id` wasn't exposed (unauthenticated `/api/family` returns `id=''`) are filtered out of the assign-to picker so selecting them can't silently set `assignedTo=''` and fail validation.
+- **Recipe photo: iOS file input**: Removed `capture="environment"` so iOS shows Photo Library / Take Photo / Files instead of forcing the back camera.
 - **Meal page order**: Snack now appears between lunch and dinner (matching `CalendarView.sortMealsByType`) instead of after dinner.
 
 ### Internal
-- **Kroger picker — modifier-aware ingredient stripping for product search**: `parseShoppingQuantity` strips leading quantity + unit, then drops everything from the first comma, `" or "`, parenthetical, or `" to taste"` onwards, so `"1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes"` searches Kroger for `"Fresno pepper"`. Original text stays visible in the picker title; "Searching Kroger for X" subtitle shows the cleaned query. Manual override input lets the user refine without skipping the item.
-- **Kroger picker — canonical unit per page**: For each item, detect the dominant dimension (weight/volume/count) across all candidates and show every same-dimension candidate's unit price in one canonical unit (lb / fl oz / ct) instead of mixing $/oz against $/lb. Mismatched-dimension outliers keep their native unit.
-- **Kroger — Cloudflare-tunnel-safe redirect**: OAuth redirect URI is now derived from the incoming request's `X-Forwarded-Host` / `X-Forwarded-Proto` and persisted in Redis with the state token so the callback's `/token` exchange uses the byte-exact URI Kroger requires.
+- **Kroger picker: modifier-aware ingredient stripping for product search**: `parseShoppingQuantity` strips leading quantity + unit, then drops everything from the first comma, `" or "`, parenthetical, or `" to taste"` onwards, so `"1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes"` searches Kroger for `"Fresno pepper"`. Original text stays visible in the picker title; "Searching Kroger for X" subtitle shows the cleaned query. Manual override input lets the user refine without skipping the item.
+- **Kroger picker: canonical unit per page**: For each item, detect the dominant dimension (weight/volume/count) across all candidates and show every same-dimension candidate's unit price in one canonical unit (lb / fl oz / ct) instead of mixing $/oz against $/lb. Mismatched-dimension outliers keep their native unit.
+- **Kroger: Cloudflare-tunnel-safe redirect**: OAuth redirect URI is now derived from the incoming request's `X-Forwarded-Host` / `X-Forwarded-Proto` and persisted in Redis with the state token so the callback's `/token` exchange uses the byte-exact URI Kroger requires.
 
 ## [1.7.2] – 2026-05-02
 
 > Same-day patch follow-up: forecast past-day filter across all weather providers + a developer-experience fix for `npx jest`.
 
 ### Bug Fixes
-- **Weather — forecast skips stale past-day entries (OWM, Pirate, Open-Meteo)**: When a cached weather response was generated before local midnight, the 7-day forecast would open with the **previous** local day (e.g. "Thu" on a Friday) until the cache TTL expired. Affected all three providers via three different mechanisms: OWM 3-hour intervals starting on non-zero UTC boundaries, Pirate Weather's pre-aggregated `daily.data[0]` carrying yesterday, and Open-Meteo's `daily.time[0]` doing the same. Each provider now filters past-day buckets server-side, and `WeatherWidget` adds a defense-in-depth client-side filter so a still-warm cache can't leak yesterday into the UI. The "N-Day Forecast" heading now matches the actual visible day count. Thanks to **@iann** for the diagnosis and the OWM/Pirate fix in PR #27 (merged via #31).
+- **Weather: forecast skips stale past-day entries (OWM, Pirate, Open-Meteo)**: When a cached weather response was generated before local midnight, the 7-day forecast would open with the **previous** local day (e.g. "Thu" on a Friday) until the cache TTL expired. Affected all three providers via three different mechanisms: OWM 3-hour intervals starting on non-zero UTC boundaries, Pirate Weather's pre-aggregated `daily.data[0]` carrying yesterday, and Open-Meteo's `daily.time[0]` doing the same. Each provider now filters past-day buckets server-side, and `WeatherWidget` adds a defense-in-depth client-side filter so a still-warm cache can't leak yesterday into the UI. The "N-Day Forecast" heading now matches the actual visible day count. Thanks to **@iann** for the diagnosis and the OWM/Pirate fix in PR #27 (merged via #31).
 
 ### Internal
 - **Local jest no longer fails on integration tests**: `src/lib/db/__tests__/integration.test.ts` now self-skips when `E2E_HAS_TEST_DB !== '1'` so `npx jest` runs clean on a dev machine that doesn't expose Postgres on localhost:5433. CI keeps the same shape (no real DB → suite skips → unit-tests job stays green).
@@ -360,49 +360,49 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 > Patch follow-up to v1.7.0. Three small fixes surfaced by post-release verification: a stale-cache trap when switching weather providers, three tables missing from the fresh-install schema snapshot, and an e2e-test chicken-and-egg around the public `/api/family` response.
 
 ### Bug Fixes
-- **Weather — provider in cache key**: Switching `WEATHER_PROVIDER` (e.g. `openweather` → `meteo`) used to serve a stale response shaped by the previous provider until the 10-minute TTL expired (manual mitigation: `redis-cli DEL weather:<location>`). Cache key now embeds the active provider, so a switch produces a non-colliding key automatically.
-- **Fresh-install schema — travel_trips + weekend_***: `src/lib/db/init/02-schema.sql` was 3 tables behind master. `travel_trips` (v1.4 — Travel Map), `weekend_places` and `weekend_visits` (v1.5 — Weekend Ideas) are now created cleanly on first init. `test-fresh-install.sh` reflects the full v1.7 surface.
+- **Weather: provider in cache key**: Switching `WEATHER_PROVIDER` (e.g. `openweather` → `meteo`) used to serve a stale response shaped by the previous provider until the 10-minute TTL expired (manual mitigation: `redis-cli DEL weather:<location>`). Cache key now embeds the active provider, so a switch produces a non-colliding key automatically.
+- **Fresh-install schema: travel_trips + weekend_***: `src/lib/db/init/02-schema.sql` was 3 tables behind master. `travel_trips` (v1.4, Travel Map), `weekend_places` and `weekend_visits` (v1.5, Weekend Ideas) are now created cleanly on first init. `test-fresh-install.sh` reflects the full v1.7 surface.
 
 ### Internal
-- **e2e helpers — test DB isolation + auth fallback**: `helpers/reset.ts` and `visual-regression.spec.ts` now respect `E2E_DB_NAME` (default `prism`) so suites can target a synthetic test database. `helpers/auth.ts` `loginViaAPI` falls back to `memberIndex` when `/api/family` returns the redacted public response (id `''`, loginIndex set) — needed for any spec that logs in from a fresh page.
-- **Weather — Open-Meteo provider, now the default** (carried over from the v1.7.0 unreleased section, shipped here): `WEATHER_PROVIDER=meteo` is the new zero-config default. No API key required. Tests cover lat/lon plumbing, env fallback, TZ-aware day labels, network error wrapping, and the no-API-key path.
+- **e2e helpers: test DB isolation + auth fallback**: `helpers/reset.ts` and `visual-regression.spec.ts` now respect `E2E_DB_NAME` (default `prism`) so suites can target a synthetic test database. `helpers/auth.ts` `loginViaAPI` falls back to `memberIndex` when `/api/family` returns the redacted public response (id `''`, loginIndex set), needed for any spec that logs in from a fresh page.
+- **Weather: Open-Meteo provider, now the default** (carried over from the v1.7.0 unreleased section, shipped here): `WEATHER_PROVIDER=meteo` is the new zero-config default. No API key required. Tests cover lat/lon plumbing, env fallback, TZ-aware day labels, network error wrapping, and the no-API-key path.
 
 ## [1.7.0] – 2026-05-02
 
-> Major calendar refactor (widget toolbar parity with the subpage, drag-and-drop in cards mode, ten view modes including 1W–4W and Schedule, click-to-edit on widget items) and a multi-provider weather system. The `/week` page is retired — the calendar subpage is now a strict superset.
+> Major calendar refactor (widget toolbar parity with the subpage, drag-and-drop in cards mode, ten view modes including 1W–4W and Schedule, click-to-edit on widget items) and a multi-provider weather system. The `/week` page is retired. The calendar subpage is now a strict superset.
 
 ### Added
-- **Calendar — drag-and-drop everywhere**: Drag meals, chores, tasks, and events between days in cards mode across all calendar views (Day, List, Week, 1W–4W, Month, 3 Months, Agenda) and inside the dashboard CalendarWidget. Uses a 5px PointerSensor activation distance so drag and click-to-edit coexist on the same card. Drop targets in every cell via `DroppableOverlayCell`; `moveError` surfaces inline if the API rejects the move.
-- **Calendar — click-to-edit from the widget**: Tasks, Chores, and Meals widget items open the same edit modals as the calendar subpage. Modals are lazy-loaded via `React.lazy` + `Suspense` so the dashboard's first paint isn't taxed.
-- **Calendar — cards display mode**: New per-day card view (alongside the existing inline list view) renders meals at top, events in the middle, chores+tasks at bottom, with a dynamic per-cell capacity probe (`useCardCapacity`) that respects the current font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped. Toggle in the View Options gear; persists per surface (subpage and widget).
-- **Calendar — view modes**: Subpage and widget now expose Agenda, Day, List, Schedule (week vertical), 1W, 2W, 3W, 4W, Month, and 3 Months. View dropdown gains stacked ▲▼ triangles for one-click cycling. Multi-week navigation now advances/retreats by `weekCount` weeks (was 1).
-- **Calendar — view options**: Hide weekends (multi-week views), merge calendars into one column, show notes column (Day/Schedule), and overlay toggles for events/meals/chores/tasks. Settings persist to localStorage and the View Options trigger shows a badge when any toggle is non-default.
-- **Calendar — meal/chore/task overlays**: Cards mode renders these alongside events on every view; bucket data comes from a shared `useDayBucketsForRange` so the subpage and widget see the same data with the same TZ handling.
-- **Weather — multi-provider system**: `WEATHER_PROVIDER` env var (`meteo` | `pirate` | `openweather`) selects the active provider via a factory in `src/lib/integrations/weather.ts`. Default is `meteo` (Open-Meteo) — no API key required. `LocationParam` (string display name OR `{lat, lon}`) is the provider-neutral input.
-- **Weather — Open-Meteo** (new default, zero config): WMO weather-code mapping, `timezone=auto` so day-of-week labels respect the response's local timezone, °F + mph units. No API key required. Activated automatically when `WEATHER_PROVIDER` is unset or `meteo`.
-- **Weather — Pirate Weather** (Dark Sky-compatible, opt-in): sunrise/sunset arc, minutely precipitation forecast, hourly timeline rendered via `merry-timeline`. New `PIRATE_WEATHER_API_KEY` and `WEATHER_LAT`/`WEATHER_LON` env vars (see `.env.example`). Thanks to **@iann** for the original PR.
+- **Calendar: drag-and-drop everywhere**: Drag meals, chores, tasks, and events between days in cards mode across all calendar views (Day, List, Week, 1W–4W, Month, 3 Months, Agenda) and inside the dashboard CalendarWidget. Uses a 5px PointerSensor activation distance so drag and click-to-edit coexist on the same card. Drop targets in every cell via `DroppableOverlayCell`; `moveError` surfaces inline if the API rejects the move.
+- **Calendar: click-to-edit from the widget**: Tasks, Chores, and Meals widget items open the same edit modals as the calendar subpage. Modals are lazy-loaded via `React.lazy` + `Suspense` so the dashboard's first paint isn't taxed.
+- **Calendar: cards display mode**: New per-day card view (alongside the existing inline list view) renders meals at top, events in the middle, chores+tasks at bottom, with a dynamic per-cell capacity probe (`useCardCapacity`) that respects the current font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped. Toggle in the View Options gear; persists per surface (subpage and widget).
+- **Calendar: view modes**: Subpage and widget now expose Agenda, Day, List, Schedule (week vertical), 1W, 2W, 3W, 4W, Month, and 3 Months. View dropdown gains stacked ▲▼ triangles for one-click cycling. Multi-week navigation now advances/retreats by `weekCount` weeks (was 1).
+- **Calendar: view options**: Hide weekends (multi-week views), merge calendars into one column, show notes column (Day/Schedule), and overlay toggles for events/meals/chores/tasks. Settings persist to localStorage and the View Options trigger shows a badge when any toggle is non-default.
+- **Calendar: meal/chore/task overlays**: Cards mode renders these alongside events on every view; bucket data comes from a shared `useDayBucketsForRange` so the subpage and widget see the same data with the same TZ handling.
+- **Weather: multi-provider system**: `WEATHER_PROVIDER` env var (`meteo` | `pirate` | `openweather`) selects the active provider via a factory in `src/lib/integrations/weather.ts`. Default is `meteo` (Open-Meteo). No API key required. `LocationParam` (string display name OR `{lat, lon}`) is the provider-neutral input.
+- **Weather: Open-Meteo** (new default, zero config): WMO weather-code mapping, `timezone=auto` so day-of-week labels respect the response's local timezone, °F + mph units. No API key required. Activated automatically when `WEATHER_PROVIDER` is unset or `meteo`.
+- **Weather: Pirate Weather** (Dark Sky-compatible, opt-in): sunrise/sunset arc, minutely precipitation forecast, hourly timeline rendered via `merry-timeline`. New `PIRATE_WEATHER_API_KEY` and `WEATHER_LAT`/`WEATHER_LON` env vars (see `.env.example`). Thanks to **@iann** for the original PR.
 
 ### Improved
-- **Calendar widget — toolbar parity**: Layout now mirrors the subpage: Today | < > | View dropdown | View Options gear | Add Event. Today button gets explicit contrast classes for transparent vs normal mode (no more white-on-white). Calendar pill chips, view-mode persistence, and notes column all match.
-- **Calendar — TZ correctness**: Forecast day-of-week labels now use `Intl.DateTimeFormat` keyed off the response's IANA timezone (was `getUTCDay()`, which rolled past midnight for late-evening users). Chore overdue stripes parse `nextDue` (a YYYY-MM-DD DATE column) as a local date instead of UTC, so today's chore isn't flagged overdue in negative-UTC zones. Same fix applied in `DayColumn`, `useDayBucketsForRange`, and the drag preview.
-- **Calendar — month view bucket range**: CalendarWidget month view now spans the full 6-week rendered grid (start-of-week containing month start through end-of-week containing month end), so overlay items on leading/trailing days from neighboring months are no longer missing.
-- **Calendar — meal sort order**: Aligned across `useDayBucketsForRange`, `useWeekViewData`, and CalendarView's `sortMealsByType` to chronological order (breakfast → lunch → snack → dinner), matching `MEAL_TIME_DEFAULTS` in `cells/itemTime.ts`. Previously the widget rendered a 3pm snack below a 6pm dinner.
+- **Calendar widget: toolbar parity**: Layout now mirrors the subpage: Today | < > | View dropdown | View Options gear | Add Event. Today button gets explicit contrast classes for transparent vs normal mode (no more white-on-white). Calendar pill chips, view-mode persistence, and notes column all match.
+- **Calendar: TZ correctness**: Forecast day-of-week labels now use `Intl.DateTimeFormat` keyed off the response's IANA timezone (was `getUTCDay()`, which rolled past midnight for late-evening users). Chore overdue stripes parse `nextDue` (a YYYY-MM-DD DATE column) as a local date instead of UTC, so today's chore isn't flagged overdue in negative-UTC zones. Same fix applied in `DayColumn`, `useDayBucketsForRange`, and the drag preview.
+- **Calendar: month view bucket range**: CalendarWidget month view now spans the full 6-week rendered grid (start-of-week containing month start through end-of-week containing month end), so overlay items on leading/trailing days from neighboring months are no longer missing.
+- **Calendar: meal sort order**: Aligned across `useDayBucketsForRange`, `useWeekViewData`, and CalendarView's `sortMealsByType` to chronological order (breakfast → lunch → snack → dinner), matching `MEAL_TIME_DEFAULTS` in `cells/itemTime.ts`. Previously the widget rendered a 3pm snack below a 6pm dinner.
 
 ### Bug Fixes
-- **Calendar drag — task time-of-day preserved**: `moveTask` now accepts the original `dueDate` and preserves its hour/minute on the target date instead of hardcoding 23:59:59 (a 9am task no longer becomes 11:59pm after drag).
-- **Calendar drag — multi-week capacity**: `MultiWeekView` cards-mode capacity now reserves space for the always-rendered overlay rows (meals at top, chores+tasks at bottom) in BOTH overflow branches via `useCardCapacity({ headerHeight, popoverHeight })`. Previously the no-overflow branch ignored overlay rows and dense days silently clipped chores/tasks with no `+N more` indicator.
-- **ChoreModal / TaskModal — clearable due dates**: Both modals now allow explicitly clearing a previously-set due date. `ChoreModal` no longer falls back to `chore?.nextDue` when the input is empty; `TaskModal`'s `onSave` widens `dueDate` to `Date | null` and the API consumers (TasksView, CalendarView, Dashboard) forward `null` so the server's clear branch fires.
-- **POST /api/meals — `mealTime` persisted**: `mealTime` field was destructured-then-not-inserted on creation, so meal time-of-day silently dropped on first save. Now persisted on both insert and the response payload.
-- **CalendarWidget DndContext — `onDragCancel`**: Escape during a drag now clears `activeDragId` and any prior `moveError` (was leaving stale state).
-- **CalendarWidget AgendaView — overlay props**: Widget's agenda view now receives `bucketsByDate`, `displayMode`, and `enableDnd` like the other six views — meals/chores/tasks no longer silently disappear in agenda mode.
-- **WeekVerticalView merged-view**: Recognizes the synthetic `all` group the same way DayViewSideBySide does — meals/chores/tasks no longer drop in the merged column.
+- **Calendar drag: task time-of-day preserved**: `moveTask` now accepts the original `dueDate` and preserves its hour/minute on the target date instead of hardcoding 23:59:59 (a 9am task no longer becomes 11:59pm after drag).
+- **Calendar drag: multi-week capacity**: `MultiWeekView` cards-mode capacity now reserves space for the always-rendered overlay rows (meals at top, chores+tasks at bottom) in BOTH overflow branches via `useCardCapacity({ headerHeight, popoverHeight })`. Previously the no-overflow branch ignored overlay rows and dense days silently clipped chores/tasks with no `+N more` indicator.
+- **ChoreModal / TaskModal: clearable due dates**: Both modals now allow explicitly clearing a previously-set due date. `ChoreModal` no longer falls back to `chore?.nextDue` when the input is empty; `TaskModal`'s `onSave` widens `dueDate` to `Date | null` and the API consumers (TasksView, CalendarView, Dashboard) forward `null` so the server's clear branch fires.
+- **POST /api/meals: `mealTime` persisted**: `mealTime` field was destructured-then-not-inserted on creation, so meal time-of-day silently dropped on first save. Now persisted on both insert and the response payload.
+- **CalendarWidget DndContext: `onDragCancel`**: Escape during a drag now clears `activeDragId` and any prior `moveError` (was leaving stale state).
+- **CalendarWidget AgendaView: overlay props**: Widget's agenda view now receives `bucketsByDate`, `displayMode`, and `enableDnd` like the other six views: meals/chores/tasks no longer silently disappear in agenda mode.
+- **WeekVerticalView merged-view**: Recognizes the synthetic `all` group the same way DayViewSideBySide does. Meals/chores/tasks no longer drop in the merged column.
 - **MonthView popover height**: Per-overlay-row reservation bumped from 20px to 26px (matches the actual sm-card + gap-1 height) so dense days don't push overlay items into clipped territory.
-- **`displayMode` default**: Aligned across state initializers, ViewOptionsMenu's non-default-count badge, and both Reset-to-defaults handlers — `inline` is the first-load default everywhere. Eliminates the spurious `1` badge on first load and the "Reset to defaults flips the calendar layout" surprise.
+- **`displayMode` default**: Aligned across state initializers, ViewOptionsMenu's non-default-count badge, and both Reset-to-defaults handlers: `inline` is the first-load default everywhere. Eliminates the spurious `1` badge on first load and the "Reset to defaults flips the calendar layout" surprise.
 - **`hideWeekends` toggle scope**: Tightened to multi-week only (the only view that honored it). Previously the toggle appeared in week / list / month view options and silently did nothing.
 - **Cookie `Secure` flag (logout)**: `/api/auth/logout` now derives HTTPS from `x-forwarded-proto` like the rest of the auth path, so cookies cleared during logout match the `Secure` flag they were set with behind a TLS-terminating proxy.
 
 ### Internal
-- **Code review modalities — multi-agent cloud review (`/ultrareview`)**: This release was reviewed in three rounds (24 candidate findings → 16 confirmed → all addressed) — caught wiring/units/TZ regressions on weather, drag-and-drop time-of-day loss, capacity miscalculations, default-state divergence, and several silent-clipping bugs that text-only review structurally misses. See `docs/code-review-modalities.md`.
+- **Code review modalities: multi-agent cloud review (`/ultrareview`)**: This release was reviewed in three rounds (24 candidate findings → 16 confirmed → all addressed): caught wiring/units/TZ regressions on weather, drag-and-drop time-of-day loss, capacity miscalculations, default-state divergence, and several silent-clipping bugs that text-only review structurally misses. See `docs/code-review-modalities.md`.
 - **`OverlayFlags` consolidated**: Single canonical definition in `useDayBucketsForRange`; cells/`DayColumn` re-exports.
 - **Dead code cleanup**: `src/app/calendar/OverlaysToolbar.tsx` (created but never imported) removed; duplicate `format as fmt` import in AgendaView removed.
 - **`/week` page retired**: `src/app/week/*` deleted, `useWeekMutations` moved to `src/lib/hooks/`. The calendar subpage is a strict superset.
@@ -412,59 +412,59 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 > Consolidates the previously-prepared (but never tagged) v1.5.2 PWA fixes with substantial reverse-proxy / install-flow reliability work, Performance Mode polish, and new CI gating.
 
 ### Improved
-- **Performance Mode — extended scope**: Existing Performance Mode toggle now also stretches polling intervals (×2.5) and renders the Photo widget as a single static image instead of a slideshow. Auto-enabled on first load when the device reports ≤2 GB RAM or ≤4 CPU cores (`navigator.deviceMemory` / `hardwareConcurrency`); your explicit choice in Settings is always respected on subsequent loads. A subtle lightning-bolt badge appears in the dashboard header while active so you know what you're seeing. Existing `?perf=1` URL param continues to work for kiosk URLs.
-- **Performance pass**: Polling now does a structural-shared compare on each fetch — when the new payload is byte-identical to current state (the common case), the existing reference is reused so React skips re-renders downstream. Wraps `useFetch` so every consumer benefits without any callsite changes. `prefers-reduced-motion` is now honored site-wide via standard accessibility CSS; full-screen celebrations (plane fly-by, seasonal goal scenes) skip their motion entirely under either reduced-motion or Performance Mode and fire their `onComplete` callback immediately. Lite-mode photo widget now requests the `?thumb=1` thumbnail variant instead of the full image. TravelWidget gained the `React.memo` wrapper its peers already had.
-- **Default dashboard — set in app**: The layout editor's More menu now exposes "Set as Default" (becomes "Default Dashboard ✓" when active). The `/api/layouts/[id]/default` endpoint already existed; this wires the UI consumer.
-- **Reverse-proxy install — fewer surprises**: Fresh installs behind nginx / Cloudflare / Caddy now Just Work. `install.sh` generates a missing `ENCRYPTION_KEY` (was a fresh-install setup-wizard failure); `verify-pin` and `logout` derive HTTPS from the per-request `x-forwarded-proto` header instead of a module-level constant, so the session cookie carries the `Secure` flag whether you're behind a TLS-terminating proxy or not.
-- **Setup-wizard recovery**: `/api/family POST` now permits unauthenticated calls during setup (when no `setupComplete` row exists) and re-locks the moment setup finishes — fixes the chicken-and-egg "log in to set up your account" trap on fresh installs.
+- **Performance Mode: extended scope**: Existing Performance Mode toggle now also stretches polling intervals (×2.5) and renders the Photo widget as a single static image instead of a slideshow. Auto-enabled on first load when the device reports ≤2 GB RAM or ≤4 CPU cores (`navigator.deviceMemory` / `hardwareConcurrency`); your explicit choice in Settings is always respected on subsequent loads. A subtle lightning-bolt badge appears in the dashboard header while active so you know what you're seeing. Existing `?perf=1` URL param continues to work for kiosk URLs.
+- **Performance pass**: Polling now does a structural-shared compare on each fetch: when the new payload is byte-identical to current state (the common case), the existing reference is reused so React skips re-renders downstream. Wraps `useFetch` so every consumer benefits without any callsite changes. `prefers-reduced-motion` is now honored site-wide via standard accessibility CSS; full-screen celebrations (plane fly-by, seasonal goal scenes) skip their motion entirely under either reduced-motion or Performance Mode and fire their `onComplete` callback immediately. Lite-mode photo widget now requests the `?thumb=1` thumbnail variant instead of the full image. TravelWidget gained the `React.memo` wrapper its peers already had.
+- **Default dashboard: set in app**: The layout editor's More menu now exposes "Set as Default" (becomes "Default Dashboard ✓" when active). The `/api/layouts/[id]/default` endpoint already existed; this wires the UI consumer.
+- **Reverse-proxy install: fewer surprises**: Fresh installs behind nginx / Cloudflare / Caddy now Just Work. `install.sh` generates a missing `ENCRYPTION_KEY` (was a fresh-install setup-wizard failure); `verify-pin` and `logout` derive HTTPS from the per-request `x-forwarded-proto` header instead of a module-level constant, so the session cookie carries the `Secure` flag whether you're behind a TLS-terminating proxy or not.
+- **Setup-wizard recovery**: `/api/family POST` now permits unauthenticated calls during setup (when no `setupComplete` row exists) and re-locks the moment setup finishes. Fixes the chicken-and-egg "log in to set up your account" trap on fresh installs.
 - **Migration reliability**: `scripts/migrate.js` now detects first-run by checking whether `0000_upgrade.sql` has been applied (not by table existence) and wraps each migration in a transaction. Recovers cleanly from partially-applied migration state instead of throwing.
-- **Crypto key compatibility**: AES key derivation now falls back to `PIN_ENCRYPTION_KEY` when `ENCRYPTION_KEY` is unset — older installs that only had the PIN key continue to work without manual `.env` surgery.
+- **Crypto key compatibility**: AES key derivation now falls back to `PIN_ENCRYPTION_KEY` when `ENCRYPTION_KEY` is unset: older installs that only had the PIN key continue to work without manual `.env` surgery.
 - **About-page version**: Settings → About now shows the actual `package.json` version (was a hardcoded `1.1.0` for several releases). Health endpoints (`/api/health`, `/api/health/deep`) report the same source of truth.
 
 ### Bug Fixes
-- **Performance Mode — light-mode widget white-out**: An `opacity: 1 !important` override on translucent surfaces forced widget bodies to solid `hsl(var(--card))`, which resolves to white in light mode — making muted/secondary content blend into the background while only chrome (titles, icons) stayed visible. Dropped the override; surfaces now show their original 85–95% translucency over the wallpaper, which reads correctly with or without backdrop-blur.
-- **PWA tiles — weather blank**: Weather tile was reading a flat data shape; fixed to use the correct nested `WeatherData.current.temperature/condition/description` structure.
-- **PWA tiles — meals wrong**: Meals tile (and rows-mode meals card) matched any meal with today's day name across all historical weeks. Now filters to the current week before looking up today's meal.
-- **PWA tiles — bus 404**: Bus tile linked to `/bus` which does not exist. Removed the link; tile now shows status inline with no navigation chevron.
+- **Performance Mode: light-mode widget white-out**: An `opacity: 1 !important` override on translucent surfaces forced widget bodies to solid `hsl(var(--card))`, which resolves to white in light mode, making muted/secondary content blend into the background while only chrome (titles, icons) stayed visible. Dropped the override; surfaces now show their original 85–95% translucency over the wallpaper, which reads correctly with or without backdrop-blur.
+- **PWA tiles: weather blank**: Weather tile was reading a flat data shape; fixed to use the correct nested `WeatherData.current.temperature/condition/description` structure.
+- **PWA tiles: meals wrong**: Meals tile (and rows-mode meals card) matched any meal with today's day name across all historical weeks. Now filters to the current week before looking up today's meal.
+- **PWA tiles: bus 404**: Bus tile linked to `/bus` which does not exist. Removed the link; tile now shows status inline with no navigation chevron.
 
 ### Internal
 - **CI gates**: New `.github/workflows/ci.yml` runs type-check + lint + jest + a gated reverse-proxy e2e suite + migration-replay on every push and PR to master. Catches the bug classes that text-only review structurally misses (deployment-shape, schema idempotency, cookie handling behind a proxy). See `docs/code-review-modalities.md` for the rationale.
-- **Test debt**: Stale unit tests aligned with current code — session TTL constants moved to 7d/1d for the "stays logged in" UX; OneDrive test suite rewritten for the async credentialStore-based API.
+- **Test debt**: Stale unit tests aligned with current code: session TTL constants moved to 7d/1d for the "stays logged in" UX; OneDrive test suite rewritten for the async credentialStore-based API.
 - **PII denylist scanner** (`scripts/scan-pii.sh`): pre-push hook that fails if tracked files match a maintainer-curated personal denylist read from outside the repo. Closes the gap that text-only LLM review can't cover.
 
 ## [1.5.1] – 2026-04-19
 
 ### Bug Fixes
-- **Shopping — category colors missing**: Grocery categories (produce, bakery, meat, dairy, frozen, pantry) were silently stripped from saved settings, causing list cards to render grey with no color and no Add Item button. Restored full category list in DB and made the hook backfill any missing defaults on load so this can't recur.
-- **Shopping — category validation**: API rejected items added to general lists (Target, etc.) with non-grocery categories (clothes, housewares, etc.) because the Zod schema used a closed enum. Changed to `z.string()` to match the open-ended category system.
-- **Shopping — duplicate New List button**: Removed the redundant New List button from the list tabs toolbar; the one in the top-right header is sufficient.
+- **Shopping: category colors missing**: Grocery categories (produce, bakery, meat, dairy, frozen, pantry) were silently stripped from saved settings, causing list cards to render grey with no color and no Add Item button. Restored full category list in DB and made the hook backfill any missing defaults on load so this can't recur.
+- **Shopping: category validation**: API rejected items added to general lists (Target, etc.) with non-grocery categories (clothes, housewares, etc.) because the Zod schema used a closed enum. Changed to `z.string()` to match the open-ended category system.
+- **Shopping: duplicate New List button**: Removed the redundant New List button from the list tabs toolbar; the one in the top-right header is sufficient.
 
 ## [1.5.0] – 2026-04-19
 
 ### Features
-- **Weekend Ideas**: New `/weekend` page — a family activity board for local places to visit. Add places to a backlog, mark them visited with a 1–5 star rating, flag favorites, and tag them (outdoor, nature, hike, food, museum, farm, etc.). Visit frequency shown as pip dots grouped in 5s. Filters for status, favorites, tags, and search. Side-panel detail view with edit, mark-visited, and favorite actions. Phase 2 (POI search + map) coming next.
-- **Weekend Ideas — group by tag**: Place cards are grouped into tag-category sections (emoji header + count) so you can scan by activity type at a glance. Untagged items fall into an "Other" bucket.
-- **Travel Map — GPS photo linking**: Geotagged OneDrive photos are automatically matched to nearby travel pins. The pin detail panel shows a photo strip of matching shots within a configurable radius (default 50 km). Photos can be browsed via a lightbox.
-- **Travel Map — re-locate pin**: Pencil icon next to a pin's coordinates opens an inline geocode search — search for a new location and pick a result to update the pin's lat/lng and place name in place (fixes pins dropped in the wrong location).
+- **Weekend Ideas**: New `/weekend` page, a family activity board for local places to visit. Add places to a backlog, mark them visited with a 1–5 star rating, flag favorites, and tag them (outdoor, nature, hike, food, museum, farm, etc.). Visit frequency shown as pip dots grouped in 5s. Filters for status, favorites, tags, and search. Side-panel detail view with edit, mark-visited, and favorite actions. Phase 2 (POI search + map) coming next.
+- **Weekend Ideas: group by tag**: Place cards are grouped into tag-category sections (emoji header + count) so you can scan by activity type at a glance. Untagged items fall into an "Other" bucket.
+- **Travel Map: GPS photo linking**: Geotagged OneDrive photos are automatically matched to nearby travel pins. The pin detail panel shows a photo strip of matching shots within a configurable radius (default 50 km). Photos can be browsed via a lightbox.
+- **Travel Map: re-locate pin**: Pencil icon next to a pin's coordinates opens an inline geocode search: search for a new location and pick a result to update the pin's lat/lng and place name in place (fixes pins dropped in the wrong location).
 
 ### Bug Fixes
-- **Travel Map — globe longitude drift**: Rotation formula now normalizes center longitude to −180..180 — fixes pins appearing in wrong ocean locations (e.g., Gulf of Mexico instead of Sanibel Island) due to accumulated coordinate drift.
-- **Travel Map — far-side pin culling**: Hidden pins now use a CSS class with `!important` flags so MapLibre styles can't override visibility — fixes pins remaining visible behind the Earth.
-- **Weekend — side nav missing**: WeekendView was missing its `<PageWrapper>` wrapper, causing the side nav to disappear when navigating to the Weekend page.
+- **Travel Map: globe longitude drift**: Rotation formula now normalizes center longitude to −180..180. Fixes pins appearing in wrong ocean locations (e.g., Gulf of Mexico instead of Sanibel Island) due to accumulated coordinate drift.
+- **Travel Map: far-side pin culling**: Hidden pins now use a CSS class with `!important` flags so MapLibre styles can't override visibility: fixes pins remaining visible behind the Earth.
+- **Weekend: side nav missing**: WeekendView was missing its `<PageWrapper>` wrapper, causing the side nav to disappear when navigating to the Weekend page.
 
 ### Improved
 - **Nav icons**: Chores icon changed to `ListChecks` (multi-check) to better differentiate from Tasks (`CheckSquare`); Weekend icon changed to `Trees`.
-- **Travel Map — globe initial zoom**: Default zoom adjusted so the Earth nearly fills the screen on load.
+- **Travel Map: globe initial zoom**: Default zoom adjusted so the Earth nearly fills the screen on load.
 
 ## [1.4.0] – 2026-04-18
 
 ### Features
-- **Travel Map — Trips**: Multi-stop trip system with three styles — **Route** (A→B→C polyline), **Loop** (closed polyline returning to start), and **Hub** (home base + day-trip spokes). Trips are a first-class object separate from standalone place pins.
-- **Travel Map — trip globe rendering**: All trips are always visible on the globe. Inactive trips render as small faded colored dots + thin low-opacity connecting lines. The active (selected) trip shows full numbered markers and a bright dashed line. Clicking any faint dot selects that trip.
-- **Travel Map — national parks in trips**: Trips support national park stops alongside regular stops. NP stops display a green tree icon in the stop list instead of a number badge.
-- **Travel Map — Place/Trip toggle**: The slide-out panel now shows a segmented Place/Trip toggle when adding something new, so you can switch between adding a standalone place and creating a trip without leaving the panel.
-- **OneDrive photo sync — folder picker**: Settings now includes a folder picker so you can select which OneDrive folder to sync photos from, rather than defaulting to the root.
-- **Photos — GPS backfill**: New `/api/photos/backfill-gps` endpoint reads GPS EXIF from already-synced photos and writes coordinates back to the database without re-downloading files.
+- **Travel Map: Trips**: Multi-stop trip system with three styles: **Route** (A→B→C polyline), **Loop** (closed polyline returning to start), and **Hub** (home base + day-trip spokes). Trips are a first-class object separate from standalone place pins.
+- **Travel Map: trip globe rendering**: All trips are always visible on the globe. Inactive trips render as small faded colored dots + thin low-opacity connecting lines. The active (selected) trip shows full numbered markers and a bright dashed line. Clicking any faint dot selects that trip.
+- **Travel Map: national parks in trips**: Trips support national park stops alongside regular stops. NP stops display a green tree icon in the stop list instead of a number badge.
+- **Travel Map: Place/Trip toggle**: The slide-out panel now shows a segmented Place/Trip toggle when adding something new, so you can switch between adding a standalone place and creating a trip without leaving the panel.
+- **OneDrive photo sync: folder picker**: Settings now includes a folder picker so you can select which OneDrive folder to sync photos from, rather than defaulting to the root.
+- **Photos: GPS backfill**: New `/api/photos/backfill-gps` endpoint reads GPS EXIF from already-synced photos and writes coordinates back to the database without re-downloading files.
 
 ### Bug Fixes
 - **OneDrive OAuth callback**: Fixed "fetch failed" error caused by Docker's bridge network not routing IPv6. A `undici` global dispatcher now forces IPv4 for all `fetch()` calls inside the container.
@@ -472,46 +472,46 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.3.0] – 2026-04-16
 
 ### Features
-- **Travel Map — Phase 1**: Interactive globe (MapLibre GL + OpenFreeMap tiles, globe projection) for tracking family travel. Pins use a drop-pin SVG marker anchored at the coordinate tip; root locations use colored drop pins (green checkmark = visited, white dot = want-to-go, amber star badge = bucket list, green tree badge = has national parks); child stops use purple circles, national parks use green circles.
-- **Travel Map — pin management**: Full inline editing in the detail panel — name, trip label, status toggle (auto-saves), bucket list star (auto-saves), visit dates, description, and tags. No separate edit modal.
-- **Travel Map — stops & parks**: Add stops via Nominatim geocode search or add national parks from a curated NPS list; sub-locations displayed as a combined drag-to-reorder list; connecting lines drawn from parent pin to selected children on the globe.
-- **Travel Map — Places tab**: Sortable list with stats bar, text search, filter pills (All / Been There / Want to Go / Bucket List / Has NP), and group-by (Year / Country / None) with country flag emoji. Selecting a place switches to the globe and opens its detail panel.
-- **Travel Map — dark map mode**: Moon/sun toggle button on the globe applies a CSS filter (`brightness · saturate · contrast · hue-rotate`) only to the map canvas — tiles darken while all markers stay at full brightness, and no tile reload is required.
-- **Travel Map — geocoding**: Nominatim proxy at `/api/travel/geocode` with Hawaiian island aliases, special-character normalization, and national park search scoring (boundary/park results ranked above natural features like volcano summits).
-- **Tasks**: Person→List and List→Person nested group modes — primary group cards with sub-group sections inside (colored left-border dividers, per-sub-group badge counts). Available in the Group dropdown when task lists exist.
-- **Undo Stack**: Global undo across shopping, tasks, wishes, and chores — undo button in the nav bar reverses the most recent mutation.
-- **Dashboard Editor**: Transparent background mode — widget cards can render over the grid background image without a double-card effect.
+- **Travel Map: Phase 1**: Interactive globe (MapLibre GL + OpenFreeMap tiles, globe projection) for tracking family travel. Pins use a drop-pin SVG marker anchored at the coordinate tip; root locations use colored drop pins (green checkmark = visited, white dot = want-to-go, amber star badge = bucket list, green tree badge = has national parks); child stops use purple circles, national parks use green circles.
+- **Travel Map: pin management**: Full inline editing in the detail panel: name, trip label, status toggle (auto-saves), bucket list star (auto-saves), visit dates, description, and tags. No separate edit modal.
+- **Travel Map: stops & parks**: Add stops via Nominatim geocode search or add national parks from a curated NPS list; sub-locations displayed as a combined drag-to-reorder list; connecting lines drawn from parent pin to selected children on the globe.
+- **Travel Map: Places tab**: Sortable list with stats bar, text search, filter pills (All / Been There / Want to Go / Bucket List / Has NP), and group-by (Year / Country / None) with country flag emoji. Selecting a place switches to the globe and opens its detail panel.
+- **Travel Map: dark map mode**: Moon/sun toggle button on the globe applies a CSS filter (`brightness · saturate · contrast · hue-rotate`) only to the map canvas: tiles darken while all markers stay at full brightness, and no tile reload is required.
+- **Travel Map: geocoding**: Nominatim proxy at `/api/travel/geocode` with Hawaiian island aliases, special-character normalization, and national park search scoring (boundary/park results ranked above natural features like volcano summits).
+- **Tasks**: Person→List and List→Person nested group modes: primary group cards with sub-group sections inside (colored left-border dividers, per-sub-group badge counts). Available in the Group dropdown when task lists exist.
+- **Undo Stack**: Global undo across shopping, tasks, wishes, and chores: undo button in the nav bar reverses the most recent mutation.
+- **Dashboard Editor**: Transparent background mode. Widget cards can render over the grid background image without a double-card effect.
 - **Dashboard Editor**: Per-widget text color and opacity controls.
 - **Dashboard Editor**: Custom color picker for theme palette swatches.
 - **Dashboard Editor**: Grid line opacity and cell background color/opacity controls for calendar and weather widgets.
-- **Camera Scanner**: Scan product barcodes with phone/tablet camera on the Shopping page — camera icon in header opens full-screen scanner overlay; automatically looks up product on Open Food Facts and adds it to the active list.
-- **Docker**: Multi-arch builds (amd64 + arm64) — Raspberry Pi support via pre-built GHCR image.
-- **Health check**: `GET /api/health` now probes PostgreSQL and Redis — returns 503 with `status: "degraded"` if either is down (previously always returned 200).
+- **Camera Scanner**: Scan product barcodes with phone/tablet camera on the Shopping page: camera icon in header opens full-screen scanner overlay; automatically looks up product on Open Food Facts and adds it to the active list.
+- **Docker**: Multi-arch builds (amd64 + arm64), Raspberry Pi support via pre-built GHCR image.
+- **Health check**: `GET /api/health` now probes PostgreSQL and Redis. Returns 503 with `status: "degraded"` if either is down (previously always returned 200).
 - **Calendar**: Profile columns now follow family member sort order from Settings; Family calendar group always sorts first before person columns.
 
 ### Improved
-- **Tasks**: Group control split into a "Group" primary select and a "Then by" secondary select — the nested `Person → List` / `List → Person` arrow-notation options are replaced by two independent dropdowns.
+- **Tasks**: Group control split into a "Group" primary select and a "Then by" secondary select. The nested `Person → List` / `List → Person` arrow-notation options are replaced by two independent dropdowns.
 - **Chores**: "Group by Person" toggle replaced with a consistent "Group" dropdown (None / Person) matching Tasks' style.
-- **Calendar**: Day view and week view hourly rows now expand to fill available widget/subpage height — `1fr` grid rows scale proportionally instead of using a fixed minimum.
-- **Bus Tracker**: Train map switches to 2-row snake layout when 6+ nodes — top row left→right, bottom row right→left, connected by a right-side vertical segment.
-- **Bus Tracker**: PM route at-school status now shows "Bus at school — en route" instead of a bogus 0-minute ETA.
+- **Calendar**: Day view and week view hourly rows now expand to fill available widget/subpage height: `1fr` grid rows scale proportionally instead of using a fixed minimum.
+- **Bus Tracker**: Train map switches to 2-row snake layout when 6+ nodes: top row left→right, bottom row right→left, connected by a right-side vertical segment.
+- **Bus Tracker**: PM route at-school status now shows "Bus at school, en route" instead of a bogus 0-minute ETA.
 - **Bus Tracker**: Route dialog "Scheduled" field renamed to "Home ETA" with helper text clarifying it is the expected arrival time at your stop.
 - **Bus Tracker**: Large minute values now display as hours and minutes (e.g., "15h 25m" instead of "925m").
 - **README**: Replaced GIF demos with static screenshots for faster loading.
 
 ### Bug Fixes
-- **Auth cookie secure flag**: Login route now detects HTTPS per-request via `X-Forwarded-Proto` header instead of a global `isSecure` flag derived from `APP_URL` — fixes "Log in to make changes" errors when accessing via `http://localhost:3000` while `APP_URL` pointed at the HTTPS public domain.
-- **Travel Map — pin creation validation**: Zod schema now accepts `null` (not just `undefined`) for all optional fields — fixes "Something went wrong" when creating a new place.
-- **Hawaii Volcanoes location**: Nominatim search for national parks now prefers boundary/park-type results over natural features — fixes Hawaii Volcanoes appearing at the volcano summit rather than the park centroid.
-- **Bucket list unstar persistence**: Star and status toggles now auto-save immediately on click rather than requiring the Save button — fixes unstar/status changes being lost on navigation.
-- **Microsoft OAuth callback**: Removed `requireAuth` requirement on the callback route — Microsoft redirects without a Prism session cookie, causing the connection flow to fail silently. Success/error toasts now display in Settings → Connected Accounts.
+- **Auth cookie secure flag**: Login route now detects HTTPS per-request via `X-Forwarded-Proto` header instead of a global `isSecure` flag derived from `APP_URL`. Fixes "Log in to make changes" errors when accessing via `http://localhost:3000` while `APP_URL` pointed at the HTTPS public domain.
+- **Travel Map: pin creation validation**: Zod schema now accepts `null` (not just `undefined`) for all optional fields: fixes "Something went wrong" when creating a new place.
+- **Hawaii Volcanoes location**: Nominatim search for national parks now prefers boundary/park-type results over natural features. Fixes Hawaii Volcanoes appearing at the volcano summit rather than the park centroid.
+- **Bucket list unstar persistence**: Star and status toggles now auto-save immediately on click rather than requiring the Save button: fixes unstar/status changes being lost on navigation.
+- **Microsoft OAuth callback**: Removed `requireAuth` requirement on the callback route. Microsoft redirects without a Prism session cookie, causing the connection flow to fail silently. Success/error toasts now display in Settings → Connected Accounts.
 - **Performance mode**: Removed animation stripping (transitions run on the compositor thread and don't cause CPU overhead); caps transitions at 150ms so the UI remains responsive without looking broken. Fixes washed-out surfaces when backdrop-blur is disabled.
-- **Virtual Keyboard**: Tapping a key no longer dismisses the keyboard after one character — `preventDefault` on `pointerDown` keeps focus in the active input field.
+- **Virtual Keyboard**: Tapping a key no longer dismisses the keyboard after one character: `preventDefault` on `pointerDown` keeps focus in the active input field.
 - **Virtual Keyboard**: Toggle button now appears correctly on touchscreen laptops where Windows converts touch events to mouse events (uses `navigator.maxTouchPoints` instead of pointer type tracking).
-- **Virtual Keyboard**: Reduced height from 38vh to 32vh — less intrusive on 1080p displays.
-- **Virtual Keyboard**: Scroll position no longer jumps after voice input adds a new list item — scroll restore is skipped when text was injected while the keyboard was open.
+- **Virtual Keyboard**: Reduced height from 38vh to 32vh, less intrusive on 1080p displays.
+- **Virtual Keyboard**: Scroll position no longer jumps after voice input adds a new list item. Scroll restore is skipped when text was injected while the keyboard was open.
 - **Camera Scanner**: Overlay now self-dismisses immediately after a successful scan; haptic feedback on successful scan; iOS AudioContext unlocked synchronously on "Open Camera" tap.
-- **UI**: Desktop/laptop font size reduced to 14px base (via `pointer: fine` media query) — previously used the same 16px as touch displays.
+- **UI**: Desktop/laptop font size reduced to 14px base (via `pointer: fine` media query). Previously used the same 16px as touch displays.
 - **Calendar**: Day name headers rotate correctly when week starts on Monday.
 - **Mobile**: Navigation no longer causes flash/slide animation on page transitions.
 - **Docker**: App health check uses node instead of curl; fresh install schema fixed; `VirtualKeyboard` and `CameraScannerOverlay` loaded via `next/dynamic` with `ssr: false`.
@@ -519,34 +519,34 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **CI**: GitHub Actions upgraded from Node.js 20 to 22; layout validation size constraints downgraded to warnings.
 
 ### Infrastructure
-- **Automatic database migrations**: Schema changes now apply automatically on container startup via `scripts/migrate.js`. Users update by running `./scripts/update.sh` (or `git pull && docker-compose up -d --build`) — no manual database commands required. `drizzle/0000_upgrade.sql` brings any existing installation (regardless of age) to the current schema; future changes go in numbered `drizzle/NNNN_description.sql` files.
+- **Automatic database migrations**: Schema changes now apply automatically on container startup via `scripts/migrate.js`. Users update by running `./scripts/update.sh` (or `git pull && docker-compose up -d --build`), no manual database commands required. `drizzle/0000_upgrade.sql` brings any existing installation (regardless of age) to the current schema; future changes go in numbered `drizzle/NNNN_description.sql` files.
 
 ### Security
-- **CSRF**: Next.js middleware validates `Origin` header on all API mutations — cross-origin requests blocked at the edge (away-mode auto-activation exempt).
+- **CSRF**: Next.js middleware validates `Origin` header on all API mutations: cross-origin requests blocked at the edge (away-mode auto-activation exempt).
 - **WiFi config**: Password now stored AES-256-GCM encrypted in the database; decrypted on read with backward-compat for existing plaintext rows.
-- **Backups**: `PGPASSWORD` moved from inline shell string to process env — prevents credential leakage in process listings.
+- **Backups**: `PGPASSWORD` moved from inline shell string to process env. Prevents credential leakage in process listings.
 - **Babysitter info**: Sensitive section content now requires authentication (`includeSensitive=true` requests gated behind `requireAuth`).
-- **Paprika import**: HTML payload capped at 5 MB — prevents memory exhaustion from oversized uploads.
+- **Paprika import**: HTML payload capped at 5 MB: prevents memory exhaustion from oversized uploads.
 - **Centralized cache invalidation**: New `invalidateEntity(entity)` helper in `src/lib/cache/cacheKeys.ts` replaces 166 ad-hoc `invalidateCache('entity:*')` calls across 65 files; cross-entity dependency graph ensures chore completions also clear points/goals cache.
-- **Redis-down 503**: `validateSession` now returns a discriminated union `{ ok, reason }` — Redis unavailability returns 503 ("service unavailable") instead of 401 ("please log in"), preventing confusing auth errors during infra outages.
+- **Redis-down 503**: `validateSession` now returns a discriminated union `{ ok, reason }`. Redis unavailability returns 503 ("service unavailable") instead of 401 ("please log in"), preventing confusing auth errors during infra outages.
 - **Request ID middleware**: All API responses include `x-request-id` header (24-char hex UUID); propagated into `logError()` for log correlation across distributed traces.
 - **`/api/health/deep`** (parent-auth): Deep health check verifying DB, Redis, last backup recency, and OAuth token expiry; triggers optional `ALERT_WEBHOOK_URL` notification on degradation.
-- **`apiError()` helper**: Standardized error responses via `src/lib/api/apiResponse.ts` — `{ error: { code, message } }` shape with typed codes: `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `VALIDATION_ERROR`, `INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`.
+- **`apiError()` helper**: Standardized error responses via `src/lib/api/apiResponse.ts`. `{ error: { code, message } }` shape with typed codes: `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `VALIDATION_ERROR`, `INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`.
 - **withAuth migration**: birthdays, calendar-notes routes migrated from raw `requireAuth` boilerplate to `withAuth` wrapper.
 - **API token scopes**: `scopes` JSONB column added to `api_tokens` table (default `["*"]` = full access); `withAuth` now enforces scope on API token requests; existing tokens unaffected.
-- **Rate limiting**: In-memory fallback limiter — rate limits now enforced even when Redis is unavailable (previously all requests passed through).
+- **Rate limiting**: In-memory fallback limiter: rate limits now enforced even when Redis is unavailable (previously all requests passed through).
 - **Backups API**: `POST /api/admin/backups` rate-limited to 5 per hour per user.
-- **API**: `GET /api/settings`, `GET /api/settings/wifi`, and `POST /api/shopping/scan` now require display/full auth — previously exposed unauthenticated.
+- **API**: `GET /api/settings`, `GET /api/settings/wifi`, and `POST /api/shopping/scan` now require display/full auth, previously exposed unauthenticated.
 
 ### Performance
-- **FamilyProvider**: Equality check on polling results before calling `setMembers` — prevents unnecessary re-renders across all consumers on every 10-minute poll when data is unchanged.
-- **CLS fix**: `AppShell` no longer removes `ml-16` from `<main>` when auto-hide fires — SideNav is `position:fixed` so layout should never shift; eliminates CLS spike caused by the 10-second auto-hide timer (CLS 0.337 → 0.07).
-- **Caching**: Messages, Tasks, and Photos GET endpoints now cache responses in Redis (60s / 60s / 300s TTLs) — reduces DB load on frequently-polled dashboard data.
-- **Visibility polling**: `useCalendarEvents` and `usePhotos` now use `useVisibilityPolling` — polling pauses when the browser tab is hidden.
+- **FamilyProvider**: Equality check on polling results before calling `setMembers`. Prevents unnecessary re-renders across all consumers on every 10-minute poll when data is unchanged.
+- **CLS fix**: `AppShell` no longer removes `ml-16` from `<main>` when auto-hide fires: SideNav is `position:fixed` so layout should never shift; eliminates CLS spike caused by the 10-second auto-hide timer (CLS 0.337 → 0.07).
+- **Caching**: Messages, Tasks, and Photos GET endpoints now cache responses in Redis (60s / 60s / 300s TTLs). Reduces DB load on frequently-polled dashboard data.
+- **Visibility polling**: `useCalendarEvents` and `usePhotos` now use `useVisibilityPolling`. Polling pauses when the browser tab is hidden.
 - **Images**: Replaced raw `<img>` tags with `next/image` (lazy loading, layout stability) in RecipeCard, RecipeDetailModal, and all four nav components.
 
 ### Quality
-- **BabysitterModeOverlay**: `useBabysitterInfo` and `useWifiConfig` now skip authenticated endpoints when babysitter mode is inactive — eliminates 401 console errors and network failures in Lighthouse best-practices audit (best-practices 96 → 100).
+- **BabysitterModeOverlay**: `useBabysitterInfo` and `useWifiConfig` now skip authenticated endpoints when babysitter mode is inactive: eliminates 401 console errors and network failures in Lighthouse best-practices audit (best-practices 96 → 100).
 
 ### Tests
 - **API error shape** (19 tests): every error code maps to correct HTTP status; `{ error: { code, message } }` shape enforced; `apiSuccess` coverage.
@@ -562,12 +562,12 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **Jest config**: Added `.test.tsx` to testMatch; ts-jest now overrides `jsx: react-jsx` for component test files.
 
 ### Refactored
-- **TasksView** (943→235 lines): extracted `TaskRow`, `GroupedTaskGrid`, `NestedGroupedTaskGrid`, `TaskContentArea`, `useTaskGrouping`, `taskGroupTypes` — all files under 250 lines.
+- **TasksView** (943→235 lines): extracted `TaskRow`, `GroupedTaskGrid`, `NestedGroupedTaskGrid`, `TaskContentArea`, `useTaskGrouping`, `taskGroupTypes`, all files under 250 lines.
 - **ChoresView** (632→213 lines): extracted `ChoreGroupCard`, `ChoreGroupGrid`, `ChoreCompletionsList`, `useChoreModals`.
-- **LayoutEditor** (901→228 lines): extracted 10 sub-components and hooks — toolbar sections, dashboard manager, measure mode, popover wrapper, shared types.
+- **LayoutEditor** (901→228 lines): extracted 10 sub-components and hooks: toolbar sections, dashboard manager, measure mode, popover wrapper, shared types.
 - **PinPad** (648→164 lines): extracted `usePinPad`, `NumberPad`, `MemberSelection`, `PinDisplay`.
 - **Days**: Consolidated 8 inline day-of-week arrays across calendar views, chore modals, WeatherWidget, and the OpenWeather integration into shared `DAYS_SHORT_ARRAY`, `DAYS_LONG_ARRAY`, and `DAYS_SINGLE_ARRAY` constants in `src/lib/constants/days.ts`.
-- **CalendarWidget**: Extracted `useCalendarWidgetPrefs` hook (view state, navigation, localStorage persistence) and `CalendarWidgetControls` sub-component — main component reduced from ~357 to ~200 lines.
+- **CalendarWidget**: Extracted `useCalendarWidgetPrefs` hook (view state, navigation, localStorage persistence) and `CalendarWidgetControls` sub-component: main component reduced from ~357 to ~200 lines.
 - **Widgets**: Added `useMemo` for filter/sort chains and `useCallback` for event handlers in ChoresWidget, TasksWidget, ShoppingWidget, and MealsWidget.
 
 ### Docs
@@ -579,20 +579,20 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.2.0] - 2026-03-29
 
 ### Added
-- **Google Tasks**: Bidirectional sync with Google Tasks — OAuth flow, list selection, task sync provider
+- **Google Tasks**: Bidirectional sync with Google Tasks: OAuth flow, list selection, task sync provider
 - **Google Tasks**: Google Tasks option in Settings → Task Sync provider picker alongside Microsoft To-Do
 - **Google Tasks**: Connected Accounts page dynamically shows "Used for: Calendars, Tasks" when Google Tasks connected
-- **Mobile PWA**: Floating action button (FAB) replaces bottom nav bar — Home, Reorder, Settings, Login
+- **Mobile PWA**: Floating action button (FAB) replaces bottom nav bar: Home, Reorder, Settings, Login
 - **Mobile PWA**: Dashboard card reorder mode (FAB → Reorder) with drag pills and amber indicator
 - **Mobile PWA**: Card visibility settings (FAB → Settings) to show/hide dashboard cards
-- **Mobile PWA**: All widget cards available — bus tracker, goals, wishes, photos, clock
+- **Mobile PWA**: All widget cards available: bus tracker, goals, wishes, photos, clock
 - **Mobile PWA**: Screensaver and away mode auto-disabled on PWA (useIsPWA hook)
 - **Mobile PWA**: Meals touch-drag between days on mobile
 - **Mobile PWA**: Light/dark PWA icon variants, apple-touch-icon support
 
 ### Improved
 - **Mobile PWA**: All grouped list pages (Tasks, Chores, Shopping, Wishes, Gift Ideas) use single-column on mobile
-- **Mobile PWA**: Calendar simplified — short date, Day/Agenda toggle, no filter pills, read-only
+- **Mobile PWA**: Calendar simplified: short date, Day/Agenda toggle, no filter pills, read-only
 - **Mobile PWA**: Messages important/expires badges on own line, edit/delete buttons visible on mobile
 - **Mobile PWA**: Shopping extra bottom padding so FAB doesn't overlap last item
 - **Mobile PWA**: GripVertical drag icons hidden on mobile across all list pages
@@ -602,17 +602,17 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.1.0] - 2026-03-16
 
 ### Added
-- **Gift Ideas**: New "Gift Ideas" tab on the Wishes page — private per-user gift tracking for other family members
+- **Gift Ideas**: New "Gift Ideas" tab on the Wishes page, private per-user gift tracking for other family members
 - **Gift Ideas**: Per-person columns with quick-add, edit, delete, and purchased toggle
-- **Gift Ideas**: Privacy-enforced — only the idea creator can see their ideas; recipients never see them
+- **Gift Ideas**: Privacy-enforced: only the idea creator can see their ideas; recipients never see them
 - **Mobile PWA**: Compact subpage headers on mobile (reduced height, smaller text, hidden icons)
-- **Mobile PWA**: Collapsible filter bars on mobile — tap "Filters" to expand/collapse
-- **Mobile PWA**: Mobile dashboard — summary card layout with weather, calendar, chores, tasks, shopping, meals, messages, birthdays
-- **Settings**: "Week Starts On" toggle (Sunday/Monday) in Settings → Display — controls calendar week boundaries, weekly goal resets, point counters, and meal planning weeks
-- **Chores**: Reset Day picker in Add/Edit Chore modals — set which day weekly chores reset (Sun-Sat), day-of-month for monthly, or MM-DD for annual
-- **Goals**: Seasonal celebration animations when a goal is fully achieved — week-based holidays: Valentine's, St. Patrick's, Easter, Spring, Memorial Day, July 4th, Halloween, Thanksgiving, Christmas, New Year's (plus default trophy)
-- **Messages**: Inline edit support — pencil icon on hover, click to edit in place, Ctrl+Enter to save
-- **Calendar Notes**: Day-tied notes panel on calendar widget list and day views — click the sticky note icon to toggle
+- **Mobile PWA**: Collapsible filter bars on mobile. Tap "Filters" to expand/collapse
+- **Mobile PWA**: Mobile dashboard: summary card layout with weather, calendar, chores, tasks, shopping, meals, messages, birthdays
+- **Settings**: "Week Starts On" toggle (Sunday/Monday) in Settings → Display. Controls calendar week boundaries, weekly goal resets, point counters, and meal planning weeks
+- **Chores**: Reset Day picker in Add/Edit Chore modals: set which day weekly chores reset (Sun-Sat), day-of-month for monthly, or MM-DD for annual
+- **Goals**: Seasonal celebration animations when a goal is fully achieved. Week-based holidays: Valentine's, St. Patrick's, Easter, Spring, Memorial Day, July 4th, Halloween, Thanksgiving, Christmas, New Year's (plus default trophy)
+- **Messages**: Inline edit support: pencil icon on hover, click to edit in place, Ctrl+Enter to save
+- **Calendar Notes**: Day-tied notes panel on calendar widget list and day views. Click the sticky note icon to toggle
 - **Calendar Notes**: Inline contentEditable editing with auto-save (2s debounce + save on blur)
 - **Calendar Notes**: Formatting shortcuts: Ctrl+B bold, Ctrl+I italic, Ctrl+U underline, Ctrl+Shift+S strikethrough, Ctrl+Shift+L bullet list, `- ` auto-converts to list
 - **Calendar Notes**: Notes column aligns row-by-row with calendar day grid in list view
@@ -625,10 +625,10 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **Dashboard Editor**: Text size (S/M/L/XL) moved inside the Text color popover alongside swatches
 
 ### Changed
-- **Auto-Hide UI**: Only wakes on mouse click, keyboard press, or touch — mouse movement/drag no longer triggers reappear
+- **Auto-Hide UI**: Only wakes on mouse click, keyboard press, or touch. Mouse movement/drag no longer triggers reappear
 
 ### Improved
-- **Away Mode**: Header layout matches babysitter mode — clock top-left, weather top-right in a compact bar
+- **Away Mode**: Header layout matches babysitter mode: clock top-left, weather top-right in a compact bar
 - **Calendar**: Multi-week 3W/4W event text size increased to match month view
 - **Calendar**: Today cell border in multi-week view uses standard grid line instead of separate white line
 - **Dashboard Editor**: Color popover z-index raised above widgets so dropdowns appear on top
@@ -636,7 +636,7 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **SideNav**: Logo background made transparent to match nav toolbar color in both themes
 
 ### Fixed
-- **Calendar**: Events from shared calendars (e.g. Family) no longer duplicate across person columns — matching by groupId instead of color
+- **Calendar**: Events from shared calendars (e.g. Family) no longer duplicate across person columns, matching by groupId instead of color
 - **Calendar**: Day widget notes column no longer shows redundant date header when viewing a single day
 - **Calendar**: Notes column integrated into DayViewSideBySide with matching header bar and grid line alignment
 - **Calendar**: Week view fills available height on calendar subpage
@@ -654,59 +654,59 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.0.4] - 2026-03-09
 
 ### Added
-- **Calendar**: Multi-week view replaces the fixed 2-week view — configurable from 1 to 4 weeks on both the calendar page and dashboard widget
+- **Calendar**: Multi-week view replaces the fixed 2-week view, configurable from 1 to 4 weeks on both the calendar page and dashboard widget
 - **Calendar**: Bordered/borderless toggle for multi-week cell outlines; rows auto-size to content
 - **Dashboard Editor**: Frosted glass background option with variable blur intensity (Light/Med/Heavy/Max)
 - **Dashboard Editor**: Default swatch (reset icon) to return any color target to theme defaults
 - **Dashboard Editor**: Harvey ball indicators on Fill/Outline/Text target buttons show color state at a glance
-- **Dashboard Editor**: Two-mode touch editing — tap widget to select (move mode), tap again for resize mode, tap again to deselect
+- **Dashboard Editor**: Two-mode touch editing: tap widget to select (move mode), tap again for resize mode, tap again to deselect
 - **Auto-Hide UI**: Nav bar and toolbar auto-hide after 10 seconds of inactivity, reappear on mouse/touch (configurable in Settings)
-- **Auto-Hide UI**: Staggered animation — header hides first, then nav; nav reappears first, then header
-- **Settings**: Location card wired to weather API — supports zip code or city/state, stored in database
+- **Auto-Hide UI**: Staggered animation: header hides first, then nav; nav reappears first, then header
+- **Settings**: Location card wired to weather API. Supports zip code or city/state, stored in database
 - **CONTRIBUTING.md**: Quality standards requiring 95% minimum Lighthouse score across all categories
 - **Drag Reorder**: Tasks, chores, goals, and family profile cards can now be reordered by drag-and-drop (touch + mouse supported)
 - **Drag Reorder**: Family profile sort order persists to database via `/api/family/reorder`; task/chore group order persists to localStorage
 - **Undo**: Tasks, chores, shopping items, and wish claims now show an "Undo" toast button when completed/checked off
-- **Wishes**: Self-purchase — cross off items on your own wish list; if someone else already secretly bought it, shows "Someone already got this for you!"
+- **Wishes**: Self-purchase: cross off items on your own wish list; if someone else already secretly bought it, shows "Someone already got this for you!"
 - **Wishes**: Quick-add input moved to top of list (consistent with tasks/chores pattern)
 - **Messages**: "Group by Person" toggle groups messages into person-colored cards
 
 ### Improved
 - **Settings**: Consolidated Screensaver Timeout, Auto-Hide Navigation, and Away Mode Auto-Activation into single "Timers & Auto-Activation" card
-- **Calendar**: Multi-week toolbar no longer resizes when switching views — grid icon doubles as border toggle
+- **Calendar**: Multi-week toolbar no longer resizes when switching views. Grid icon doubles as border toggle
 - **Calendar**: Multi-week today highlight preserved in screensaver mode (data-keep-bg attribute)
-- **SideNav**: Tap-to-expand drawer replaces hover-based expansion — works reliably on touch devices, collapses on outside tap or navigation
+- **SideNav**: Tap-to-expand drawer replaces hover-based expansion: works reliably on touch devices, collapses on outside tap or navigation
 - **Weather**: Location resolved from DB settings with fallback chain (query param → DB → env var → default)
 - **Screensaver**: Fixed `--primary` CSS variable override that turned today highlight bar white
-- **Accessibility**: Dashboard editor uses dashed border for move mode, solid for resize — distinguishable without color
+- **Accessibility**: Dashboard editor uses dashed border for move mode, solid for resize, distinguishable without color
 
 ### Fixed
-- **Navigation**: Fixed nav bar appearing behind page content on iPad — removed wrapper divs that created CSS containing blocks breaking `position: fixed`
-- **Navigation**: Fixed auto-hide SSR hydration mismatch — localStorage read deferred to useEffect
-- **Navigation**: Auto-hide now limited to dashboard pages only — no more jarring nav animations on subpages
-- **Google Calendar**: Fixed events beyond 250-event page being silently dropped — added pagination loop following `nextPageToken`
+- **Navigation**: Fixed nav bar appearing behind page content on iPad. Removed wrapper divs that created CSS containing blocks breaking `position: fixed`
+- **Navigation**: Fixed auto-hide SSR hydration mismatch: localStorage read deferred to useEffect
+- **Navigation**: Auto-hide now limited to dashboard pages only, no more jarring nav animations on subpages
+- **Google Calendar**: Fixed events beyond 250-event page being silently dropped. Added pagination loop following `nextPageToken`
 - **Google Calendar**: Cancelled recurring event instances now filtered out during sync instead of appearing as active events
-- **Bus Tracking**: Fixed token mismatch between discover and sync — stale Gmail credentials now deleted on `TokenRevokedError`
+- **Bus Tracking**: Fixed token mismatch between discover and sync. Stale Gmail credentials now deleted on `TokenRevokedError`
 - **Layout Editor**: Added `busTracking` to widget validation constraints (fixes "unknown widget ID" error)
-- **Layout Editor**: Fixed dashboard save showing "Saved!" but not actually persisting — save button now awaits the API call and shows error on failure
+- **Layout Editor**: Fixed dashboard save showing "Saved!" but not actually persisting: save button now awaits the API call and shows error on failure
 - **Safe Zones**: Shortened default label from "Example safe zone (edit me)" to "1080p" to prevent preview cutoff
 - **Calendar**: Multi-day all-day events now span all their days instead of only appearing on the start date (affected all calendar views + widget)
 
 ### Improved
 - **Performance**: Split RecipesView into RecipeCard, RecipeDetailModal, RecipeFormModal, ImportUrlModal, and ImportPaprikaModal sub-components
 - **Performance**: Split ShoppingView into ShoppingCategoryCard and extracted useShoppingCelebration, useShoppingDragReorder, useShoppingInlineInput hooks
-- **Performance**: Lazy-load layout editor and dnd-kit (only loaded in edit mode) — LCP improved from 7.2s to 3.9s, TBT from 2.4s to 1.4s
+- **Performance**: Lazy-load layout editor and dnd-kit (only loaded in edit mode): LCP improved from 7.2s to 3.9s, TBT from 2.4s to 1.4s
 - **Performance**: Bundle analyzer added to build config (`ANALYZE=true npx next build`)
-- **Bus Tracking**: Sync lock changed from 60s cooldown to mutex (release on completion) — updates arrive within seconds
+- **Bus Tracking**: Sync lock changed from 60s cooldown to mutex (release on completion). Updates arrive within seconds
 - **Bus Tracking**: Response cache reduced to 5s, polling ramps to 5s when ETA ≤ 3 min
 
 ### Fixed
 - **Recipes**: Fixed crash when opening "Add Recipe" form (missing optional chain on ingredients)
-- **Layout Editor (iPad)**: Fix scrolling stopping too early — grid now extends 20+ rows (or half a screen) below the last widget
-- **Layout Editor (iPad)**: Fix touch drag not working — tap to select a widget, then drag to move (selected widgets disable browser scroll so dnd-kit receives the gesture)
+- **Layout Editor (iPad)**: Fix scrolling stopping too early: grid now extends 20+ rows (or half a screen) below the last widget
+- **Layout Editor (iPad)**: Fix touch drag not working. Tap to select a widget, then drag to move (selected widgets disable browser scroll so dnd-kit receives the gesture)
 - **Layout Editor (iPad)**: Enforce minimum 16px cell size so grid remains usable on narrow screens
 - **Layout Editor**: Add "Move" grip indicator on selected widgets for touch discoverability
-- **Bus Tracking**: Fix arrival event timestamps off by 6 hours in UTC Docker containers — arrival parsers now use the email Date header (timezone-correct) instead of parsing body text times as naive UTC
+- **Bus Tracking**: Fix arrival event timestamps off by 6 hours in UTC Docker containers: arrival parsers now use the email Date header (timezone-correct) instead of parsing body text times as naive UTC
 
 ### Changed
 - **Dashboard Grid**: Migrated from 12-column to 48-column grid for finer widget positioning (~20px increments vs ~80px)
@@ -721,9 +721,9 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
   - Touch support via dnd-kit TouchSensor
   - Removes 5 packages from bundle (react-grid-layout and dependencies)
 - **Performance**: Lighthouse optimization pass (desktop score: 52 → 96)
-  - Lazy-load overlays (Screensaver, AwayMode, BabysitterMode) — broke transitive import chain that pulled entire widget registry into root layout
+  - Lazy-load overlays (Screensaver, AwayMode, BabysitterMode): broke transitive import chain that pulled entire widget registry into root layout
   - Extract screensaver storage utilities to break circular dependency between Screensaver and useDashboardLayout
-  - Lazy-load Add modals (task, message, chore, shopping) — deferred from critical path
+  - Lazy-load Add modals (task, message, chore, shopping), deferred from critical path
   - Add React.memo to eager-loaded widgets (Clock, Weather, Calendar) to prevent unnecessary re-renders
 - **Accessibility**: Lighthouse accessibility score 92 → 100
   - Fix WCAG color contrast: rewrite `isLightColor` with proper sRGB linearization and WCAG contrast ratio calculation
@@ -784,7 +784,7 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **General List Type**: New "General" shopping list type with preset categories (Clothes, Housewares, Gardening, Electronics, Office, Gifts)
 - **General Categories**: Added 6 general-purpose shopping categories alongside grocery categories
 - **Shopping Categories Settings**: New Settings section for global category management (add, remove, reorder, reset to defaults)
-- **Inline Category Editing in List Modal**: Category chips in the create/edit list dialog are now interactive toggles — select a preset (Grocery, General, All, Custom) then fine-tune by toggling individual categories on/off. Replaces the separate "Categories" button.
+- **Inline Category Editing in List Modal**: Category chips in the create/edit list dialog are now interactive toggles: select a preset (Grocery, General, All, Custom) then fine-tune by toggling individual categories on/off. Replaces the separate "Categories" button.
 - **Tasks Group by List**: Tasks view now supports grouping by Person, List, or None (flat list)
 - **Tasks Show/Hide Completed**: Quick eye toggle in the Tasks header to show/hide completed tasks
 - **Tasks Click-to-Complete**: All task view modes (flat list, grouped) now support clicking a row to toggle completion (like shopping)
@@ -802,11 +802,11 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.0.1] - 2026-02-25
 
 ### Added
-- **Shopping Categories**: Custom categories for all list types — add, remove, and reorder via "Manage Categories" modal. Stored in settings with auto-assigned emoji and color. Removed "hardware" list type
+- **Shopping Categories**: Custom categories for all list types: add, remove, and reorder via "Manage Categories" modal. Stored in settings with auto-assigned emoji and color. Removed "hardware" list type
 - **Gallery Mode**: Full-screen photo slideshow from the Photos page. Respects active filters (orientation, usage, favorites). Tap to exit
 - **Inline Task Add**: Quick task creation via inline text input (type + ENTER) in Tasks view. Available in both grouped and flat list modes
 - **Babysitter Mode Toggle**: Activate Babysitter Mode directly from the /babysitter page header
-- **Vertical Week View**: New "List" calendar view — planner-style vertical layout with days as rows and color-coded events. Profile grouping columns when multiple calendars configured. Today highlighted, past days dimmed
+- **Vertical Week View**: New "List" calendar view: planner-style vertical layout with days as rows and color-coded events. Profile grouping columns when multiple calendars configured. Today highlighted, past days dimmed
 - **Calendar Re-auth Flow**: Detect expired/revoked Google Calendar tokens, show warning in Settings with "Re-authenticate" button that updates existing calendar source tokens
 
 ### Fixed
@@ -838,7 +838,7 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 ## [1.0.1] - 2026-02-22
 
 ### Fixed
-- **Background opacity**: Widget background opacity no longer makes text/icons transparent — uses rgba background color instead of CSS opacity
+- **Background opacity**: Widget background opacity no longer makes text/icons transparent. Uses rgba background color instead of CSS opacity
 - **Color picker touch targets**: Increased button sizes to meet 44px HIG minimum, prevented RGL drag from intercepting touch events on color picker
 - **Pencil icon**: Edit icon in dashboard toolbar now opens rename dialog on click
 - **Rename dialog**: Replaced browser `window.prompt()` with styled modal dialog (consistent with v1.0 polish)
@@ -875,12 +875,12 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
   - Services: photo-storage, photo-sync, avatar-storage
   - API routes: chore complete/approve workflow, family member deletion, recipe URL import, withAuth middleware
   - E2E (Playwright): auth flows, dashboard, tasks/chores/shopping/calendar/settings navigation, CRUD mutations for all 5 modules, away/babysitter mode
-- **Extracted calculateNextDue**: DRY refactor — shared utility used by both chore complete and approve routes
+- **Extracted calculateNextDue**: DRY refactor, shared utility used by both chore complete and approve routes
 - **CI Type Check Fix**: All test files pass strict `tsc --noEmit`
 - **API Tokens**: Long-lived bearer tokens for machine-to-machine access
   - Generate tokens in Settings → Security → API Tokens
   - Tokens grant parent-level access to all API endpoints
-  - SHA-256 hashed storage — raw token shown only once at creation
+  - SHA-256 hashed storage, raw token shown only once at creation
   - Revoke tokens at any time; `lastUsedAt` tracked per token
   - All existing API routes automatically support `Authorization: Bearer <token>`
 - **Iframe Embedding**: Configurable `ALLOWED_FRAME_ANCESTORS` env var for embedding Prism in Home Assistant, Node-RED dashboards, or any iframe consumer
@@ -910,8 +910,8 @@ Security-hardening release from a full codebase audit. It closes a cluster of ac
 - **Per-Dashboard Orientation**: Screen orientation (landscape/portrait) saved per-dashboard in DB instead of localStorage
 
 ### Changed
-- **Away Mode Icon**: Moon icon replaced with palm tree (`TreePalm`) — more intuitive "vacation/away" meaning, avoids confusion with dark mode
-- **Screensaver Icon**: Monitor-with-play icon replaced with lamp/nightlight — better represents ambient display mode
+- **Away Mode Icon**: Moon icon replaced with palm tree (`TreePalm`): more intuitive "vacation/away" meaning, avoids confusion with dark mode
+- **Screensaver Icon**: Monitor-with-play icon replaced with lamp/nightlight. Better represents ambient display mode
 
 ### Improved
 - **Auto-Slug Migration**: Existing layouts automatically receive URL slugs on first API fetch

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -1,6 +1,6 @@
 # Prism User Guide
 
-A configurable family dashboard for large wall-mounted screens, tablets, and phones. Connects to Google Calendar, Microsoft To Do, Google Tasks, OneDrive, Kroger, Gmail/FirstView, and more — surfacing the information your family actually needs in one place.
+A configurable family dashboard for large wall-mounted screens, tablets, and phones. Connects to Google Calendar, Microsoft To Do, Google Tasks, OneDrive, Kroger, Gmail/FirstView, and more, surfacing the information your family actually needs in one place.
 
 > **This page is the overview.** For deep-dive guides on each feature, follow the links below.
 
@@ -10,19 +10,19 @@ A configurable family dashboard for large wall-mounted screens, tablets, and pho
 
 Five quick steps:
 
-1. **Install Prism** — [installation guide](getting-started/install.md).
-2. **Add family members** — *Settings → Family Members → Add Member.* Each gets a name, color, avatar, role (parent or child), and a personal 4- or 6-digit PIN.
-3. **Set PINs** — each member has their own 4- or 6-digit PIN, chosen in the setup wizard when you first install, or later in *Settings → Security.* A fresh install boots straight into the setup wizard (there is no default-PIN login screen); the optional demo seed uses `1234` for every user, so change those before real use.
-4. **Connect integrations** — *Settings → Integrations.* Most families want at least Google Calendar, weather (Open-Meteo is the zero-config default), and OneDrive. See the [first-time setup walkthrough](getting-started/first-time-setup.md).
-5. **Customize the dashboard** — click the **grid icon** to enter layout edit mode and arrange widgets.
+1. **Install Prism**: [installation guide](getting-started/install.md).
+2. **Add family members**: *Settings → Family Members → Add Member.* Each gets a name, color, avatar, role (parent or child), and a personal 4- or 6-digit PIN.
+3. **Set PINs**: each member has their own 4- or 6-digit PIN, chosen in the setup wizard when you first install, or later in *Settings → Security.* A fresh install boots straight into the setup wizard (there is no default-PIN login screen); the optional demo seed uses `1234` for every user, so change those before real use.
+4. **Connect integrations**: *Settings → Integrations.* Most families want at least Google Calendar, weather (Open-Meteo is the zero-config default), and OneDrive. See the [first-time setup walkthrough](getting-started/first-time-setup.md).
+5. **Customize the dashboard**: click the **grid icon** to enter layout edit mode and arrange widgets.
 
-When you're done with setup, install Prism as a PWA on phones and tablets — [Mobile guide](features/MOBILE.md).
+When you're done with setup, install Prism as a PWA on phones and tablets: [Mobile guide](features/MOBILE.md).
 
 ---
 
 ## Logging in
 
-Tap your avatar, enter your PIN (4 or 6 digits, depending on how it was set). The PIN auto-submits once its full length is reached. Keyboard input works too (0-9, Backspace, Enter). Sessions use a sliding window — parents stay signed in ~7 days, children 1 day — up to an absolute cap (parents 30 days, children 7 days). There is no shared-device toggle.
+Tap your avatar, enter your PIN (4 or 6 digits, depending on how it was set). The PIN auto-submits once its full length is reached. Keyboard input works too (0-9, Backspace, Enter). Sessions use a sliding window (parents stay signed in ~7 days, children 1 day) up to an absolute cap (parents 30 days, children 7 days). There is no shared-device toggle.
 
 ---
 
@@ -65,7 +65,7 @@ To-do items with assignment, due dates, priorities, lists, nested grouping (Pers
 
 ### [Goals & Points](features/GOALS.md)
 
-Kids earn points from approved chores. Parents set goals — recurring (allowance) or one-time (LEGO set). Waterfall allocation fills goals in priority order. Seasonal celebration animations when a goal is achieved.
+Kids earn points from approved chores. Parents set goals: recurring (allowance) or one-time (LEGO set). Waterfall allocation fills goals in priority order. Seasonal celebration animations when a goal is achieved.
 
 ### [Messages](features/MESSAGES.md)
 
@@ -93,7 +93,7 @@ School bus arrival predictions via Gmail/FirstView email parsing. Adaptive polli
 
 ### [Display Modes](features/DISPLAY-MODES.md)
 
-Screensaver, Away Mode, and Babysitter Mode — three overlay modes that layer on top of the dashboard for idle, privacy, and caregiver scenarios.
+Screensaver, Away Mode, and Babysitter Mode: three overlay modes that layer on top of the dashboard for idle, privacy, and caregiver scenarios.
 
 ### [Mobile & PWA](features/MOBILE.md)
 
@@ -101,9 +101,9 @@ Installable as a PWA on iOS, Android, and desktop. Phone viewports get a Floatin
 
 ### Integrations
 
-- **[Kroger / Mariano's cart push](features/KROGER.md)** — send your shopping list to your online cart at any Kroger banner.
-- **[Home Assistant](home-assistant.md)** — read Prism data into HA via the Voice API tokens.
-- **[Voice API + Alexa skill](voice-api.md)** — token-authenticated `/api/v1/voice/*` endpoints; personal Alexa skill for asking "Alexa, ask Prism what's on today."
+- **[Kroger / Mariano's cart push](features/KROGER.md)**: send your shopping list to your online cart at any Kroger banner.
+- **[Home Assistant](home-assistant.md)**: read Prism data into HA via the Voice API tokens.
+- **[Voice API + Alexa skill](voice-api.md)**: token-authenticated `/api/v1/voice/*` endpoints; personal Alexa skill for asking "Alexa, ask Prism what's on today."
 
 ---
 
@@ -119,7 +119,7 @@ Views: **Group by Person** (cards per family member), **List view** (sortable), 
 
 ### Meals
 
-Weekly meal planner. Plan meals by day + meal type (breakfast / lunch / snack / dinner); each meal can carry an optional time of day (defaulting to breakfast 7am / lunch 12pm / snack 3pm / dinner 6pm) used for calendar placement. Link recipes from the [Recipes](features/RECIPES.md) library so opening a planned meal jumps to its recipe. Mark as cooked to track. Drag between days — including from the dashboard Meals widget on touch devices. Filter the week by one or more meal types using the breakfast/lunch/dinner/snack pills. Pull a meal plan from Tandoor or Mealie via **Add ▾ → Sync meal plan…** (review-and-approve; imported meals bring their recipes along). Week starts on your configured day (*Settings → General → Week Starts On*).
+Weekly meal planner. Plan meals by day + meal type (breakfast / lunch / snack / dinner); each meal can carry an optional time of day (defaulting to breakfast 7am / lunch 12pm / snack 3pm / dinner 6pm) used for calendar placement. Link recipes from the [Recipes](features/RECIPES.md) library so opening a planned meal jumps to its recipe. Mark as cooked to track. Drag between days, including from the dashboard Meals widget on touch devices. Filter the week by one or more meal types using the breakfast/lunch/dinner/snack pills. Pull a meal plan from Tandoor or Mealie via **Add ▾ → Sync meal plan…** (review-and-approve; imported meals bring their recipes along). Week starts on your configured day (*Settings → General → Week Starts On*).
 
 ### Performance Mode
 
@@ -131,23 +131,23 @@ Auto-enabled on devices reporting ≤2 GB RAM or ≤4 CPU cores. Stretches polli
 
 A short tour of *Settings*. (Each section's deep behavior is documented in the linked feature pages above where relevant.)
 
-- **Account & Profile** — current session and default display user.
-- **Family Members** — add / edit / remove members. Names, colors, avatars, roles, sort order.
-- **General** — weather location (city or postal code), time zone, Week Starts On.
-- **Integrations** — one card per provider brand: Google (Calendar, Tasks), Microsoft (To Do, OneDrive), Gmail (bus tracking), Apple / CalDAV, Kroger (shopping cart push), plus Photo Sources. Per-list Task / Shopping / Wish List sync is mapped inside the Microsoft or Google provider card.
-- **Displays** — per-dashboard font scale.
-- **Appearance** — Color Scheme (Light / Dark / System), Theme Palette, Seasonal Theme, Performance Mode, Screensaver / Photo Rotation / Auto-Hide Navigation / Away Mode timers, Orientation Override.
-- **Photos** — manage sources (Local, OneDrive, Immich); folder picker; display filters (orientation, resolution); GPS backfill; pinned wallpaper / screensaver.
-- **Bus Tracking** — Gmail connection, route configuration, route auto-discovery, Gmail label filter.
-- **Input** — on-screen keyboard and barcode-scanner toggles.
-- **Babysitter Info** — emergency contacts, house info (WiFi password stored AES-256-GCM encrypted), child info, house rules.
-- **Features** — show / hide individual nav pages.
-- **Security** — PINs + API tokens (with Voice / Full scope picker).
-- **Backups & Data** — create, download, restore, or delete database backups. Includes dangerous operations (Truncate, Seed demo data) gated behind explicit confirmation.
-- **Activity Log** — filterable log of every action taken in the app.
-- **About** — version, links, re-run the setup wizard.
+- **Account & Profile**: current session and default display user.
+- **Family Members**: add / edit / remove members. Names, colors, avatars, roles, sort order.
+- **General**: weather location (city or postal code), time zone, Week Starts On.
+- **Integrations**: one card per provider brand: Google (Calendar, Tasks), Microsoft (To Do, OneDrive), Gmail (bus tracking), Apple / CalDAV, Kroger (shopping cart push), plus Photo Sources. Per-list Task / Shopping / Wish List sync is mapped inside the Microsoft or Google provider card.
+- **Displays**: per-dashboard font scale.
+- **Appearance**: Color Scheme (Light / Dark / System), Theme Palette, Seasonal Theme, Performance Mode, Screensaver / Photo Rotation / Auto-Hide Navigation / Away Mode timers, Orientation Override.
+- **Photos**: manage sources (Local, OneDrive, Immich); folder picker; display filters (orientation, resolution); GPS backfill; pinned wallpaper / screensaver.
+- **Bus Tracking**: Gmail connection, route configuration, route auto-discovery, Gmail label filter.
+- **Input**: on-screen keyboard and barcode-scanner toggles.
+- **Babysitter Info**: emergency contacts, house info (WiFi password stored AES-256-GCM encrypted), child info, house rules.
+- **Features**: show / hide individual nav pages.
+- **Security**: PINs + API tokens (with Voice / Full scope picker).
+- **Backups & Data**: create, download, restore, or delete database backups. Includes dangerous operations (Truncate, Seed demo data) gated behind explicit confirmation.
+- **Activity Log**: filterable log of every action taken in the app.
+- **About**: version, links, re-run the setup wizard.
 
-> Calendar management (enable / assign / color synced calendars, iCal subscriptions, and Calendar Hours) is no longer a Settings section — it now lives behind the **Manage** button on the Calendar page.
+> Calendar management (enable / assign / color synced calendars, iCal subscriptions, and Calendar Hours) is no longer a Settings section. It now lives behind the **Manage** button on the Calendar page.
 
 ---
 
@@ -195,7 +195,7 @@ Ask a parent to reset in *Settings → Security → Member PINs.*
 
 ### Stuck in Away or Babysitter Mode
 
-A parent PIN exits both modes. If you forgot it, run `docker exec prism-db psql -U prism -d prism -c "UPDATE users SET pin='\$2a\$12\$...' WHERE role='parent';"` to manually reset — see the install guide for details.
+A parent PIN exits both modes. If you forgot it, run `docker exec prism-db psql -U prism -d prism -c "UPDATE users SET pin='\$2a\$12\$...' WHERE role='parent';"` to manually reset. See the install guide for details.
 
 ### "Failed to save" / "Failed to add"
 
@@ -212,4 +212,4 @@ Refresh the page (Ctrl+Shift+R for a hard reload). For PWA installs: uninstall +
 - **Documentation**: <https://sandydargoport.github.io/prism/>
 - **Report bugs**: [GitHub Issues](https://github.com/sandydargoport/prism/issues)
 - **Source code**: [GitHub Repository](https://github.com/sandydargoport/prism)
-- **License**: PolyForm Noncommercial 1.0.0 — free for personal and non-commercial use.
+- **License**: PolyForm Noncommercial 1.0.0: free for personal and non-commercial use.

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -2,7 +2,7 @@
 
 A factual comparison for anyone evaluating a shared family display.
 
-The TL;DR: Skylight is the easiest if you're willing to pay forever, Dakboard is fine if you trust someone else with your calendar, MagicMirror² is great if you enjoy YAML and live alone, and Prism is the answer if you want **no subscription, no cloud, and a touch-first interface the whole family will actually use** — and you're comfortable running Docker.
+The TL;DR: Skylight is the easiest if you're willing to pay forever, Dakboard is fine if you trust someone else with your calendar, MagicMirror² is great if you enjoy YAML and live alone, and Prism is the answer if you want **no subscription, no cloud, and a touch-first interface the whole family will actually use**, and you're comfortable running Docker.
 
 Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with subtle depth) over a per-display wallpaper, designed to look at home on a kitchen wall display rather than read like a configuration screen.
 
@@ -14,7 +14,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 |---|---|---|---|---|
 | **License** | Open source ([PolyForm NC](https://polyformproject.org/licenses/noncommercial/1.0.0/)) | Closed, proprietary | Closed, proprietary | Open source (MIT) |
 | **Hardware** | Bring your own (any browser + touch optional) | Branded device only ($159–$299) | Bring your own (any browser) | Optimized for one-way mirror + Raspberry Pi |
-| **Data storage** | **100% local** — Postgres in your house | Their cloud | Their cloud (some self-host tiers) | Local on the Pi |
+| **Data storage** | **100% local**: Postgres in your house | Their cloud | Their cloud (some self-host tiers) | Local on the Pi |
 | **Subscription** | **$0/month, forever** | ~$80/yr Plus subscription | $0–$15/mo per display | $0 |
 | **Setup difficulty** | Docker Compose + ~15 min | Plug in, done | Sign up, done | Linux + JS modules + community plugins |
 | **Touch UI** | ✅ Designed touch-first | ✅ | Partial (kiosk-mode-ish) | ❌ Display-only |
@@ -30,7 +30,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 | **Shopping with Kroger / Mariano's push** | ✅ One-click cart push | ❌ | ❌ | ❌ |
 | **Home Assistant integration** | ✅ [Embed as a panel, REST sensors, + one-click add-on](home-assistant.md) | ❌ | Limited | ✅ Native HA card available |
 | **Voice / Alexa skill** | ✅ Voice API foundation (v1.8) | ❌ | ❌ | Via module |
-| **Vendor lock-in** | None — your data, your DB | High | Medium | None |
+| **Vendor lock-in** | None: your data, your DB | High | Medium | None |
 | **You own your data** | ✅ Always | ❌ Hosted by Skylight | ❌ Hosted by Dakboard | ✅ |
 | **Works offline (your LAN)** | ✅ | ❌ | ❌ | ✅ |
 
@@ -49,7 +49,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 
 - You already have a spare display you want to repurpose
 - You're OK with the subscription cost for the convenience
-- You don't need touch interactivity — Dakboard is primarily a display dashboard
+- You don't need touch interactivity. Dakboard is primarily a display dashboard
 
 ### Choose MagicMirror² if…
 
@@ -63,7 +63,7 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 - The whole family needs to interact with it (touch, multi-user PINs, chore tracking, shopping list updates from your phone)
 - You refuse to pay $80/yr forever for software that should be open
 - You want your calendar, chores, and photos to **stay in your house**
-- You're comfortable running `docker-compose up` (or are willing to learn — there's an installer)
+- You're comfortable running `docker-compose up` (or are willing to learn: there's an installer)
 
 ---
 
@@ -72,10 +72,10 @@ Prism's visual style is a **glassmorphism** layout (frosted-glass widgets with s
 Being fair:
 
 - **Hardware curation.** Skylight ships a beautiful purpose-built display. You have to source your own (a 27" 4K display + a small PC works great, but you have to pick it).
-- **Onboarding friction.** Skylight is plug-and-play. Prism needs Docker + ~15 minutes of setup — though Prism now installs as a [Home Assistant add-on](home-assistant.md) for a much simpler path if you already run HA.
+- **Onboarding friction.** Skylight is plug-and-play. Prism needs Docker + ~15 minutes of setup, though Prism now installs as a [Home Assistant add-on](home-assistant.md) for a much simpler path if you already run HA.
 - **Mature ecosystem.** MagicMirror² has a community module for everything. Prism is younger; we're integration-rich but not module-exhaustive.
 
-If those trade-offs are deal-breakers for your household, one of the others is the better fit. If they aren't — Prism is what you've been looking for.
+If those trade-offs are deal-breakers for your household, one of the others is the better fit. If they aren't, Prism is what you've been looking for.
 
 ---
 

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -6,14 +6,14 @@ This page explains how a public Prism demo (e.g. at a hostname like `prism-demo.
 
 ## What the demo is
 
-A read-only public Prism instance seeded with **synthetic** data — fictional family Alex / Jordan / Emma / Sophie, no real names, addresses, schools, calendars, or photos. The dashboard, calendar, chores, meals, etc. all work; mutations are intercepted by middleware and rejected with a friendly *"this is a read-only demo"* message. The database is wiped and reseeded nightly so any state that does change (login session, locally-cached layout) returns to baseline.
+A read-only public Prism instance seeded with **synthetic** data: fictional family Alex / Jordan / Emma / Sophie, no real names, addresses, schools, calendars, or photos. The dashboard, calendar, chores, meals, etc. all work; mutations are intercepted by middleware and rejected with a friendly *"this is a read-only demo"* message. The database is wiped and reseeded nightly so any state that does change (login session, locally-cached layout) returns to baseline.
 
 ## Why this shape
 
 Three things need to be true for the demo to be safe to leave running on the open internet:
 
 1. **No real PII.** The seed file `src/lib/db/init/03-seed.sql` only ever contained fictional data. Demo deployments never receive `.env` keys for real Google Calendar / OneDrive / Gmail, so even if a visitor tried to connect external accounts, the integration credentials don't exist.
-2. **Visitors can't trash it for everyone else.** `DEMO_MODE=true` is checked in `src/middleware.ts` — every `POST/PUT/PATCH/DELETE` returns 403 with a `demo_mode` error code, except auth login/logout/session (so visitors can switch between Alex/Jordan/Emma/Sophie to see role-based UI).
+2. **Visitors can't trash it for everyone else.** `DEMO_MODE=true` is checked in `src/middleware.ts`. Every `POST/PUT/PATCH/DELETE` returns 403 with a `demo_mode` error code, except auth login/logout/session (so visitors can switch between Alex/Jordan/Emma/Sophie to see role-based UI).
 3. **State drift is bounded.** A nightly cron job runs `scripts/demo-reset.sh`, which truncates every table in the public schema (except migration bookkeeping) and reapplies the seed. Worst case, the demo is wrong for ≤24 hours.
 
 The demo is never the same host as your real install. Standing it up needs its own VM, its own DNS name, its own `.env`.
@@ -24,13 +24,13 @@ The demo is never the same host as your real install. Standing it up needs its o
 
 Why this is the default recommendation:
 
-- **Predictable capacity** — pick the image, click Create, the VM is yours in 30 seconds. No region-roulette like Oracle.
-- **x86, not ARM** — same architecture as your dev machine, so any ad-hoc `docker run` debugging works without `--platform` flags.
-- **Trivially small bill** — CPX11 is 2 vCPU / 2 GB / 40 GB SSD for ~€3.79/mo. A demo for marketing purposes is worth $4/mo.
-- **Linear UX** — the Hetzner Cloud Console has roughly 4 screens. You won't get lost.
+- **Predictable capacity**: pick the image, click Create, the VM is yours in 30 seconds. No region-roulette like Oracle.
+- **x86, not ARM**: same architecture as your dev machine, so any ad-hoc `docker run` debugging works without `--platform` flags.
+- **Trivially small bill**: CPX11 is 2 vCPU / 2 GB / 40 GB SSD for ~€3.79/mo. A demo for marketing purposes is worth $4/mo.
+- **Linear UX**: the Hetzner Cloud Console has roughly 4 screens. You won't get lost.
 
 Caveats:
-- Not free (but it's $4/mo — calibrate accordingly).
+- Not free (but it's $4/mo, calibrate accordingly).
 - 2 GB RAM is tight if you also run the optional bus-tracking integration. For a demo without external integrations, it's fine.
 
 ### Alternative: Oracle Cloud Always Free
@@ -39,8 +39,8 @@ Why someone might pick this: it's actually free, indefinitely, and the free tier
 
 Caveats:
 - **Capacity is the catch.** ARM Always Free instances are frequently exhausted. People have spent days running scripts that retry every few minutes until capacity opens up. For a "ship it tonight" demo this is unacceptable; for a "I'm fine waiting" hobbyist it's free hardware.
-- ARM-only — Prism's Dockerfile is multi-arch so this works, but cross-arch debugging from your x86 dev machine is one extra friction point.
-- Console is dense. Networking has a learning curve (VCN, subnets, security lists, route tables) — you don't need to understand it deeply, but the first walkthrough takes longer.
+- ARM-only: Prism's Dockerfile is multi-arch so this works, but cross-arch debugging from your x86 dev machine is one extra friction point.
+- Console is dense. Networking has a learning curve (VCN, subnets, security lists, route tables). You don't need to understand it deeply, but the first walkthrough takes longer.
 
 ### Other alternatives
 
@@ -53,11 +53,11 @@ For a demo, the sweet spot is "public, low-friction, not connected to your home 
 
 ## DNS
 
-You need a public hostname that **does not** point at your home network or any tied to your real identity. A free DDNS name is sufficient — DuckDNS, FreeDNS, or No-IP all work. Pick something neutral (`prism-demo.duckdns.org`).
+You need a public hostname that **does not** point at your home network or any tied to your real identity. A free DDNS name is sufficient: DuckDNS, FreeDNS, or No-IP all work. Pick something neutral (`prism-demo.duckdns.org`).
 
 > Do **not** reuse the same hostname pattern as your real install (e.g. `prism.<your-real-domain>`). Keep the demo on its own DNS so visitors of the demo can never see traffic from your real install and vice versa.
 
-## Walkthrough — Hetzner CPX11 (recommended)
+## Walkthrough: Hetzner CPX11 (recommended)
 
 End-to-end, this is ~30 minutes the first time.
 
@@ -67,7 +67,7 @@ You need a public hostname pointing at your demo VM that **isn't tied to your re
 
 - Go to https://www.duckdns.org and sign in with GitHub.
 - On the dashboard, type a subdomain (e.g. `prism-demo`) and click **add domain**.
-- Save the **token** at the top of the page — you'll need it in step 4.
+- Save the **token** at the top of the page, you'll need it in step 4.
 - The hostname will be `<whatever>.duckdns.org`. Don't fill in the IP yet; you'll do that after the VM is provisioned.
 
 > Don't reuse your real install's hostname pattern (e.g. don't pick `prism.<your-real-domain>`). Keep the demo on its own DNS so visitors of the demo can never see traffic from your real install and vice versa.
@@ -96,7 +96,7 @@ You need a public hostname pointing at your demo VM that **isn't tied to your re
 - **Name**: `prism-demo`
 - Click **Create & Buy now**.
 
-After ~30 seconds the server is running. Note the **public IPv4 address** — you'll need it next.
+After ~30 seconds the server is running. Note the **public IPv4 address**, you'll need it next.
 
 ### 4. Point DDNS at the VM
 
@@ -109,7 +109,7 @@ After ~30 seconds the server is running. Note the **public IPv4 address** — yo
 ssh root@<your-vm-ip>
 ```
 
-(First time only — accept the host fingerprint.)
+(First time only, accept the host fingerprint.)
 
 ```bash
 # Make a non-root user so we don't run Docker as root
@@ -121,7 +121,7 @@ chown -R prism:prism /home/prism/.ssh
 chmod 700 /home/prism/.ssh
 chmod 600 /home/prism/.ssh/authorized_keys
 
-# Basic firewall — only HTTP/HTTPS/SSH exposed
+# Basic firewall: only HTTP/HTTPS/SSH exposed
 ufw allow OpenSSH
 ufw allow 80
 ufw allow 443
@@ -131,7 +131,7 @@ ufw --force enable
 curl -fsSL https://get.docker.com | sh
 usermod -aG docker prism
 
-# Install Caddy (provides automatic TLS via Let's Encrypt — zero config)
+# Install Caddy (provides automatic TLS via Let's Encrypt, zero config)
 apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
@@ -188,7 +188,7 @@ docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d
 docker compose ps   # wait until app shows "healthy"
 ```
 
-First build takes 5-10 minutes. After it's up, visit `https://prism-demo.duckdns.org` — you should see:
+First build takes 5-10 minutes. After it's up, visit `https://prism-demo.duckdns.org`. You should see:
 
 - The amber **"Prism Demo · Read-only · Resets daily at midnight UTC"** banner across the top
 - The dashboard with the synthetic Alex / Jordan / Emma / Sophie family
@@ -214,15 +214,15 @@ The reset truncates every table in the public schema, reapplies `03-seed.sql`, a
 
 Open a PR adding the public demo link to the project README so visitors discover it.
 
-## Walkthrough — Oracle Cloud Always Free (alternative)
+## Walkthrough: Oracle Cloud Always Free (alternative)
 
 Oracle gives you more hardware for $0 if you can stomach the friction. The high-level flow:
 
 ### 1. Sign up
 
 - https://www.oracle.com/cloud/free
-- Fill in the (long) form. Credit card is required even for the free tier — they verify it but don't charge.
-- Pick a **home region** carefully — this is permanent and capacity varies wildly. Phoenix and Frankfurt typically have more ARM headroom than Ashburn.
+- Fill in the (long) form. Credit card is required even for the free tier, they verify it but don't charge.
+- Pick a **home region** carefully. This is permanent and capacity varies wildly. Phoenix and Frankfurt typically have more ARM headroom than Ashburn.
 
 ### 2. Provision the VM
 
@@ -233,19 +233,19 @@ Oracle gives you more hardware for $0 if you can stomach the friction. The high-
 - **SSH keys**: upload your `~/.ssh/id_ed25519.pub`
 - Click **Create**
 
-If you get **"Out of capacity for shape VM.Standard.A1.Flex"**, you'll need to retry — either manually every few hours or via a retry script. There are GitHub repos like `hitrov/oci-arm-host-capacity` that automate this.
+If you get **"Out of capacity for shape VM.Standard.A1.Flex"**, you'll need to retry: either manually every few hours or via a retry script. There are GitHub repos like `hitrov/oci-arm-host-capacity` that automate this.
 
 ### 3. Open ports in the VCN
 
 - **Networking → Virtual Cloud Networks → your VCN → Subnets → your subnet → Default Security List → Add Ingress Rules**:
   - Source CIDR `0.0.0.0/0`, IP Protocol TCP, Destination Port Range `80`
   - Source CIDR `0.0.0.0/0`, IP Protocol TCP, Destination Port Range `443`
-- **Do not** open `5432` or `6379` — those stay container-internal.
+- **Do not** open `5432` or `6379`. Those stay container-internal.
 - On the VM itself, also `iptables -I INPUT -p tcp --dport 80 -j ACCEPT` and `--dport 443` (Oracle's Ubuntu image has aggressive default iptables rules).
 
 ### 4. Continue from Hetzner step 0
 
-The DDNS, SSH, Docker, Caddy, env, compose, and cron steps are identical to the Hetzner walkthrough. Skip to **step 0** above and continue from there. The user on Oracle's Ubuntu image is `ubuntu` instead of `root` — adjust the `adduser` step accordingly.
+The DDNS, SSH, Docker, Caddy, env, compose, and cron steps are identical to the Hetzner walkthrough. Skip to **step 0** above and continue from there. The user on Oracle's Ubuntu image is `ubuntu` instead of `root`, adjust the `adduser` step accordingly.
 
 ## Security model
 
@@ -267,7 +267,7 @@ docker compose -f docker-compose.yml -f docker-compose.demo.yml build app
 docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d --force-recreate app
 ```
 
-The `--force-recreate` is important — without it the container can keep running the old image even after a successful build.
+The `--force-recreate` is important. Without it the container can keep running the old image even after a successful build.
 
 ## Tearing down
 

--- a/docs/features-index.md
+++ b/docs/features-index.md
@@ -6,7 +6,7 @@ Every feature, what it does, who it's for. Designed to be quotable in one senten
 
 ## Calendar
 
-A unified family calendar that reads from Google Calendar, Apple iCloud (CalDAV), and any iCal/webcal URL — events from every source merged into one view. Day, week, multi-week, month, and 3-month views. Per-member color coding. Touch-friendly for tapping a day to see details.
+A unified family calendar that reads from Google Calendar, Apple iCloud (CalDAV), and any iCal/webcal URL: events from every source merged into one view. Day, week, multi-week, month, and 3-month views. Per-member color coding. Touch-friendly for tapping a day to see details.
 
 → Full docs: [Calendar](features/CALENDAR.md)
 
@@ -64,19 +64,19 @@ Pulls school-bus arrival emails from Gmail (FirstView), parses the route, shows 
 
 ## Display modes
 
-- **Screensaver** — full-screen photo slideshow when idle
-- **Away Mode** — privacy screen when nobody's home
-- **Babysitter Mode** — caregiver-friendly overlay with emergency info, house rules, and Wi-Fi password
+- **Screensaver**: full-screen photo slideshow when idle
+- **Away Mode**: privacy screen when nobody's home
+- **Babysitter Mode**: caregiver-friendly overlay with emergency info, house rules, and Wi-Fi password
 
 → Full docs: [Display Modes](features/DISPLAY-MODES.md)
 
 ## Multi-user PIN authentication
 
-Each family member has a PIN. Touch your avatar, tap your PIN, you're logged in. No usernames, no passwords — designed for shared family devices. Parents have admin rights for sensitive actions (chore approval, settings, goal redemption).
+Each family member has a PIN. Touch your avatar, tap your PIN, you're logged in. No usernames, no passwords, designed for shared family devices. Parents have admin rights for sensitive actions (chore approval, settings, goal redemption).
 
 ## Multiple dashboards per household
 
-Run one dashboard on the kitchen 27" display, a different layout on a 22" hallway tablet, and a third on the kids' iPad — all from the same Prism instance, each with its own widget arrangement and font scale.
+Run one dashboard on the kitchen 27" display, a different layout on a 22" hallway tablet, and a third on the kids' iPad, all from the same Prism instance, each with its own widget arrangement and font scale.
 
 → Full docs: [Display settings + multiple dashboards](features/DISPLAY-MODES.md)
 
@@ -88,7 +88,7 @@ Install Prism as a Progressive Web App on any phone. Adds chores, ticks tasks, s
 
 ## Voice control (Alexa)
 
-Voice API foundation (v1.8). Ask Alexa "what's on the family calendar today" or "remind dad to take out trash" — Alexa hits Prism's voice API to read or write.
+Voice API foundation (v1.8). Ask Alexa "what's on the family calendar today" or "remind dad to take out trash". Alexa hits Prism's voice API to read or write.
 
 → Full docs: [Voice API](voice-api.md)
 
@@ -102,7 +102,7 @@ Reads from / writes to: **Google Calendar**, **Apple iCloud (CalDAV + CardDAV)**
 
 ## What Prism explicitly is NOT
 
-- Not a CMS — it doesn't try to be your family's blog, photo storage, or document archive
-- Not a home automation controller — Home Assistant is better at that (we integrate, we don't compete)
-- Not a smart-mirror display — MagicMirror² is better for that specific form factor
-- Not cloud-hosted — your data stays in your house. If that's a feature you'd rather not have, see [Skylight or Dakboard](alternatives.md) instead
+- Not a CMS: it doesn't try to be your family's blog, photo storage, or document archive
+- Not a home automation controller: Home Assistant is better at that (we integrate, we don't compete)
+- Not a smart-mirror display: MagicMirror² is better for that specific form factor
+- Not cloud-hosted: your data stays in your house. If that's a feature you'd rather not have, see [Skylight or Dakboard](alternatives.md) instead

--- a/docs/features/BUS.md
+++ b/docs/features/BUS.md
@@ -9,7 +9,7 @@ If your district uses FirstView, you can have your dashboard show "Bus 4 minutes
 ## How it works (at a glance)
 
 1. You connect Gmail in *Settings → Bus Tracking → Gmail Connection*.
-2. You configure one or more **bus routes** — each route is a student + AM/PM trip + ordered geofence checkpoints.
+2. You configure one or more **bus routes**: each route is a student + AM/PM trip + ordered geofence checkpoints.
 3. Prism polls Gmail for new FirstView emails, parses them, and updates each route's state (next checkpoint, ETA, status).
 4. The dashboard widget shows the status in real time. As the bus gets closer, polling interval shrinks so the ETA stays accurate.
 
@@ -27,7 +27,7 @@ OAuth flow. Prism requests read-only access to your Gmail (specifically: `gmail.
 
 *Settings → Bus Tracking → Discover from Emails.*
 
-This scans your existing Gmail for FirstView emails (up to the most recent ~100 FirstView emails in your mailbox) and **creates any new routes it finds** in one click — routes with a trip ID + direction you already have are skipped. Each created route captures:
+This scans your existing Gmail for FirstView emails (up to the most recent ~100 FirstView emails in your mailbox) and **creates any new routes it finds** in one click. Routes with a trip ID + direction you already have are skipped. Each created route captures:
 
 - The FirstView trip ID (e.g. "28-C").
 - The direction (AM / PM).
@@ -39,12 +39,12 @@ Edit or delete any routes you don't want afterward. Created routes go into your 
 
 For each route, set:
 
-- **Student name** — what to display ("Emma", not just "Trip 28-C").
-- **Family member** — optional link to a Prism user; lets the widget filter to one kid.
-- **Home ETA** — expected arrival time at your stop, HH:mm format (e.g. `07:42`).
-- **Checkpoints** — ordered list of geofence labels you want to display. The emails reference checkpoint names from FirstView's geofencing setup; you list the ones you care about (e.g. "Bus barn", "Maple & 3rd", "Pine Grove").
-- **Your Stop** — a dropdown that picks which of your listed checkpoints is your stop; it becomes the ETA target for the arrival prediction.
-- **School name** — the school. Implicit final checkpoint for AM, starting checkpoint for PM.
+- **Student name**: what to display ("Emma", not just "Trip 28-C").
+- **Family member**: optional link to a Prism user; lets the widget filter to one kid.
+- **Home ETA**: expected arrival time at your stop, HH:mm format (e.g. `07:42`).
+- **Checkpoints**: ordered list of geofence labels you want to display. The emails reference checkpoint names from FirstView's geofencing setup; you list the ones you care about (e.g. "Bus barn", "Maple & 3rd", "Pine Grove").
+- **Your Stop**: a dropdown that picks which of your listed checkpoints is your stop; it becomes the ETA target for the arrival prediction.
+- **School name**: the school. Implicit final checkpoint for AM, starting checkpoint for PM.
 
 Active days default to Mon–Fri (`[1,2,3,4,5]`) and are not currently editable in the route dialog.
 
@@ -61,19 +61,19 @@ Defaults to scanning all mail. If you have a noisy inbox, the label filter speed
 The BusTracker widget shows one row per route. Each row has:
 
 - **Route label + Home ETA time.**
-- **Checkpoint progress dots** — one dot per checkpoint, filled in as the bus crosses each geofence.
+- **Checkpoint progress dots**: one dot per checkpoint, filled in as the bus crosses each geofence.
 - **Status color**:
-  - **Gray** — before activation (route is enabled but the bus hasn't started moving for today's trip).
-  - **Amber** — bus is moving, on the way.
-  - **Green** — bus arrived at your stop (AM: arrived at school; PM: arrived at your stop).
-  - **Red** — overdue (past the scheduled time with no arrival).
-- **ETA text** — "~4 min away" / "3–5 min away" / "Arrived at stop" / "Arrived at school" / "Overdue — no updates".
+  - **Gray**: before activation (route is enabled but the bus hasn't started moving for today's trip).
+  - **Amber**: bus is moving, on the way.
+  - **Green**: bus arrived at your stop (AM: arrived at school; PM: arrived at your stop).
+  - **Red**: overdue (past the scheduled time with no arrival).
+- **ETA text**: "~4 min away" / "3–5 min away" / "Arrived at stop" / "Arrived at school" / "Overdue: no updates".
 
-When 6+ checkpoints exist, the progress dots wrap into a 2-row layout that follows reading order — top row L→R, bottom row L→R, joined by a U-turn connector on the right — so the widget doesn't sprawl horizontally.
+When 6+ checkpoints exist, the progress dots wrap into a 2-row layout that follows reading order: top row L→R, bottom row L→R, joined by a U-turn connector on the right, so the widget doesn't sprawl horizontally.
 
 ### On the screensaver
 
-The same Bus Tracker widget can be placed on the screensaver canvas (it's hidden by default). It renders the full train-map widget, not a separate simplified variant — handy when a kid's checking the wall display before walking out the door.
+The same Bus Tracker widget can be placed on the screensaver canvas (it's hidden by default). It renders the full train-map widget, not a separate simplified variant. Handy when a kid's checking the wall display before walking out the door.
 
 ---
 
@@ -87,14 +87,14 @@ The pulse rate adapts based on how close the bus is:
 - **ETA 3–5 minutes:** 10 seconds.
 - **ETA ≤3 minutes:** 5 seconds.
 
-Outside the route's ±60-minute display window, polling is disabled entirely (interval 0) — it isn't merely slowed. Note that a route that has already **arrived** keeps a slow 30-second poll until it leaves that ±60-minute window; it does not pause on arrival.
+Outside the route's ±60-minute display window, polling is disabled entirely (interval 0). It isn't merely slowed. Note that a route that has already **arrived** keeps a slow 30-second poll until it leaves that ±60-minute window; it does not pause on arrival.
 
 Polling pauses entirely when:
 
-- It's not an active day for any route (weekend, holiday) — nothing is within the ±60-minute window.
-- The browser tab is hidden — paused via `useVisibilityPolling`. Resumes when the tab is foregrounded.
+- It's not an active day for any route (weekend, holiday). Nothing is within the ±60-minute window.
+- The browser tab is hidden, paused via `useVisibilityPolling`. Resumes when the tab is foregrounded.
 
-The visibility pause is important — without it, an open dashboard tab would poll Gmail every 10 seconds indefinitely, which the Gmail API quota doesn't appreciate.
+The visibility pause is important: without it, an open dashboard tab would poll Gmail every 10 seconds indefinitely, which the Gmail API quota doesn't appreciate.
 
 ---
 
@@ -102,21 +102,21 @@ The visibility pause is important — without it, an open dashboard tab would po
 
 FirstView sends three notification types per trip:
 
-1. **Distance-based** — "Bus is 2 miles away." Contains a distance + ETA estimate.
-2. **Arrived at stop** — "Bus has arrived at your stop." Sent when the bus crosses the stop geofence.
-3. **Arrived at school** — "Bus has arrived at school." Sent when the bus crosses the school geofence (AM trip).
+1. **Distance-based**: "Bus is 2 miles away." Contains a distance + ETA estimate.
+2. **Arrived at stop**: "Bus has arrived at your stop." Sent when the bus crosses the stop geofence.
+3. **Arrived at school**: "Bus has arrived at school." Sent when the bus crosses the school geofence (AM trip).
 
 The parser extracts:
 
 - **Event type** (one of the three above).
-- **Checkpoint name** — which geofence was crossed (matches the configured `checkpoints` for that route).
-- **Event time** — from the email's `Date:` header (timezone-correct; the body text uses naive local times that broke in UTC Docker containers before v1.3).
-- **Trip date** — derived from event time + active day check.
-- **Gmail message ID** — for dedup. The `bus_geofence_log` table has a unique index on `gmail_message_id` so reprocessing a message twice is a no-op.
+- **Checkpoint name**: which geofence was crossed (matches the configured `checkpoints` for that route).
+- **Event time**: from the email's `Date:` header (timezone-correct; the body text uses naive local times that broke in UTC Docker containers before v1.3).
+- **Trip date**: derived from event time + active day check.
+- **Gmail message ID**: for dedup. The `bus_geofence_log` table has a unique index on `gmail_message_id` so reprocessing a message twice is a no-op.
 
 ### Fuzzy checkpoint matching
 
-FirstView's checkpoint names can drift — "Maple & 3rd" might show up as "Maple and 3rd", "Maple/3rd", or just "Maple 3rd" across different emails. The parser does fuzzy matching against your configured checkpoint list so minor variations match cleanly.
+FirstView's checkpoint names can drift: "Maple & 3rd" might show up as "Maple and 3rd", "Maple/3rd", or just "Maple 3rd" across different emails. The parser does fuzzy matching against your configured checkpoint list so minor variations match cleanly.
 
 ### Historical median transit times
 
@@ -130,13 +130,13 @@ If the median for `Pine Grove → Our stop` is 4 minutes, and the bus just cross
 
 Each route walks through these states per trip:
 
-1. **Pre-activation** (gray) — before the first email of the day arrives. Polls slowly.
-2. **In transit** (amber) — at least one email has arrived; bus is between checkpoints.
-3. **Approaching** (amber, fast polling) — within 3-5 minutes of predicted arrival.
-4. **Arrived** (green) — final email received. AM: at school. PM: at your stop.
-5. **Overdue** (red) — past the scheduled arrival time + 30 minute grace, with no arrival email.
+1. **Pre-activation** (gray): before the first email of the day arrives. Polls slowly.
+2. **In transit** (amber): at least one email has arrived; bus is between checkpoints.
+3. **Approaching** (amber, fast polling): within 3-5 minutes of predicted arrival.
+4. **Arrived** (green): final email received. AM: at school. PM: at your stop.
+5. **Overdue** (red): past the scheduled arrival time + 30 minute grace, with no arrival email.
 
-The overdue state intentionally has a grace window — buses run a few minutes late routinely, and you don't want a false alarm every Tuesday.
+The overdue state intentionally has a grace window: buses run a few minutes late routinely, and you don't want a false alarm every Tuesday.
 
 ---
 
@@ -150,11 +150,11 @@ Active days aren't currently editable from the route dialog, so routes that only
 
 ## Privacy
 
-Bus tracking is your data, on your instance. The only external service involved is Gmail — Prism's read-only access lets it parse the FirstView emails you already receive.
+Bus tracking is your data, on your instance. The only external service involved is Gmail. Prism's read-only access lets it parse the FirstView emails you already receive.
 
 - Gmail OAuth tokens are stored AES-256-GCM encrypted at rest.
 - Parsed email bodies are not stored verbatim; only the structured fields (checkpoint, event time, event type) plus the Gmail message ID for dedup.
-- Disconnect anytime — *Settings → Bus Tracking → Gmail Connection → Disconnect*. Tokens are deleted; existing bus tracking data stays in your DB but stops updating.
+- Disconnect anytime: *Settings → Bus Tracking → Gmail Connection → Disconnect*. Tokens are deleted; existing bus tracking data stays in your DB but stops updating.
 
 ---
 
@@ -182,12 +182,12 @@ When the bus is late, the widget shows what happened: which checkpoints were cro
 
 ### "Bus tracker shows nothing"
 
-Most common cause: no FirstView emails in your inbox yet for today. The widget activates when the first email of the day arrives. Check Gmail directly — do you see today's emails?
+Most common cause: no FirstView emails in your inbox yet for today. The widget activates when the first email of the day arrives. Check Gmail directly: do you see today's emails?
 
 If yes but Prism doesn't, check:
 
-1. *Settings → Bus Tracking → Gmail Connection* — still connected?
-2. *Settings → Bus Tracking → Gmail label* — is the label filter correct? (If your filter routes to a `bus` label, the default "scan all mail" might not find them either — but the label-specific scan would.)
+1. *Settings → Bus Tracking → Gmail Connection*: still connected?
+2. *Settings → Bus Tracking → Gmail label*: is the label filter correct? (If your filter routes to a `bus` label, the default "scan all mail" might not find them either, but the label-specific scan would.)
 3. Force a sync: *Settings → Bus Tracking → Sync now.*
 
 ### Route auto-discovery missed a trip
@@ -196,7 +196,7 @@ Discovery scans up to the most recent ~100 FirstView emails in your mailbox. If 
 
 ### Checkpoint progress dots don't fill in
 
-The checkpoint names must match (fuzzily) what FirstView sends. If a checkpoint never fills, check the parsed `bus_geofence_log` rows — what `checkpoint_name` did Prism actually parse? Update your `checkpoints` config to match.
+The checkpoint names must match (fuzzily) what FirstView sends. If a checkpoint never fills, check the parsed `bus_geofence_log` rows: what `checkpoint_name` did Prism actually parse? Update your `checkpoints` config to match.
 
 ### "Overdue" status on weekends
 
@@ -204,7 +204,7 @@ Routes default to active Mon–Fri (`[1,2,3,4,5]`), so weekends should already s
 
 ### ETA shows "925m" or other huge value
 
-Was a bug in older versions — large minute values weren't being converted to "h m" format. Fixed in v1.3. Should now show "15h 25m". Hard-reload if you still see raw minutes.
+Was a bug in older versions: large minute values weren't being converted to "h m" format. Fixed in v1.3. Should now show "15h 25m". Hard-reload if you still see raw minutes.
 
 ### Gmail rate-limited
 
@@ -212,8 +212,8 @@ Gmail's API has a generous quota but it's not infinite. The visibility-pause + a
 
 ### "Bus at school" shows 0-minute ETA at pickup time
 
-Was an old display bug where PM routes showed "0 min" before the bus left school instead of "at school, en route." Fixed — now shows "Bus at school — en route."
+Was an old display bug where PM routes showed "0 min" before the bus left school instead of "at school, en route." Fixed. Now shows "Bus at school, en route."
 
 ### Arrival timestamps were off by 6 hours
 
-Was a TZ bug in early v1.3 — arrival parsers were parsing the email body's text time as naive UTC instead of the email's `Date:` header (which is timezone-aware). Fixed. If you see this on old data, it'll correct itself for new arrivals; historical rows can be re-parsed by deleting and re-syncing.
+Was a TZ bug in early v1.3: arrival parsers were parsing the email body's text time as naive UTC instead of the email's `Date:` header (which is timezone-aware). Fixed. If you see this on old data, it'll correct itself for new arrivals; historical rows can be re-parsed by deleting and re-syncing.

--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -10,38 +10,38 @@ The calendar brings every family member's schedule together with meals, chores, 
 
 ### Personal & Family calendars (no integration needed)
 
-You don't have to connect anything to start using the calendar. On a fresh install every family member automatically gets their **own personal calendar**, plus there's a single shared **Family** calendar for household-wide events. Add and assign events to any of these right away — connected accounts (below) just layer additional sources on top.
+You don't have to connect anything to start using the calendar. On a fresh install every family member automatically gets their **own personal calendar**, plus there's a single shared **Family** calendar for household-wide events. Add and assign events to any of these right away. Connected accounts (below) just layer additional sources on top.
 
-### Google Calendar (OAuth — bidirectional)
+### Google Calendar (OAuth, bidirectional)
 
 *Settings → Integrations → Google → Connect.*
 
 OAuth grants Prism read+write access to your Google Calendars. You can create, edit, drag, and delete events in Prism, and changes push back to Google Calendar within seconds. Each individual calendar in your Google account (personal, family-shared, work, etc.) shows up in the **Manage** overlay on the Calendar page where you decide which to display.
 
-The connection covers Calendar specifically — if you also want Google Tasks sync, that's configured per-list inside the Google provider card on the same *Settings → Integrations* page.
+The connection covers Calendar specifically. If you also want Google Tasks sync, that's configured per-list inside the Google provider card on the same *Settings → Integrations* page.
 
 ### iCal subscriptions (read-only)
 
 *Open the Calendar page → **Manage** → Subscribe to a calendar → paste URL.*
 
-For any calendar published as an `.ics` URL — school calendars, sports leagues, holiday feeds, your spouse's outlook.live.com calendar — paste the URL and Prism subscribes. Events sync periodically and appear alongside Google events. iCal sources are read-only by definition (no write endpoint exists for these feeds), so the dashboard treats them like any other source for display but won't offer edit affordances on their events.
+For any calendar published as an `.ics` URL (school calendars, sports leagues, holiday feeds, your spouse's outlook.live.com calendar), paste the URL and Prism subscribes. Events sync periodically and appear alongside Google events. iCal sources are read-only by definition (no write endpoint exists for these feeds), so the dashboard treats them like any other source for display but won't offer edit affordances on their events.
 
 ### Apple Calendar / iCloud (read-only via the iCal feed)
 
 iCloud doesn't speak OAuth or expose a public REST API, so Prism rides the same iCal-subscription path. Apple makes a `webcal://` URL available for any calendar you mark as Public. From a Mac:
 
 1. Open *Calendar.app*, right-click the calendar in the sidebar → *Share Calendar*.
-2. Tick **Public Calendar** — a URL appears underneath.
+2. Tick **Public Calendar**: a URL appears underneath.
 3. Click the *share* button next to the URL and *Copy Link* (it'll start with `webcal://`).
 4. In Prism: open the Calendar page → **Manage** → *Subscribe to a calendar*, paste the URL, give it a name, click *Add*.
 
 From iCloud.com it's the same idea: *Calendar → ⓘ next to the calendar → Public Calendar → Copy Link*.
 
-Caveats: this is a one-way feed (changes you make in Prism don't push back to iCloud — there's no UI to "edit" these events because the feed is read-only), and the calendar has to be marked Public on iCloud's side.
+Caveats: this is a one-way feed (changes you make in Prism don't push back to iCloud: there's no UI to "edit" these events because the feed is read-only), and the calendar has to be marked Public on iCloud's side.
 
-### Apple iCloud (CalDAV — private calendars + Reminders) — *alpha*
+### Apple iCloud (CalDAV, private calendars + Reminders), *alpha*
 
-For calendars you don't want to mark Public — or to sync **Reminders** as tasks — Prism supports iCloud over CalDAV. This is the same protocol the macOS/iOS Calendar app uses.
+For calendars you don't want to mark Public, or to sync **Reminders** as tasks, Prism supports iCloud over CalDAV. This is the same protocol the macOS/iOS Calendar app uses.
 
 1. Generate an app-specific password at [appleid.apple.com](https://appleid.apple.com) → *Sign-In and Security → App-Specific Passwords → Generate*.
 2. In Prism: *Settings → Integrations → Apple iCloud / CalDAV → Connect*.
@@ -53,31 +53,31 @@ For calendars you don't want to mark Public — or to sync **Reminders** as task
 
 The same flow works for **Nextcloud** (`https://your-server/remote.php/dav`), **Radicale**, **Baikal** (`https://your-server/dav.php`), and **Synology Calendar** (`https://your-nas:5001/caldav/`).
 
-Caveats: this path is **read-only for create/edit** — events and tasks pulled from CalDAV appear in the dashboard but can't be created or edited from Prism. There is one exception: **deleting a single (non-recurring) synced event in Prism now removes it from the source server too** (iCloud/Nextcloud/etc.), so treat that delete as destructive upstream. Recurring series still delete locally only. App-specific passwords are stored encrypted in the Prism database and never leave your server. Apple Reminders sync into Prism's Tasks list with the same priorities and due dates the iOS app uses.
+Caveats: this path is **read-only for create/edit**: events and tasks pulled from CalDAV appear in the dashboard but can't be created or edited from Prism. There is one exception: **deleting a single (non-recurring) synced event in Prism now removes it from the source server too** (iCloud/Nextcloud/etc.), so treat that delete as destructive upstream. Recurring series still delete locally only. App-specific passwords are stored encrypted in the Prism database and never leave your server. Apple Reminders sync into Prism's Tasks list with the same priorities and due dates the iOS app uses.
 
-> Wondering what *else* you can pull from iCloud (Reminders, Notes, Photos, Find My)? See the [iCloud integration overview](ICLOUD.md) — short answer: calendars and contacts work, nothing else does, and there's a structural reason.
+> Wondering what *else* you can pull from iCloud (Reminders, Notes, Photos, Find My)? See the [iCloud integration overview](ICLOUD.md). Short answer: calendars and contacts work, nothing else does, and there's a structural reason.
 
 ### Per-calendar customization
 
 In the **Manage** overlay on the Calendar page, each source supports:
 
-- **Enable/disable** — toggle off without disconnecting. Disabled calendars don't appear anywhere in the UI.
-- **Assign to a family member** — links the calendar to a person so its events appear in that person's column on Day/List views. Mark a calendar as **Family** if it's a shared household calendar.
-- **Display name** — override the Google/iCal name (e.g. "Mike's Work" → "Work").
-- **Color** — override the source's default color.
-- **Show in Add Event modal** — uncheck for subscription / read-only calendars so they don't appear as creation targets.
+- **Enable/disable**: toggle off without disconnecting. Disabled calendars don't appear anywhere in the UI.
+- **Assign to a family member**: links the calendar to a person so its events appear in that person's column on Day/List views. Mark a calendar as **Family** if it's a shared household calendar.
+- **Display name**: override the Google/iCal name (e.g. "Mike's Work" → "Work").
+- **Color**: override the source's default color.
+- **Show in Add Event modal**: uncheck for subscription / read-only calendars so they don't appear as creation targets.
 
 ---
 
 ## Server-side sync
 
-A 10-minute background cron job keeps Google + iCal events in sync without depending on anyone having the dashboard open. The default sync window is **−90 days to +365 days** — past three months stay populated for historic views, and the next school year fits comfortably ahead.
+A 10-minute background cron job keeps Google + iCal events in sync without depending on anyone having the dashboard open. The default sync window is **−90 days to +365 days**: past three months stay populated for historic views, and the next school year fits comfortably ahead.
 
-Events outside the window are not deleted — once an event is synced into Prism's database, it remains there permanently. The delete-on-remove pass only operates inside the window, so manually shrinking the window won't lose your archive.
+Events outside the window are not deleted. Once an event is synced into Prism's database, it remains there permanently. The delete-on-remove pass only operates inside the window, so manually shrinking the window won't lose your archive.
 
 ### Review before deleting
 
-Sync never silently removes events. When an event that used to exist disappears from its source, Prism **holds** the removal instead of applying it and surfaces a **Review N** badge on the calendar. Open it and decide per event: **Keep** (it stays in Prism) or **Delete** (it's removed). Applying a deletion requires delete permission. Adds and updates from the source still apply automatically — only removals wait for your review.
+Sync never silently removes events. When an event that used to exist disappears from its source, Prism **holds** the removal instead of applying it and surfaces a **Review N** badge on the calendar. Open it and decide per event: **Keep** (it stays in Prism) or **Delete** (it's removed). Applying a deletion requires delete permission. Adds and updates from the source still apply automatically. Only removals wait for your review.
 
 Set `PRISM_DISABLE_CALENDAR_CRON=true` in your `.env` to fall back to user-triggered syncs only (e.g. on a low-power device where you don't want background work). Manual sync is always available from the **Manage** overlay on the Calendar page (*Sync*).
 
@@ -91,16 +91,16 @@ Both the calendar subpage and the dashboard widget expose the same set of ten vi
 |---|---|
 | **Agenda** | Upcoming-events list. Default view on mobile. |
 | **Day** | Hourly breakdown with side-by-side calendar columns. |
-| **List** | Vertical week view — each day stacks its events. Pairs well with the notes column. |
+| **List** | Vertical week view: each day stacks its events. Pairs well with the notes column. |
 | **Schedule** | Week shown as one tall vertical column. Good for narrow displays. |
 | **1W** | Single week, 7-day grid with hourly rows. |
-| **2W / 3W / 4W** | Multi-week grids — 2 / 3 / 4 weeks visible at once. |
+| **2W / 3W / 4W** | Multi-week grids: 2 / 3 / 4 weeks visible at once. |
 | **Month** | Standard calendar grid (6-week rendered span). |
 | **3 Months** | Three months side-by-side. Long-term planning. |
 
 The view dropdown has ▲▼ triangles for one-click cycling. Multi-week navigation advances/retreats by `weekCount` (so 4W view's "next" jumps 4 weeks ahead, not 1).
 
-On phones, calendar views collapse to Agenda only — no view switcher, no chevrons. Header reads "Upcoming Events."
+On phones, calendar views collapse to Agenda only: no view switcher, no chevrons. Header reads "Upcoming Events."
 
 ---
 
@@ -108,12 +108,12 @@ On phones, calendar views collapse to Agenda only — no view switcher, no chevr
 
 The **View Options** gear (next to the view dropdown) lets you switch between two ways of laying out events within each day cell:
 
-- **Inline** — compact rows of event titles. Original look. Highest event density per cell.
-- **Cards** — each day becomes a small card with meals at top, events in the middle, chores+tasks at bottom. A dynamic capacity probe respects your font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped.
+- **Inline**: compact rows of event titles. Original look. Highest event density per cell.
+- **Cards**: each day becomes a small card with meals at top, events in the middle, chores+tasks at bottom. A dynamic capacity probe respects your font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped.
 
 Cards mode is what unlocks drag-and-drop and overlays.
 
-The toggle persists per surface — the calendar subpage and the dashboard CalendarWidget remember independently which display mode you prefer.
+The toggle persists per surface: the calendar subpage and the dashboard CalendarWidget remember independently which display mode you prefer.
 
 ---
 
@@ -128,13 +128,13 @@ When you're in **cards mode**, you can drag any of these between days:
 
 Works on Day, List, Week, 1W-4W, Month, 3 Months, and Agenda. Works on the dashboard CalendarWidget too. The drag activates after 5px of pointer movement, so single taps still trigger click-to-edit on the same card.
 
-If the API rejects the move (e.g. moving a recurring event instance is restricted), the error surfaces inline as a `moveError` chip on the source cell — no silent failures.
+If the API rejects the move (e.g. moving a recurring event instance is restricted), the error surfaces inline as a `moveError` chip on the source cell. No silent failures.
 
 ### What gets preserved when you drag
 
-- **Tasks** — the task's time-of-day stays (a 9am task on Tuesday dragged to Thursday is still 9am, not 23:59).
-- **Events** — start/end times are preserved; only the date shifts.
-- **Meals + chores** — these don't have specific times by default, so they just move to the new day.
+- **Tasks**: the task's time-of-day stays (a 9am task on Tuesday dragged to Thursday is still 9am, not 23:59).
+- **Events**: start/end times are preserved; only the date shifts.
+- **Meals + chores**: these don't have specific times by default, so they just move to the new day.
 
 ---
 
@@ -142,7 +142,7 @@ If the API rejects the move (e.g. moving a recurring event instance is restricte
 
 Tasks, chores, and meals shown on the dashboard CalendarWidget are clickable. Tapping any of them opens the same edit modal the calendar subpage uses. The modals lazy-load so the dashboard's first paint isn't taxed.
 
-This means you can do most calendar interactions without leaving the dashboard — edit a chore, drag a meal, click an event for details, all without navigating to `/calendar`.
+This means you can do most calendar interactions without leaving the dashboard: edit a chore, drag a meal, click an event for details, all without navigating to `/calendar`.
 
 ---
 
@@ -150,12 +150,12 @@ This means you can do most calendar interactions without leaving the dashboard �
 
 The gear next to the view dropdown opens View Options. Available toggles depend on the active view:
 
-- **Hide weekends** — multi-week views only (the only views that meaningfully respect weekends).
-- **Merge calendars** — combine all events into one column on Day/List views instead of splitting by person.
-- **Show notes column** — Day and Schedule views only. Renders the calendar-notes panel beside the events.
-- **Overlay toggles** — show/hide events, meals, chores, and tasks independently. The badge on the View Options trigger flags when any toggle is non-default.
-- **Display mode** — Inline / Cards (also reachable here, in addition to the per-view default).
-- **Reset to defaults** — restores everything.
+- **Hide weekends**: multi-week views only (the only views that meaningfully respect weekends).
+- **Merge calendars**: combine all events into one column on Day/List views instead of splitting by person.
+- **Show notes column**: Day and Schedule views only. Renders the calendar-notes panel beside the events.
+- **Overlay toggles**: show/hide events, meals, chores, and tasks independently. The badge on the View Options trigger flags when any toggle is non-default.
+- **Display mode**: Inline / Cards (also reachable here, in addition to the per-view default).
+- **Reset to defaults**: restores everything.
 
 Settings persist to localStorage, separately for the subpage and the dashboard widget.
 
@@ -178,10 +178,10 @@ Filter buttons at the top of the calendar let you show/hide specific calendar gr
 
 Click the **sticky note icon** in the calendar header to open a notes panel beside Day or List views. Notes are:
 
-- **Day-tied** — anchored to a specific calendar date.
-- **Family-shared** — anyone in the family sees the same content; no per-user notes.
-- **Auto-saving** — saves after 2 seconds of idle typing and on focus loss.
-- **Formatted** — supports light Markdown via keyboard shortcuts.
+- **Day-tied**: anchored to a specific calendar date.
+- **Family-shared**: anyone in the family sees the same content; no per-user notes.
+- **Auto-saving**: saves after 2 seconds of idle typing and on focus loss.
+- **Formatted**: supports light Markdown via keyboard shortcuts.
 
 Formatting shortcuts (while focused in a note):
 
@@ -202,7 +202,7 @@ Hide a time range from Day/Schedule/Week views so most of the visible space goes
 - Set start hour (e.g. midnight)
 - Set end hour (e.g. 6 AM)
 
-Toggle visibility with the **clock button** in calendar views — it dims when active. The remaining visible hours auto-resize to fill the panel; you don't get tiny event blocks scrunched into a tall column.
+Toggle visibility with the **clock button** in calendar views. It dims when active. The remaining visible hours auto-resize to fill the panel; you don't get tiny event blocks scrunched into a tall column.
 
 ---
 
@@ -221,12 +221,12 @@ Cross-calendar events (e.g. the same event in your Google personal calendar and 
 Click **Add Event** in the calendar header (or on the CalendarWidget). The modal includes:
 
 - **Title** (required)
-- **Calendar** — picker filtered to calendars marked "Show in Add Event modal".
-- **Color** — preset palette + your profile color.
+- **Calendar**: picker filtered to calendars marked "Show in Add Event modal".
+- **Color**: preset palette + your profile color.
 - **Description**
 - **Location**
 - **Start / End time** or **All day** toggle.
-- **Recurrence** — None, Daily, Every weekday, Weekly, Monthly, Yearly (writes to Google Calendar's RRULE format if syncing to Google).
+- **Recurrence**: None, Daily, Every weekday, Weekly, Monthly, Yearly (writes to Google Calendar's RRULE format if syncing to Google).
 
 Subscription / read-only calendars are auto-hidden from the picker.
 
@@ -234,7 +234,7 @@ Subscription / read-only calendars are auto-hidden from the picker.
 
 ## Mobile behavior
 
-- Calendar shows the **Agenda view only** on phone viewports — list of upcoming events, swipe to dismiss.
+- Calendar shows the **Agenda view only** on phone viewports: list of upcoming events, swipe to dismiss.
 - View switcher hidden.
 - Header simplified to "Upcoming Events."
 - Swipe left/right to navigate periods.
@@ -247,14 +247,14 @@ This is intentional: full grid views don't fit comfortably on a phone, and the a
 
 ### Events not showing
 
-1. Open the Calendar page → **Manage** — is the calendar enabled?
+1. Open the Calendar page → **Manage**. Is the calendar enabled?
 2. Tap **Sync** to force a refresh.
-3. Check *Settings → Integrations* — is Google still connected? (OAuth tokens can expire if revoked from the Google side.)
-4. The server-side sync cron also runs every 10 minutes — wait one cycle.
+3. Check *Settings → Integrations*. Is Google still connected? (OAuth tokens can expire if revoked from the Google side.)
+4. The server-side sync cron also runs every 10 minutes. Wait one cycle.
 
 ### Events appearing in the wrong person's column
 
-Check the calendar's assignment in the **Manage** overlay on the Calendar page. Cross-calendar events (same event in personal + Family calendars) dedupe by `groupId` — if you're seeing duplicates, file an issue with the calendar names.
+Check the calendar's assignment in the **Manage** overlay on the Calendar page. Cross-calendar events (same event in personal + Family calendars) dedupe by `groupId`. If you're seeing duplicates, file an issue with the calendar names.
 
 ### Sync cron not running
 
@@ -262,7 +262,7 @@ Check the calendar's assignment in the **Manage** overlay on the Calendar page. 
 
 ### Drag-and-drop not working
 
-Drag-and-drop requires **cards display mode** — switch via the View Options gear. Also: hold a chore/meal/task for ~5px of movement before dragging; a quick click triggers the edit modal instead.
+Drag-and-drop requires **cards display mode**. Switch via the View Options gear. Also: hold a chore/meal/task for ~5px of movement before dragging; a quick click triggers the edit modal instead.
 
 ### "Failed to move" error chip
 
@@ -274,4 +274,4 @@ Hours are configured in 24-hour format (e.g. `0` to `6` for midnight-to-6am). Ch
 
 ### Forecast day-of-week labels are off
 
-This was a TZ bug in older versions — events would show on the wrong day for users in negative-UTC zones when an event crossed midnight UTC. Fixed in v1.7. If you still see it, hard-reload the PWA to clear cached chunks.
+This was a TZ bug in older versions: events would show on the wrong day for users in negative-UTC zones when an event crossed midnight UTC. Fixed in v1.7. If you still see it, hard-reload the PWA to clear cached chunks.

--- a/docs/features/DASHBOARD.md
+++ b/docs/features/DASHBOARD.md
@@ -66,23 +66,31 @@ Most templates tile the canvas exactly; **Ambient** is the intentional exception
 
 ## Community gallery
 
-Click **Community** in the editor toolbar to browse dashboard layouts shared by other Prism users. The gallery loads a community index and shows each layout as a card with a live thumbnail preview, its name, description, author, widget count, and the screen sizes it was designed for.
+Click **Community** in the editor toolbar to browse dashboard layouts shared by other Prism users. The gallery loads a community index and shows each layout as a card with a live thumbnail preview, its name, description, author, widget count, and orientation.
 
 - **Search** — type in the search box and press **Enter** to match layouts by name/description; the field has a clear (×) button.
-- **Filter by screen size** — tap a size chip (1920×1080, 2560×1440, 3840×2160, 2560×1600, 2048×1536, 1366×768) to show only layouts tagged for that display; tap again to clear it.
-- **Preview** — every card renders a miniature board floating on a neutral "photo field", auto-oriented so portrait boards don't overflow.
+- **Filter by orientation** — tap **▭ Landscape** or **▯ Portrait** to show only matching layouts; tap again to clear. The filter defaults to the orientation of the dashboard you're editing. (Layouts stretch to fill whatever screen they're shown on, so the exact resolution doesn't matter — orientation is what counts, since a portrait layout letterboxes on a landscape screen and vice-versa.)
+- **Preview** — every card renders a miniature board floating on a neutral "photo field", auto-oriented so portrait boards don't overflow, with an orientation badge.
 - **Apply layout** — click it to drop that design onto your dashboard.
-- **Clear filters** — shown when a search/size filter returns nothing.
+- **Clear filters** — shown when a search/orientation filter returns nothing.
 
 The gallery has a separate **dashboard** and **screensaver** mode, so screensaver layouts are browsed the same way.
 
-### Share, Export & Import
+### Sharing your layout with the community
 
-From the **More** menu in the editor:
+Made a board worth sharing? From the **More** menu, click **Share**:
 
-- **Share** — submit your own layout to the community gallery. It opens a pre-filled GitHub submission that works from any Prism instance (including hosted ones), so you don't need a local checkout to contribute.
-- **Export** — copy your current layout as JSON to hand to someone directly.
-- **Import** — paste a layout JSON to load someone else's design.
+1. Fill in a **name, description, author**, and pick the **orientation** (plus optional tags).
+2. Click **Submit** — Prism opens a pre-filled **GitHub issue** (the *Community Layout Submission* form) in your browser, with your layout's JSON already filled in. This works from **any** Prism instance, including hosted ones like PikaPods — no local checkout or `git` needed.
+3. **Sign in to GitHub** (a free account is all it takes), tick the license checkbox, and submit the issue.
+4. A bot **automatically validates** the layout and, if it passes, **opens a pull request** adding it to the gallery. A maintainer gives it a quick review and merges — after which it appears in every instance's Community gallery.
+
+The GitHub sign-in is intentional: the small bit of friction keeps the gallery free of junk submissions and gives maintainers a moment to review before anything is published to everyone.
+
+### Export & Import
+
+- **Export** (More → Export) — copy your current layout as JSON to hand to someone directly.
+- **Import** (More → Import) — paste a layout JSON to load someone else's design.
 
 ---
 

--- a/docs/features/DASHBOARD.md
+++ b/docs/features/DASHBOARD.md
@@ -1,8 +1,8 @@
 # Dashboard & Layouts
 
-The dashboard is the wall-display face of Prism — a full-screen board of live widgets (calendar, weather, clock, meals, tasks, chores, photos, and more) arranged however you like. You design it with a drag-and-resize layout editor, start from one of six built-in templates, borrow a design from the community gallery, and keep separate boards for separate rooms.
+The dashboard is the wall-display face of Prism: a full-screen board of live widgets (calendar, weather, clock, meals, tasks, chores, photos, and more) arranged however you like. You design it with a drag-and-resize layout editor, start from one of six built-in templates, borrow a design from the community gallery, and keep separate boards for separate rooms.
 
-Everything on this page is edited in **dashboard edit mode** (parent only). It is a desktop/large-screen tool — the editor is hidden on phones, which get a simplified single-column dashboard instead (see [Mobile (PWA)](MOBILE.md)).
+Everything on this page is edited in **dashboard edit mode** (parent only). It is a desktop/large-screen tool: the editor is hidden on phones, which get a simplified single-column dashboard instead (see [Mobile (PWA)](MOBILE.md)).
 
 ---
 
@@ -10,13 +10,13 @@ Everything on this page is edited in **dashboard edit mode** (parent only). It i
 
 Tap the **grid icon** (four squares) in the dashboard header to enter edit mode. Only members with layout-edit permission (parents) see it.
 
-Edit mode swaps the live board for an editable grid and reveals two toolbars — a slim vertical toolbar on the left (Widgets, Templates, Community, Mini-map) and a right-hand toolbar (Preview, orientation, Screensaver, Save, and the **More** menu). Exit by saving or leaving edit mode.
+Edit mode swaps the live board for an editable grid and reveals two toolbars: a slim vertical toolbar on the left (Widgets, Templates, Community, Mini-map) and a right-hand toolbar (Preview, orientation, Screensaver, Save, and the **More** menu). Exit by saving or leaving edit mode.
 
 ---
 
 ## The layout grid
 
-Prism lays widgets out on a fixed **design canvas**, not on your literal pixels — so one design looks right on many screens:
+Prism lays widgets out on a fixed **design canvas**, not on your literal pixels, so one design looks right on many screens:
 
 - **Landscape** canvas: **48 columns × 27 rows** (16:9).
 - **Portrait** canvas: **36 columns × 64 rows** (9:16).
@@ -56,7 +56,7 @@ The templates follow a deliberate composition rubric: one **hero** widget per bo
 | **Command Center** | Everything at a glance. | Calendar hero plus weather, clock, messages, and task + chore list columns. |
 | **Meal Planner** | Kitchen board. | Meals hero, a tall shopping-list column, and a weather + clock corner. |
 | **School Mornings** | Out-the-door board. | Calendar hero, a bus departure countdown, weather, homework tasks, and the lunch menu. |
-| **Ambient** | Photo-forward. | Intentionally sparse — a couple of frosted-glass clock/weather accents floating over open space so a photo **wallpaper** shows through as the hero. Pair it with a photo wallpaper. |
+| **Ambient** | Photo-forward. | Intentionally sparse: a couple of frosted-glass clock/weather accents floating over open space so a photo **wallpaper** shows through as the hero. Pair it with a photo wallpaper. |
 
 Most templates tile the canvas exactly; **Ambient** is the intentional exception, leaving the middle open for the wallpaper.
 
@@ -68,29 +68,22 @@ Most templates tile the canvas exactly; **Ambient** is the intentional exception
 
 Click **Community** in the editor toolbar to browse dashboard layouts shared by other Prism users. The gallery loads a community index and shows each layout as a card with a live thumbnail preview, its name, description, author, widget count, and orientation.
 
-- **Search** — type in the search box and press **Enter** to match layouts by name/description; the field has a clear (×) button.
-- **Filter by orientation** — tap **▭ Landscape** or **▯ Portrait** to show only matching layouts; tap again to clear. The filter defaults to the orientation of the dashboard you're editing. (Layouts stretch to fill whatever screen they're shown on, so the exact resolution doesn't matter — orientation is what counts, since a portrait layout letterboxes on a landscape screen and vice-versa.)
-- **Preview** — every card renders a miniature board floating on a neutral "photo field", auto-oriented so portrait boards don't overflow, with an orientation badge.
-- **Apply layout** — click it to drop that design onto your dashboard.
-- **Clear filters** — shown when a search/orientation filter returns nothing.
+- **Search**: type in the search box and press **Enter** to match layouts by name/description; the field has a clear (×) button.
+- **Filter by orientation**: tap **▭ Landscape** or **▯ Portrait** to show only matching layouts; tap again to clear. The filter defaults to the orientation of the dashboard you're editing. (Layouts stretch to fill whatever screen they're shown on, so the exact resolution doesn't matter: orientation is what counts, since a portrait layout letterboxes on a landscape screen and vice-versa.)
+- **Preview**: every card renders a miniature board floating on a neutral "photo field", auto-oriented so portrait boards don't overflow, with an orientation badge.
+- **Apply layout**: click it to drop that design onto your dashboard.
+- **Clear filters**: shown when a search/orientation filter returns nothing.
 
 The gallery has a separate **dashboard** and **screensaver** mode, so screensaver layouts are browsed the same way.
 
 ### Sharing your layout with the community
 
-Made a board worth sharing? From the **More** menu, click **Share**:
-
-1. Fill in a **name, description, author**, and pick the **orientation** (plus optional tags).
-2. Click **Submit** — Prism opens a pre-filled **GitHub issue** (the *Community Layout Submission* form) in your browser, with your layout's JSON already filled in. This works from **any** Prism instance, including hosted ones like PikaPods — no local checkout or `git` needed.
-3. **Sign in to GitHub** (a free account is all it takes), tick the license checkbox, and submit the issue.
-4. A bot **automatically validates** the layout and, if it passes, **opens a pull request** adding it to the gallery. A maintainer gives it a quick review and merges — after which it appears in every instance's Community gallery.
-
-The GitHub sign-in is intentional: the small bit of friction keeps the gallery free of junk submissions and gives maintainers a moment to review before anything is published to everyone.
+Made a board worth sharing? Open the **More** menu and click **Share**, fill in a name, description, author, and orientation, then submit. Prism opens a pre-filled submission for you (this works from any instance, including hosted ones), and once it's approved your layout appears in everyone's Community gallery.
 
 ### Export & Import
 
-- **Export** (More → Export) — copy your current layout as JSON to hand to someone directly.
-- **Import** (More → Import) — paste a layout JSON to load someone else's design.
+- **Export** (More → Export): copy your current layout as JSON to hand to someone directly.
+- **Import** (More → Import): paste a layout JSON to load someone else's design.
 
 ---
 
@@ -98,13 +91,13 @@ The GitHub sign-in is intentional: the small bit of friction keeps the gallery f
 
 Click **Mini-map** in the left toolbar to see a miniature map of your whole layout. It shows widget positions and flags issues like overlapping or undersized widgets. Click anywhere on the mini-map to scroll the grid to that area.
 
-Alongside it, a **device preview gallery** shows how your single design renders on each common screen size — so you can confirm one layout works across your displays without maintaining a separate design per resolution.
+Alongside it, a **device preview gallery** shows how your single design renders on each common screen size, so you can confirm one layout works across your displays without maintaining a separate design per resolution.
 
 ---
 
 ## Preview mode
 
-Click **Preview** in the right toolbar (or press **Ctrl+Shift+M**) to temporarily hide the editor chrome and see the board as it will actually appear; click **Exit Preview** to return. Use the **Show Nav / Hide Nav** toggle to check how it looks with and without the navigation sidebar — useful for fine-tuning layouts on dedicated wall displays.
+Click **Preview** in the right toolbar (or press **Ctrl+Shift+M**) to temporarily hide the editor chrome and see the board as it will actually appear; click **Exit Preview** to return. Use the **Show Nav / Hide Nav** toggle to check how it looks with and without the navigation sidebar. Useful for fine-tuning layouts on dedicated wall displays.
 
 For a permanently clean look, enable **Auto-Hide Navigation** in *Settings → Appearance*: the nav and toolbar hide after a period of inactivity and reappear on click or keyboard input.
 
@@ -114,7 +107,7 @@ For a permanently clean look, enable **Auto-Hide Navigation** in *Settings → A
 
 Each dashboard has its **own** screensaver layout. In edit mode, click the **Screensaver** button to switch to editing the screensaver widget arrangement (the Templates and Community pickers switch to their screensaver sets too).
 
-The screensaver activates after a configurable idle period — set it under *Settings → Appearance → Timers & Auto-Activation (Screensaver → Activate after)*; the timeout options are **30s / 1m / 2m / 10m / 1h / Never**, defaulting to **2m**. It shows a photo slideshow with your chosen widgets overlaid. The screensaver templates keep the calendar — or tonight's meals — as the hero, with small clock, weather, and message accents floating over one clean photo region so the wallpaper stays the star.
+The screensaver activates after a configurable idle period. Set it under *Settings → Appearance → Timers & Auto-Activation (Screensaver → Activate after)*; the timeout options are **30s / 1m / 2m / 10m / 1h / Never**, defaulting to **2m**. It shows a photo slideshow with your chosen widgets overlaid. The screensaver templates keep the calendar, or tonight's meals, as the hero, with small clock, weather, and message accents floating over one clean photo region so the wallpaper stays the star.
 
 See [Display Modes](DISPLAY-MODES.md) for more on the screensaver and Away Mode.
 
@@ -124,7 +117,7 @@ See [Display Modes](DISPLAY-MODES.md) for more on the screensaver and Away Mode.
 
 Create separate dashboards for different rooms or displays. Click the dashboard-name dropdown in the editor toolbar to switch between dashboards or create new ones.
 
-- The **default** dashboard lives at **`/`** — make any dashboard the default via **More → Set as Default**.
+- The **default** dashboard lives at **`/`**. Make any dashboard the default via **More → Set as Default**.
 - Named dashboards get URLs like **`/d/kitchen`** or **`/d/living-room`**.
 - Each dashboard has an **independent** widget layout, screensaver layout, and orientation.
 - Bookmark a dashboard URL on a dedicated device for instant access.
@@ -151,7 +144,7 @@ Layout editing is parent-only. Log in as a member with layout-edit permission.
 
 ### My layout doesn't fill the screen / leaves a gap
 
-The live board stretches the content bounding box to fill the display. If a template leaves a gap, it usually means the widgets don't reach the canvas edge — extend the outermost widgets to the last row/column, or start from a template that tiles the full canvas.
+The live board stretches the content bounding box to fill the display. If a template leaves a gap, it usually means the widgets don't reach the canvas edge: extend the outermost widgets to the last row/column, or start from a template that tiles the full canvas.
 
 ### Edit-mode toolbar clicks don't respond under browser fullscreen (F11)
 

--- a/docs/features/DISPLAY-MODES.md
+++ b/docs/features/DISPLAY-MODES.md
@@ -2,9 +2,9 @@
 
 Three "what's on the screen right now" modes beyond the default dashboard:
 
-- **Screensaver** — idle photo slideshow with widget overlays.
-- **Away Mode** — privacy screen showing only photos + clock, parent PIN to exit.
-- **Babysitter Mode** — caregiver overlay with house info, contacts, child notes.
+- **Screensaver**: idle photo slideshow with widget overlays.
+- **Away Mode**: privacy screen showing only photos + clock, parent PIN to exit.
+- **Babysitter Mode**: caregiver overlay with house info, contacts, child notes.
 
 All three are layered on top of the dashboard. The dashboard is always running behind the scenes; these modes just cover it with a different presentation.
 
@@ -12,7 +12,7 @@ All three are layered on top of the dashboard. The dashboard is always running b
 
 ## Screensaver
 
-Activates after a configurable idle period. Shows a rotating photo slideshow with a configurable set of overlay widgets — clock, weather, calendar, etc.
+Activates after a configurable idle period. Shows a rotating photo slideshow with a configurable set of overlay widgets: clock, weather, calendar, etc.
 
 ### Each dashboard has its own screensaver
 
@@ -24,23 +24,23 @@ Edit the screensaver layout in dashboard edit mode by clicking the **Screensaver
 
 Screensaver timing lives under *Settings → Appearance → Timers & Auto-Activation (Screensaver):*
 
-- **Screensaver Timeout** — how long idle before activating. Options: 30 seconds / 1 minute / 2 minutes / 10 minutes / 1 hour / Never (default 2 minutes).
-- **Photo Rotation Interval** — how fast photos cycle within the screensaver (5 seconds up to 1 hour, or Never for a static image).
+- **Screensaver Timeout**: how long idle before activating. Options: 30 seconds / 1 minute / 2 minutes / 10 minutes / 1 hour / Never (default 2 minutes).
+- **Photo Rotation Interval**: how fast photos cycle within the screensaver (5 seconds up to 1 hour, or Never for a static image).
 
 Which photos appear is configured under *Settings → Photos:*
 
-- **Source filter** — which photo source(s) to draw from.
-- **Orientation filter** — landscape / portrait / square, applied per display context (gallery / wallpaper / screensaver).
-- **Pinned photo** — override the slideshow with a single static photo (for the surfaces you want stable).
+- **Source filter**: which photo source(s) to draw from.
+- **Orientation filter**: landscape / portrait / square, applied per display context (gallery / wallpaper / screensaver).
+- **Pinned photo**: override the slideshow with a single static photo (for the surfaces you want stable).
 
 ### Activation behavior
 
 - Mouse / touch / keyboard activity resets the idle timer.
-- Tab visibility doesn't matter — even an idle but visible tab triggers the screensaver. (This is the kiosk use case: nobody's interacting with the wall display, so show the slideshow.)
+- Tab visibility doesn't matter. Even an idle but visible tab triggers the screensaver. (This is the kiosk use case: nobody's interacting with the wall display, so show the slideshow.)
 - The screensaver is suppressed when:
   - The Edit dashboard mode is active.
   - A modal is open.
-  - The PWA detects mobile mode (auto-disabled — phones don't need screensavers).
+  - The PWA detects mobile mode (auto-disabled: phones don't need screensavers).
 
 ### Exiting
 
@@ -55,7 +55,7 @@ A privacy overlay for when nobody's home (or when you don't want a casual passer
 
 ### Why this exists
 
-Imagine your dashboard is mounted in a kitchen visible from the front door. A delivery person, neighbor, or visiting house sitter glances through the window. The dashboard shows your family's calendar, today's chores, what tasks are due — too much information for a stranger to see.
+Imagine your dashboard is mounted in a kitchen visible from the front door. A delivery person, neighbor, or visiting house sitter glances through the window. The dashboard shows your family's calendar, today's chores, what tasks are due. Too much information for a stranger to see.
 
 Away mode strips that down to: clock, weather, photo. Nothing else.
 
@@ -63,9 +63,9 @@ Away mode strips that down to: clock, weather, photo. Nothing else.
 
 Two ways:
 
-1. **Manual** — tap the **palm-tree icon** in the dashboard header. Asks "really activate Away mode?" → yes → mode engages.
-2. **Auto** — configurable in *Settings → Appearance → Timers & Auto-Activation → Away Mode Auto-Activation:*
-   - **Never (manual only)** — never auto-activate.
+1. **Manual**: tap the **palm-tree icon** in the dashboard header. Asks "really activate Away mode?" → yes → mode engages.
+2. **Auto**: configurable in *Settings → Appearance → Timers & Auto-Activation → Away Mode Auto-Activation:*
+   - **Never (manual only)**: never auto-activate.
    - **4 hours** of no interaction → activate.
    - **8 hours** of no interaction → activate.
    - **12 hours** of no interaction → activate.
@@ -90,16 +90,16 @@ No calendar, no chores, no tasks, no messages, no widgets. Just the time, weathe
 
 ### Exiting
 
-Tap anywhere. A PIN keypad appears. Enter a **parent PIN** to exit. Children can't exit Away mode — by design, since the use case is keeping the family's info private during periods when adults aren't around to authorize seeing it.
+Tap anywhere. A PIN keypad appears. Enter a **parent PIN** to exit. Children can't exit Away mode, by design, since the use case is keeping the family's info private during periods when adults aren't around to authorize seeing it.
 
-If you forget the PIN: reset it offline with the bundled recovery script from inside the app container — `docker compose exec app node scripts/reset-pin.js --list` to see member names, then `docker compose exec app node scripts/reset-pin.js "Name" 1234` to set a new PIN for that member. It hashes the PIN exactly like the app and touches only that member's row.
+If you forget the PIN: reset it offline with the bundled recovery script from inside the app container: `docker compose exec app node scripts/reset-pin.js --list` to see member names, then `docker compose exec app node scripts/reset-pin.js "Name" 1234` to set a new PIN for that member. It hashes the PIN exactly like the app and touches only that member's row.
 
 ### Use cases
 
-- **Kitchen with view of the street** — auto-activate after 8 hours so the dashboard goes private overnight.
-- **Vacation home** — manual-activate when leaving so the cleaner / property manager doesn't see your full schedule.
-- **Extended trips** — auto-activate at 1 week so even house-sitters don't see returning family's schedule.
-- **Always-on screens used part-time** — auto-activate at 4 hours so the screen doesn't sit on the dashboard view during work hours when nobody's checking.
+- **Kitchen with view of the street**: auto-activate after 8 hours so the dashboard goes private overnight.
+- **Vacation home**: manual-activate when leaving so the cleaner / property manager doesn't see your full schedule.
+- **Extended trips**: auto-activate at 1 week so even house-sitters don't see returning family's schedule.
+- **Always-on screens used part-time**: auto-activate at 4 hours so the screen doesn't sit on the dashboard view during work hours when nobody's checking.
 
 ---
 
@@ -111,11 +111,11 @@ A caregiver overlay with essential household details. Activates manually (or via
 
 Configurable in *Settings → Babysitter Info.* Sections include:
 
-- **Emergency contacts** — phone numbers for parents, grandparents, doctor, school, poison control, emergency services. Tap to call (if the device supports it).
-- **House info** — WiFi name + password (with QR code for one-tap connection), door codes, security system codes, garage code, address, nearest cross street.
-- **Per-child info** — allergies, medications + dosing schedule, bedtime, dietary restrictions, special notes ("Sophie won't sleep without her bunny").
-- **House rules** — guidelines for the caregiver. Screen time policy, snack policy, what to do if [scenario], whatever you want them to know.
-- **Pet info** (if you set it up) — feeding schedule, where pet food lives, vet contact.
+- **Emergency contacts**: phone numbers for parents, grandparents, doctor, school, poison control, emergency services. Tap to call (if the device supports it).
+- **House info**: WiFi name + password (with QR code for one-tap connection), door codes, security system codes, garage code, address, nearest cross street.
+- **Per-child info**: allergies, medications + dosing schedule, bedtime, dietary restrictions, special notes ("Sophie won't sleep without her bunny").
+- **House rules**: guidelines for the caregiver. Screen time policy, snack policy, what to do if [scenario], whatever you want them to know.
+- **Pet info** (if you set it up): feeding schedule, where pet food lives, vet contact.
 
 ### Sensitive sections
 
@@ -125,14 +125,14 @@ Mark any section as **sensitive** in *Settings → Babysitter Info.* Sensitive s
 - WiFi password if you're casual about who sees the babysitter mode.
 - Per-child medical info if you only want the caregiver to see it when they specifically need it.
 
-Sensitive sections show a placeholder ("Tap to reveal — parent PIN required") until unlocked. Once unlocked, they stay visible for that session.
+Sensitive sections show a placeholder ("Tap to reveal: parent PIN required") until unlocked. Once unlocked, they stay visible for that session.
 
 ### Activation
 
 Two ways:
 
 1. **Tap the babysitter icon** in the dashboard header.
-2. **Share the public URL** `/babysitter` — works without login. You can send this URL to a sitter ahead of time so they have the info on their phone too.
+2. **Share the public URL** `/babysitter`: works without login. You can send this URL to a sitter ahead of time so they have the info on their phone too.
 
 ### The /babysitter public URL
 
@@ -142,20 +142,20 @@ Anyone with the URL can access the babysitter view. Use cases:
 - Pin it on the fridge as a QR code.
 - Share with a one-time caregiver who isn't going to use the wall display.
 
-The public URL respects the sensitive-section gating — sensitive sections still require PIN unlock when viewed via the public URL.
+The public URL respects the sensitive-section gating: sensitive sections still require PIN unlock when viewed via the public URL.
 
 ### Exiting
 
 Tap anywhere → PIN keypad → enter parent PIN → returns to the dashboard.
 
-(The public URL `/babysitter` doesn't have an exit per se — it's just a webpage. Close the tab.)
+(The public URL `/babysitter` doesn't have an exit per se. It's just a webpage. Close the tab.)
 
 ### Use cases
 
-- **First-time sitter** — they arrive, you tap babysitter mode, walk through the screen with them, leave. The wall display now shows the info they need without needing your phone for any of it.
-- **Grandparents visiting** — same idea, even if they're family. House codes, WiFi password, your phone numbers all visible.
-- **Pet sitter** — extends the babysitter sections to include pet-specific info.
-- **Long-term caregivers** — set sensitive sections so the day-to-day visible info is the basics; PIN-protect medications + bedrooms + specific medical notes.
+- **First-time sitter**: they arrive, you tap babysitter mode, walk through the screen with them, leave. The wall display now shows the info they need without needing your phone for any of it.
+- **Grandparents visiting**: same idea, even if they're family. House codes, WiFi password, your phone numbers all visible.
+- **Pet sitter**: extends the babysitter sections to include pet-specific info.
+- **Long-term caregivers**: set sensitive sections so the day-to-day visible info is the basics; PIN-protect medications + bedrooms + specific medical notes.
 
 ---
 
@@ -167,19 +167,19 @@ These modes are layered, not exclusive. The dashboard always exists underneath; 
 - Away mode overlay → photo slideshow + clock + weather (no widgets).
 - Babysitter mode overlay → babysitter info screen (full-screen, no slideshow).
 
-Switching between modes is done via the header icons (when not in away/babysitter — those require PIN to exit first).
+Switching between modes is done via the header icons (when not in away/babysitter, those require PIN to exit first).
 
 ---
 
 ## Performance considerations
 
-Each overlay is lazy-loaded — the screensaver, away mode, and babysitter mode components only load when activated, not on every dashboard render. The transitive import chain that pulled them into the root layout was broken in v1.0.4 specifically to keep the dashboard's first paint fast.
+Each overlay is lazy-loaded: the screensaver, away mode, and babysitter mode components only load when activated, not on every dashboard render. The transitive import chain that pulled them into the root layout was broken in v1.0.4 specifically to keep the dashboard's first paint fast.
 
 In Performance Mode:
 
 - Screensaver still works, but photo rotation pauses (single static image instead of cycling).
-- Away mode runs normally — minimal overhead.
-- Babysitter mode runs normally — static content.
+- Away mode runs normally, minimal overhead.
+- Babysitter mode runs normally, static content.
 
 ---
 
@@ -202,7 +202,7 @@ If you're worried about what a babysitter or short-term guest needs to know: Bab
 
 ### Screensaver doesn't activate
 
-- Check *Settings → Appearance → Timers & Auto-Activation → Screensaver Timeout* — is it set to "Never"?
+- Check *Settings → Appearance → Timers & Auto-Activation → Screensaver Timeout*. Is it set to "Never"?
 - Is the dashboard in edit mode? Edit mode suppresses the screensaver.
 - Is a modal open? Modals suppress the screensaver.
 - On mobile PWA installs, the screensaver is intentionally auto-disabled. This is by design.
@@ -221,11 +221,11 @@ Check that the PIN belongs to a **parent** role. Child PINs can't unlock sensiti
 
 ### Public /babysitter URL not loading
 
-Make sure you've configured at least one section in *Settings → Babysitter Info* — an empty babysitter view has nothing to render. Also confirm the device can reach the Prism host on your network.
+Make sure you've configured at least one section in *Settings → Babysitter Info*. An empty babysitter view has nothing to render. Also confirm the device can reach the Prism host on your network.
 
 ### Photo slideshow stutters during screensaver
 
-Performance Mode might be active — slideshows pause in performance mode (single image instead of rotation). Disable Performance Mode if you want the cycle behavior on a low-spec device, but watch CPU.
+Performance Mode might be active: slideshows pause in performance mode (single image instead of rotation). Disable Performance Mode if you want the cycle behavior on a low-spec device, but watch CPU.
 
 ### Wrong photo source on the screensaver
 

--- a/docs/features/GOALS.md
+++ b/docs/features/GOALS.md
@@ -2,7 +2,7 @@
 
 ![Goals page with points waterfall](../demos/goals.png){ .hero-image }
 
-Kids earn points by completing chores. Parents set goals — toys, treats, privileges — with point costs. Earned points flow into goals in priority order via a "waterfall" allocation, and seasonal celebrations fire when a goal is achieved.
+Kids earn points by completing chores. Parents set goals (toys, treats, privileges) with point costs. Earned points flow into goals in priority order via a "waterfall" allocation, and seasonal celebrations fire when a goal is achieved.
 
 ---
 
@@ -14,7 +14,7 @@ Points come from approved chore completions:
 
 1. A parent creates a chore with a `pointValue` (any integer, 0+).
 2. A child marks the chore complete.
-3. If the chore requires approval, it sits in "Pending approval" — points haven't been awarded yet.
+3. If the chore requires approval, it sits in "Pending approval": points haven't been awarded yet.
 4. A parent approves. Points hit the child's running totals.
 5. If the chore is auto-approved (parent did it themselves, or `requiresApproval=false`), step 4 is instant.
 
@@ -24,10 +24,10 @@ Each completion records the point value awarded (`pointsAwarded` column on `chor
 
 Each child has running totals at multiple windows:
 
-- **This week** — Sun-Sat (or Mon-Sun depending on *Settings → General → Week Starts On*).
-- **This month** — calendar month.
-- **This year** — calendar year.
-- **All time** — since the chore tracking started.
+- **This week**: Sun-Sat (or Mon-Sun depending on *Settings → General → Week Starts On*).
+- **This month**: calendar month.
+- **This year**: calendar year.
+- **All time**: since the chore tracking started.
 
 Pending-approval points (chores marked complete but not yet approved) display separately so kids can see what's queued.
 
@@ -37,26 +37,26 @@ Pending-approval points (chores marked complete but not yet approved) display se
 
 A goal is a thing kids work toward by accumulating points. Examples from the seed:
 
-- **Weekly Allowance** — 50 pts, recurring weekly. Resets every Sunday.
-- **Ice Cream Trip** — 100 pts, one-time. Accumulates across weeks.
-- **Movie Night Pick** — 75 pts, one-time.
-- **New LEGO Set** — 300 pts, one-time. Slow burn.
-- **Sleepover** — 200 pts, one-time.
+- **Weekly Allowance**: 50 pts, recurring weekly. Resets every Sunday.
+- **Ice Cream Trip**: 100 pts, one-time. Accumulates across weeks.
+- **Movie Night Pick**: 75 pts, one-time.
+- **New LEGO Set**: 300 pts, one-time. Slow burn.
+- **Sleepover**: 200 pts, one-time.
 
 ### Per-goal config
 
 - **Name** (required)
 - **Description**
-- **Emoji** — chosen from a fixed palette of preset icons (🎯 🍦 🎬 🎮 📱 🎁 🏖️ 🎪 ⭐ 💰 🍕 🎵).
+- **Emoji**: chosen from a fixed palette of preset icons (🎯 🍦 🎬 🎮 📱 🎁 🏖️ 🎪 ⭐ 💰 🍕 🎵).
 - **Point cost**
-- **Priority** — integer, 1 = highest. Used for the waterfall.
-- **Recurring** — boolean.
-- **Recurrence period** — `weekly` / `monthly` / `yearly` when recurring.
+- **Priority**: integer, 1 = highest. Used for the waterfall.
+- **Recurring**: boolean.
+- **Recurrence period**: `weekly` / `monthly` / `yearly` when recurring.
 
 ### One-time vs. Recurring
 
 - **One-time**: points accumulate continuously until the goal is achieved. Once a parent resets an achieved goal, its progress starts over at 0 (or it can be deleted).
-- **Recurring**: points only count for the current period. At period reset (Sunday midnight for weekly), unspent points expire — the kid has to re-earn them next period. Used for steady rewards like allowance.
+- **Recurring**: points only count for the current period. At period reset (Sunday midnight for weekly), unspent points expire. The kid has to re-earn them next period. Used for steady rewards like allowance.
 
 ---
 
@@ -74,7 +74,7 @@ When a child earns points, those points fill goals in priority order, not equall
 
 In practice this means: if Emma has 50 points and her Weekly Allowance (50 pts, priority 1) isn't filled, every point goes there first. Once allowance is filled, overflow continues down the list to Ice Cream Trip, Movie Night, etc.
 
-You can change which goal gets filled first by adjusting priority order — *Goals page → priority arrows ▲▼* next to each goal.
+You can change which goal gets filled first by adjusting priority order: *Goals page → priority arrows ▲▼* next to each goal.
 
 ---
 
@@ -85,8 +85,8 @@ You can change which goal gets filled first by adjusting priority order — *Goa
 Each child has their own section showing:
 
 - Avatar + name + color.
-- **Point counters** — This Week / This Month / This Year totals.
-- **Goal progress cards** — one per active goal, with progress bar.
+- **Point counters**: This Week / This Month / This Year totals.
+- **Goal progress cards**: one per active goal, with progress bar.
 
 Click into a goal card for details and (parent-only) controls.
 
@@ -96,7 +96,7 @@ Each card shows:
 
 - Emoji + goal name.
 - Point cost.
-- Progress bar — child's progress toward the goal.
+- Progress bar: child's progress toward the goal.
 - **Recurring** badge (if applicable) with the period.
 - **Achieved!** checkmark when the bar fills.
 
@@ -106,10 +106,10 @@ When a goal is achieved, the celebration animation fires (see below).
 
 Parents see additional controls per goal:
 
-- **Edit** — modify any field.
-- **Delete** — remove the goal.
-- **Reorder priority** — ▲▼ buttons or drag.
-- **Reset** — an inline button on achieved one-time goals. Clears the goal's achieved/progress state and starts it over from 0.
+- **Edit**: modify any field.
+- **Delete**: remove the goal.
+- **Reorder priority**: ▲▼ buttons or drag.
+- **Reset**: an inline button on achieved one-time goals. Clears the goal's achieved/progress state and starts it over from 0.
 
 Children see goals and progress but cannot create, edit, or reset.
 
@@ -117,7 +117,7 @@ Children see goals and progress but cannot create, edit, or reset.
 
 ## Celebrations
 
-When a child's progress on a goal hits 100%, an animation plays. The animation is **season-aware** — the same "you reached your goal" event plays a different scene depending on the week of the year:
+When a child's progress on a goal hits 100%, an animation plays. The animation is **season-aware**: the same "you reached your goal" event plays a different scene depending on the week of the year:
 
 | Window | Animation |
 |---|---|
@@ -133,7 +133,7 @@ When a child's progress on a goal hits 100%, an animation plays. The animation i
 | New Year's week | Fireworks + confetti |
 | All other times | Trophy + confetti |
 
-The animation respects `prefers-reduced-motion` and Performance Mode — both skip the visual but still fire the completion event so the celebration counter increments.
+The animation respects `prefers-reduced-motion` and Performance Mode. Both skip the visual but still fire the completion event so the celebration counter increments.
 
 ---
 
@@ -166,9 +166,9 @@ When a one-time goal is achieved, a parent can reset it to start over:
 
 Reset clears the goal's achieved/progress state for the goal as a whole (all children who were working toward it), not just one child. It is not PIN-gated and is not recorded in the activity log.
 
-The reset is the "give the kid the reward, then start fresh" moment — Prism doesn't track delivery, just the bookkeeping.
+The reset is the "give the kid the reward, then start fresh" moment. Prism doesn't track delivery, just the bookkeeping.
 
-For recurring goals (allowance), reset isn't a thing — the points simply roll over at period reset.
+For recurring goals (allowance), reset isn't a thing. The points simply roll over at period reset.
 
 ---
 
@@ -228,9 +228,9 @@ Hard-reload the dashboard. The cache invalidation should be automatic but a stal
 
 The reset happens at midnight local time on the configured week start. If your *Week Starts On* setting is Monday, recurring weekly goals reset Mondays.
 
-### Two kids have the same goal — point totals are wrong
+### Two kids have the same goal: point totals are wrong
 
-Goals are global (one row per goal), but progress is tracked per-child via the `goal_achievements` table. Each child has independent progress on the same goal. If you're seeing wrong totals, check that the chore completion `completedBy` is correct — that's the field that determines whose points-jar gets credit.
+Goals are global (one row per goal), but progress is tracked per-child via the `goal_achievements` table. Each child has independent progress on the same goal. If you're seeing wrong totals, check that the chore completion `completedBy` is correct. That's the field that determines whose points-jar gets credit.
 
 ### Celebration animation didn't fire
 

--- a/docs/features/ICLOUD.md
+++ b/docs/features/ICLOUD.md
@@ -2,7 +2,7 @@
 
 What Prism can and can't pull from iCloud, and why.
 
-If you have an Apple household and want Prism to surface family data living in iCloud — calendars, contacts, photos, Reminders, Notes, Find My — read this once. The answer is consistent across the table, the rule explains the table, and the rule isn't going to change.
+If you have an Apple household and want Prism to surface family data living in iCloud (calendars, contacts, photos, Reminders, Notes, Find My), read this once. The answer is consistent across the table, the rule explains the table, and the rule isn't going to change.
 
 ---
 
@@ -10,12 +10,12 @@ If you have an Apple household and want Prism to surface family data living in i
 
 | iCloud surface | Supported? | How / why not |
 |---|---|---|
-| **Calendars** | ✅ Yes | CalDAV (`caldav.icloud.com`) — read + upstream delete of single events; full create/edit write-back is not yet wired. See [Calendar setup](CALENDAR.md#apple-icloud-caldav-private-calendars-reminders-alpha). |
+| **Calendars** | ✅ Yes | CalDAV (`caldav.icloud.com`): read + upstream delete of single events; full create/edit write-back is not yet wired. See [Calendar setup](CALENDAR.md#apple-icloud-caldav-private-calendars-reminders-alpha). |
 | **Contacts** (incl. birthdays) | ✅ Yes, read-only | CardDAV (`contacts.icloud.com`). Used by the planned [family contacts page](https://github.com/sandydargoport/prism/issues/75). |
 | **Reminders / Tasks** | ❌ No | Apple migrated Reminders off CalDAV-VTODO years ago; iCloud Reminders are CloudKit-only with no public web API. |
 | **Notes** | ❌ No | iCloud-synced Notes have always been CloudKit-only. No IMAP-style or web API. |
 | **Photos (shared album)** | ❌ No (was attempted) | Apple migrated public shares from the old `sharedstreams` endpoint to a new "iCloud Links" CloudKit backend in 2024–2025. The legacy endpoint returns 404 for modern shares; no public replacement exists, and no community library targets the new backend as of mid-2026. See [photo source setup](PHOTOS.md#sources) for the OneDrive-based workaround. |
-| **Photos (full library)** | ❌ No | Would require CloudKit Web, which requires an Apple Developer subscription, container ID per app, and per-user consent flow — wrong shape for a self-hosted family dashboard. |
+| **Photos (full library)** | ❌ No | Would require CloudKit Web, which requires an Apple Developer subscription, container ID per app, and per-user consent flow. Wrong shape for a self-hosted family dashboard. |
 | **Find My** (devices / people) | ❌ No | The iCloud.com web client uses an undocumented private CloudKit endpoint. Community libraries like `pyicloud` scrape it, but Apple breaks them with each iOS release, and **Advanced Data Protection** end-to-end encrypts Find My data so the scrape no longer returns it at all. Best upstream path today: [Home Assistant's iCloud3 / FindMy integration](https://github.com/gcobb321/icloud3), which has a community actively wrangling these breaks; Prism could in principle read HA's `device_tracker` entities. Not on the roadmap, but the door isn't closed. |
 | **Health / Activity** | ❌ No | HealthKit data is on-device + iCloud-encrypted; only accessible via a paired iOS app, no web API. |
 | **iMessage** | ❌ No | No public API, ever. |
@@ -32,7 +32,7 @@ Everything else lives in CloudKit, which is:
 1. Proprietary
 2. Not publicly documented for third-party server access
 3. Designed around per-user iOS-app consent, not server-to-server federation
-4. Increasingly end-to-end encrypted via Advanced Data Protection — even if you reverse-engineer the endpoints, the payloads are useless without the user's device keys
+4. Increasingly end-to-end encrypted via Advanced Data Protection. Even if you reverse-engineer the endpoints, the payloads are useless without the user's device keys
 
 This means there's no "more research" path that turns a ❌ into a ✅. If you see a community library that claims iCloud Reminders or Find My, it is either:
 
@@ -53,4 +53,4 @@ This means there's no "more research" path that turns a ❌ into a ✅. If you s
 
 Because every six months somebody (often me) asks "wait, can't we just hit the iCloud API for X?" and goes off to investigate, finds a stale community library, builds half of an integration, and discovers the same wall. This page is the doctrine note: the wall is structural, not "we haven't tried hard enough," and the energy is better spent on the mirror approach.
 
-The shared-album resolver that hit this wall (the legacy `sharedstreams` protocol details — partition discovery, the `330` / `X-Apple-MMe-Host` redirect, short-lived signed URLs) was captured in the [decisions log](../decisions-log.md) before its branch was deleted, so the next person doesn't re-reverse-engineer it.
+The shared-album resolver that hit this wall (the legacy `sharedstreams` protocol details: partition discovery, the `330` / `X-Apple-MMe-Host` redirect, short-lived signed URLs) was captured in the [decisions log](../decisions-log.md) before its branch was deleted, so the next person doesn't re-reverse-engineer it.

--- a/docs/features/KROGER.md
+++ b/docs/features/KROGER.md
@@ -1,22 +1,22 @@
 # Kroger online cart integration
 
-Push your Prism shopping list straight into the online cart of any Kroger banner — for pickup, delivery, or in-store reference. One Kroger account works across every banner:
+Push your Prism shopping list straight into the online cart of any Kroger banner, for pickup, delivery, or in-store reference. One Kroger account works across every banner:
 
 > Kroger · Mariano's · Ralphs · King Soopers · Fred Meyer · QFC · Smith's · Fry's · Harris Teeter · Pick 'n Save · Metro Market · Pay Less · Food 4 Less · Foods Co. · Bakers' Plus · City Market · Copps · Dillons · Gerbes · Jay C · Ruler Foods
 
-The integration uses Kroger's public Developer API. It's free, has a 10,000-call/day quota (plenty for a family), and respects OAuth 2.0 user consent — Prism never sees your shopper password.
+The integration uses Kroger's public Developer API. It's free, has a 10,000-call/day quota (plenty for a family), and respects OAuth 2.0 user consent. Prism never sees your shopper password.
 
 ---
 
 ## What it does
 
-- **Per-user OAuth** — each Prism family member who wants to push to Kroger connects their own shopper account in **Settings → Integrations → "Kroger / Mariano's cart"** card. Tokens are AES-256-GCM encrypted at rest with the existing `ENCRYPTION_KEY`.
-- **SKU picker per item** — for each unchecked shopping item, Prism fetches up to 5 candidate products from Kroger and shows them in a picker with image, name, size, price, and a normalized unit price (lb / fl oz / ct) so candidates within a page are directly comparable.
-- **SKU caching** — once you pick *"Mariano's 2% Reduced Fat Milk Gallon"* for the abstract item *"milk"*, that productId is remembered on the shopping item. Next time you push *"milk"*, the same SKU is pre-selected. One-tap weekly staples after the first trip.
-- **Quantity controls** — bump the cart quantity per item (1-99) with +/- buttons; review-screen shows `× 2` next to multiples.
-- **Search override** — every page has an editable search box so you can refine the term when the parser strips too much (or not enough).
-- **Default-store picker** — set your preferred Mariano's (or any banner) by zip code. Subsequent searches use that store's location-aware pricing and stock.
-- **Modifier-aware parsing** — recipe-derived items like *"1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes"* search Kroger for *"Fresno pepper"* (drops quantity, unit, comma modifiers, `" or "` alternatives, and parentheticals).
+- **Per-user OAuth**: each Prism family member who wants to push to Kroger connects their own shopper account in **Settings → Integrations → "Kroger / Mariano's cart"** card. Tokens are AES-256-GCM encrypted at rest with the existing `ENCRYPTION_KEY`.
+- **SKU picker per item**: for each unchecked shopping item, Prism fetches up to 5 candidate products from Kroger and shows them in a picker with image, name, size, price, and a normalized unit price (lb / fl oz / ct) so candidates within a page are directly comparable.
+- **SKU caching**: once you pick *"Mariano's 2% Reduced Fat Milk Gallon"* for the abstract item *"milk"*, that productId is remembered on the shopping item. Next time you push *"milk"*, the same SKU is pre-selected. One-tap weekly staples after the first trip.
+- **Quantity controls**: bump the cart quantity per item (1-99) with +/- buttons; review-screen shows `× 2` next to multiples.
+- **Search override**: every page has an editable search box so you can refine the term when the parser strips too much (or not enough).
+- **Default-store picker**: set your preferred Mariano's (or any banner) by zip code. Subsequent searches use that store's location-aware pricing and stock.
+- **Modifier-aware parsing**: recipe-derived items like *"1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes"* search Kroger for *"Fresno pepper"* (drops quantity, unit, comma modifiers, `" or "` alternatives, and parentheticals).
 
 ---
 
@@ -29,45 +29,45 @@ This takes about 5 minutes.
 ### 1. Create a Kroger developer account
 
 - Go to **https://developer.kroger.com/**
-- Click **Sign In** (top right). You can use your existing Kroger / Mariano's shopper account — Kroger creates a separate "developer" profile automatically.
+- Click **Sign In** (top right). You can use your existing Kroger / Mariano's shopper account. Kroger creates a separate "developer" profile automatically.
 - If you don't have a Kroger account at all, sign up. Free.
 
-> **Heads up on the 403 trap:** the developer portal's session sometimes drops without telling you. If you hit `403 Forbidden` trying to create an app, sign out and back in (or use an incognito window). Ad blockers and Brave's strict mode can also break the portal — disable them on `developer.kroger.com` if needed.
+> **Heads up on the 403 trap:** the developer portal's session sometimes drops without telling you. If you hit `403 Forbidden` trying to create an app, sign out and back in (or use an incognito window). Ad blockers and Brave's strict mode can also break the portal. Disable them on `developer.kroger.com` if needed.
 
 ### 2. Register the application
 
 - Manage → **Applications** → **Add Application** (https://developer.kroger.com/manage/apps).
 - Fill in:
-  - **Application Name**: anything — `Prism Family Dashboard` works.
+  - **Application Name**: anything. `Prism Family Dashboard` works.
   - **Environment**: **Production**. (Skip "Certification"; it has fake data.)
-  - **Description**: anything — *"Personal family shopping list integration"* is fine.
-  - **Website**: your Prism URL — `https://prism.example.com`.
-- **Logo URL (optional)**: only the OAuth consent screen sees it, and only you / your family will see it. If you want a logo, use a public PNG URL. **Don't use a URL behind Cloudflare Access or any login gate** — Kroger's servers can't fetch it. The Prism repo icon works: `https://raw.githubusercontent.com/sandydargoport/prism/master/public/icons/icon-512.png`. Or leave blank.
+  - **Description**: anything. *"Personal family shopping list integration"* is fine.
+  - **Website**: your Prism URL, `https://prism.example.com`.
+- **Logo URL (optional)**: only the OAuth consent screen sees it, and only you / your family will see it. If you want a logo, use a public PNG URL. **Don't use a URL behind Cloudflare Access or any login gate**: Kroger's servers can't fetch it. The Prism repo icon works: `https://raw.githubusercontent.com/sandydargoport/prism/master/public/icons/icon-512.png`. Or leave blank.
 - Save.
 
 ### 3. Configure the app
 
 On the app's detail page:
 
-**Redirect URIs (Authorized Redirect URIs)** — paste exactly:
+**Redirect URIs (Authorized Redirect URIs)**. Paste exactly:
 
 ```
 https://your-prism-host/api/auth/kroger/callback
 ```
 
-Exact-match. No trailing slash, must be `https`. If you reach Prism from multiple hosts (e.g. a public WAN hostname and a LAN IP for inside the house) you can register both — Prism dynamically builds the redirect URI from each incoming request, so OAuth from LAN stays on LAN and WAN stays on WAN. Kroger accepts `http://192.168.x.x:3000/...` for LAN; some other OAuth providers don't.
+Exact-match. No trailing slash, must be `https`. If you reach Prism from multiple hosts (e.g. a public WAN hostname and a LAN IP for inside the house) you can register both. Prism dynamically builds the redirect URI from each incoming request, so OAuth from LAN stays on LAN and WAN stays on WAN. Kroger accepts `http://192.168.x.x:3000/...` for LAN; some other OAuth providers don't.
 
-**Scopes** — check these three:
+**Scopes**. Check these three:
 
 - `product.compact` (search products)
 - `cart.basic:write` (write to the user's cart)
-- `profile.compact` (identify which user is consenting — required by the OAuth flow even though no profile data is read)
+- `profile.compact` (identify which user is consenting, required by the OAuth flow even though no profile data is read)
 
 Save. Kroger sometimes shows the app as "pending approval" for a few minutes after registration. If OAuth fails on the first try, wait ~5 min.
 
 ### 4. Copy your credentials
 
-The app detail page shows a **Client ID** and a **Client Secret**. Click **Show** / **Reveal** to expose the secret — Kroger sometimes only shows it once, so copy it now.
+The app detail page shows a **Client ID** and a **Client Secret**. Click **Show** / **Reveal** to expose the secret. Kroger sometimes only shows it once, so copy it now.
 
 ### 5. Plug into Prism
 
@@ -75,9 +75,9 @@ In Prism:
 
 1. **Settings → Integrations → "Kroger / Mariano's cart"** card (deep link `/settings?section=integrations#kroger`).
 2. If credentials aren't configured yet, click **Enter Kroger credentials** and paste the Client ID + Client Secret. Prism encrypts them at rest.
-3. Click **Connect Kroger**. You'll bounce to `kroger.com`, sign in with your **shopper account** (the one you actually shop with — different from the dev portal account if you used two different emails), and approve the requested scopes.
+3. Click **Connect Kroger**. You'll bounce to `kroger.com`, sign in with your **shopper account** (the one you actually shop with, different from the dev portal account if you used two different emails), and approve the requested scopes.
 4. You land back at Prism with **Connected** status.
-5. Click **Set store**, enter your zip code, and pick your home banner. Without this, searches use Kroger's default pricing — items still go to your cart, just without location-aware prices in the picker.
+5. Click **Set store**, enter your zip code, and pick your home banner. Without this, searches use Kroger's default pricing. Items still go to your cart, just without location-aware prices in the picker.
 
 You're done. Go to **Shopping**, add some items, and tap **Send to Kroger** in the header.
 
@@ -85,9 +85,9 @@ You're done. Go to **Shopping**, add some items, and tap **Send to Kroger** in t
 
 ## Things to know
 
-- **The Kroger consent prompt wants your *shopper* account, not your dev portal account** — they can be the same email or different. If you accidentally try to consent with the dev account you'll either fail or end up writing to the wrong cart.
+- **The Kroger consent prompt wants your *shopper* account, not your dev portal account**. They can be the same email or different. If you accidentally try to consent with the dev account you'll either fail or end up writing to the wrong cart.
 - **Kroger rotates the Client Secret occasionally** when you edit an app's URI list or scopes. If OAuth starts failing after a config change, re-copy the Client Secret from the dev portal and re-paste into Prism's Kroger card.
-- **No public AnyList-style webview** — Prism is a PWA, not a native app, so we can't embed Kroger's website inside our own UI. The flow is: pick SKUs in Prism → cart is updated server-side via the Cart API → you open the Kroger / Mariano's app or website to check out.
+- **No public AnyList-style webview**: Prism is a PWA, not a native app, so we can't embed Kroger's website inside our own UI. The flow is: pick SKUs in Prism → cart is updated server-side via the Cart API → you open the Kroger / Mariano's app or website to check out.
 - **"No price" on every candidate** = no default store set (or store has no pricing data for that product). Set your store first.
 - **OAuth state** is bound to your Prism user via Redis with a 10-minute TTL so the callback can't be hijacked or replayed.
 
@@ -96,7 +96,7 @@ You're done. Go to **Shopping**, add some items, and tap **Send to Kroger** in t
 ## Privacy
 
 - Stored on your Prism instance: encrypted access + refresh tokens, your preferred Kroger location id + display name, and a `kroger_product_id` cache on each shopping item. Nothing else.
-- Sent to Kroger: only what you'd send by using their website yourself — product search terms, productIds for items you choose to add to your cart, and standard OAuth identity claims.
+- Sent to Kroger: only what you'd send by using their website yourself: product search terms, productIds for items you choose to add to your cart, and standard OAuth identity claims.
 - Disconnect anytime from the same settings card. That wipes the encrypted tokens; Kroger's side can also be revoked at https://www.kroger.com/account/secure-preferences.
 
 ---
@@ -107,7 +107,7 @@ You're done. Go to **Shopping**, add some items, and tap **Send to Kroger** in t
 |---|---|
 | `403 Forbidden` on developer.kroger.com | Stale session. Sign out, incognito tab, sign back in. |
 | `kroger_state_mismatch` after consent | Redis was flushed or 10 min elapsed between starting and finishing OAuth. Click Connect again. |
-| `kroger_token_exchange_failed` | Most often: secret was rotated. Re-paste credentials. Less often: redirect URI mismatch — check exact-match in the dev portal vs. the URL your browser hit. |
+| `kroger_token_exchange_failed` | Most often: secret was rotated. Re-paste credentials. Less often: redirect URI mismatch. Check exact-match in the dev portal vs. the URL your browser hit. |
 | Picker shows `no price` everywhere | Default store not set. Settings → Integrations → "Kroger / Mariano's card" → "Set store". |
 | Picker can't find your item | Use the search box above the candidates to refine the term (e.g. shorten `"jumbo, raw, tail-on shrimp, peeled and deveined"` to `"shrimp"`). |
 | "Too many items (max 200 per request)" | One shopping list has more than 200 unchecked items. Split it. |
@@ -117,5 +117,5 @@ You're done. Go to **Shopping**, add some items, and tap **Send to Kroger** in t
 ## What's NOT supported (yet)
 
 - The in-Kroger-app "shopping list" feature has no public API endpoint. The cart is what we write to; the in-app list is separate.
-- Coupons / digital coupon application — Kroger has a Coupons API but Prism doesn't surface it.
-- Order placement — Prism stops at "items in cart". You open the Kroger / Mariano's app or website to choose pickup time and check out.
+- Coupons / digital coupon application. Kroger has a Coupons API but Prism doesn't surface it.
+- Order placement: Prism stops at "items in cart". You open the Kroger / Mariano's app or website to choose pickup time and check out.

--- a/docs/features/MESSAGES.md
+++ b/docs/features/MESSAGES.md
@@ -8,12 +8,12 @@ Family message board for shared updates. Lower-friction than texting (no notific
 
 ## What a message has
 
-- **Message text** — what you're saying. Up to 500 characters (a live counter shows remaining length while posting/editing).
-- **Author** — whoever was logged in when it was posted.
-- **Pinned** — boolean. Pinned messages sort to the top regardless of age.
-- **Important** — boolean. Renders with red accent / icon for visual emphasis.
-- **Expires at** — optional timestamp. After the window passes the message is hidden from all views (filtered server-side on read); the row stays in the database.
-- **Created at** / **Updated at** — auto.
+- **Message text**: what you're saying. Up to 500 characters (a live counter shows remaining length while posting/editing).
+- **Author**: whoever was logged in when it was posted.
+- **Pinned**: boolean. Pinned messages sort to the top regardless of age.
+- **Important**: boolean. Renders with red accent / icon for visual emphasis.
+- **Expires at**: optional timestamp. After the window passes the message is hidden from all views (filtered server-side on read); the row stays in the database.
+- **Created at** / **Updated at**: auto.
 
 ---
 
@@ -21,8 +21,8 @@ Family message board for shared updates. Lower-friction than texting (no notific
 
 Two ways:
 
-1. **From the dashboard MessagesWidget** — the **+** (Add message) button opens the Post Message dialog.
-2. **From the full Messages page** — *nav → Messages* → input at the top.
+1. **From the dashboard MessagesWidget**: the **+** (Add message) button opens the Post Message dialog.
+2. **From the full Messages page**: *nav → Messages* → input at the top.
 
 Both require login. The author is auto-set to the logged-in user; you can't impersonate someone else.
 
@@ -39,15 +39,15 @@ Pick from a dropdown when posting:
 - **3 days**
 - **7 days**
 
-Useful for temporary notices: "Pizza in the fridge from tonight" (expires in 12h), "Snow day — no school" (expires in 1d), "Hosting brunch Sunday, RSVP by Friday" (expires in 3d).
+Useful for temporary notices: "Pizza in the fridge from tonight" (expires in 12h), "Snow day: no school" (expires in 1d), "Hosting brunch Sunday, RSVP by Friday" (expires in 3d).
 
-Once a message's expiration window passes it is hidden from every view (the server filters expired rows out on read). The rows themselves remain in the database — there is no periodic purge job.
+Once a message's expiration window passes it is hidden from every view (the server filters expired rows out on read). The rows themselves remain in the database. There is no periodic purge job.
 
 ---
 
 ## Pinning
 
-Pinning is chosen **when you post**, via the **Pin to top** checkbox in the Post Message dialog. There is currently no in-list pin/unpin toggle — to change a message's pinned state you re-post it. Pinned messages:
+Pinning is chosen **when you post**, via the **Pin to top** checkbox in the Post Message dialog. There is currently no in-list pin/unpin toggle. To change a message's pinned state you re-post it. Pinned messages:
 
 - Sort to the top of the list (above everything, regardless of age).
 - Render with a slight visual highlight (pin icon, subtle background tint).
@@ -64,7 +64,7 @@ Mark a message **important** for visual emphasis:
 - Slightly darker background tint.
 - Reads as a louder version of "you should look at this."
 
-Independent from pinning — a message can be pinned + important, just pinned, just important, or neither.
+Independent from pinning, a message can be pinned + important, just pinned, just important, or neither.
 
 ---
 
@@ -89,7 +89,7 @@ Trash icon on each message (visible on hover/long-press):
 - **Parents** can delete any message.
 - Children cannot delete others' messages.
 
-A confirmation dialog ("Delete this message?" / "This action cannot be undone.") appears before the message is removed. Deletion is permanent — there is no undo.
+A confirmation dialog ("Delete this message?" / "This action cannot be undone.") appears before the message is removed. Deletion is permanent. There is no undo.
 
 ---
 
@@ -97,8 +97,8 @@ A confirmation dialog ("Delete this message?" / "This action cannot be undone.")
 
 The Messages page has a **Group by Person** toggle:
 
-- **Off** — one chronological list, newest first (pinned first within that).
-- **On** — messages organize into person-colored cards (one card per family member). Each card shows that person's recent messages.
+- **Off**: one chronological list, newest first (pinned first within that).
+- **On**: messages organize into person-colored cards (one card per family member). Each card shows that person's recent messages.
 
 Group-by mode is useful when you have a lot of message traffic and want to see "what has Jordan posted recently?" at a glance.
 
@@ -136,7 +136,7 @@ These pinned messages function as a lightweight house wiki.
 Expire-in-1-day messages for things that matter today and not tomorrow:
 
 - "Pizza in fridge from tonight."
-- "Don't use the upstairs shower — fixing it Wednesday."
+- "Don't use the upstairs shower. Fixing it Wednesday."
 - "Mom's at the dentist 'til 3."
 
 ### Encouragement / "great job"
@@ -151,9 +151,9 @@ Sometimes you and your spouse need a shared note that's more durable than a text
 
 ## Privacy
 
-Messages are family-internal — only logged-in family members see them. The babysitter and away-mode views do not show messages.
+Messages are family-internal: only logged-in family members see them. The babysitter and away-mode views do not show messages.
 
-Messages live in your Prism database. No external sync to MS To Do, Google, or anywhere else (intentionally — messages are ephemeral; they're not lists, they don't belong in a task-tracking system).
+Messages live in your Prism database. No external sync to MS To Do, Google, or anywhere else (intentionally: messages are ephemeral; they're not lists, they don't belong in a task-tracking system).
 
 ---
 
@@ -161,7 +161,7 @@ Messages live in your Prism database. No external sync to MS To Do, Google, or a
 
 ### Message vanished after a few hours
 
-Most likely an expiration was set. Check the expiration dropdown when posting — default is "No expiration."
+Most likely an expiration was set. Check the expiration dropdown when posting. The default is "No expiration."
 
 ### Edit pencil doesn't appear
 
@@ -171,8 +171,8 @@ Either:
 
 ### Message order looks weird
 
-Sort is: pinned first (within pinned, newest first), then non-pinned by created_at descending. If you're seeing different order, you're probably looking at the per-person grouped view — each person's section sorts independently.
+Sort is: pinned first (within pinned, newest first), then non-pinned by created_at descending. If you're seeing different order, you're probably looking at the per-person grouped view, where each person's section sorts independently.
 
 ### Important badge color clashes with theme
 
-The important-message accent uses your theme's destructive color (typically red). On the default light theme it's pure red; on dark theme it's slightly muted. Custom theme palettes may override — check *Settings → Appearance*.
+The important-message accent uses your theme's destructive color (typically red). On the default light theme it's pure red; on dark theme it's slightly muted. Custom theme palettes may override, so check *Settings → Appearance*.

--- a/docs/features/MOBILE.md
+++ b/docs/features/MOBILE.md
@@ -2,7 +2,7 @@
 
 ![Mobile dashboard](../demos/dashboard-mobile.png){ .hero-image-mobile width="300" }
 
-Prism is built as a Progressive Web App (PWA) that adapts to whatever you install it on — phone, tablet, kiosk, or wall-mounted display. Same code, same data, different UI surface depending on screen size, orientation, and pointer type.
+Prism is built as a Progressive Web App (PWA) that adapts to whatever you install it on: phone, tablet, kiosk, or wall-mounted display. Same code, same data, different UI surface depending on screen size, orientation, and pointer type.
 
 ---
 
@@ -15,7 +15,7 @@ Prism is built as a Progressive Web App (PWA) that adapts to whatever you instal
 3. Select **Add to Home Screen**.
 4. Tap **Add**.
 
-The app opens without browser chrome (no URL bar, no Safari toolbar). Standard iOS PWA — supports notification badges, theme color, splash screen.
+The app opens without browser chrome (no URL bar, no Safari toolbar). Standard iOS PWA: supports notification badges, theme color, splash screen.
 
 ### Android (Chrome / Edge)
 
@@ -31,7 +31,7 @@ App launches standalone, full screen.
 2. Click the **install icon** in the address bar (the small `+` or computer icon).
 3. The app opens in its own window without browser chrome.
 
-Useful for a dedicated dashboard machine — pin to taskbar, set to launch on startup.
+Useful for a dedicated dashboard machine: pin to taskbar, set to launch on startup.
 
 ---
 
@@ -51,10 +51,10 @@ Custom shortcuts can be added by editing `public/manifest.json`.
 
 The service worker (`public/sw.js`) precaches static assets:
 
-- App shell (the `_next` static assets — CSS, JS chunks) is precached on install.
+- App shell (the `_next` static assets: CSS, JS chunks) is precached on install.
 - The start URL (`/`) is served **network-first**, falling back to the cached copy when offline.
 
-That's the extent of it. There is **no** API-response caching, **no** offline mutation queue, and **no** background-sync retry. Prism is not an offline-first app — if the device is offline, expect to refresh manually once you're back online, and don't expect changes made while offline to be captured.
+That's the extent of it. There is **no** API-response caching, **no** offline mutation queue, and **no** background-sync retry. Prism is not an offline-first app. If the device is offline, expect to refresh manually once you're back online, and don't expect changes made while offline to be captured.
 
 ---
 
@@ -76,18 +76,18 @@ The Floating Action Button is a single circular button in the bottom corner. Tap
 
 Always available:
 
-- **Home** — back to dashboard.
-- **Settings** — opens the full Settings page.
-- **Login / Logout** — switch users (shows **Login** when logged out).
+- **Home**: back to dashboard.
+- **Settings**: opens the full Settings page.
+- **Login / Logout**: switch users (shows **Login** when logged out).
 
 On the dashboard only:
 
-- **Reorder** — drag cards on the dashboard into your preferred order.
-- **Cards** — show/hide dashboard cards (plus layout + theme controls, see below).
+- **Reorder**: drag cards on the dashboard into your preferred order.
+- **Cards**: show/hide dashboard cards (plus layout + theme controls, see below).
 
 On the Shopping page only:
 
-- **Scan Barcode** — scan an item into the active list.
+- **Scan Barcode**: scan an item into the active list.
 
 Designed to use minimum screen space and stay out of the way during regular use.
 
@@ -97,12 +97,12 @@ In FAB → Reorder, dashboard cards become draggable with grip pills on each one
 
 ### FAB → Cards
 
-FAB → Cards shows a toggle for each available card. Turn off cards you don't use (e.g. Bus Tracker if you don't have one). Hidden cards don't render at all — saves render cycles on a phone.
+FAB → Cards shows a toggle for each available card. Turn off cards you don't use (e.g. Bus Tracker if you don't have one). Hidden cards don't render at all. Saves render cycles on a phone.
 
 The same panel also carries two extra controls:
 
-- **Layout** — switch the mobile dashboard between **Rows** and **Tiles**.
-- **Theme** — cycle **Light / Dark / Auto**.
+- **Layout**: switch the mobile dashboard between **Rows** and **Tiles**.
+- **Theme**: cycle **Light / Dark / Auto**.
 
 ---
 
@@ -110,14 +110,14 @@ The same panel also carries two extra controls:
 
 On phones, the full dashboard grid collapses into a single-column summary card layout:
 
-- **Weather card** — current temp + conditions + a small forecast strip.
-- **Calendar card** — agenda-only, next 5 events.
-- **Tasks card** — top 5 incomplete tasks.
-- **Shopping card** — top 5 active list items.
-- **Chores card** — pending chores for everyone.
-- **Meals card** — today's planned meals.
-- **Messages card** — last 3 messages.
-- **Birthdays card** — upcoming birthdays.
+- **Weather card**: current temp + conditions + a small forecast strip.
+- **Calendar card**: agenda-only, next 5 events.
+- **Tasks card**: top 5 incomplete tasks.
+- **Shopping card**: top 5 active list items.
+- **Chores card**: pending chores for everyone.
+- **Meals card**: today's planned meals.
+- **Messages card**: last 3 messages.
+- **Birthdays card**: upcoming birthdays.
 
 These eight are the defaults. **Clock, Bus Tracker, Recipes, Goals, Wishes, and Photos** are also available and can be turned on via FAB → Cards.
 
@@ -141,13 +141,13 @@ Why: the multi-week + month + schedule grid views don't fit comfortably on a pho
 
 ## Touch targets + interactions
 
-All interactive elements meet or exceed the **44px touch target** minimum (Apple HIG standard, also Material Design's recommendation). Buttons, list rows, checkboxes, drag handles — everything is sized to be tappable without precision.
+All interactive elements meet or exceed the **44px touch target** minimum (Apple HIG standard, also Material Design's recommendation). Buttons, list rows, checkboxes, drag handles: everything is sized to be tappable without precision.
 
 Common gestures:
 
-- **Tap** — primary action. Shopping items toggle, calendar cards open, dashboard cards navigate.
-- **Long-press** — secondary actions (edit, delete, drag). Some lists also use long-press for drag activation so vertical scrolling stays the default.
-- **Swipe left/right** — navigate calendar periods. 50px threshold so accidental swipes during scroll don't trigger.
+- **Tap**: primary action. Shopping items toggle, calendar cards open, dashboard cards navigate.
+- **Long-press**: secondary actions (edit, delete, drag). Some lists also use long-press for drag activation so vertical scrolling stays the default.
+- **Swipe left/right**: navigate calendar periods. 50px threshold so accidental swipes during scroll don't trigger.
 
 ---
 
@@ -165,7 +165,7 @@ html { font-size: 16px; }                                        /* phone defaul
 
 The `pointer: fine` vs `pointer: coarse` media query distinguishes mouse-controlled (desktop laptop) from touch (tablet kiosk) at the same screen size. Same physical 13" display gets 14px on a laptop (mouse) but 20px on a tablet (touch).
 
-Override globally via *Settings → Appearance → Font Scale* (planned — not yet shipped as of v1.8).
+Override globally via *Settings → Appearance → Font Scale* (planned, not yet shipped as of v1.8).
 
 ---
 
@@ -173,7 +173,7 @@ Override globally via *Settings → Appearance → Font Scale* (planned — not 
 
 The `useOrientation` hook listens to `resize` + `orientationchange` events and returns the current orientation. The `AppShell` re-evaluates nav choice on every orientation change.
 
-Set an orientation in *Settings → Appearance → Orientation Override* (Landscape / Portrait / Auto). Note this override only drives **photo and wallpaper orientation matching** — it does not change which navigation or layout is shown. The nav still follows the physically detected orientation (width vs height).
+Set an orientation in *Settings → Appearance → Orientation Override* (Landscape / Portrait / Auto). Note this override only drives **photo and wallpaper orientation matching**. It does not change which navigation or layout is shown. The nav still follows the physically detected orientation (width vs height).
 
 ---
 
@@ -181,19 +181,19 @@ Set an orientation in *Settings → Appearance → Orientation Override* (Landsc
 
 PWA installations **auto-disable** screensaver and Away mode. Rationale:
 
-- Phone PWAs don't have idle states the way kiosks do — your phone is either in your pocket or actively in use.
+- Phone PWAs don't have idle states the way kiosks do. Your phone is either in your pocket or actively in use.
 - Auto-activating Away mode on a phone would lock the family member out of their own device.
 - Screensaver photo slideshow on a phone screen is wasted battery.
 
 The `useIsPWA` hook detects standalone display mode and short-circuits both.
 
-If you specifically want the screensaver on a phone (rare — maybe a kid's bedside iPad), turn off PWA mode by opening Prism in the browser instead of the installed app.
+If you specifically want the screensaver on a phone (rare, maybe a kid's bedside iPad), turn off PWA mode by opening Prism in the browser instead of the installed app.
 
 ---
 
 ## Notification badges (planned)
 
-iOS 16+ and Android Chrome support PWA notification badges (the little number next to the icon). Prism doesn't currently set badge counts, but the infrastructure is in place — tracked as a follow-up to surface unapproved chores or unread messages.
+iOS 16+ and Android Chrome support PWA notification badges (the little number next to the icon). Prism doesn't currently set badge counts, but the infrastructure is in place, tracked as a follow-up to surface unapproved chores or unread messages.
 
 ---
 
@@ -205,15 +205,15 @@ Install as PWA on the phone. Default opens to dashboard summary cards. Tap a car
 
 ### Tablet permanently mounted in the kitchen
 
-Don't install as PWA — open in fullscreen Chrome or use kiosk mode. SideNav stays visible, no nav restrictions, dashboard grid + Calendar + Shopping all accessible. Set orientation override to whatever the mount uses.
+Don't install as PWA. Open in fullscreen Chrome or use kiosk mode. SideNav stays visible, no nav restrictions, dashboard grid + Calendar + Shopping all accessible. Set orientation override to whatever the mount uses.
 
 ### Phone in shopping mode at the grocery store
 
-Install as PWA. Open Shopping. Hit the maximize icon (top right) to enter shopping mode — full screen, no nav, tap items to strike through. Camera icon in the header to scan barcodes.
+Install as PWA. Open Shopping. Hit the maximize icon (top right) to enter shopping mode: full screen, no nav, tap items to strike through. Camera icon in the header to scan barcodes.
 
 ### Spouse uses iOS, you use Android
 
-Both install as PWA on their own devices. Different shopping mode preferences, different filter presets — but the same data, the same family. PIN-based login means switching users on a shared device (e.g. the kitchen tablet) is a tap + a per-member PIN (4 or 6 digits).
+Both install as PWA on their own devices. Different shopping mode preferences, different filter presets, but the same data, the same family. PIN-based login means switching users on a shared device (e.g. the kitchen tablet) is a tap + a per-member PIN (4 or 6 digits).
 
 ---
 
@@ -223,7 +223,7 @@ Both install as PWA on their own devices. Different shopping mode preferences, d
 
 PWA install criteria: served over HTTPS, valid manifest, valid service worker, not already installed. If the install prompt doesn't appear in Chrome, check the address bar for the install icon (small `+`), or DevTools → Application → Manifest for errors.
 
-iOS Safari doesn't show a "Install" prompt at all — install is always via Share → Add to Home Screen.
+iOS Safari doesn't show a "Install" prompt at all. Install is always via Share → Add to Home Screen.
 
 ### Updates not showing after a deploy
 
@@ -237,15 +237,15 @@ The service worker is configured to skip-waiting on new versions, so reloads usu
 
 ### Bottom nav covers content
 
-Mobile pages have extra bottom padding to clear the nav bar. If you see overlap, file an issue with the specific page — almost always a missing `pb-20` (or equivalent) on a recently-added page.
+Mobile pages have extra bottom padding to clear the nav bar. If you see overlap, file an issue with the specific page: almost always a missing `pb-20` (or equivalent) on a recently-added page.
 
 ### Calendar showing month view on phone (not agenda)
 
-The agenda-only restriction was added in v1.8. If you're seeing month view on your phone, you're on an older client build — hard-refresh.
+The agenda-only restriction was added in v1.8. If you're seeing month view on your phone, you're on an older client build. Hard-refresh.
 
 ### FAB missing
 
-FAB only shows on phone viewports (`max-width: 767px`). On tablets you should see PortraitNav (bottom drawer) instead. The FAB is present on phone viewports whether or not anyone is logged in — when logged out it simply offers a **Login** action.
+FAB only shows on phone viewports (`max-width: 767px`). On tablets you should see PortraitNav (bottom drawer) instead. The FAB is present on phone viewports whether or not anyone is logged in. When logged out it simply offers a **Login** action.
 
 ### Cards in mobile dashboard appearing in wrong order
 

--- a/docs/features/PHOTOS.md
+++ b/docs/features/PHOTOS.md
@@ -14,7 +14,7 @@ Two types of photo sources:
 
 Photos uploaded directly through Prism's UI live in `data/photos/` on the host (or wherever you've mapped the volume). Good for family photos you've already curated.
 
-Upload via *Photos → Add photos* — drag-and-drop or file picker, multiple files at once. Supported formats: JPEG, PNG, HEIC (converted to JPEG), WebP.
+Upload via *Photos → Add photos*: drag-and-drop or file picker, multiple files at once. Supported formats: JPEG, PNG, HEIC (converted to JPEG), WebP.
 
 Behind the scenes, sharp pipeline:
 
@@ -23,32 +23,32 @@ Behind the scenes, sharp pipeline:
 - Re-encoded as JPEG quality 85.
 - ≤10 MB cap per file.
 
-The original-resolution file isn't kept after processing — the resized version is the canonical asset. If you want full-res archival, keep your originals elsewhere.
+The original-resolution file isn't kept after processing. The resized version is the canonical asset. If you want full-res archival, keep your originals elsewhere.
 
 ### OneDrive sync
 
 Connect Microsoft in *Settings → Integrations → Microsoft*. Then in *Settings → Photos → OneDrive*:
 
-- **Folder picker** — browse your OneDrive tree and pick which folder to sync from. Defaults to nothing (you must pick). Avoids the trap of accidentally syncing your entire drive.
+- **Folder picker**: browse your OneDrive tree and pick which folder to sync from. Defaults to nothing (you must pick). Avoids the trap of accidentally syncing your entire drive.
 
-The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved. **Auto-sync runs automatically about every 30 minutes** — drop a photo into the folder and it appears on the dashboard within the half hour, no manual trigger needed. (Hit the manual sync button in settings if you want it immediately.)
+The sync downloads new files into `data/photos/onedrive/`. EXIF metadata is preserved. **Auto-sync runs automatically about every 30 minutes**. Drop a photo into the folder and it appears on the dashboard within the half hour, no manual trigger needed. (Hit the manual sync button in settings if you want it immediately.)
 
-Orientation and resolution aren't sync-time filters — every photo in the picked folder syncs. Orientation allow-lists and the low-resolution warning are display-side settings under *Settings → Photos*; see [Filtering](#filtering) for the Below HD filter.
+Orientation and resolution aren't sync-time filters: every photo in the picked folder syncs. Orientation allow-lists and the low-resolution warning are display-side settings under *Settings → Photos*; see [Filtering](#filtering) for the Below HD filter.
 
-You can have multiple OneDrive sources — useful if you want one folder for "family slideshow" and another for "wallpaper-only".
+You can have multiple OneDrive sources, useful if you want one folder for "family slideshow" and another for "wallpaper-only".
 
 #### Getting photos into the folder from your iPhone
 
 OneDrive backs up your whole camera roll to one big folder, but doesn't map iOS albums or favorites to a specific folder. So you populate the Prism folder one of three ways:
 
-1. **iOS Shortcut (recommended)** — a one-tap "Add to Prism" action on the Photos share sheet. Build it once:
+1. **iOS Shortcut (recommended)**: a one-tap "Add to Prism" action on the Photos share sheet. Build it once:
    - Open the **Shortcuts** app → **+** → name it "Add to Prism"
    - Add action **Save File** (from the Documents category)
    - Set the destination to your OneDrive Prism folder, turn **off** "Ask Where to Save"
    - In the shortcut's settings (ⓘ), enable **Show in Share Sheet** and set "Accepted Types" to Images
    - Now: in Photos, select any photos → Share → **Add to Prism**. They upload straight to the folder.
-2. **OneDrive app** — open OneDrive, select photos in your Camera Roll backup → **Copy to** → Prism folder.
-3. **From a computer** — drag files into the folder in the OneDrive web UI or synced desktop folder.
+2. **OneDrive app**: open OneDrive, select photos in your Camera Roll backup → **Copy to** → Prism folder.
+3. **From a computer**: drag files into the folder in the OneDrive web UI or synced desktop folder.
 
 > Why not iCloud Shared Albums? Apple migrated public share URLs to a CloudKit-only backend that has no public API. See [iCloud integration](ICLOUD.md#what-works-what-doesnt) for the full story; OneDrive + the iOS Shortcut above is the workflow for iPhone users.
 
@@ -56,8 +56,8 @@ OneDrive backs up your whole camera roll to one big folder, but doesn't map iOS 
 
 If you back up the same photos to **more than one** source (e.g. local uploads plus an OneDrive folder, or two OneDrive folders that overlap), Prism shows each photo **once** rather than twice. When the same shot is found in multiple sources:
 
-- Photos are matched by **capture time + dimensions** (a cropped edit keeps the original timestamp but changes dimensions, so edits and originals both show — only true duplicates are collapsed).
-- The copy from your **preferred source wins**. Order your sources in *Settings → Photos* with the ▲▼ controls — top of the list = preferred. Reordering takes effect immediately; no re-sync needed.
+- Photos are matched by **capture time + dimensions** (a cropped edit keeps the original timestamp but changes dimensions, so edits and originals both show; only true duplicates are collapsed).
+- The copy from your **preferred source wins**. Order your sources in *Settings → Photos* with the ▲▼ controls, top of the list = preferred. Reordering takes effect immediately; no re-sync needed.
 
 Example: rank "OneDrive: originals" above "OneDrive: web-optimized" and any photo in both folders serves from the originals folder while the smaller copy is suppressed from display.
 
@@ -65,7 +65,7 @@ Example: rank "OneDrive: originals" above "OneDrive: web-optimized" and any phot
 
 ## GPS data
 
-Each photo row stores latitude/longitude if the EXIF data has them. This powers the Travel Map's photo-linking feature — geotagged photos auto-link to nearby travel pins.
+Each photo row stores latitude/longitude if the EXIF data has them. This powers the Travel Map's photo-linking feature: geotagged photos auto-link to nearby travel pins.
 
 iOS strips GPS on share by default; toggle "Preserve location" in Photo settings or use AirDrop with location preserved to keep GPS data when sharing photos to OneDrive.
 
@@ -81,32 +81,32 @@ The Photos page is a paginated grid. Each thumbnail loads lazily. Click for the 
 
 - Full-resolution image.
 - Arrow keys (or swipe on mobile) for next/previous.
-- **Tag for:** usage toggles — add or remove the photo from Wallpaper, Gallery, and/or Screensaver (see [Usage tags](#usage-tags)).
-- **Delete** — removes the photo from Prism.
+- **Tag for:** usage toggles: add or remove the photo from Wallpaper, Gallery, and/or Screensaver (see [Usage tags](#usage-tags)).
+- **Delete**: removes the photo from Prism.
 - A resolution-quality dot plus the photo's dimensions and orientation.
 
 ### Filtering
 
-- **Orientation** — show only landscape, portrait, or square.
-- **Usage** — filter to photos tagged for Wallpaper, Gallery, or Screensaver.
-- **Favorites** — show only photos flagged as favorites.
-- **Below HD** — show only photos under 1920×1080 (handy for finding low-resolution shots that won't look good full-screen).
+- **Orientation**: show only landscape, portrait, or square.
+- **Usage**: filter to photos tagged for Wallpaper, Gallery, or Screensaver.
+- **Favorites**: show only photos flagged as favorites.
+- **Below HD**: show only photos under 1920×1080 (handy for finding low-resolution shots that won't look good full-screen).
 
 ### Bulk actions (desktop)
 
 On desktop, tap **Select** to enter multi-select mode (hidden on mobile):
 
-- Tap photos to select them, or use **Select all** to select the entire filtered library — not just the current page.
-- **Show in:** — bulk-add or remove the selected photos' Wallpaper / Gallery / Screensaver usage tags in one action.
-- **Remove from Prism** — bulk-delete the selected photos from Prism. Source files (including OneDrive) are untouched; photos removed from a synced source stay removed rather than re-downloading on the next sync.
+- Tap photos to select them, or use **Select all** to select the entire filtered library, not just the current page.
+- **Show in:** bulk-add or remove the selected photos' Wallpaper / Gallery / Screensaver usage tags in one action.
+- **Remove from Prism**: bulk-delete the selected photos from Prism. Source files (including OneDrive) are untouched; photos removed from a synced source stay removed rather than re-downloading on the next sync.
 
 ### Resolution indicator
 
 Each thumbnail (and the lightbox) shows a small resolution-quality dot compared against 1920×1080 (HD):
 
-- **Green** — at or above HD.
-- **Yellow** — at least 75% of HD.
-- **Red** — low resolution.
+- **Green**: at or above HD.
+- **Yellow**: at least 75% of HD.
+- **Red**: low resolution.
 
 Combined with the **Below HD** filter, this makes it easy to spot photos too small to look good as a full-screen wallpaper.
 
@@ -116,9 +116,9 @@ Combined with the **Below HD** filter, this makes it easy to spot photos too sma
 
 Rather than free-form labels, each photo carries **usage tags** that control where it can appear. Open a photo's lightbox and use the **Tag for:** row to toggle it into any combination of:
 
-- **Wallpaper** — eligible to be shown as the dashboard background.
-- **Gallery** — shown in the main Photos grid.
-- **Screensaver** — included in the screensaver rotation.
+- **Wallpaper**: eligible to be shown as the dashboard background.
+- **Gallery**: shown in the main Photos grid.
+- **Screensaver**: included in the screensaver rotation.
 
 A photo can carry any combination of these (or none). Usage tags double as gallery filters (see [Filtering](#filtering)). There's also a **Favorites** filter for photos flagged as favorites.
 
@@ -134,10 +134,10 @@ Used by:
 
 Each surface configures its own:
 
-- **Rotation interval** — how often to cycle (defaults vary by surface).
-- **Source filter** — which photo sources to draw from.
-- **Usage filter** — draw only from photos tagged for that surface (Wallpaper / Gallery / Screensaver).
-- **Orientation filter** — only show landscape (good for full-screen displays) or only portrait, etc.
+- **Rotation interval**: how often to cycle (defaults vary by surface).
+- **Source filter**: which photo sources to draw from.
+- **Usage filter**: draw only from photos tagged for that surface (Wallpaper / Gallery / Screensaver).
+- **Orientation filter**: only show landscape (good for full-screen displays) or only portrait, etc.
 
 Photos are pre-fetched and rotated client-side. No server round-trip per rotation.
 
@@ -147,12 +147,12 @@ Photos are pre-fetched and rotated client-side. No server round-trip per rotatio
 
 Override the slideshow for specific surfaces with a single static image. Pinning is set in *Settings → Photos* (the Pinned Photos card), not from the lightbox:
 
-- **Pinned wallpaper** — the dashboard renders this one static image behind widgets instead of cycling.
-- **Pinned screensaver** — same idea for screensaver mode.
+- **Pinned wallpaper**: the dashboard renders this one static image behind widgets instead of cycling.
+- **Pinned screensaver**: same idea for screensaver mode.
 
 Useful for "we want THIS family portrait as the dashboard background, not random photos cycling."
 
-Pinning is **per-device** — the pinned photo is stored in that browser's local storage, so each display can pin its own wallpaper/screensaver (or none). You can pin one photo as wallpaper and let the screensaver still cycle through the rest.
+Pinning is **per-device**: the pinned photo is stored in that browser's local storage, so each display can pin its own wallpaper/screensaver (or none). You can pin one photo as wallpaper and let the screensaver still cycle through the rest.
 
 To change or clear a pin, use the same Pinned Photos card in *Settings → Photos*.
 
@@ -203,7 +203,7 @@ Sync a "Best of 2025" folder from OneDrive. Configure the screensaver to cycle t
 
 ### Travel scrapbook
 
-Geotag your phone photos (iOS: keep "Preserve location" on when sharing to OneDrive). Sync the travel folder. Open the Travel Map — pins for places you've been now show photo strips of shots taken nearby.
+Geotag your phone photos (iOS: keep "Preserve location" on when sharing to OneDrive). Sync the travel folder. Open the Travel Map. Pins for places you've been now show photo strips of shots taken nearby.
 
 ### Static dashboard wallpaper
 
@@ -219,9 +219,9 @@ Babysitter mode uses the screensaver photo source by default, so it draws from p
 
 ### Photos not showing up after OneDrive sync
 
-1. *Settings → Photos → OneDrive* — is the folder picker pointing at the right folder?
+1. *Settings → Photos → OneDrive*. Is the folder picker pointing at the right folder?
 2. Tap **Sync now**.
-3. Check the sync log on the Photos settings page — any errors?
+3. Check the sync log on the Photos settings page. Any errors?
 4. Every photo in the picked folder syncs (nothing is skipped by size); if a photo is missing, confirm it's actually in that folder.
 
 ### Slideshow shows a thumbnail-quality image, not full
@@ -243,7 +243,7 @@ The slideshow shuffles within the filter set. If your filter is too narrow (e.g.
 ### "Backfill GPS" finds no new GPS data
 
 Either:
-- The photos genuinely don't have EXIF GPS (most common — iOS strips it on share by default).
+- The photos genuinely don't have EXIF GPS (most common: iOS strips it on share by default).
 - The photos were synced via OneDrive's "stripped metadata" mode (some OneDrive Photos settings strip GPS).
 
 Verify by opening a photo's file properties directly and checking the EXIF data.

--- a/docs/features/RECIPES.md
+++ b/docs/features/RECIPES.md
@@ -2,7 +2,7 @@
 
 ![Recipe library](../demos/recipes.png){ .hero-image }
 
-Browse, import (URL, Paprika, paste-text), photograph, scale, and cook recipes — designed for a large kitchen screen so you don't have to keep unlocking your phone while your hands are covered in flour.
+Browse, import (URL, Paprika, paste-text), photograph, scale, and cook recipes, designed for a large kitchen screen so you don't have to keep unlocking your phone while your hands are covered in flour.
 
 ---
 
@@ -12,15 +12,15 @@ Each recipe has:
 
 - **Name** (required)
 - **Description**
-- **Ingredients** — structured as an array of `{ text }` or `{ heading }` entries. Headings render bolded; text entries are the actual ingredients.
-- **Instructions** — plain text, line-breaks become step separators.
+- **Ingredients**: structured as an array of `{ text }` or `{ heading }` entries. Headings render bolded; text entries are the actual ingredients.
+- **Instructions**: plain text, line-breaks become step separators.
 - **Prep time + cook time** (minutes)
 - **Servings**
 - **Cuisine** (Italian, Mexican, Thai, etc.)
 - **Category** (Main Dish, Dessert, Breakfast, Bread, etc.)
-- **Tags** — free-form (`weeknight`, `kid-friendly`, `vegetarian`, `sheet-pan`).
-- **Source URL** — optional link back to the original.
-- **Image** — uploaded photo OR remote URL.
+- **Tags**: free-form (`weeknight`, `kid-friendly`, `vegetarian`, `sheet-pan`).
+- **Source URL**: optional link back to the original.
+- **Image**: uploaded photo OR remote URL.
 - **Rating** (1-5 stars)
 - **Notes**
 - **Favorite** boolean
@@ -31,7 +31,7 @@ Each recipe has:
 
 ## Importing recipes
 
-Four methods cover ~95% of inputs — plus a fifth for syncing from an existing recipe manager:
+Four methods cover ~95% of inputs, plus a fifth for syncing from an existing recipe manager:
 
 ### URL import
 
@@ -41,7 +41,7 @@ Paste a recipe URL. Prism parses **schema.org Recipe JSON-LD** (the standard str
 
 Extracts: name, ingredients, instructions, prep/cook times, servings, image URL, cuisine, category.
 
-If the site doesn't publish JSON-LD, the import fails gracefully — fall back to paste-text or manual entry.
+If the site doesn't publish JSON-LD, the import fails gracefully. Fall back to paste-text or manual entry.
 
 ### Paprika import
 
@@ -58,19 +58,19 @@ The killer feature for physical recipe cards. Workflow:
 1. Take a photo of the recipe card with iOS Live Text (or Google Lens on Android).
 2. "Select all → Copy" the recognized text.
 3. Open Prism on your phone (or wherever you keep your laptop), paste into the modal.
-4. A heuristic parser splits the dump into title, ingredients, instructions, prep/cook time, and servings — preserves section headings inside ingredients.
+4. A heuristic parser splits the dump into title, ingredients, instructions, prep/cook time, and servings. Preserves section headings inside ingredients.
 
 What the parser handles:
 
-- **Title casing** — applies AP-style title case (`a / an / the / and / or / for / of / with` stay lowercase mid-title; everything else capitalized).
-- **Section markers** — `Ingredients:`, `Instructions:`, `Method:`, `Directions:`, `For the X:` headers.
-- **Sub-section headings inside ingredients** — `Fries:`, `Meatballs:`, `Sauce:` get stored as `{ heading }` entries and render bolded in the detail view.
-- **"Step N:" prefixes** — split as instruction steps.
-- **Comma modifiers in ingredients** — `1 onion, diced and sautéed` is preserved as-is.
-- **`" or "` alternatives** — `1 tsp dried oregano or 1 tbsp fresh oregano` preserved.
-- **Parentheticals** — `(about 4 cups)` preserved.
-- **Inline step markers** — `1. Preheat oven. 2. Mix dry ingredients.` gets line-broken.
-- **Times** — `Prep: 15 min`, `Cook: 30 min`, `Total: 45 min`, `Servings: 4` extracted.
+- **Title casing**: applies AP-style title case (`a / an / the / and / or / for / of / with` stay lowercase mid-title; everything else capitalized).
+- **Section markers**: `Ingredients:`, `Instructions:`, `Method:`, `Directions:`, `For the X:` headers.
+- **Sub-section headings inside ingredients**: `Fries:`, `Meatballs:`, `Sauce:` get stored as `{ heading }` entries and render bolded in the detail view.
+- **"Step N:" prefixes**: split as instruction steps.
+- **Comma modifiers in ingredients**: `1 onion, diced and sautéed` is preserved as-is.
+- **`" or "` alternatives**: `1 tsp dried oregano or 1 tbsp fresh oregano` preserved.
+- **Parentheticals**: `(about 4 cups)` preserved.
+- **Inline step markers**: `1. Preheat oven. 2. Mix dry ingredients.` gets line-broken.
+- **Times**: `Prep: 15 min`, `Cook: 30 min`, `Total: 45 min`, `Servings: 4` extracted.
 
 Pre-fills the same form the manual-entry modal uses, so you can review + tweak before saving.
 
@@ -85,7 +85,7 @@ The fallback. *Recipes → Add → Create manually*. Full form for every field. 
 If you already keep your recipes in [Tandoor](https://tandoor.dev/) or [Mealie](https://mealie.io/), connect the server with its base URL and a **read-only API token** to pull recipes in.
 
 - Sync runs a **review-and-approve diff**: adds and updates are pre-selected, and removals are opt-in (with a mass-delete guard so a misconfigured source can't wipe your library).
-- Re-syncing is **idempotent** — recipes already imported are matched and updated in place rather than duplicated.
+- Re-syncing is **idempotent**: recipes already imported are matched and updated in place rather than duplicated.
 
 ---
 
@@ -93,9 +93,9 @@ If you already keep your recipes in [Tandoor](https://tandoor.dev/) or [Mealie](
 
 Each recipe can carry its own image. In the recipe form:
 
-- **Upload from device** — opens the native photo picker. On iOS, shows the standard sheet (camera / library / files); doesn't force the camera (`capture="environment"` was intentionally removed).
-- **Remote URL** — paste a URL to use it directly.
-- **Remove** — clears the photo.
+- **Upload from device**: opens the native photo picker. On iOS, shows the standard sheet (camera / library / files); doesn't force the camera (`capture="environment"` was intentionally removed).
+- **Remote URL**: paste a URL to use it directly.
+- **Remove**: clears the photo.
 
 Uploaded photos go through a sharp pipeline:
 
@@ -117,7 +117,7 @@ The Recipes page shows a grid of recipe cards with image, name, cuisine, categor
 
 Filters:
 
-- **Search** — case-insensitive match across name, description, cuisine, and category.
+- **Search**: case-insensitive match across name, description, cuisine, and category.
 - **Cuisine** dropdown.
 - **Category** dropdown.
 - **Favorites only** toggle.
@@ -135,7 +135,7 @@ Click a recipe card to open the detail view. Features:
 
 - Recipe name, cuisine + category badges, prep/cook time.
 - **Favorite toggle** (heart).
-- **Maximize** — expand to a larger modal for a wall display.
+- **Maximize**: expand to a larger modal for a wall display.
 
 ### Servings + scaling
 
@@ -145,12 +145,12 @@ The servings line shows current servings with **+/- buttons** to adjust by 1. Be
 
 Tap any pill to instantly multiply the original servings by that factor. ½× rounds up to the nearest whole serving so a 3-serving recipe scales to 2, not 1.5. The active multiplier highlights so you know what you're seeing.
 
-Ingredient quantities auto-recalculate. Smart fractions: scaled amounts that hit common fractions display as fractions (rendered as ASCII — `1/4`, `1/3`, `1/2`, `2/3`, `3/4`); otherwise as numbers rounded to two decimal places.
+Ingredient quantities auto-recalculate. Smart fractions: scaled amounts that hit common fractions display as fractions (rendered as ASCII: `1/4`, `1/3`, `1/2`, `2/3`, `3/4`); otherwise as numbers rounded to two decimal places.
 
 ### Ingredients
 
 - Section headings render bolded.
-- Tap an ingredient row to strikethrough — useful while cooking ("got this one in the bowl").
+- Tap an ingredient row to strikethrough, useful while cooking ("got this one in the bowl").
 - Strikethroughs reset when you close the modal.
 - Scaled quantities are reflected in the displayed text.
 
@@ -158,12 +158,12 @@ Ingredient quantities auto-recalculate. Smart fractions: scaled amounts that hit
 
 - Step-by-step, one line per step.
 - Line breaks preserved from the source.
-- `whitespace-pre-wrap` rendering — long steps wrap cleanly.
+- `whitespace-pre-wrap` rendering: long steps wrap cleanly.
 
 ### Add to shopping list
 
-- **Add to Shopping List** dropdown — pick which list to send the ingredients to.
-- Active scaling applies — if you're viewing the recipe at 2×, the shopping items go in at 2× quantities.
+- **Add to Shopping List** dropdown: pick which list to send the ingredients to.
+- Active scaling applies: if you're viewing the recipe at 2×, the shopping items go in at 2× quantities.
 - Section headings are filtered out automatically (they're visual grouping, not items to buy).
 
 ### Notes + URL
@@ -181,7 +181,7 @@ Recipes link to meals on the Meals weekly planner:
 - Selecting a recipe auto-fills: meal name, description, prep time, cook time, recipe URL.
 - Marking a meal as **cooked** increments the linked recipe's `timesMade` counter and updates `lastMadeAt`.
 
-You can also schedule straight from a recipe: the detail modal has an inline **Add to Meal Plan** mini-calendar. Pick a day on the 2-week grid, choose a meal type (Breakfast / Lunch / Dinner / Snack — defaults to Dinner), and tap **Add to Plan** to drop the recipe onto the meal planner.
+You can also schedule straight from a recipe: the detail modal has an inline **Add to Meal Plan** mini-calendar. Pick a day on the 2-week grid, choose a meal type (Breakfast / Lunch / Dinner / Snack, defaults to Dinner), and tap **Add to Plan** to drop the recipe onto the meal planner.
 
 Each recipe card shows a **Made N×** badge once it's been cooked, so you can eyeball what's in rotation vs. what's been gathering dust.
 
@@ -189,7 +189,7 @@ Each recipe card shows a **Made N×** badge once it's been cooked, so you can ey
 
 ## Print + share (planned)
 
-Currently the detail modal is the only "share" — you can show someone the screen or save the page URL. A dedicated print stylesheet and a shareable read-only link are on the roadmap but not shipped.
+Currently the detail modal is the only "share": you can show someone the screen or save the page URL. A dedicated print stylesheet and a shareable read-only link are on the roadmap but not shipped.
 
 ---
 
@@ -213,11 +213,11 @@ Smart fractions only kick in for ¼, ⅓, ½, ⅔, ¾ (shown as ASCII: `1/4`, `1
 
 ### Photo upload "Failed to remove photo"
 
-Real error from the API — earlier versions returned generic "Failed" without surfacing the actual cause. Updated to propagate the real reason in v1.8.
+Real error from the API. Earlier versions returned generic "Failed" without surfacing the actual cause. Updated to propagate the real reason in v1.8.
 
 ### Photo doesn't show on web (only on phone)
 
-Stale cache. Hard-reload (Ctrl+Shift+R) or uninstall+reinstall the PWA. Images are served via `GET /api/recipes/<id>/image` and the response has a cache-busting query param — but a service worker with an aggressive cache can override.
+Stale cache. Hard-reload (Ctrl+Shift+R) or uninstall+reinstall the PWA. Images are served via `GET /api/recipes/<id>/image` and the response has a cache-busting query param, but a service worker with an aggressive cache can override.
 
 ### "Add to Shopping List" returns "too many requests"
 
@@ -225,4 +225,4 @@ Rate limit. Recipe imports add ingredients one-by-one in sequence, and long list
 
 ### Section headings appearing as ingredients on the shopping list
 
-Shouldn't happen — headings filter out via the `{ heading }` field. If they do, the recipe probably has `Fries:` typed as a `{ text }` entry (an actual ingredient). Edit the recipe and re-format with the section as a heading.
+Shouldn't happen: headings filter out via the `{ heading }` field. If they do, the recipe probably has `Fries:` typed as a `{ text }` entry (an actual ingredient). Edit the recipe and re-format with the section as a heading.

--- a/docs/features/SHOPPING.md
+++ b/docs/features/SHOPPING.md
@@ -10,19 +10,19 @@ Multiple lists, drag-to-reorder categories, per-person attribution, camera + USB
 
 A Prism instance can hold any number of shopping lists. Common shapes:
 
-- **Grocery** — produce / dairy / meat / bakery / frozen / pantry layout.
-- **Hardware** — Home Depot / Lowe's style.
-- **General** — Target, Costco, anywhere else with mixed categories.
-- **Per-store lists** — separate Mariano's and Costco lists for the same week (different default stores in the Kroger picker).
+- **Grocery**: produce / dairy / meat / bakery / frozen / pantry layout.
+- **Hardware**: Home Depot / Lowe's style.
+- **General**: Target, Costco, anywhere else with mixed categories.
+- **Per-store lists**: separate Mariano's and Costco lists for the same week (different default stores in the Kroger picker).
 
 Create one in *Shopping → New List*. Each list has:
 
 - **Name**
 - **Icon** (Lucide icon name)
 - **Color**
-- **List type** — `grocery` / `hardware` / `general`. Affects category layout (grocery uses the 6-category grid).
-- **Visible categories** — null = show all; or pick a subset for non-grocery lists.
-- **Assigned member** (optional) — for personal lists that should only show to one family member.
+- **List type**: `grocery` / `hardware` / `general`. Affects category layout (grocery uses the 6-category grid).
+- **Visible categories**: null = show all; or pick a subset for non-grocery lists.
+- **Assigned member** (optional): for personal lists that should only show to one family member.
 
 Tap a list tab to switch between them. The active list persists in localStorage.
 
@@ -39,7 +39,7 @@ For grocery lists, items fall into a 6-category grid:
 - **Frozen** (cyan)
 - **Pantry** (amber)
 
-For non-grocery lists, categories are open-ended — you can use any string (`clothes`, `housewares`, `electronics`, `garden`).
+For non-grocery lists, categories are open-ended: you can use any string (`clothes`, `housewares`, `electronics`, `garden`).
 
 ### Drag-to-reorder
 
@@ -55,15 +55,15 @@ Each category card shows 6 empty lines by default. **+1 / -1 / +5** buttons adju
 
 Three ways:
 
-1. **Inline input** — text field in each category card. Type, press Enter, item added with that category pre-assigned. Tab or click away also adds.
-2. **+ button** in the category header — opens the Add Item modal with the category pre-selected. Use this when you want to set quantity, unit, or notes at creation time.
-3. **Barcode scan** — phone camera or USB scanner (see below). Auto-fills name from Open Food Facts, picks a category.
+1. **Inline input**: text field in each category card. Type, press Enter, item added with that category pre-assigned. Tab or click away also adds.
+2. **+ button** in the category header: opens the Add Item modal with the category pre-selected. Use this when you want to set quantity, unit, or notes at creation time.
+3. **Barcode scan**: phone camera or USB scanner (see below). Auto-fills name from Open Food Facts, picks a category.
 
 Each item supports:
 
 - **Name** (required)
 - **Quantity** (integer)
-- **Unit** (`gallon`, `lbs`, `oz`, `dozen`, `box`, etc. — free text)
+- **Unit** (`gallon`, `lbs`, `oz`, `dozen`, `box`, etc., free text)
 - **Category**
 - **Notes**
 
@@ -73,7 +73,7 @@ Each item supports:
 
 Tap an item row to mark it checked. Visually: strikethrough text, dimmed color. The progress bar at the top of each list animates in real time as items get checked off.
 
-No checkboxes — the entire row is the tap target. Cleaner on mobile, easier in-store with one hand.
+No checkboxes: the entire row is the tap target. Cleaner on mobile, easier in-store with one hand.
 
 Optimistic UI: the check fires before the API responds, so the strikethrough is instant even on a slow connection. If the server rejects (rare), the row reverts.
 
@@ -83,8 +83,8 @@ Optimistic UI: the check fires before the API responds, so the strikethrough is 
 
 Each item row has always-visible inline **Edit** (pencil) and **Delete** (trash) buttons on the right:
 
-- **Edit** — tap to open the modal with current values.
-- **Delete** — removes immediately. There is no undo for deletes; the Undo button in the nav bar only reverses a check-off.
+- **Edit**: tap to open the modal with current values.
+- **Delete**: removes immediately. There is no undo for deletes; the Undo button in the nav bar only reverses a check-off.
 
 ---
 
@@ -97,7 +97,7 @@ Tap the **camera icon** in the Shopping header to open a full-screen scanner ove
 1. Haptic feedback fires (where supported).
 2. Audio tone plays (unlocks on iOS via the synchronous "Open Camera" tap).
 3. Overlay auto-dismisses.
-4. Product is looked up against **Open Food Facts** (no API key required) — name, category, image.
+4. Product is looked up against **Open Food Facts** (no API key required): name, category, image.
 5. Item is added to the active list with a suggested category.
 
 If the scanned item is already on a list, Prism prompts you to pick which list to add it to (or cancel).
@@ -118,11 +118,11 @@ The picker walks through each unchecked item in the active list:
 
 - Up to 5 SKU candidates per item.
 - Each candidate shows: product image, name (line-clamp-2), brand, size, **price**, and a **normalized unit price** (lb / fl oz / ct) so candidates within the page can be compared directly.
-- **Quantity controls** — +/- buttons bump cart count (1-99) per item.
-- **Search override** — refine the search term when the parser strips too much.
-- **Skip** — leave the item out of the cart (still on the Prism list).
-- **Back** — re-pick the previous item.
-- **Add** — push the chosen SKU to the cart, advance.
+- **Quantity controls**: +/- buttons bump cart count (1-99) per item.
+- **Search override**: refine the search term when the parser strips too much.
+- **Skip**: leave the item out of the cart (still on the Prism list).
+- **Back**: re-pick the previous item.
+- **Add**: push the chosen SKU to the cart, advance.
 
 When the picker finishes, you get a review screen showing every SKU added with `× N` for multiples and total estimated price. Then you open the Kroger / Mariano's app or website to choose a pickup time and check out.
 
@@ -138,7 +138,7 @@ Once you pick a specific product (`Mariano's 2% Reduced Fat Milk Gallon`) for th
 
 ### Setup
 
-Full setup walkthrough in the [Kroger integration guide](KROGER.md) — covers creating the Kroger developer app, getting Client ID / Secret, connecting in Prism, picking your default store.
+Full setup walkthrough in the [Kroger integration guide](KROGER.md), covers creating the Kroger developer app, getting Client ID / Secret, connecting in Prism, picking your default store.
 
 ---
 
@@ -172,13 +172,13 @@ Designed for one-handed phone use while pushing a cart. Tap **minimize** to exit
 
 A progress bar at the top of each list shows checked / total. When you check off the last item, the celebration animation plays: a shopping cart slides across the screen with a kid riding inside (arms up), confetti exhaust particles, and an "All Done!" text bounce. Auto-dismisses after 3 seconds.
 
-The animation honors `prefers-reduced-motion` and Performance Mode — both skip it.
+The animation honors `prefers-reduced-motion` and Performance Mode. Both skip it.
 
 ---
 
 ## Per-person attribution
 
-Each item carries an `addedBy` — the family member who added it. This is stored with the item, but the list UI does not currently surface it or offer a per-person filter.
+Each item carries an `addedBy`, the family member who added it. This is stored with the item, but the list UI does not currently surface it or offer a per-person filter.
 
 ---
 
@@ -186,10 +186,10 @@ Each item carries an `addedBy` — the family member who added it. This is store
 
 Common family pattern:
 
-1. **Grocery** — the primary list, syncs to MS To Do, pushed to Kroger weekly.
-2. **Costco** — separate list, no Kroger push (Costco isn't on the Kroger API), bulk items only.
-3. **Hardware** — non-grocery, Home Depot / Lowe's runs.
-4. **Target** — open category list for the random Target trip.
+1. **Grocery**: the primary list, syncs to MS To Do, pushed to Kroger weekly.
+2. **Costco**: separate list, no Kroger push (Costco isn't on the Kroger API), bulk items only.
+3. **Hardware**: non-grocery, Home Depot / Lowe's runs.
+4. **Target**: open category list for the random Target trip.
 
 Each has its own default store, its own check-off cadence, its own sync config.
 
@@ -211,7 +211,7 @@ No default store set. *Settings → Integrations → Kroger → Set store* and e
 
 ### SKU picker can't find an obvious item
 
-The search parser drops quantity, units, comma modifiers, and `" or "` alternatives. For `1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes`, it searches `Fresno pepper`. Sometimes that's still wrong — use the **search override** input above the candidates to refine the term.
+The search parser drops quantity, units, comma modifiers, and `" or "` alternatives. For `1 Fresno pepper, seeded and sliced, or ½ teaspoon crushed red pepper flakes`, it searches `Fresno pepper`. Sometimes that's still wrong. Use the **search override** input above the candidates to refine the term.
 
 ### Barcode scanner shows the wrong category
 
@@ -223,4 +223,4 @@ USB HID scanners need keyboard focus on something in the Prism page. If a modal 
 
 ### Microsoft To Do sync stuck
 
-In the **Microsoft** provider card under *Settings → Integrations*, tap **Sync now**. If still stuck, check that card's connection — the token may have expired.
+In the **Microsoft** provider card under *Settings → Integrations*, tap **Sync now**. If still stuck, check that card's connection: the token may have expired.

--- a/docs/features/TASKS.md
+++ b/docs/features/TASKS.md
@@ -9,13 +9,13 @@ To-do items with assignment, due dates, priorities, lists, and bidirectional syn
 ## What's in a task
 
 - **Title** (required)
-- **Description** — not editable in the Prism task modal; it only round-trips from Microsoft To Do / Google Tasks notes on sync.
-- **List** — which task list it belongs to. Nullable (inbox).
-- **Assigned to** — family member, or unassigned.
-- **Due date** — date+time, optional.
-- **Priority** — high / medium / low. Defaults to medium; there is no "none".
-- **Category** — free-form tag (`Health`, `School`, `Errands`, `Shopping`).
-- **Completed** — boolean. When completed, `completedAt` and `completedBy` populate.
+- **Description**: not editable in the Prism task modal; it only round-trips from Microsoft To Do / Google Tasks notes on sync.
+- **List**: which task list it belongs to. Nullable (inbox).
+- **Assigned to**: family member, or unassigned.
+- **Due date**: date+time, optional.
+- **Priority**: high / medium / low. Defaults to medium; there is no "none".
+- **Category**: free-form tag (`Health`, `School`, `Errands`, `Shopping`).
+- **Completed**: boolean. When completed, `completedAt` and `completedBy` populate.
 
 ---
 
@@ -23,18 +23,18 @@ To-do items with assignment, due dates, priorities, lists, and bidirectional syn
 
 Lists are the primary organizational unit. Common patterns:
 
-- **Inbox** — catch-all for unsorted tasks.
-- **Family** — household-shared (groceries, errands).
-- **Home** — house maintenance, repairs.
-- **Work** — per-parent work tasks.
-- **School** — per-child school tasks.
+- **Inbox**: catch-all for unsorted tasks.
+- **Family**: household-shared (groceries, errands).
+- **Home**: house maintenance, repairs.
+- **Work**: per-parent work tasks.
+- **School**: per-child school tasks.
 
 Create lists in *Settings → Integrations → (Google or Microsoft) card → New List*. Each list has:
 
 - **Name**
-- **Color** — colored dot in the picker + per-task tag.
-- **Sort order** — drag to reorder in the picker.
-- **External sync source** — optional Microsoft To Do or Google Tasks list to bidirectionally sync with.
+- **Color**: colored dot in the picker + per-task tag.
+- **Sort order**: drag to reorder in the picker.
+- **External sync source**: optional Microsoft To Do or Google Tasks list to bidirectionally sync with.
 
 Delete a list and its tasks become unassigned (moved to the inbox); they're not deleted.
 
@@ -42,8 +42,8 @@ Delete a list and its tasks become unassigned (moved to the inbox); they're not 
 
 ## Adding tasks
 
-- **Add Task** button — opens the modal with all fields.
-- **Inline text input** — at the top of the Tasks page, type a title, press Enter, task created in the current filter view.
+- **Add Task** button: opens the modal with all fields.
+- **Inline text input**: at the top of the Tasks page, type a title, press Enter, task created in the current filter view.
 
 Both require login (parent or child). The inline form auto-assigns the current logged-in user as `createdBy`.
 
@@ -59,16 +59,16 @@ If the task syncs to MS To Do / Google Tasks, the completed status propagates to
 
 ## Filtering + sorting
 
-- **By list** — picker dropdown, "All lists" / "Unassigned" / specific list.
-- **By person** — avatar filter pills at the top.
-- **By priority** — filter chip.
-- **Show completed** toggle — off by default. When on, completed tasks appear at the bottom with the strikethrough.
+- **By list**: picker dropdown, "All lists" / "Unassigned" / specific list.
+- **By person**: avatar filter pills at the top.
+- **By priority**: filter chip.
+- **Show completed** toggle: off by default. When on, completed tasks appear at the bottom with the strikethrough.
 
 Sort options:
 
-- **By due date** — overdue first, then today, then upcoming, then no-date last.
-- **By priority** — high → medium → low.
-- **By title** — alphabetical (A→Z).
+- **By due date**: overdue first, then today, then upcoming, then no-date last.
+- **By priority**: high → medium → low.
+- **By title**: alphabetical (A→Z).
 
 ---
 
@@ -76,10 +76,10 @@ Sort options:
 
 The Group dropdown supports nested grouping:
 
-- **None** — flat list.
-- **By Person** — cards per family member.
-- **By List** — cards per task list.
-- **Then by** secondary group — when the primary group is Person, you can also sub-group by List (or vice versa). Sub-groups render as colored left-border dividers inside the primary group card.
+- **None**: flat list.
+- **By Person**: cards per family member.
+- **By List**: cards per task list.
+- **Then by** secondary group: when the primary group is Person, you can also sub-group by List (or vice versa). Sub-groups render as colored left-border dividers inside the primary group card.
 
 The drag-reordered order of the group columns persists to localStorage (`prism:task-group-order` when flat-grouped, `prism:task-nested-group-order` when nested). The chosen grouping mode itself is not persisted.
 
@@ -87,7 +87,7 @@ The drag-reordered order of the group columns persists to localStorage (`prism:t
 
 ## Reordering
 
-Drag-and-drop within a group (touch + mouse). Note there is no per-task order persistence — only the drag order of the group columns is stored (see Grouping).
+Drag-and-drop within a group (touch + mouse). Note there is no per-task order persistence: only the drag order of the group columns is stored (see Grouping).
 
 For cross-list moves, drag a task onto a different list's card header to reassign.
 
@@ -99,17 +99,17 @@ Pick one provider per Prism instance:
 
 ### Microsoft To Do (bidirectional)
 
-1. *Settings → Integrations → Microsoft* card — connect your account.
+1. *Settings → Integrations → Microsoft* card: connect your account.
 2. In the same card, for each Prism list pick an MS To Do list to sync it with.
 
 Bidirectional, newest-wins. Fields synced: title, notes (= description), completed, due date. Subtasks in MS To Do are flattened into the notes field (Prism doesn't have a subtask concept).
 
 ### Google Tasks (bidirectional)
 
-1. *Settings → Integrations → Google* card — connect your account (same Google OAuth used for Calendar — Tasks scope added).
+1. *Settings → Integrations → Google* card: connect your account (same Google OAuth used for Calendar, Tasks scope added).
 2. In the same card, pick which Google Tasks list maps to which Prism list.
 
-Same shape as MS — bidirectional, newest-wins, title + notes + completed + due date.
+Same shape as MS: bidirectional, newest-wins, title + notes + completed + due date.
 
 ### Auto-sync
 
@@ -119,7 +119,7 @@ Same shape as MS — bidirectional, newest-wins, title + notes + completed + due
 - Re-fires on visibility return.
 - Also covers the screensaver mode when the Tasks widget is shown.
 
-Manual sync button always available — useful right after adding a task on the other side.
+Manual sync button always available, useful right after adding a task on the other side.
 
 ---
 
@@ -133,7 +133,7 @@ A global undo stack covers tasks, chores, shopping items, and wishes. After comp
 
 - Single-column layout.
 - Compact header.
-- Collapsible filters — tap "Filters" to expand/collapse.
+- Collapsible filters: tap "Filters" to expand/collapse.
 - GripVertical drag icons hidden (touch-drag uses long-press on the row).
 - Card-level drag disabled so vertical scroll works naturally; item-level drag still works.
 
@@ -145,11 +145,11 @@ A global undo stack covers tasks, chores, shopping items, and wishes. After comp
 
 Sometimes "Take out trash every Friday" is more of a personal todo than a points-eligible chore. Add it as a task with a weekly due date in the Home list. When you complete it, manually duplicate it with next Friday's date.
 
-(Native recurring-task support isn't shipped — it's tracked as a follow-up.)
+(Native recurring-task support isn't shipped; it's tracked as a follow-up.)
 
 ### Grocery list as tasks
 
-Some families prefer the Shopping page; others would rather have everything in one task list. The Microsoft To Do sync lets shopping items flow into a To Do list automatically — see the [Shopping guide](SHOPPING.md) for the per-list sync config.
+Some families prefer the Shopping page; others would rather have everything in one task list. The Microsoft To Do sync lets shopping items flow into a To Do list automatically. See the [Shopping guide](SHOPPING.md) for the per-list sync config.
 
 ### Sharing a list with a non-Prism family member
 
@@ -161,10 +161,10 @@ The MS To Do / Google Tasks sync is the bridge. Share the Microsoft/Google list 
 
 ### Tasks not syncing
 
-1. *Settings → Integrations → (Google or Microsoft) card* — is the provider still connected?
-2. In the same card — is the per-list connection enabled?
+1. *Settings → Integrations → (Google or Microsoft) card*: is the provider still connected?
+2. In the same card: is the per-list connection enabled?
 3. Tap **Sync now** to force a refresh.
-4. Check the external list directly — does it have the task you expect?
+4. Check the external list directly: does it have the task you expect?
 
 ### Two-way sync created duplicates
 
@@ -180,7 +180,7 @@ Lists are created from *Settings → Integrations → (Google or Microsoft) card
 
 ### List deletion deleted my tasks
 
-It shouldn't — tasks become unassigned (inbox) when a list is deleted. If tasks did disappear, check the audit log (*Settings → Activity Log*) for the actual operation.
+It shouldn't: tasks become unassigned (inbox) when a list is deleted. If tasks did disappear, check the audit log (*Settings → Activity Log*) for the actual operation.
 
 ### Sub-grouping (Person → List) looks weird
 

--- a/docs/features/TRAVEL.md
+++ b/docs/features/TRAVEL.md
@@ -2,7 +2,7 @@
 
 ![Travel globe with pins](../demos/travel-globe.png){ .hero-image }
 
-Interactive 3D globe for tracking family travel. Drop pins for places you've visited or want to visit, build multi-stop trips (route / loop / hub), and link GPS-tagged OneDrive photos to the places where they were taken. Built with MapLibre GL + OpenFreeMap tiles — no API keys, no rate limits, no vendor lock-in.
+Interactive 3D globe for tracking family travel. Drop pins for places you've visited or want to visit, build multi-stop trips (route / loop / hub), and link GPS-tagged OneDrive photos to the places where they were taken. Built with MapLibre GL + OpenFreeMap tiles: no API keys, no rate limits, no vendor lock-in.
 
 ---
 
@@ -10,8 +10,8 @@ Interactive 3D globe for tracking family travel. Drop pins for places you've vis
 
 The Travel Map has two object types:
 
-- **Pin** — a single place. Anchored by lat/lng coordinates, has a name, status (visited / want-to-go), bucket-list flag, dates, notes, tags.
-- **Trip** — a multi-stop journey composed of pins. Has its own name + style (route / loop / hub) + dates. Each stop in a trip is itself a pin (with `pinType: 'stop'` or `'national_park'`).
+- **Pin**: a single place. Anchored by lat/lng coordinates, has a name, status (visited / want-to-go), bucket-list flag, dates, notes, tags.
+- **Trip**: a multi-stop journey composed of pins. Has its own name + style (route / loop / hub) + dates. Each stop in a trip is itself a pin (with `pinType: 'stop'` or `'national_park'`).
 
 Both render on the globe simultaneously. Standalone pins are independent; trip stops are children of a trip object.
 
@@ -23,13 +23,13 @@ The **Places** tab lists every standalone pin with stats, filters, and search.
 
 ### Statuses
 
-Pins have a status — color-coded on the globe:
+Pins have a status, color-coded on the globe:
 
-- **Been there** (green checkmark) — visited.
-- **Want to go** (white dot) — on the wishlist.
-- **Bucket list** (amber star) — high-priority must-visit. Independent flag, works on either status.
+- **Been there** (green checkmark): visited.
+- **Want to go** (white dot): on the wishlist.
+- **Bucket list** (amber star): high-priority must-visit. Independent flag, works on either status.
 
-Toggling status auto-saves immediately — no Save button needed for the toggle.
+Toggling status auto-saves immediately. No Save button needed for the toggle.
 
 ### National parks badge
 
@@ -39,7 +39,7 @@ Pins with at least one entry in their `nationalParks` array get a **green tree b
 
 Filter pills at the top of the Places tab:
 
-- **All** — every pin
+- **All**: every pin
 - **Been there**
 - **Want to Go**
 - **Bucket List**
@@ -47,8 +47,8 @@ Filter pills at the top of the Places tab:
 
 Plus:
 
-- **Group by** — Year / Country / None. Country grouping shows the country flag emoji as the section header.
-- **Search** — case-insensitive substring match on place/trip name.
+- **Group by**: Year / Country / None. Country grouping shows the country flag emoji as the section header.
+- **Search**: case-insensitive substring match on place/trip name.
 
 The list is ordered automatically (there's no sort control): visited places sort newest-first by visit date; everything else falls back to alphabetical by name.
 
@@ -63,23 +63,23 @@ Two ways:
 1. **Geocoded search.** Type a place name in the side panel, pick from Nominatim suggestions. The pin lands at the geocoded coordinates with the official name + country.
 2. **Click on the globe.** Drop a pin at any clicked coordinate. The geocode runs in reverse to fetch a place name.
 
-The slide-out panel has a **Place / Trip toggle** when adding something new — switch between adding a standalone pin and creating a multi-stop trip without leaving the panel.
+The slide-out panel has a **Place / Trip toggle** when adding something new. Switch between adding a standalone pin and creating a multi-stop trip without leaving the panel.
 
 ### Editing a pin
 
-Click any pin to open its detail panel. Edits happen inline — no separate edit modal:
+Click any pin to open its detail panel. Edits happen inline, no separate edit modal:
 
 - **Name**
-- **Trip label** (a free-text grouping like "Spring Break 2026" — independent of formal Trip objects)
+- **Trip label** (a free-text grouping like "Spring Break 2026", independent of formal Trip objects)
 - **Status toggle** (auto-saves)
 - **Bucket list star** (auto-saves)
-- **Visit dates** — start + optional end.
+- **Visit dates**: start + optional end.
 - **Description**
 - **Tags**
 
 ### Re-locating a misplaced pin
 
-Pencil icon next to the coordinates opens an inline geocode search. Type a new location, pick a result, the pin's lat/lng + place name update in place. Useful when the geocoder dropped a pin in the wrong town with the same name (e.g. "Springfield" — there are like 30 of them).
+Pencil icon next to the coordinates opens an inline geocode search. Type a new location, pick a result, the pin's lat/lng + place name update in place. Useful when the geocoder dropped a pin in the wrong town with the same name (e.g. "Springfield", there are like 30 of them).
 
 ---
 
@@ -87,9 +87,9 @@ Pencil icon next to the coordinates opens an inline geocode search. Type a new l
 
 A trip is a multi-stop journey. Three styles, picked when you create the trip:
 
-- **Route** — A → B → C → D. Polyline connects stops in order.
-- **Loop** — A → B → C → A. Closed polyline returning to the start.
-- **Hub** — home base + day-trip spokes. The home stop is marked `isHub: true`; other stops radiate from it.
+- **Route**: A → B → C → D. Polyline connects stops in order.
+- **Loop**: A → B → C → A. Closed polyline returning to the start.
+- **Hub**: home base + day-trip spokes. The home stop is marked `isHub: true`; other stops radiate from it.
 
 Trips are first-class objects separate from standalone pins. Creating a trip happens via the **Place / Trip toggle** in the add panel.
 
@@ -99,7 +99,7 @@ Each stop in a trip is a pin with `pinType: 'stop'` or `pinType: 'national_park'
 
 - All the same fields as standalone pins.
 - A **sortOrder** for drawing the polyline in the right sequence.
-- An optional **national park** flag — NP stops render with a green tree icon instead of a number badge.
+- An optional **national park** flag: NP stops render with a green tree icon instead of a number badge.
 
 Drag-to-reorder stops within a trip from the trip's detail panel.
 
@@ -129,7 +129,7 @@ If your OneDrive photo sync is configured, **geotagged photos automatically matc
 
 ### How matching works
 
-Matching is computed **live** each time you open a pin's detail panel — there are no stored links and no background linking job.
+Matching is computed **live** each time you open a pin's detail panel. There are no stored links and no background linking job.
 
 1. When a photo syncs from OneDrive, its EXIF GPS coordinates (if present) are stored on the `photos` row.
 2. When the pin panel opens, the Travel Map calculates the Haversine distance from the pin (and all its child stops / national parks) to every photo that has GPS, using a bounding-box SQL prefilter followed by a precise radius check.
@@ -141,7 +141,7 @@ For photos that synced before GPS was captured, run *Settings → Photos → Bac
 
 ### Match radius
 
-The 50 km match radius (`photoRadiusKm`) is a fixed default set on the API/DB side — there is no UI to change it per pin today, and the value isn't editable from the pin panel.
+The 50 km match radius (`photoRadiusKm`) is a fixed default set on the API/DB side. There is no UI to change it per pin today, and the value isn't editable from the pin panel.
 
 ---
 
@@ -149,9 +149,9 @@ The 50 km match radius (`photoRadiusKm`) is a fixed default set on the API/DB si
 
 - **Drag** to rotate.
 - **Scroll wheel** / **pinch** to zoom.
-- **Sun / moon button** in the corner toggles a dark-map filter. The filter applies a CSS `brightness · saturate · contrast · hue-rotate` chain only to the tile canvas, not to markers — tiles darken, markers stay at full brightness. No tile reload required.
-- **Globe vs. flat projection** — default is globe (3D); MapLibre's `projection: globe` config. At certain zoom levels MapLibre may smoothly transition to mercator-flat for closer views.
-- **Sub-locations toggle** (top-left) — when on, every pin's child stops and national parks are shown on the globe at once; when off, children appear only for the currently selected pin.
+- **Sun / moon button** in the corner toggles a dark-map filter. The filter applies a CSS `brightness · saturate · contrast · hue-rotate` chain only to the tile canvas, not to markers: tiles darken, markers stay at full brightness. No tile reload required.
+- **Globe vs. flat projection**: default is globe (3D); MapLibre's `projection: globe` config. At certain zoom levels MapLibre may smoothly transition to mercator-flat for closer views.
+- **Sub-locations toggle** (top-left): when on, every pin's child stops and national parks are shown on the globe at once; when off, children appear only for the currently selected pin.
 
 ### Initial zoom
 
@@ -163,14 +163,14 @@ Default zoom is set so the Earth nearly fills the screen on load. Adjust by mani
 
 Two services power location lookup:
 
-- **Nominatim** — OpenStreetMap-based, accessed via `/api/travel/geocode` (server-side proxy to OpenStreetMap's Nominatim). Used for general place search.
-- **NPS curated list** — for the "Add national park" action in trips, a static curated list of US National Parks + Monuments. This bypasses Nominatim because Nominatim's results for park names often surface natural features (e.g. "Hawai'i Volcanoes" matches the volcano summit, not the park boundary).
+- **Nominatim**: OpenStreetMap-based, accessed via `/api/travel/geocode` (server-side proxy to OpenStreetMap's Nominatim). Used for general place search.
+- **NPS curated list**: for the "Add national park" action in trips, a static curated list of US National Parks + Monuments. This bypasses Nominatim because Nominatim's results for park names often surface natural features (e.g. "Hawai'i Volcanoes" matches the volcano summit, not the park boundary).
 
 ### Quirks the geocoder handles
 
-- **Hawaiian island aliases** — "Big Island" → "Hawaiʻi Island"; "Kauai" → "Kauaʻi".
-- **Special characters** — diacritics normalized for fuzzy matching.
-- **National park boundary scoring** — for NP queries, results with `class=boundary` or `class=park` rank above natural features.
+- **Hawaiian island aliases**: "Big Island" → "Hawaiʻi Island"; "Kauai" → "Kauaʻi".
+- **Special characters**: diacritics normalized for fuzzy matching.
+- **National park boundary scoring**: for NP queries, results with `class=boundary` or `class=park` rank above natural features.
 
 ---
 
@@ -202,7 +202,7 @@ The geocoder calls `/api/travel/geocode` server-side, which proxies to Nominatim
 
 Tile rendering uses OpenFreeMap (`https://tiles.openfreemap.org/...`). Map tile requests are public web requests; they reveal which part of the globe you're zoomed into when interacting with the map, but no personal data.
 
-If you want extra isolation, self-host OpenFreeMap tiles — the project publishes Docker images for the tile server. Then update the tile URL in the globe component.
+If you want extra isolation, self-host OpenFreeMap tiles. The project publishes Docker images for the tile server. Then update the tile URL in the globe component.
 
 ---
 
@@ -218,11 +218,11 @@ In older versions, the Zod schema rejected `null` for optional fields (only `und
 
 ### Pin visible on the wrong side of the globe (through the Earth)
 
-Was a bug in early v1.5 — far-side pin culling wasn't applying the `!important` CSS flag, so MapLibre overrode visibility. Fixed. Hard-reload to clear cached chunks.
+Was a bug in early v1.5: far-side pin culling wasn't applying the `!important` CSS flag, so MapLibre overrode visibility. Fixed. Hard-reload to clear cached chunks.
 
 ### Status toggle doesn't persist
 
-Each status toggle (been there / want to go) and bucket list star auto-saves on click. If a toggle reverts, check the network tab for the PATCH request — most often a 401 (session expired). Re-login.
+Each status toggle (been there / want to go) and bucket list star auto-saves on click. If a toggle reverts, check the network tab for the PATCH request. Most often a 401 (session expired). Re-login.
 
 ### Photos not linking to pins
 
@@ -242,7 +242,7 @@ MapLibre's globe projection is GPU-intensive. On low-power hardware:
 
 ### "Hawaii Volcanoes" pin is on top of the volcano summit
 
-Was a Nominatim ranking quirk — fixed by boosting boundary/park results over natural features for NP queries. If you still see this on Hawai'i Volcanoes (or another park), file an issue and update the manual override list.
+Was a Nominatim ranking quirk, fixed by boosting boundary/park results over natural features for NP queries. If you still see this on Hawai'i Volcanoes (or another park), file an issue and update the manual override list.
 
 ### Trip polyline crosses the antimeridian (180° line) awkwardly
 

--- a/docs/features/WEEKEND.md
+++ b/docs/features/WEEKEND.md
@@ -11,15 +11,15 @@ A family activity board for local places to visit. Lower-stakes than the Travel 
 A "weekend place" is anywhere your family might spend a few hours: parks, restaurants, museums, trails, farms, drive-ins, indoor play spots. Each entry has:
 
 - **Name** (required)
-- **Description** — what it is, why it's worth going.
-- **Website** — optional link to the place's website.
-- **Status** — `Want to Try` (haven't been yet) or `Been There` (visited).
-- **Favorite** — boolean star for filtering.
-- **Rating** — 1-5 stars, set on the place (available once it's marked "Been There").
-- **Notes** — free-form text.
-- **Tags** — chosen from a fixed preset palette (see [Tags](#tags)).
-- **Visit count** — increments each time you log a visit.
-- **Last visited** — the date of the most recent logged visit.
+- **Description**: what it is, why it's worth going.
+- **Website**: optional link to the place's website.
+- **Status**: `Want to Try` (haven't been yet) or `Been There` (visited).
+- **Favorite**: boolean star for filtering.
+- **Rating**: 1-5 stars, set on the place (available once it's marked "Been There").
+- **Notes**: free-form text.
+- **Tags**: chosen from a fixed preset palette (see [Tags](#tags)).
+- **Visit count**: increments each time you log a visit.
+- **Last visited**: the date of the most recent logged visit.
 
 Places also carry optional location fields (place name, address, latitude/longitude) that show in the detail panel when present, but these are not currently editable from the app UI.
 
@@ -31,8 +31,8 @@ Places also carry optional location fields (place name, address, latitude/longit
 
 Two starting statuses:
 
-- **Want to Try** — default. You haven't been yet, this is something to try.
-- **Been There** — already been; you're adding it retroactively as a favorite or for record-keeping. Marking a place "Been There" reveals the star rating field.
+- **Want to Try**: default. You haven't been yet, this is something to try.
+- **Been There**: already been; you're adding it retroactively as a favorite or for record-keeping. Marking a place "Been There" reveals the star rating field.
 
 ---
 
@@ -40,7 +40,7 @@ Two starting statuses:
 
 ### Cards grouped by tag
 
-When your places span more than one tag, place cards group into sections — one section per preset tag they use, in preset order — so you can scan by activity type at a glance. Each section is headed by the tag's emoji and label (e.g. 🌳 Outdoor, 🍽️ Food, 🏛️ Museum, 🌾 Farm) with a count. A place is bucketed by the first of its tags that matches a preset.
+When your places span more than one tag, place cards group into sections (one section per preset tag they use, in preset order) so you can scan by activity type at a glance. Each section is headed by the tag's emoji and label (e.g. 🌳 Outdoor, 🍽️ Food, 🏛️ Museum, 🌾 Farm) with a count. A place is bucketed by the first of its tags that matches a preset.
 
 Places whose tags don't match any preset (or have no tags) fall into a final 📍 **Other** section.
 
@@ -54,10 +54,10 @@ Each visited card shows pip dots representing visit count, grouped in 5s. So 12 
 
 Filter chips at the top:
 
-- **Status** — All / Want to Try / Been There.
+- **Status**: All / Want to Try / Been There.
 - **Favorites only** toggle.
-- **Tags** — multi-select chips from the preset palette; a place must carry every selected tag to show.
-- **Search** — free-text match on place name.
+- **Tags**: multi-select chips from the preset palette; a place must carry every selected tag to show.
+- **Search**: free-text match on place name.
 
 ### Side panel detail view
 
@@ -72,13 +72,13 @@ Tap any card to slide out the detail panel with:
 
 ## Marking a visit
 
-Tapping **Mark as Visited** (or **Log Another Visit** on a place you've already been to) is a single tap — there's no per-visit date/rating/notes prompt. It immediately:
+Tapping **Mark as Visited** (or **Log Another Visit** on a place you've already been to) is a single tap. There's no per-visit date/rating/notes prompt. It immediately:
 
 - flips the status to `Been There` (if it was still `Want to Try`),
 - increments the visit count,
 - sets last-visited to today.
 
-Rating lives on the place itself and is set via **Edit**, not per visit. Subsequent visits don't change status — they just increment the count and update last-visited.
+Rating lives on the place itself and is set via **Edit**, not per visit. Subsequent visits don't change status. They just increment the count and update last-visited.
 
 ---
 
@@ -100,7 +100,7 @@ Filter to `Want to Try`, then narrow by a tag or two you're in the mood for. Sur
 
 ### "Where do we always have a good time?"
 
-Turn on **Favorites only** — your regulars, and the ones with the fullest pip rows, rise to the top.
+Turn on **Favorites only**: your regulars, and the ones with the fullest pip rows, rise to the top.
 
 ### "We're hosting cousins this weekend"
 
@@ -122,11 +122,11 @@ Weekend places are local to your Prism database. Nothing about your places, visi
 
 The current Weekend Ideas is Phase 1 (manual entry, list/filter UI). On the roadmap:
 
-- **Per-visit history** — record each visit as its own dated entry (who went, rating, notes) rather than just a running count.
-- **Location editing + geocoder** — search a place by name or paste a maps link to attach coordinates from the app.
-- **POI search + map view** — search nearby attractions and add directly from results; visualize your backlog as pins on a regional map.
-- **Suggest mode** — given current weather + season + family preferences, surface a few suggestions for "today's outing."
-- **Share / collaborate** — share a backlog with another family.
+- **Per-visit history**: record each visit as its own dated entry (who went, rating, notes) rather than just a running count.
+- **Location editing + geocoder**: search a place by name or paste a maps link to attach coordinates from the app.
+- **POI search + map view**: search nearby attractions and add directly from results; visualize your backlog as pins on a regional map.
+- **Suggest mode**: given current weather + season + family preferences, surface a few suggestions for "today's outing."
+- **Share / collaborate**: share a backlog with another family.
 
 ---
 
@@ -134,7 +134,7 @@ The current Weekend Ideas is Phase 1 (manual entry, list/filter UI). On the road
 
 ### Side panel doesn't open on tap
 
-Was a bug in v1.5.0 — `WeekendView` was missing its `<PageWrapper>` wrapper, causing the side panel context to not initialize. Fixed in v1.5.1. If you still see this, hard-reload.
+Was a bug in v1.5.0: `WeekendView` was missing its `<PageWrapper>` wrapper, causing the side panel context to not initialize. Fixed in v1.5.1. If you still see this, hard-reload.
 
 ### Group "Other" has places I expected to be categorized
 

--- a/docs/features/WISHES.md
+++ b/docs/features/WISHES.md
@@ -10,8 +10,8 @@ Per-family-member wish lists with secret claim tracking for gift surprises, plus
 
 The Wishes page has two tabs:
 
-- **My Wishes** — public-within-the-family wish lists. Each family member has their own. Other family members can secretly mark items as purchased.
-- **Gift Ideas** — private per-user gift idea tracking for OTHER family members. Only the creator sees their own ideas; recipients never see them.
+- **My Wishes**: public-within-the-family wish lists. Each family member has their own. Other family members can secretly mark items as purchased.
+- **Gift Ideas**: private per-user gift idea tracking for OTHER family members. Only the creator sees their own ideas; recipients never see them.
 
 Same general data shape, different privacy model.
 
@@ -21,19 +21,19 @@ Same general data shape, different privacy model.
 
 ### Per-person wish lists
 
-Each family member has their own list. By default the tab shows a combined flat list of everyone's wishes. Use the **person-filter chip-bar** at the top to narrow to specific members, and the **Group: None / Person** toggle to switch views — **Person** restores the side-by-side per-column layout, one column per family member. In that per-column view the columns themselves can be dragged to reorder (order is remembered locally).
+Each family member has their own list. By default the tab shows a combined flat list of everyone's wishes. Use the **person-filter chip-bar** at the top to narrow to specific members, and the **Group: None / Person** toggle to switch views: **Person** restores the side-by-side per-column layout, one column per family member. In that per-column view the columns themselves can be dragged to reorder (order is remembered locally).
 
 Each item carries:
 
 - **Name** (required)
-- **URL** — optional link.
-- **Notes** — size, color, model number, "the one from the aquarium gift shop."
-- **Added by** — who added it.
-- **Claim state** — see below.
+- **URL**: optional link.
+- **Notes**: size, color, model number, "the one from the aquarium gift shop."
+- **Added by**: who added it.
+- **Claim state**: see below.
 
 ### Adding wishes
 
-Every wish is added through the **+ Add wish** modal — tap the **+** in the tab header (or on a person's column in the Person view) to open it, then fill in name, URL, and notes.
+Every wish is added through the **+ Add wish** modal: tap the **+** in the tab header (or on a person's column in the Person view) to open it, then fill in name, URL, and notes.
 
 Anyone in the family can add items to anyone else's list. Useful when a parent wants to add a gift idea on behalf of a kid who hasn't gotten around to it.
 
@@ -43,7 +43,7 @@ When someone is shopping for another family member's gift, they can **claim** an
 
 - Clicking an item on **another person's** list marks it claimed.
 - The claim is **secret from the wish-list owner.** They don't see who claimed what, or even that anything is claimed. The list looks unchanged from their perspective.
-- Other family members (the potential gift-givers) see a **"Purchased by {name}"** label — so two people don't accidentally buy Emma the same roller skates.
+- Other family members (the potential gift-givers) see a **"Purchased by {name}"** label, so two people don't accidentally buy Emma the same roller skates.
 
 So the workflow is:
 
@@ -56,9 +56,9 @@ The claim is visible to Alex (who claimed it), Jordan, and Sophie. Not to Emma.
 
 ### Cross off (got it myself)
 
-The owner can **cross off** items they got themselves — e.g. Emma bought a book she'd had on her list. The item is marked complete from her perspective.
+The owner can **cross off** items they got themselves, e.g. Emma bought a book she'd had on her list. The item is marked complete from her perspective.
 
-But here's the catch: **if someone else has already secretly bought it,** crossing it off shows the message *"Someone already got this for you!"* — without revealing who. So Emma can't accidentally undo Alex's gift planning by crossing off skates that Alex secretly already bought.
+But here's the catch: **if someone else has already secretly bought it,** crossing it off shows the message *"Someone already got this for you!"*, without revealing who. So Emma can't accidentally undo Alex's gift planning by crossing off skates that Alex secretly already bought.
 
 ### Microsoft To Do sync
 
@@ -68,9 +68,9 @@ Each family member's wish list can sync bidirectionally with a Microsoft To Do l
 - Pick which MS To Do list maps to that member's wish list.
 - Sync covers: name, URL (in notes), claimed status.
 
-Useful if a family member uses MS To Do on their phone — they can add to their wish list from anywhere, and the items flow into Prism.
+Useful if a family member uses MS To Do on their phone, they can add to their wish list from anywhere, and the items flow into Prism.
 
-**Gift Ideas do NOT sync to MS To Do** — privacy protection. We don't want to leak private gift planning into a synced list that might be shared with the recipient.
+**Gift Ideas do NOT sync to MS To Do**: privacy protection. We don't want to leak private gift planning into a synced list that might be shared with the recipient.
 
 ---
 
@@ -86,24 +86,24 @@ This solves a real problem: you've been keeping a mental note that Emma loves wa
 
 The Gift Ideas tab shows columns for every OTHER family member. So Alex sees columns for Jordan, Emma, and Sophie (no Alex column). Each column is Alex's private gift-idea list for that person.
 
-Jordan, viewing the same page, sees columns for Alex, Emma, and Sophie — Jordan's own private gift-idea lists.
+Jordan, viewing the same page, sees columns for Alex, Emma, and Sophie, Jordan's own private gift-idea lists.
 
 ### Per-idea data
 
-- **Name** — what the gift is.
-- **URL** — link to where to buy it.
-- **Notes** — size, color, "she mentioned wanting this in December."
-- **Price** — record a price per idea.
-- **Purchased** — boolean. Set when you've actually bought it.
+- **Name**: what the gift is.
+- **URL**: link to where to buy it.
+- **Notes**: size, color, "she mentioned wanting this in December."
+- **Price**: record a price per idea.
+- **Purchased**: boolean. Set when you've actually bought it.
 - **Sort order**.
 
 ### Privacy enforcement
 
 The privacy model is enforced at three layers:
 
-1. **UI** — the Gift Ideas tab never shows ideas for yourself (no self-column).
-2. **API** — the `/api/gift-ideas` endpoints filter by `created_by = currentUser.id`. You only ever get ideas you created.
-3. **MS To Do sync** — gift ideas are excluded from all external sync. They live only in Prism.
+1. **UI**: the Gift Ideas tab never shows ideas for yourself (no self-column).
+2. **API**: the `/api/gift-ideas` endpoints filter by `created_by = currentUser.id`. You only ever get ideas you created.
+3. **MS To Do sync**: gift ideas are excluded from all external sync. They live only in Prism.
 
 If a child opened Prism with their PIN and went to the Gift Ideas tab, they'd see THEIR ideas for OTHER people. They would not see what their parents have been planning for them. Same goes for any family member.
 
@@ -115,7 +115,7 @@ Purchased ideas stay in the column but are shown dimmed and struck-through, so "
 
 ### Data refresh on user switch
 
-The Gift Ideas tab refreshes data immediately when a user switches login. This is intentional — without the refresh, you might briefly see the previous user's stale data in the tab while their cache lingered. Was a confusing privacy quirk in early versions; fixed in v1.1.
+The Gift Ideas tab refreshes data immediately when a user switches login. This is intentional, without the refresh you might briefly see the previous user's stale data in the tab while their cache lingered. Was a confusing privacy quirk in early versions; fixed in v1.1.
 
 ---
 
@@ -131,7 +131,7 @@ Same pattern at higher volume. Track ideas + purchased status as you shop, and r
 
 ### Coordinating with extended family
 
-Pin Grandma's gift idea ("she mentioned wanting a new tea kettle") in your Gift Ideas. Share with relatives who are coordinating Christmas if needed — but always via Prism, never via group text where the recipient might glimpse it.
+Pin Grandma's gift idea ("she mentioned wanting a new tea kettle") in your Gift Ideas. Share with relatives who are coordinating Christmas if needed, but always via Prism, never via group text where the recipient might glimpse it.
 
 ### Self-purchase
 
@@ -167,7 +167,7 @@ Privacy violation. File an issue immediately. The API filter on `created_by` sho
 
 ### "Someone already got this for you" appeared on an unclaimed item
 
-The claim system uses the `claimed` flag. Check the database row directly — was claimed unexpectedly set? Could happen if a claim was made and the user later denied claiming it; the state should clear when they unclaim.
+The claim system uses the `claimed` flag. Check the database row directly. Was claimed unexpectedly set? Could happen if a claim was made and the user later denied claiming it; the state should clear when they unclaim.
 
 ### Wish list sync to MS To Do creates duplicates
 
@@ -179,7 +179,7 @@ The MS To Do side marked the corresponding task incomplete, and newest-wins reso
 
 ### Self-column showing in Gift Ideas
 
-You shouldn't see a column for yourself in Gift Ideas — that defeats the privacy model. If you do, file an issue with your user setup.
+You shouldn't see a column for yourself in Gift Ideas: that defeats the privacy model. If you do, file an issue with your user setup.
 
 ### Bought a gift through Gift Ideas but the wish list still shows unclaimed
 

--- a/docs/features/global-input-system.md
+++ b/docs/features/global-input-system.md
@@ -1,4 +1,4 @@
-# Global Input System — Implementation Spec
+# Global Input System: Implementation Spec
 
 ## Prism v1.3 | Date: 2026-04-02
 
@@ -25,7 +25,7 @@
 
 ```
 src/app/layout.tsx (Server Component)
-  └── <Providers> (client boundary — ThemeProvider, FamilyProvider, AuthProvider)
+  └── <Providers> (client boundary: ThemeProvider, FamilyProvider, AuthProvider)
         └── <GlobalInputProvider>          ← NEW: wraps all pages once
               ├── <VirtualKeyboard />      ← NEW: portals to document.body
               ├── <KeyboardToggleButton /> ← NEW: portals to document.body
@@ -137,7 +137,7 @@ if (lastPointerType === 'touch' && !isMobile && !suppressedForScan && virtualKey
 **`focusout`:**
 ```ts
 const next = e.relatedTarget as Element | null;
-if (next && isInsideKeyboard(next)) return; // keyboard buttons stole focus — ignore
+if (next && isInsideKeyboard(next)) return; // keyboard buttons stole focus, ignore
 activeInputRef.current = null;
 setKeyboardVisible(false);
 restoreScroll();
@@ -185,7 +185,7 @@ When a scan fires, set `suppressedForScan = true` for 500ms. During this window,
 npm install simple-keyboard
 ```
 
-Pin to a specific minor version (e.g., `"simple-keyboard": "3.7.x"`) — the library has breaking changes between minor versions.
+Pin to a specific minor version (e.g., `"simple-keyboard": "3.7.x"`). The library has breaking changes between minor versions.
 
 ### Layout
 
@@ -227,7 +227,7 @@ min-height: 320px
 max-height: 480px
 ```
 
-> Note: the scroll math (§7) and the `--keyboard-height` CSS var both use **32vh**. The `VirtualKeyboard.tsx` container style still hardcodes `38vh`, so the visual height and scroll math don't yet agree — reconcile to 32vh.
+> Note: the scroll math (§7) and the `--keyboard-height` CSS var both use **32vh**. The `VirtualKeyboard.tsx` container style still hardcodes `38vh`, so the visual height and scroll math don't yet agree. Reconcile to 32vh.
 
 Key height ≥ 52px, key font size 18px. Sized for comfortable use on 24" 1080p display.
 
@@ -253,7 +253,7 @@ keyboardRef.current = new Keyboard(containerRef.current, {
   syncInstanceInputs: false,
 });
 
-// When active input changes — sync keyboard state to existing value:
+// When active input changes, sync keyboard state to existing value:
 keyboardRef.current?.setInput(activeInputRef.current?.value ?? '');
 ```
 
@@ -370,7 +370,7 @@ Body: { barcode: string, dryRun?: boolean, listId?: string, category?: ShoppingC
 403:          { error: ... }                  // scanner.enabled is false
 ```
 
-Requires a display session — `getDisplayAuth()` returns 401 if absent. Returns 403 when `scanner.enabled` is `false`. Optional body fields: `dryRun` (look up and report without adding), `listId` (override target list), `category` (override resolved category). Otherwise reads the `scanner.defaultListId` setting to determine the target list.
+Requires a display session: `getDisplayAuth()` returns 401 if absent. Returns 403 when `scanner.enabled` is `false`. Optional body fields: `dryRun` (look up and report without adding), `listId` (override target list), `category` (override resolved category). Otherwise reads the `scanner.defaultListId` setting to determine the target list.
 
 ### 5.3 Product Lookup Cascade
 
@@ -389,11 +389,11 @@ export async function lookupBarcode(barcode: string): Promise<ProductLookupResul
 ```
 
 **Provider order:**
-1. **Redis cache** — key `barcode:{barcode}`, TTL 7 days — check first
-2. **Open Food Facts** — free, no key, best grocery coverage
-3. **UPCitemdb** — free tier (100/day), good US coverage, handles non-food pantry items
+1. **Redis cache**: key `barcode:{barcode}`, TTL 7 days, check first
+2. **Open Food Facts**: free, no key, best grocery coverage
+3. **UPCitemdb**: free tier (100/day), good US coverage, handles non-food pantry items
 
-3-second timeout per provider via `AbortController`. (Nutritionix/Edamam were considered but are not implemented — no `integrations.nutritionix.*` / `integrations.edamam.*` settings exist.)
+3-second timeout per provider via `AbortController`. (Nutritionix/Edamam were considered but are not implemented: no `integrations.nutritionix.*` / `integrations.edamam.*` settings exist.)
 
 ### 5.4 Route Logic
 
@@ -439,11 +439,11 @@ async function dispatchScan(barcode: string) {
 
 ### 5.6 Database
 
-`shopping_items.source` column already exists with `default('internal')`. Add `'scan'` as a new valid value — no migration needed. Document in a schema comment.
+`shopping_items.source` column already exists with `default('internal')`. Add `'scan'` as a new valid value. No migration needed. Document in a schema comment.
 
 ### 5.7 Audio Feedback
 
-Beeps are **synthesized with the Web Audio API** — no MP3 assets are bundled. `playBeep()` builds an `AudioContext` oscillator and plays a short tone: **1800 Hz** for the `"scan"` (Scanner chirp) style, **1200 Hz** for the `"beep"` (Short beep) style.
+Beeps are **synthesized with the Web Audio API**. No MP3 assets are bundled. `playBeep()` builds an `AudioContext` oscillator and plays a short tone: **1800 Hz** for the `"scan"` (Scanner chirp) style, **1200 Hz** for the `"beep"` (Short beep) style.
 
 ```ts
 function playBeep() {
@@ -486,8 +486,8 @@ Besides USB/Bluetooth keyboard-wedge (HID) scanners, the Shopping page ships a *
 - **Trigger:** a camera icon in the Shopping page header. It's opened by dispatching the `prism:open-barcode-scanner` event; `ShoppingView` lazy-loads the overlay (dynamic import) and toggles `showCameraScanner`.
 - **Full-screen overlay:** the camera viewfinder fills the screen and self-dismisses on a successful read.
 - **Two decode paths:**
-  - **`BarcodeDetector`** (native, Android/Chrome) — continuous live scanning of the video stream.
-  - **`@zxing/browser` photo-capture fallback** (iOS/Safari, where `BarcodeDetector` is unavailable) — captures a still frame and decodes it.
+  - **`BarcodeDetector`** (native, Android/Chrome): continuous live scanning of the video stream.
+  - **`@zxing/browser` photo-capture fallback** (iOS/Safari, where `BarcodeDetector` is unavailable): captures a still frame and decodes it.
 - **Feedback:** haptic buzz + the same synthesized beep (§5.7) on a hit.
 - A decoded barcode is handed to the same `dispatchScan` flow (§5.5), so lookup/dedup/add behavior is identical to the HID path.
 
@@ -604,7 +604,7 @@ Auto-dismiss is synchronous and runs before the barcode buffer check, so USB bar
 
 ### Settings UI
 
-New section: `{ id: 'input', label: 'Input', icon: Keyboard }` — add to sections array in `SettingsView.tsx` after `'display'`.
+New section: `{ id: 'input', label: 'Input', icon: Keyboard }`. Add to sections array in `SettingsView.tsx` after `'display'`.
 
 **File:** `src/app/settings/sections/InputSection.tsx`
 
@@ -612,7 +612,7 @@ New section: `{ id: 'input', label: 'Input', icon: Keyboard }` — add to sectio
 - Enable scanner (Switch)
 - Default list (Select from shopping lists)
 - Scanner sound (Switch)
-- Sound style (Select: Short beep / Scanner chirp — disabled when sound off)
+- Sound style (Select: Short beep / Scanner chirp, disabled when sound off)
 
 **Card 2: Virtual Keyboard**
 - Enable on-screen keyboard (Switch)
@@ -657,13 +657,13 @@ New section: `{ id: 'input', label: 'Input', icon: Keyboard }` — add to sectio
 
 | # | Item |
 |---|---|
-| 1 | **simple-keyboard CSS isolation** — import scoped to `[data-virtual-keyboard]` via PostCSS to prevent class bleed |
-| 2 | **Voice language** — hardcoded `en-US` in v1; add `speech.language` setting in v2 |
-| 3 | **Interim speech results** — suppressed in v1; v2 can show as floating chip above active input (`interimText` state already in context shape) |
-| 4 | **Caps lock behavior** — double-tap `{shift}` activates caps lock; requires careful state tracking in `handleShift()` |
-| 5 | **MS To-Do sync on scan** — verify `microsoft-todo.ts` sync function is callable server-side from route handler; if not, queue the sync |
-| 6 | **Camera-based scanning on mobile** — ✅ SHIPPED (see §5.10): `BarcodeDetector` with a `@zxing/browser` + `getUserMedia` photo-capture fallback, triggered from the Shopping page header |
-| 7 | **PIN entry on login page** — verify PIN pad uses buttons (not `input[type=text]`) and is excluded from keyboard trigger |
-| 8 | **Accessibility** — add `role="application"` and `aria-label="Virtual keyboard"` to keyboard container; `aria-hidden` if AT should skip |
-| 9 | **Hardware mic availability** — ViewSonic TD2465 has audio I/O ports but no built-in mic; USB mic needed; test before voice goes live |
-| 10 | **`AppShell` bottom padding** — pages with fixed-height layouts (Shopping, Tasks) need inner scroll container to consume `--keyboard-height` var directly rather than relying on padding on `<main>` |
+| 1 | **simple-keyboard CSS isolation**: import scoped to `[data-virtual-keyboard]` via PostCSS to prevent class bleed |
+| 2 | **Voice language**: hardcoded `en-US` in v1; add `speech.language` setting in v2 |
+| 3 | **Interim speech results**: suppressed in v1; v2 can show as floating chip above active input (`interimText` state already in context shape) |
+| 4 | **Caps lock behavior**: double-tap `{shift}` activates caps lock; requires careful state tracking in `handleShift()` |
+| 5 | **MS To-Do sync on scan**: verify `microsoft-todo.ts` sync function is callable server-side from route handler; if not, queue the sync |
+| 6 | **Camera-based scanning on mobile**: ✅ SHIPPED (see §5.10): `BarcodeDetector` with a `@zxing/browser` + `getUserMedia` photo-capture fallback, triggered from the Shopping page header |
+| 7 | **PIN entry on login page**: verify PIN pad uses buttons (not `input[type=text]`) and is excluded from keyboard trigger |
+| 8 | **Accessibility**: add `role="application"` and `aria-label="Virtual keyboard"` to keyboard container; `aria-hidden` if AT should skip |
+| 9 | **Hardware mic availability**: ViewSonic TD2465 has audio I/O ports but no built-in mic; USB mic needed; test before voice goes live |
+| 10 | **`AppShell` bottom padding**: pages with fixed-height layouts (Shopping, Tasks) need inner scroll container to consume `--keyboard-height` var directly rather than relying on padding on `<main>` |

--- a/docs/getting-started/first-time-setup.md
+++ b/docs/getting-started/first-time-setup.md
@@ -1,15 +1,15 @@
 # First-Time Setup
 
-After [installing Prism](install.md), the first run drops you into a short, keyless setup wizard — no accounts or API keys needed to get going.
+After [installing Prism](install.md), the first run drops you into a short, keyless setup wizard. No accounts or API keys needed to get going.
 
 ## The setup wizard
 
 A fresh install boots straight into the wizard (there's no default-PIN login screen). It has four steps:
 
-1. **Welcome** — a quick intro.
-2. **Family** — add each family member (name, role, avatar) and choose a **4- or 6-digit PIN** for each one.
-3. **Household** — set your location by city or ZIP/postal code (time zone is detected automatically) and pick which day your week starts on.
-4. **Done** — you land on a dashboard that already shows your calendar, with no one needing to sign in.
+1. **Welcome**: a quick intro.
+2. **Family**: add each family member (name, role, avatar) and choose a **4- or 6-digit PIN** for each one.
+3. **Household**: set your location by city or ZIP/postal code (time zone is detected automatically) and pick which day your week starts on.
+4. **Done**: you land on a dashboard that already shows your calendar, with no one needing to sign in.
 
 Everything the wizard sets can be revisited later in Settings. The steps below cover those edit paths plus the optional extras (integrations, layout, PWA install).
 
@@ -23,7 +23,7 @@ Each member gets a name, role (parent or child), and an avatar. Parents can appr
 
 **Settings → Family Members** (or **Settings → Security**).
 
-Each member has their own PIN — **4 or 6 digits**, chosen per member (first in the wizard's Family step, later here). The pad auto-submits once that member's digit count is reached, so it's fast on shared devices. There is no shared family PIN and no default child PIN — set a real PIN for everyone before exposing a deployment.
+Each member has their own PIN: **4 or 6 digits**, chosen per member (first in the wizard's Family step, later here). The pad auto-submits once that member's digit count is reached, so it's fast on shared devices. There is no shared family PIN and no default child PIN. Set a real PIN for everyone before exposing a deployment.
 
 ## 3. Connect integrations
 
@@ -33,15 +33,15 @@ You don't need any of these to share or assign events: Prism gives every member 
 
 Most families want at least:
 
-- **Google Calendar** — for school, work, and shared family events. OAuth-based bidirectional sync.
-- **Weather** — Open-Meteo is the zero-config default (no API key). OpenWeatherMap and Pirate Weather are alternatives.
-- **OneDrive** — for the photo slideshow on the screensaver and the dashboard photo widget.
-- **Microsoft To Do** — if your family already uses it for tasks, shopping, or wish lists.
+- **Google Calendar**: for school, work, and shared family events. OAuth-based bidirectional sync.
+- **Weather**: Open-Meteo is the zero-config default (no API key). OpenWeatherMap and Pirate Weather are alternatives.
+- **OneDrive**: for the photo slideshow on the screensaver and the dashboard photo widget.
+- **Microsoft To Do**: if your family already uses it for tasks, shopping, or wish lists.
 
 Optional but popular:
 
-- **[Kroger / Mariano's cart push](../features/KROGER.md)** — send your shopping list straight into your online cart for pickup or delivery.
-- **Gmail + FirstView** — school bus arrival tracking via geofence email notifications.
+- **[Kroger / Mariano's cart push](../features/KROGER.md)**: send your shopping list straight into your online cart for pickup or delivery.
+- **Gmail + FirstView**: school bus arrival tracking via geofence email notifications.
 
 ## 4. Customize the dashboard
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -2,8 +2,8 @@
 
 Prism ships as a Docker Compose application. You have two install paths:
 
-1. **Clone and build** — for any platform with Docker + git.
-2. **Pull pre-built image** — for amd64 or ARM64 (Raspberry Pi).
+1. **Clone and build**: for any platform with Docker + git.
+2. **Pull pre-built image**: for amd64 or ARM64 (Raspberry Pi).
 
 After installation, open **<http://localhost:3000>**. A fresh install has no accounts yet, so it opens the **setup wizard** (Welcome → Family → Household → Done), where you create each family member and choose their PIN. (If you loaded the optional demo seed instead, every seeded user has PIN `1234`.)
 
@@ -52,7 +52,7 @@ bash scripts/install.sh
 
 ## Option 2: Pull pre-built image
 
-Works on both amd64 and ARM64 — the manifest auto-selects the right binary.
+Works on both amd64 and ARM64. The manifest auto-selects the right binary.
 
 ```bash
 # Download docker-compose.yml and .env.example
@@ -65,13 +65,13 @@ docker-compose up -d
 ```
 
 !!! note "Raspberry Pi"
-    Tested on Pi 4 (4 GB+). Works with the pre-built ARM64 image — no compilation needed.
+    Tested on Pi 4 (4 GB+). Works with the pre-built ARM64 image, no compilation needed.
 
 ---
 
 ## First login
 
-Open **<http://localhost:3000>**. On a fresh install this lands on the **setup wizard**, where you create your family members and set each one's PIN (4 or 6 digits). There is no default login PIN — you choose them here. (The optional demo seed is the only case with preset PINs, and it uses `1234` for every user.)
+Open **<http://localhost:3000>**. On a fresh install this lands on the **setup wizard**, where you create your family members and set each one's PIN (4 or 6 digits). There is no default login PIN: you choose them here. (The optional demo seed is the only case with preset PINs, and it uses `1234` for every user.)
 
 Next: [first-time setup](first-time-setup.md).
 
@@ -88,11 +88,11 @@ installer chowns it for you; if you created the directory manually, fix it with:
 docker run --rm -v "$PWD/data":/d alpine chown -R 1001:1001 /d
 ```
 
-No container restart is needed — permissions are checked at write time.
+No container restart is needed. Permissions are checked at write time.
 
-### Locked out — forgot a PIN
+### Locked out: forgot a PIN
 
-Each member picks their own PIN — **4 or 6 digits** — in the setup wizard or
+Each member picks their own PIN (**4 or 6 digits**) in the setup wizard or
 under **Settings → Security**. If someone forgets their PIN, that member can be
 locked out. Reset it from the server with the recovery script:
 
@@ -105,4 +105,4 @@ docker compose exec app node scripts/reset-pin.js "Jordan" 1234
 ```
 
 It hashes the new PIN exactly like the app and updates only that member. They
-can log in immediately with the new PIN — no restart needed.
+can log in immediately with the new PIN, no restart needed.

--- a/docs/getting-started/updating.md
+++ b/docs/getting-started/updating.md
@@ -8,7 +8,7 @@ git pull
 docker compose up -d --build
 ```
 
-Your database, settings, and uploaded files are stored in Docker volumes and are preserved across rebuilds. Database migrations run automatically on container startup — no manual `drizzle-kit push` needed.
+Your database, settings, and uploaded files are stored in Docker volumes and are preserved across rebuilds. Database migrations run automatically on container startup: no manual `drizzle-kit push` needed.
 
 ## Trying a feature branch
 
@@ -28,7 +28,7 @@ git checkout master
 docker compose up -d --build
 ```
 
-Switching branches rebuilds the app but preserves your data. Feature branches may have rough edges — use at your own risk.
+Switching branches rebuilds the app but preserves your data. Feature branches may have rough edges. Use at your own risk.
 
 ## Major version notes
 

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -55,9 +55,9 @@ API tokens let Home Assistant query Prism's REST API without PIN-based login.
 1. Open Prism Settings (gear icon)
 2. Go to **Security**
 3. Under **API Tokens**, enter a name (e.g. "Home Assistant")
-4. Choose a **scope** — **Voice API only** (the default and recommended; sufficient for the Voice API and the read-only REST sensors below) or **Full access (legacy)** if you also need to drive write endpoints directly
+4. Choose a **scope**: **Voice API only** (the default and recommended; sufficient for the Voice API and the read-only REST sensors below) or **Full access (legacy)** if you also need to drive write endpoints directly
 5. Click **Generate Token**
-6. **Copy the token immediately** — it's only shown once
+6. **Copy the token immediately** (it's only shown once)
 7. Store it in your HA `secrets.yaml`:
 
 ```yaml
@@ -69,10 +69,10 @@ prism_token: "paste-your-64-char-token-here"
 
 Tokens carry a **scope** chosen when you generate them:
 
-- **Voice API only** (default, recommended) — reaches the Voice API (`/api/v1/voice/*`) and the read-only REST sensors in Section 3. This is all most HA setups need.
-- **Full access (legacy)** — every endpoint, including writes and admin routes. Only pick this if an automation calls a write endpoint directly instead of going through the Voice API.
+- **Voice API only** (default, recommended): reaches the Voice API (`/api/v1/voice/*`) and the read-only REST sensors in Section 3. This is all most HA setups need.
+- **Full access (legacy)**: every endpoint, including writes and admin routes. Only pick this if an automation calls a write endpoint directly instead of going through the Voice API.
 
-The read sensors below (calendar, chores, shopping, meals) work with a **Voice API only** token — they are read-only GETs. Write actions (adding a shopping item, completing a chore) are exposed through the Voice API endpoints (see Section 5), which a voice-scoped token can also reach.
+The read sensors below (calendar, chores, shopping, meals) work with a **Voice API only** token. They are read-only GETs. Write actions (adding a shopping item, completing a chore) are exposed through the Voice API endpoints (see Section 5), which a voice-scoped token can also reach.
 
 - Tokens never expire but can be revoked from Settings at any time
 - Each request updates the token's "Last used" timestamp
@@ -203,17 +203,17 @@ Prism ships a purpose-built **Voice API** under `/api/v1/voice/*` that is the su
 
 Available endpoints include:
 
-- `GET /api/v1/voice/calendar/today` and `/calendar/upcoming` — today's and upcoming events
-- `GET /api/v1/voice/chores/today` — chores due today
-- `GET /api/v1/voice/tasks/today` — tasks due today
-- `GET /api/v1/voice/meals/today` — today's planned meals
-- `GET /api/v1/voice/weather/today` — today's weather
-- `GET /api/v1/voice/birthdays/upcoming` — upcoming birthdays
-- `GET /api/v1/voice/bus/status` — bus tracking status
-- `GET /api/v1/voice/family` — family members
-- `GET /api/v1/voice/message/recent` and `POST /api/v1/voice/message/post` — read/post messages
-- `POST /api/v1/voice/shopping/add` — add a shopping item
-- `POST /api/v1/voice/chore/complete` — mark a chore complete
+- `GET /api/v1/voice/calendar/today` and `/calendar/upcoming`: today's and upcoming events
+- `GET /api/v1/voice/chores/today`: chores due today
+- `GET /api/v1/voice/tasks/today`: tasks due today
+- `GET /api/v1/voice/meals/today`: today's planned meals
+- `GET /api/v1/voice/weather/today`: today's weather
+- `GET /api/v1/voice/birthdays/upcoming`: upcoming birthdays
+- `GET /api/v1/voice/bus/status`: bus tracking status
+- `GET /api/v1/voice/family`: family members
+- `GET /api/v1/voice/message/recent` and `POST /api/v1/voice/message/post`: read/post messages
+- `POST /api/v1/voice/shopping/add`: add a shopping item
+- `POST /api/v1/voice/chore/complete`: mark a chore complete
 
 Example REST sensor using the spoken response:
 
@@ -228,7 +228,7 @@ sensor:
     scan_interval: 3600
 ```
 
-Because the write endpoints (`shopping/add`, `chore/complete`) are part of the Voice API, a **Voice API only** token can drive them too — you do not need a Full access token for these.
+Because the write endpoints (`shopping/add`, `chore/complete`) are part of the Voice API, a **Voice API only** token can drive them too. You do not need a Full access token for these.
 
 See [docs/voice-api.md](voice-api.md) for the full endpoint reference, request/response shapes, and more examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,13 +29,13 @@ Prism is a configurable family dashboard for large wall-mounted screens, tablets
 
 - :material-cart-outline: **Shopping & Kroger push**
 
-    Multiple lists, drag-to-reorder categories, barcode scanning, and one-click "Send to Kroger" — works at every Kroger banner (Mariano's, Ralphs, King Soopers, Fred Meyer, QFC, Smith's, Fry's, Harris Teeter, and 13 more).
+    Multiple lists, drag-to-reorder categories, barcode scanning, and one-click "Send to Kroger". Works at every Kroger banner (Mariano's, Ralphs, King Soopers, Fred Meyer, QFC, Smith's, Fry's, Harris Teeter, and 13 more).
 
     [Shopping guide →](features/SHOPPING.md) · [Kroger setup →](features/KROGER.md)
 
 - :material-chef-hat: **Recipes**
 
-    URL import, Paprika import, and "paste OCR'd recipe text" — point your phone at a recipe card, Live Text it, paste, and Prism splits it into title, ingredients (sections preserved), and step-by-step instructions.
+    URL import, Paprika import, and "paste OCR'd recipe text": point your phone at a recipe card, Live Text it, paste, and Prism splits it into title, ingredients (sections preserved), and step-by-step instructions.
 
     [Recipes guide →](features/RECIPES.md)
 
@@ -59,13 +59,13 @@ Prism is a configurable family dashboard for large wall-mounted screens, tablets
 
 ## Display modes
 
-- **Screensaver** — photo slideshow after idle timeout, configurable templates.
-- **Away Mode** — privacy screen with photos and clock only, auto-activates after extended inactivity. Parent PIN to exit.
-- **Babysitter Mode** — caregiver overlay with emergency contacts, WiFi QR, and house rules.
+- **Screensaver**: photo slideshow after idle timeout, configurable templates.
+- **Away Mode**: privacy screen with photos and clock only, auto-activates after extended inactivity. Parent PIN to exit.
+- **Babysitter Mode**: caregiver overlay with emergency contacts, WiFi QR, and house rules.
 
 ## Voice (optional)
 
-If you have an Echo, the **Alexa skill** lets you ask Prism for today's events, today's tasks, the weather, the family list, upcoming birthdays, and (if configured) the school bus ETA. Single-user personal skill — no AWS Lambda, no third-party hosting.
+If you have an Echo, the **Alexa skill** lets you ask Prism for today's events, today's tasks, the weather, the family list, upcoming birthdays, and (if configured) the school bus ETA. Single-user personal skill: no AWS Lambda, no third-party hosting.
 
 [Voice API reference →](voice-api.md)
 
@@ -74,6 +74,6 @@ If you have an Echo, the **Alexa skill** lets you ask Prism for today's events, 
 - All data stays on your hardware. No vendor accounts, no telemetry, no subscriptions.
 - PIN-based auth optimized for shared family devices. Parent vs. child roles for sensitive actions.
 - Runs as Docker Compose on anything from a Raspberry Pi 4 to a beefy NAS.
-- Works as a PWA — same UI on wall displays, tablets, and phones.
+- Works as a PWA: same UI on wall displays, tablets, and phones.
 
 [Install Prism →](getting-started/install.md){ .md-button .md-button--primary }

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -5,7 +5,7 @@ hide:
 
 # Screenshots
 
-A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jordan / Emma / Sophie family). Your own dashboard will look different — these images are illustrative.
+A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jordan / Emma / Sophie family). Your own dashboard will look different. These images are illustrative.
 
 === "Dashboard"
 
@@ -27,7 +27,7 @@ A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jord
 
 === "Calendar"
 
-    Prism has five calendar views — pick the one that matches how your family thinks about time. Each view can also switch into **cards mode** to show stacked event cards plus optional overlay rows for meals, chores, and tasks per day.
+    Prism has five calendar views: pick the one that matches how your family thinks about time. Each view can also switch into **cards mode** to show stacked event cards plus optional overlay rows for meals, chores, and tasks per day.
 
     <div class="grid cards" markdown>
 
@@ -35,7 +35,7 @@ A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jord
 
         ![Calendar month view](demos/calendar-month.png)
 
-    -   **Month — cards mode**
+    -   **Month (cards mode)**
 
         ![Calendar month cards mode](demos/calendar-month-cards.png)
 
@@ -43,7 +43,7 @@ A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jord
 
         ![Calendar multi-week view](demos/calendar-multiweek.png)
 
-    -   **Multi-week — cards mode**
+    -   **Multi-week (cards mode)**
 
         ![Calendar multi-week cards mode](demos/calendar-multiweek-cards.png)
 
@@ -63,7 +63,7 @@ A visual tour of Prism, captured against a fresh seed (the synthetic Alex / Jord
 
         ![Mobile calendar](demos/calendar-mobile.png){ width="300" }
 
-    -   **Mobile — cards mode**
+    -   **Mobile (cards mode)**
 
         ![Mobile calendar cards mode](demos/calendar-mobile-cards.png){ width="300" }
 

--- a/docs/voice-api.md
+++ b/docs/voice-api.md
@@ -1,10 +1,10 @@
 # Voice API (`/api/v1/voice/*`)
 
-The Voice API is a versioned, token-authenticated surface designed for voice and home-automation integrations (Alexa skills, Home Assistant components, Google Assistant via HA, scripting hooks). It is intentionally separate from the internal session-cookie-authenticated routes the dashboard uses — the contract here is **stable** and external callers can rely on it.
+The Voice API is a versioned, token-authenticated surface designed for voice and home-automation integrations (Alexa skills, Home Assistant components, Google Assistant via HA, scripting hooks). It is intentionally separate from the internal session-cookie-authenticated routes the dashboard uses. The contract here is **stable** and external callers can rely on it.
 
 ## Auth
 
-Every Voice API endpoint requires `Authorization: Bearer <token>` where the token's scopes include either `voice` or `*`. **Session cookies are rejected** — this is intentionally a machine-to-machine surface, so a stolen browser session can't reach voice endpoints.
+Every Voice API endpoint requires `Authorization: Bearer <token>` where the token's scopes include either `voice` or `*`. **Session cookies are rejected**: this is intentionally a machine-to-machine surface, so a stolen browser session can't reach voice endpoints.
 
 Tokens are issued via `POST /api/auth/tokens` (parent-only), SHA-256 hashed at rest, and never re-displayed after creation. The recommended scope for voice integrations is `['voice']` so a token leak cannot read or modify anything outside `/api/v1/voice/*`.
 
@@ -15,7 +15,7 @@ curl -X POST http://localhost:3000/api/auth/tokens \
   -d '{ "name": "Alexa skill", "scopes": ["voice"] }'
 ```
 
-The response includes `token` — store it immediately, it is not retrievable later.
+The response includes `token`. Store it immediately, it is not retrievable later.
 
 ### Known scopes
 
@@ -36,9 +36,9 @@ Every endpoint returns:
 }
 ```
 
-- `ok` — boolean. `false` for errors.
-- `spoken` — natural-language string the caller speaks back to the user. Pre-formatted on the server so callers don't need templating.
-- `data` — optional structured payload. Present on success; omitted on error.
+- `ok`: boolean. `false` for errors.
+- `spoken`: natural-language string the caller speaks back to the user. Pre-formatted on the server so callers don't need templating.
+- `data`: optional structured payload. Present on success; omitted on error.
 
 Errors return the same shape with `ok: false`, an HTTP error status, and a user-friendly `spoken` apology (no stack traces or IDs).
 
@@ -121,7 +121,7 @@ Fuzzy-matches the chore name (case-insensitive substring on `title`). See "Secur
 
 **Spoken (success)**: `"Marked feed the dog complete."`
 **Spoken (pending approval)**: `"Marked feed the dog complete. A parent will need to approve in the app."`
-**Spoken (ambiguous, ok:false)**: `"Multiple chores match 'feed the dog'. Which family member: Emma, Sophie?"` — `data.candidates` lists each option; caller resends with `assignee`.
+**Spoken (ambiguous, ok:false)**: `"Multiple chores match 'feed the dog'. Which family member: Emma, Sophie?"`. `data.candidates` lists each option; caller resends with `assignee`.
 
 ### `POST /api/v1/voice/message/post`
 
@@ -202,11 +202,11 @@ Returns the most recent (non-expired) family messages, newest first. `count` def
 
 Voice cannot escalate privileges. Specifically:
 
-- **Chore completions inherit the chore's `assignedTo`** as the completer — voice does not let one family member claim another's points.
-- **Ambiguous chore names require disambiguation.** If a fuzzy name match returns multiple chores assigned to different family members (e.g. both Emma and Sophie have "Feed the dog"), the endpoint returns `ok: false` with a `spoken` prompt asking for the assignee (*"Multiple chores match 'feed the dog' — which family member?"*) and `data.candidates: [...]`. The caller resends with `assignee` in the body. A single match completes immediately.
+- **Chore completions inherit the chore's `assignedTo`** as the completer. Voice does not let one family member claim another's points.
+- **Ambiguous chore names require disambiguation.** If a fuzzy name match returns multiple chores assigned to different family members (e.g. both Emma and Sophie have "Feed the dog"), the endpoint returns `ok: false` with a `spoken` prompt asking for the assignee (*"Multiple chores match 'feed the dog'. Which family member?"*) and `data.candidates: [...]`. The caller resends with `assignee` in the body. A single match completes immediately.
 - **Chores with `requiresApproval: true` create *pending* completions** when completed via voice, just like the in-app flow. The `spoken` response makes this explicit (e.g. *"Marked feed the dog complete. A parent will need to approve in the app."*).
-- **Approval is in-app only**, behind the Parent PIN. Voice has no way to approve a pending chore — there is no way to verify the speaker is a parent.
+- **Approval is in-app only**, behind the Parent PIN. Voice has no way to approve a pending chore: there is no way to verify the speaker is a parent.
 
 ## Roadmap
 
-The next phase is the Alexa skill itself, then a HACS-published Home Assistant `custom_component` — tracked in [#56](https://github.com/sandydargoport/prism/issues/56). A later "device-control intents" phase will add a server-sent command bus so voice can drive the running dashboard UI (e.g. *"pull up the lasagna recipe"*).
+The next phase is the Alexa skill itself, then a HACS-published Home Assistant `custom_component`, tracked in [#56](https://github.com/sandydargoport/prism/issues/56). A later "device-control intents" phase will add a server-sent command bus so voice can drive the running dashboard UI (e.g. *"pull up the lasagna recipe"*).

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -161,7 +161,7 @@ function GettingStarted() {
       <H2>First-Time Setup</H2>
       <Ul>
         <Li><strong>Add family members</strong> in Settings &gt; Family Members</Li>
-        <Li><strong>Set a PIN</strong> (4 or 6 digits) for each member — chosen during the setup wizard on a fresh install, or later in Settings &gt; Security. Each member&apos;s PIN length is independent; there is no shared family PIN.</Li>
+        <Li><strong>Set a PIN</strong> (4 or 6 digits) for each member, chosen during the setup wizard on a fresh install, or later in Settings &gt; Security. Each member&apos;s PIN length is independent; there is no shared family PIN.</Li>
         <Li><strong>Connect integrations</strong> (Google, Microsoft, Apple/CalDAV, weather) in Settings &gt; Integrations</Li>
         <Li><strong>Customize your dashboard</strong> layout using the Edit button</Li>
         <Li><strong>Install as an app</strong> on phones and tablets for quick access</Li>
@@ -214,7 +214,7 @@ function DashboardHelp() {
       </Ul>
 
       <H2>Starter Templates</H2>
-      <P>The <strong>Templates</strong> button offers six built-in dashboards — <strong>Family Central</strong>, <strong>Calendar Focus</strong>, <strong>Command Center</strong>, <strong>Meal Planner</strong>, <strong>School Mornings</strong>, and a photo-forward <strong>Ambient</strong>. Each is built around a single hero widget (usually the calendar) with the other widgets sized to their natural shape and grouped into a couple of balanced zones — a starting point you then rearrange. Every template ships in both landscape and portrait versions, and the screensaver has its own matching set.</P>
+      <P>The <strong>Templates</strong> button offers six built-in dashboards: <strong>Family Central</strong>, <strong>Calendar Focus</strong>, <strong>Command Center</strong>, <strong>Meal Planner</strong>, <strong>School Mornings</strong>, and a photo-forward <strong>Ambient</strong>. Each is built around a single hero widget (usually the calendar) with the other widgets sized to their natural shape and grouped into a couple of balanced zones, a starting point you then rearrange. Every template ships in both landscape and portrait versions, and the screensaver has its own matching set.</P>
 
       <H2>Mini-map &amp; Validation</H2>
       <P>Click <strong>Mini-map</strong> in the left toolbar to see a miniature map of your layout. It highlights widget positions and flags any issues like overlapping or undersized widgets. Click on the mini-map to scroll the grid to that area. A separate <strong>device preview gallery</strong> shows how your one design looks on each common screen size.</P>
@@ -224,12 +224,12 @@ function DashboardHelp() {
       <P>For a permanent clean look, enable <strong>Auto-Hide Navigation</strong> in Settings &gt; Appearance. The nav and toolbar will automatically hide after a period of inactivity and reappear on click or keyboard input.</P>
 
       <H2>Screensaver Layout</H2>
-      <P>Each dashboard has its own screensaver layout. In edit mode, click the <strong>Screensaver</strong> button to switch to editing the screensaver widget arrangement. The screensaver activates after a configurable idle period (Settings &gt; Appearance &gt; Timers &amp; Auto-Activation) and shows a photo slideshow with your chosen widgets overlaid. Its templates keep the calendar — or tonight&apos;s meals — as the hero, with small clock, weather, and message accents floating over one clean photo region so the wallpaper stays the star.</P>
+      <P>Each dashboard has its own screensaver layout. In edit mode, click the <strong>Screensaver</strong> button to switch to editing the screensaver widget arrangement. The screensaver activates after a configurable idle period (Settings &gt; Appearance &gt; Timers &amp; Auto-Activation) and shows a photo slideshow with your chosen widgets overlaid. Its templates keep the calendar, or tonight&apos;s meals, as the hero, with small clock, weather, and message accents floating over one clean photo region so the wallpaper stays the star.</P>
 
       <H2>Import, Export &amp; Community Layouts</H2>
       <Ul>
         <Li><strong>Community gallery</strong>: Click <strong>Community</strong> in the editor toolbar to browse layouts shared by other Prism users. Search by name and filter by <strong>orientation</strong> (Landscape/Portrait, pre-set to the dashboard you&apos;re editing), preview each as a thumbnail, then <strong>Apply layout</strong> to drop it onto a new dashboard.</Li>
-        <Li><strong>Share</strong>: Submit your own layout (More &gt; Share). Fill in the details and Prism opens a pre-filled <strong>GitHub issue form</strong> from any instance — sign in with a free GitHub account and submit; a bot validates it and opens a pull request, and a maintainer merges it into the gallery.</Li>
+        <Li><strong>Share</strong>: Submit your own layout (More &gt; Share). Fill in the details and submit; Prism opens a pre-filled submission, and once it&apos;s approved your layout appears in the gallery.</Li>
         <Li><strong>Export</strong>: Copy your current layout as JSON to share it directly (More &gt; Export)</Li>
         <Li><strong>Import</strong>: Paste a layout JSON to load someone else&apos;s design (More &gt; Import)</Li>
         <Li><strong>Reset</strong>: Revert unsaved edits back to the last saved layout (More &gt; Reset)</Li>
@@ -238,7 +238,7 @@ function DashboardHelp() {
       <H2>Multiple Dashboards</H2>
       <P>Create separate dashboards for different rooms or displays. Click the dashboard name dropdown in the editor toolbar to switch between dashboards or create new ones.</P>
       <Ul>
-        <Li>Default dashboard lives at <strong>/</strong> — make any dashboard the default via <strong>More &gt; Set as Default</strong></Li>
+        <Li>Default dashboard lives at <strong>/</strong>: make any dashboard the default via <strong>More &gt; Set as Default</strong></Li>
         <Li>Named dashboards get URLs like <strong>/d/kitchen</strong> or <strong>/d/living-room</strong></Li>
         <Li>Each has independent widget layout, screensaver layout, and orientation (landscape/portrait)</Li>
         <Li>Bookmark a dashboard URL on a dedicated device for instant access</Li>
@@ -265,15 +265,15 @@ function CalendarHelp({ isMobile }: { isMobile: boolean }) {
       <P>View and manage events from Google Calendar, Microsoft, and local calendars.</P>
 
       <H2>Personal &amp; Family calendars (no setup needed)</H2>
-      <P>Every family member automatically gets their own personal calendar, plus a shared <strong>Family</strong> calendar — so you can add and assign events right away without connecting anything. Connected accounts (below) simply layer on top.</P>
+      <P>Every family member automatically gets their own personal calendar, plus a shared <strong>Family</strong> calendar, so you can add and assign events right away without connecting anything. Connected accounts (below) simply layer on top.</P>
 
       <H2>Setting Up Connected Calendars</H2>
       <P>Connect Google, Microsoft, or Apple/CalDAV calendars in <strong>Settings &gt; Integrations</strong> (Google Calendar via OAuth; Apple iCloud via the CalDAV card). Once connected, open the <strong>calendar page and tap Manage</strong> to configure individual calendars, where you can:</P>
       <Ul>
         <Li><strong>Enable/disable</strong> individual calendars from showing on the dashboard</Li>
-        <Li><strong>Assign to a family member</strong> — each calendar is linked to a person or marked as &quot;Family&quot; (shared)</Li>
-        <Li><strong>Set display names</strong> — customize how a calendar appears in the UI</Li>
-        <Li><strong>Change colors</strong> — override the default color for any calendar</Li>
+        <Li><strong>Assign to a family member</strong>: each calendar is linked to a person or marked as &quot;Family&quot; (shared)</Li>
+        <Li><strong>Set display names</strong>: customize how a calendar appears in the UI</Li>
+        <Li><strong>Change colors</strong>: override the default color for any calendar</Li>
       </Ul>
       <P>Google Calendar is <strong>two-way</strong>: events you add, edit, or delete in Prism are pushed back to the connected Google calendar. (Old <strong>Settings &gt; Connected Accounts</strong> and <strong>Settings &gt; Calendars</strong> links redirect to these locations.)</P>
 
@@ -331,8 +331,8 @@ function ChoresHelp() {
       <H2>How It Works</H2>
       <Ul>
         <Li>A parent creates a chore with a frequency and point value</Li>
-        <Li>A child marks it complete — it enters &quot;Pending Approval&quot;</Li>
-        <Li>A parent approves — points are awarded and the next due date advances</Li>
+        <Li>A child marks it complete. It enters &quot;Pending Approval&quot;</Li>
+        <Li>A parent approves. Points are awarded and the next due date advances</Li>
         <Li>If a parent completes it, it&apos;s auto-approved</Li>
       </Ul>
       <H2>Reset Day</H2>
@@ -346,14 +346,14 @@ function GoalsHelp() {
     <>
       <P>Set goals that children work toward by earning points from chore completions.</P>
       <H2>How Points Work</H2>
-      <P>Points are earned from approved chores. The waterfall system allocates points in priority order — highest priority goals fill first, overflow goes to the next goal.</P>
+      <P>Points are earned from approved chores. The waterfall system allocates points in priority order: highest priority goals fill first, overflow goes to the next goal.</P>
       <H2>Recurring vs One-Time</H2>
       <Ul>
         <Li><strong>Recurring</strong> goals reset each period (weekly, monthly, yearly)</Li>
         <Li><strong>One-time</strong> goals accumulate until achieved, then a parent taps <strong>Reset</strong> on the goal to start it over</Li>
       </Ul>
       <H2>Celebrations</H2>
-      <P>When a goal is fully achieved, a seasonal celebration animation plays — themed to the nearest holiday (St. Patrick&apos;s, Easter, July 4th, Halloween, Thanksgiving, Christmas, etc.).</P>
+      <P>When a goal is fully achieved, a seasonal celebration animation plays, themed to the nearest holiday (St. Patrick&apos;s, Easter, July 4th, Halloween, Thanksgiving, Christmas, etc.).</P>
     </>
   );
 }
@@ -363,14 +363,14 @@ function ShoppingHelp() {
     <>
       <P>Manage multiple shopping lists with categories and per-person tracking.</P>
       <Ul>
-        <Li><strong>Multiple lists</strong> — Groceries, Hardware, General, etc.</Li>
-        <Li><strong>Categories</strong> — Produce, Dairy, Bakery, Meat, etc.</Li>
-        <Li><strong>Group by person</strong> — See who requested each item</Li>
-        <Li><strong>Reorder categories</strong> — Drag category headers to match your store layout (desktop)</Li>
-        <Li><strong>Edit / Delete</strong> — Each row has always-visible pencil and trash buttons. Deletes are immediate (the Undo button only reverses a check-off)</Li>
-        <Li><strong>Scan barcodes</strong> — Add items with a USB scanner or the camera scanner on the Shopping page</Li>
-        <Li><strong>Send to Kroger</strong> — Push unchecked items to your Kroger / Mariano&apos;s online cart (see the Kroger help section)</Li>
-        <Li><strong>Shopping mode</strong> — Tap the expand icon for a full-screen, in-store view</Li>
+        <Li><strong>Multiple lists</strong>: Groceries, Hardware, General, etc.</Li>
+        <Li><strong>Categories</strong>: Produce, Dairy, Bakery, Meat, etc.</Li>
+        <Li><strong>Group by person</strong>: See who requested each item</Li>
+        <Li><strong>Reorder categories</strong>: Drag category headers to match your store layout (desktop)</Li>
+        <Li><strong>Edit / Delete</strong>: Each row has always-visible pencil and trash buttons. Deletes are immediate (the Undo button only reverses a check-off)</Li>
+        <Li><strong>Scan barcodes</strong>: Add items with a USB scanner or the camera scanner on the Shopping page</Li>
+        <Li><strong>Send to Kroger</strong>: Push unchecked items to your Kroger / Mariano&apos;s online cart (see the Kroger help section)</Li>
+        <Li><strong>Shopping mode</strong>: Tap the expand icon for a full-screen, in-store view</Li>
         <Li><strong>Sync</strong> with Microsoft To Do (configure per-list in Settings &gt; Integrations)</Li>
       </Ul>
     </>
@@ -382,8 +382,8 @@ function MealsHelp() {
     <>
       <P>Weekly meal planner with optional recipe integration.</P>
       <Ul>
-        <Li><strong>Plan meals</strong> per day — a name is all you need; optionally link a recipe from your library</Li>
-        <Li><strong>Multiple meal types</strong> — Breakfast, Lunch, Dinner, Snack, with an optional time of day</Li>
+        <Li><strong>Plan meals</strong> per day: a name is all you need; optionally link a recipe from your library</Li>
+        <Li><strong>Multiple meal types</strong>: Breakfast, Lunch, Dinner, Snack, with an optional time of day</Li>
         <Li><strong>Drag meals between days</strong> to reschedule (touch supported)</Li>
         <Li><strong>Mark as cooked</strong> to track what&apos;s been prepared</Li>
         <Li>Days follow your <strong>Week Starts On</strong> setting (Settings &gt; General)</Li>
@@ -401,8 +401,8 @@ function MessagesHelp() {
         <Li><strong>Post</strong> messages attributed to whoever is logged in</Li>
         <Li><strong>Pin</strong> important messages to the top</Li>
         <Li><strong>Set expiration</strong> for temporary notices (12h to 7 days)</Li>
-        <Li><strong>Edit</strong> — Click the pencil icon, Ctrl+Enter to save</Li>
-        <Li><strong>Delete</strong> — Authors can delete their own; parents can delete any</Li>
+        <Li><strong>Edit</strong>: Click the pencil icon, Ctrl+Enter to save</Li>
+        <Li><strong>Delete</strong>: Authors can delete their own; parents can delete any</Li>
       </Ul>
     </>
   );
@@ -412,11 +412,11 @@ function WishesHelp() {
   return (
     <>
       <H2>Wish Lists</H2>
-      <P>Each family member has their own wish list. Others can secretly mark items as purchased — the owner doesn&apos;t see who bought what.</P>
+      <P>Each family member has their own wish list. Others can secretly mark items as purchased. The owner doesn&apos;t see who bought what.</P>
       <Ul>
         <Li><strong>Add</strong> items with name, link, and notes</Li>
-        <Li><strong>Claim</strong> — Mark as purchased (secret from the owner)</Li>
-        <Li><strong>Cross off</strong> — Owner can cross off items they got themselves</Li>
+        <Li><strong>Claim</strong>: Mark as purchased (secret from the owner)</Li>
+        <Li><strong>Cross off</strong>: Owner can cross off items they got themselves</Li>
         <Li><strong>Sync</strong> with Microsoft To Do per member (Settings)</Li>
       </Ul>
       <H2>Gift Ideas</H2>
@@ -425,7 +425,7 @@ function WishesHelp() {
         <Li>See columns for each family member (except yourself)</Li>
         <Li>Add ideas with name, link, price, and notes</Li>
         <Li>Mark as purchased when you buy them</Li>
-        <Li><strong>Privacy</strong>: Only you can see your ideas — they are never visible to the recipient or other family members</Li>
+        <Li><strong>Privacy</strong>: Only you can see your ideas. They are never visible to the recipient or other family members</Li>
       </Ul>
     </>
   );
@@ -436,12 +436,12 @@ function PhotosHelp() {
     <>
       <P>Photo gallery with local uploads plus OneDrive and Immich sync.</P>
       <Ul>
-        <Li><strong>Gallery</strong> — Browse all photos with lightbox view; filter to <strong>Favorites</strong></Li>
-        <Li><strong>Slideshow</strong> — Auto-rotating display for screensaver and away mode</Li>
-        <Li><strong>Sources</strong> — Local uploads, OneDrive, or Immich. Synced sources refresh automatically about every 30 minutes</Li>
-        <Li><strong>Tag for:</strong> — In the lightbox, toggle where each photo may appear — <strong>Wallpaper</strong>, <strong>Gallery</strong>, and/or <strong>Screensaver</strong></Li>
-        <Li><strong>Bulk select</strong> (desktop) — Select many photos to show in / remove from Prism at once</Li>
-        <Li><strong>Below-HD indicator</strong> — A resolution dot flags low-resolution photos so you can filter them out of wallpapers</Li>
+        <Li><strong>Gallery</strong>: Browse all photos with lightbox view; filter to <strong>Favorites</strong></Li>
+        <Li><strong>Slideshow</strong>: Auto-rotating display for screensaver and away mode</Li>
+        <Li><strong>Sources</strong>: Local uploads, OneDrive, or Immich. Synced sources refresh automatically about every 30 minutes</Li>
+        <Li><strong>Tag for:</strong> In the lightbox, toggle where each photo may appear: <strong>Wallpaper</strong>, <strong>Gallery</strong>, and/or <strong>Screensaver</strong></Li>
+        <Li><strong>Bulk select</strong> (desktop): Select many photos to show in / remove from Prism at once</Li>
+        <Li><strong>Below-HD indicator</strong>: A resolution dot flags low-resolution photos so you can filter them out of wallpapers</Li>
       </Ul>
       <P>Manage sources and set a static wallpaper or screensaver in Settings &gt; Photos.</P>
     </>
@@ -495,19 +495,19 @@ function SettingsHelp({ isMobile }: { isMobile: boolean }) {
       <H3>Family Members</H3>
       <P>Add, edit, or remove members. Set names, colors, avatars, and roles.</P>
       <H3>Security</H3>
-      <P>Set or change each member&apos;s PIN (4 or 6 digits). Generate API tokens for external integrations — each token carries a <strong>scope</strong>; pick the smallest that works (&quot;Voice API only (recommended)&quot; for Alexa / Home Assistant, or &quot;Full access (legacy)&quot;).</P>
+      <P>Set or change each member&apos;s PIN (4 or 6 digits). Generate API tokens for external integrations. Each token carries a <strong>scope</strong>; pick the smallest that works (&quot;Voice API only (recommended)&quot; for Alexa / Home Assistant, or &quot;Full access (legacy)&quot;).</P>
       <H3>General</H3>
       <Ul>
-        <Li><strong>Weather location</strong> — Set by ZIP / postal code</Li>
-        <Li><strong>Week Starts On</strong> — Sunday or Monday</Li>
+        <Li><strong>Weather location</strong>: Set by ZIP / postal code</Li>
+        <Li><strong>Week Starts On</strong>: Sunday or Monday</Li>
       </Ul>
       <H3>Integrations</H3>
-      <P>One place to connect providers — Google, Microsoft, Apple iCloud / CalDAV, Kroger, and more — shown as provider cards. Task, Shopping, and Wish List sync are configured per-list inside the Microsoft or Google card. (Old &quot;Connected Accounts&quot; / &quot;Task Sync&quot; / &quot;Shopping Sync&quot; links redirect here.)</P>
+      <P>One place to connect providers (Google, Microsoft, Apple iCloud / CalDAV, Kroger, and more) shown as provider cards. Task, Shopping, and Wish List sync are configured per-list inside the Microsoft or Google card. (Old &quot;Connected Accounts&quot; / &quot;Task Sync&quot; / &quot;Shopping Sync&quot; links redirect here.)</P>
       <H3>Appearance</H3>
       <Ul>
-        <Li><strong>Theme &amp; palette</strong> — Light, Dark, or System, plus seasonal themes</Li>
-        {!isMobile && <Li><strong>Timers &amp; Auto-Activation</strong> — Screensaver and Away Mode idle timers, photo rotation</Li>}
-        {!isMobile && <Li><strong>Auto-Hide Navigation</strong> — Hide nav after inactivity</Li>}
+        <Li><strong>Theme &amp; palette</strong>: Light, Dark, or System, plus seasonal themes</Li>
+        {!isMobile && <Li><strong>Timers &amp; Auto-Activation</strong>: Screensaver and Away Mode idle timers, photo rotation</Li>}
+        {!isMobile && <Li><strong>Auto-Hide Navigation</strong>: Hide nav after inactivity</Li>}
       </Ul>
       {!isMobile && (
         <>
@@ -536,7 +536,7 @@ function IntegrationsHelp() {
     <>
       <P>Everything connects from one place: <strong>Settings &gt; Integrations</strong>, shown as provider cards.</P>
       <H2>Google Calendar</H2>
-      <P>Connect in Settings &gt; Integrations (Google card). <strong>Two-way sync</strong> — events you add, edit, or delete in Prism are pushed back to the connected Google calendar.</P>
+      <P>Connect in Settings &gt; Integrations (Google card). <strong>Two-way sync</strong>: events you add, edit, or delete in Prism are pushed back to the connected Google calendar.</P>
       <H2>Microsoft To Do</H2>
       <P>Bidirectional sync for Tasks, Shopping Lists, and Wish Lists, with newest-wins conflict resolution. Connect the Microsoft card, then turn on sync per-list inside that card.</P>
       <H2>Google Tasks</H2>
@@ -552,7 +552,7 @@ function IntegrationsHelp() {
       <H2>OneDrive / Immich Photos</H2>
       <P>Sync photos from OneDrive folders or an Immich server. Configure in Settings &gt; Photos. Synced sources refresh automatically about every 30 minutes.</P>
       <H2>Weather</H2>
-      <P>Works out of the box via <strong>Open-Meteo</strong> — no API key needed. Set your location by ZIP / postal code in Settings &gt; General. OpenWeatherMap is optional (set <code>WEATHER_PROVIDER=openweather</code> plus a key).</P>
+      <P>Works out of the box via <strong>Open-Meteo</strong>. No API key needed. Set your location by ZIP / postal code in Settings &gt; General. OpenWeatherMap is optional (set <code>WEATHER_PROVIDER=openweather</code> plus a key).</P>
       <H2>Home Assistant &amp; Voice API</H2>
       <P>Control Prism by voice via Home Assistant, Alexa skills, or Node-RED. See the <strong>Home Assistant &amp; Voice API</strong> help section.</P>
     </>
@@ -606,7 +606,7 @@ function TroubleshootingHelp() {
       <H3>Forgot PIN</H3>
       <P>Ask a parent to reset it in Settings &gt; Security &gt; Member PINs.</P>
       <H3>Calendar events not showing</H3>
-      <P>Open the calendar page and tap <strong>Manage</strong> — is the calendar enabled? Tap &quot;Sync&quot; to force a refresh. Verify the Google / Microsoft / Apple connection is active in Settings &gt; Integrations.</P>
+      <P>Open the calendar page and tap <strong>Manage</strong>. Is the calendar enabled? Tap &quot;Sync&quot; to force a refresh. Verify the Google / Microsoft / Apple connection is active in Settings &gt; Integrations.</P>
       <H3>Tasks/Shopping not syncing</H3>
       <P>Verify Microsoft (or Google) is connected in Settings &gt; Integrations. Check that sync is enabled on the list. Tap &quot;Sync All&quot; to force a refresh.</P>
       <H3>Widget not loading</H3>
@@ -621,17 +621,17 @@ function RecipesHelp() {
       <P>A recipe library you can scale, shop from, and drop onto the meal planner.</P>
       <H2>Adding Recipes</H2>
       <Ul>
-        <Li><strong>Import from URL</strong> — Paste a recipe web address and Prism pulls in the details</Li>
-        <Li><strong>Import from Paprika</strong> — Upload a Paprika export file</Li>
-        <Li><strong>Paste text</strong> — Paste raw recipe text and Prism structures it</Li>
-        <Li><strong>Add manually</strong> — Fill in the form, including an optional photo</Li>
-        <Li><strong>Sync from Tandoor / Mealie</strong> — Connect a server with a read-only API token; the review screen pre-selects adds and updates while removals are opt-in, and re-syncing is safe to repeat</Li>
+        <Li><strong>Import from URL</strong>: Paste a recipe web address and Prism pulls in the details</Li>
+        <Li><strong>Import from Paprika</strong>: Upload a Paprika export file</Li>
+        <Li><strong>Paste text</strong>: Paste raw recipe text and Prism structures it</Li>
+        <Li><strong>Add manually</strong>: Fill in the form, including an optional photo</Li>
+        <Li><strong>Sync from Tandoor / Mealie</strong>: Connect a server with a read-only API token; the review screen pre-selects adds and updates while removals are opt-in, and re-syncing is safe to repeat</Li>
       </Ul>
       <H2>Using a Recipe</H2>
       <Ul>
-        <Li><strong>Scale servings</strong> — Use the servings stepper or the quick multiplier buttons (½×, 1×, 2×…); ingredient amounts rescale automatically</Li>
-        <Li><strong>Add to shopping list</strong> — Send the (scaled) ingredients straight to a shopping list</Li>
-        <Li><strong>Add to Meal Plan</strong> — Pick a day on the two-week mini-calendar and a meal type (defaults to Dinner) to place it on the planner</Li>
+        <Li><strong>Scale servings</strong>: Use the servings stepper or the quick multiplier buttons (½×, 1×, 2×…); ingredient amounts rescale automatically</Li>
+        <Li><strong>Add to shopping list</strong>: Send the (scaled) ingredients straight to a shopping list</Li>
+        <Li><strong>Add to Meal Plan</strong>: Pick a day on the two-week mini-calendar and a meal type (defaults to Dinner) to place it on the planner</Li>
         <Li><strong>Favorite</strong> and search across name, description, cuisine, and category; filter by cuisine or category</Li>
       </Ul>
     </>
@@ -643,10 +643,10 @@ function WeekendHelp() {
     <>
       <P>A shared board of places and activities to try together on weekends.</P>
       <Ul>
-        <Li><strong>Want to Try / Been There</strong> — Switch between the two status tabs; add places with the Add Place button</Li>
-        <Li><strong>Favorites</strong> — Star places and filter to just your favorites</Li>
-        <Li><strong>Tags</strong> — Pick from a fixed preset list (Outdoor, Nature, Hike, Food, Museum, Park, Playground…); the board groups places by tag, and you can filter by one or more tags</Li>
-        <Li><strong>Mark as Visited</strong> — One tap bumps the visit count (shown as pips) and records the last-visited date, moving the place to Been There</Li>
+        <Li><strong>Want to Try / Been There</strong>: Switch between the two status tabs; add places with the Add Place button</Li>
+        <Li><strong>Favorites</strong>: Star places and filter to just your favorites</Li>
+        <Li><strong>Tags</strong>: Pick from a fixed preset list (Outdoor, Nature, Hike, Food, Museum, Park, Playground…); the board groups places by tag, and you can filter by one or more tags</Li>
+        <Li><strong>Mark as Visited</strong>: One tap bumps the visit count (shown as pips) and records the last-visited date, moving the place to Been There</Li>
       </Ul>
     </>
   );
@@ -657,10 +657,10 @@ function TravelHelp() {
     <>
       <P>A 3D globe and list of places your family has been or wants to go.</P>
       <Ul>
-        <Li><strong>Globe &amp; Places tabs</strong> — Spin the globe to see your pins, or switch to the Places list. A dark-mode toggle restyles the globe</Li>
-        <Li><strong>Pins</strong> — Add locations, trip stops, or national parks; each pin is either <strong>Want to Go</strong> or <strong>Been There</strong> and can hold photos</Li>
-        <Li><strong>Search</strong> — Type a place name to look it up and drop a pin at the right spot</Li>
-        <Li><strong>Trips</strong> — Group multiple stops into a trip</Li>
+        <Li><strong>Globe &amp; Places tabs</strong>: Spin the globe to see your pins, or switch to the Places list. A dark-mode toggle restyles the globe</Li>
+        <Li><strong>Pins</strong>: Add locations, trip stops, or national parks; each pin is either <strong>Want to Go</strong> or <strong>Been There</strong> and can hold photos</Li>
+        <Li><strong>Search</strong>: Type a place name to look it up and drop a pin at the right spot</Li>
+        <Li><strong>Trips</strong>: Group multiple stops into a trip</Li>
       </Ul>
       <P>For satellite-quality globe imagery you can add a Mapbox token in Settings; the globe still works without one.</P>
     </>
@@ -672,9 +672,9 @@ function BusHelp() {
     <>
       <P>Track school-bus arrival times from FirstView email alerts and show them on the dashboard.</P>
       <Ul>
-        <Li><strong>Connect Gmail</strong> — In Settings &gt; Bus Tracking, connect the Gmail account that receives FirstView emails (optionally set a Gmail label to narrow the search)</Li>
-        <Li><strong>Discover routes</strong> — Prism scans for FirstView emails and creates the routes it finds, each with its stop</Li>
-        <Li><strong>Bus Tracker widget</strong> — Add the Bus Tracker widget to a dashboard to see predicted arrival times</Li>
+        <Li><strong>Connect Gmail</strong>: In Settings &gt; Bus Tracking, connect the Gmail account that receives FirstView emails (optionally set a Gmail label to narrow the search)</Li>
+        <Li><strong>Discover routes</strong>: Prism scans for FirstView emails and creates the routes it finds, each with its stop</Li>
+        <Li><strong>Bus Tracker widget</strong>: Add the Bus Tracker widget to a dashboard to see predicted arrival times</Li>
       </Ul>
     </>
   );
@@ -685,9 +685,9 @@ function InputHelp() {
     <>
       <P>Kiosk-friendly input options for touchscreens and shared displays. Configure these in Settings &gt; Input.</P>
       <Ul>
-        <Li><strong>On-screen keyboard</strong> — A touch keyboard appears automatically when you tap a text field</Li>
-        <Li><strong>Voice-to-text</strong> — Tap the mic key on the keyboard to dictate instead of typing</Li>
-        <Li><strong>Barcode scanning</strong> — Add shopping items with a USB barcode scanner, or use the camera scanner on the Shopping page</Li>
+        <Li><strong>On-screen keyboard</strong>: A touch keyboard appears automatically when you tap a text field</Li>
+        <Li><strong>Voice-to-text</strong>: Tap the mic key on the keyboard to dictate instead of typing</Li>
+        <Li><strong>Barcode scanning</strong>: Add shopping items with a USB barcode scanner, or use the camera scanner on the Shopping page</Li>
       </Ul>
     </>
   );
@@ -696,7 +696,7 @@ function InputHelp() {
 function CalDAVHelp() {
   return (
     <>
-      <P>Connect Apple iCloud — or any CalDAV / CardDAV server (e.g. Nextcloud) — for private calendars, Reminders, and contact birthdays.</P>
+      <P>Connect Apple iCloud, or any CalDAV / CardDAV server (e.g. Nextcloud), for private calendars, Reminders, and contact birthdays.</P>
       <H2>Setup</H2>
       <Ul>
         <Li>Create an <strong>app-specific password</strong> at appleid.apple.com (your normal Apple password won&apos;t work)</Li>
@@ -706,7 +706,7 @@ function CalDAVHelp() {
       <H2>What syncs</H2>
       <Ul>
         <Li>Calendars and events; Reminders (as tasks); optional contact <strong>birthdays</strong></Li>
-        <Li>Read-only for creates and edits, but <strong>deleting a single (non-recurring) synced event in Prism removes it from the source too</strong> — this is destructive upstream. Recurring series only delete locally.</Li>
+        <Li>Read-only for creates and edits, but <strong>deleting a single (non-recurring) synced event in Prism removes it from the source too</strong>. This is destructive upstream. Recurring series only delete locally.</Li>
       </Ul>
     </>
   );
@@ -717,9 +717,9 @@ function KrogerHelp() {
     <>
       <P>Push your shopping list to your online Kroger or Mariano&apos;s cart.</P>
       <Ul>
-        <Li><strong>Connect</strong> — In Settings &gt; Integrations, open the <strong>Kroger</strong> card, add your API credentials, connect your account (per-user OAuth), and pick your store</Li>
-        <Li><strong>Send to Kroger</strong> — From the Shopping page, tap Send to Kroger to push unchecked items; match each item to a product (SKU) and set a quantity</Li>
-        <Li>This is a one-way push to your cart on demand — it is not a two-way list sync</Li>
+        <Li><strong>Connect</strong>: In Settings &gt; Integrations, open the <strong>Kroger</strong> card, add your API credentials, connect your account (per-user OAuth), and pick your store</Li>
+        <Li><strong>Send to Kroger</strong>: From the Shopping page, tap Send to Kroger to push unchecked items; match each item to a product (SKU) and set a quantity</Li>
+        <Li>This is a one-way push to your cart on demand. It is not a two-way list sync</Li>
       </Ul>
     </>
   );
@@ -731,7 +731,7 @@ function VoiceApiHelp() {
       <P>Control and read Prism by voice through Home Assistant, Alexa skills, or Node-RED via the built-in Voice API.</P>
       <Ul>
         <Li><strong>Generate a token</strong> in Settings &gt; Security</Li>
-        <Li><strong>Pick a scope</strong> — Choose <strong>Voice API only (recommended)</strong> for Alexa / Home Assistant; it reaches the Voice API plus read-only REST sensors, not writes. Full access (legacy) is broader</Li>
+        <Li><strong>Pick a scope</strong>: Choose <strong>Voice API only (recommended)</strong> for Alexa / Home Assistant; it reaches the Voice API plus read-only REST sensors, not writes. Full access (legacy) is broader</Li>
         <Li>Point your automation platform at the Voice API with the token; see the Home Assistant and Voice API docs for endpoints</Li>
       </Ul>
     </>

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -228,8 +228,8 @@ function DashboardHelp() {
 
       <H2>Import, Export &amp; Community Layouts</H2>
       <Ul>
-        <Li><strong>Community gallery</strong>: Click <strong>Community</strong> in the editor toolbar to browse layouts shared by other Prism users. Search by name and filter by screen size, preview each one as a thumbnail, then <strong>Apply layout</strong> to drop it onto a new dashboard.</Li>
-        <Li><strong>Share</strong>: Submit your own layout to the community gallery (More &gt; Share) — it opens a pre-filled GitHub submission that works from any Prism instance</Li>
+        <Li><strong>Community gallery</strong>: Click <strong>Community</strong> in the editor toolbar to browse layouts shared by other Prism users. Search by name and filter by <strong>orientation</strong> (Landscape/Portrait, pre-set to the dashboard you&apos;re editing), preview each as a thumbnail, then <strong>Apply layout</strong> to drop it onto a new dashboard.</Li>
+        <Li><strong>Share</strong>: Submit your own layout (More &gt; Share). Fill in the details and Prism opens a pre-filled <strong>GitHub issue form</strong> from any instance — sign in with a free GitHub account and submit; a bot validates it and opens a pull request, and a maintainer merges it into the gallery.</Li>
         <Li><strong>Export</strong>: Copy your current layout as JSON to share it directly (More &gt; Export)</Li>
         <Li><strong>Import</strong>: Paste a layout JSON to load someone else&apos;s design (More &gt; Import)</Li>
         <Li><strong>Reset</strong>: Revert unsaved edits back to the last saved layout (More &gt; Reset)</Li>


### PR DESCRIPTION
Follows #211 (orientation filter + share-via-issue-form) by bringing the docs and in-app Help in line with the shipped behavior.

## Changes
- **`docs/features/DASHBOARD.md`**
  - Community gallery: replaced the retired **screen-size filter** with **orientation** (▭ Landscape / ▯ Portrait, defaulting to the board you're editing), and explained *why* (layouts stretch to fill any screen; orientation is the axis that letterboxes).
  - Added a step-by-step **"Sharing your layout with the community"** walkthrough: More → Share → the pre-filled **GitHub issue form** → sign in with a free account → bot auto-validates → auto-opens a PR → maintainer merges. Notes that the GitHub sign-in is a deliberate anti-junk / pre-merge-review gate.
- **In-app Help (`HelpView.tsx`)** — same orientation-filter correction and a concise version of the sharing walkthrough.

## Verification
- `tsc --noEmit`: clean · `mkdocs build --strict`: builds. No stale community screen-size references remain.

Opening for review rather than auto-merging, per request — flag any wording you want changed.