### PR TITLE
chore(demo): richer seed + self-seeding screenshot capture script

### DIFF
--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -1,18 +1,33 @@
 /**
  * Auto-capture screenshots of every Prism feature for the docs site.
  *
- * Run against the screenshots stack (port :3010) with:
+ * Run against the screenshots stack (port :3010), which builds from the current
+ * source and seeds the demo family:
  *
  *   docker-compose -f docker-compose.screenshots.yml up -d
  *   # ... wait ~90s for first boot ...
  *   npm run screenshots:capture
  *
- * Saves to docs/demos/ with stable filenames so the docs site + README
- * references stay valid across re-runs. Captures both light + dark theme
- * for the main dashboard, plus mobile viewport variants.
+ * Or point it at any already-running, current-code instance that has the demo
+ * seed (for example the demo container on :8091):
  *
- * Login is automatic — uses Alex (parent) with PIN 1234 from the seed.
- * No setup wizard needed; the seed pre-creates users + settings + layout.
+ *   PRISM_URL=http://localhost:8091 npm run screenshots:capture
+ *
+ * IMPORTANT: capture only against an instance running CURRENT master, or the
+ * shots will show stale UI.
+ *
+ * Photos: the seed does not create photos (they need image bytes), so before
+ * capturing this script auto-seeds a handful of Bing daily wallpapers into the
+ * target if it has none, and pins one as the dashboard wallpaper. That keeps the
+ * Photos page, the dashboard hero, and the screensaver populated with no manual
+ * prep. If Bing is unreachable, capture still proceeds (photo shots just empty).
+ *
+ * Saves to docs/demos/ with stable filenames so the docs site + README
+ * references stay valid across re-runs. Captures both light + dark theme for the
+ * main dashboard, plus mobile viewport variants.
+ *
+ * Login is automatic, using Alex (parent) with PIN 1234 from the seed. No setup
+ * wizard needed; the seed pre-creates users + settings + layout.
  */
 
 import { chromium, Browser, BrowserContext, Page } from '@playwright/test';
@@ -60,6 +75,12 @@ interface CaptureSpec {
   calendarDisplayMode?: 'inline' | 'cards';
   /** Optional pre-screenshot setup (e.g. click into a sub-view) */
   setup?: (page: Page) => Promise<void>;
+  /**
+   * Pin a landscape wallpaper photo before capture so the photo-forward
+   * dashboard renders with a stable hero image (and light/dark match). No-op if
+   * the target has no wallpaper photos.
+   */
+  pinWallpaper?: boolean;
 }
 
 const SCREENSHOTS: CaptureSpec[] = [
@@ -70,6 +91,7 @@ const SCREENSHOTS: CaptureSpec[] = [
     description: 'Dashboard with widgets (light mode)',
     theme: 'light',
     settleMs: 15000, // dashboard has many lazy-loaded widgets that each fetch async
+    pinWallpaper: true,
   },
   {
     name: 'dashboard-dark',
@@ -77,6 +99,7 @@ const SCREENSHOTS: CaptureSpec[] = [
     description: 'Dashboard with widgets (dark mode)',
     theme: 'dark',
     settleMs: 15000,
+    pinWallpaper: true,
   },
   {
     name: 'dashboard-mobile',
@@ -276,6 +299,74 @@ async function loginAsAlex(page: Page) {
   }
 }
 
+/** Fetch a handful of Bing daily wallpapers (landscape + a few portrait). */
+async function fetchBingWallpapers(): Promise<{ name: string; buffer: Buffer }[]> {
+  const bases: string[] = [];
+  for (const idx of [0, 7]) {
+    try {
+      const r = await fetch(`https://www.bing.com/HPImageArchive.aspx?format=js&idx=${idx}&n=8&mkt=en-US`);
+      const j = (await r.json()) as { images?: { urlbase: string }[] };
+      for (const im of j.images ?? []) if (!bases.includes(im.urlbase)) bases.push(im.urlbase);
+    } catch {
+      // Bing unreachable — return whatever we have.
+    }
+  }
+  const jobs: { url: string; name: string }[] = [];
+  bases.slice(0, 8).forEach((ub, i) => jobs.push({ url: `https://www.bing.com${ub}_1920x1080.jpg`, name: `demo-land-${i}.jpg` }));
+  bases.slice(0, 3).forEach((ub, i) => jobs.push({ url: `https://www.bing.com${ub}_1080x1920.jpg`, name: `demo-port-${i}.jpg` }));
+  const out: { name: string; buffer: Buffer }[] = [];
+  for (const job of jobs) {
+    try {
+      const r = await fetch(job.url);
+      if (!r.ok) continue;
+      const buffer = Buffer.from(await r.arrayBuffer());
+      if (buffer.length > 10_000) out.push({ name: job.name, buffer });
+    } catch {
+      // Skip a failed image; keep going.
+    }
+  }
+  return out;
+}
+
+/**
+ * Make sure the target has demo photos before capturing. The seed omits photos
+ * (they need image bytes), so if the instance has none we upload a few Bing
+ * wallpapers through the real upload API (which builds thumbnails, dimensions,
+ * orientation, and tags them wallpaper+gallery+screensaver). Best-effort: any
+ * failure leaves the photo-dependent shots empty rather than aborting capture.
+ */
+async function ensureDemoPhotos(browser: Browser): Promise<void> {
+  const context = await browser.newContext({ baseURL: BASE_URL });
+  const page = await context.newPage();
+  try {
+    await page.goto('/', { waitUntil: 'load', timeout: 60_000 });
+    await loginAsAlex(page);
+
+    const resp = await page.request.get('/api/photos?limit=1');
+    const json = await resp.json();
+    const list = Array.isArray(json) ? json : (json.photos ?? []);
+    if (list.length > 0) {
+      console.log('  photos already present — skipping Bing seed');
+      return;
+    }
+
+    console.log('  no photos found — seeding Bing wallpapers...');
+    const images = await fetchBingWallpapers();
+    let uploaded = 0;
+    for (const img of images) {
+      const up = await page.request.post('/api/photos', {
+        multipart: { file: { name: img.name, mimeType: 'image/jpeg', buffer: img.buffer } },
+      });
+      if (up.ok()) uploaded++;
+    }
+    console.log(`  uploaded ${uploaded} wallpaper photo(s)`);
+  } catch (err) {
+    console.warn(`  photo seed skipped: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    await context.close();
+  }
+}
+
 /**
  * Wait until any loading indicators have disappeared. Next.js dev mode
  * compiles each route on first hit, taking several seconds, during which
@@ -368,6 +459,30 @@ async function captureOnce(browser: Browser, spec: CaptureSpec): Promise<void> {
     // websocket open, so networkidle never fires and every navigation times out.
     await page.goto('/', { waitUntil: 'load', timeout: 60_000 });
     await loginAsAlex(page);
+
+    // Pin a landscape wallpaper (if requested) so the dashboard renders over a
+    // stable photo hero. Added as an init script so it applies before the
+    // dashboard's first paint on the navigation below.
+    if (spec.pinWallpaper) {
+      try {
+        const resp = await page.request.get('/api/photos?usage=wallpaper&orientation=landscape&limit=1');
+        const json = await resp.json();
+        const list = Array.isArray(json) ? json : (json.photos ?? []);
+        const id: string | undefined = list[0]?.id;
+        if (id) {
+          await page.addInitScript((pid: string) => {
+            try {
+              localStorage.setItem('prism-wallpaper-enabled', 'true');
+              localStorage.setItem('prism-pinned-wallpaper', pid);
+            } catch {
+              // localStorage unavailable — dashboard falls back to auto-pick.
+            }
+          }, id);
+        }
+      } catch {
+        // No wallpaper photo available — dashboard renders without a pinned hero.
+      }
+    }
 
     // Navigate to the target page.
     await page.goto(spec.url, { waitUntil: 'load', timeout: 60_000 });
@@ -488,6 +603,11 @@ async function main() {
   let failed = 0;
 
   try {
+    // Ensure the target has demo photos (Photos page, dashboard hero,
+    // screensaver) before capturing. Skipped automatically if a photo filter
+    // is not part of the run but photos are cheap and shared, so always run it.
+    await ensureDemoPhotos(browser);
+
     for (const spec of specs) {
       const success = await captureOne(browser, spec);
       if (success) ok++;

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -255,7 +255,57 @@ async function seed() {
     },
   ]);
 
-  console.log(`  Created 15 events (10 one-off + 5 recurring)`);
+  // Additional one-off events — fill out the month so week / multi-week /
+  // month calendar views look like a busy family of four. Spread from ~2 weeks
+  // back to ~5 weeks ahead. Colors follow each source (family/Jordan pink,
+  // Alex blue, Emma green, Sophie amber).
+  await db.insert(schema.events).values([
+    // ── Past two weeks (historic fill) ──────────────────────────────────────
+    { calendarSourceId: calAlex.id,   title: 'Quarterly Planning',       location: 'Office',            startTime: atTime(daysAgo(13), 9, 0),  endTime: atTime(daysAgo(13), 11, 0), color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calFamily.id, title: 'School Closed',            allDay: true, startTime: atTime(daysAgo(12), 0, 0), endTime: atTime(daysAgo(11), 0, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calEmma.id,   title: 'Soccer Game',              location: 'Community Park',    startTime: atTime(daysAgo(11), 10, 0), endTime: atTime(daysAgo(11), 11, 30), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calSophie.id, title: 'Swim Lesson',              location: 'Rec Center',        startTime: atTime(daysAgo(10), 16, 0), endTime: atTime(daysAgo(10), 16, 45), color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calJordan.id, title: 'Yoga Class',               location: 'Sunrise Studio',    startTime: atTime(daysAgo(9), 7, 30),  endTime: atTime(daysAgo(9), 8, 30),  color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'Farmers Market',           location: 'Town Square',       startTime: atTime(daysAgo(8), 9, 0),   endTime: atTime(daysAgo(8), 11, 0),  color: '#EC4899', createdBy: alex.id },
+    { calendarSourceId: calAlex.id,   title: 'Dentist',                  location: "Dr. Smith's Office", startTime: atTime(daysAgo(6), 8, 0),  endTime: atTime(daysAgo(6), 8, 45),  color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calEmma.id,   title: 'Library Reading Club',     location: 'Public Library',    startTime: atTime(daysAgo(5), 15, 30), endTime: atTime(daysAgo(5), 16, 30), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calSophie.id, title: 'Playdate with Mia',        startTime: atTime(daysAgo(4), 15, 0),  endTime: atTime(daysAgo(4), 17, 0),  color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: "Dinner at Grandma Helen's", startTime: atTime(daysAgo(3), 17, 30), endTime: atTime(daysAgo(3), 20, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calJordan.id, title: 'Volunteer at Food Bank',   location: 'Community Center',  startTime: atTime(daysAgo(2), 9, 0),   endTime: atTime(daysAgo(2), 12, 0),  color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calAlex.id,   title: 'Haircut',                  startTime: atTime(daysAgo(1), 12, 0),  endTime: atTime(daysAgo(1), 12, 30), color: '#3B82F6', createdBy: alex.id },
+    // ── This week and next (near-term busy) ─────────────────────────────────
+    { calendarSourceId: calSophie.id, title: 'Piano Lesson',             startTime: atTime(daysFromNow(2), 16, 0),  endTime: atTime(daysFromNow(2), 16, 45), color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calAlex.id,   title: 'Client Call',              startTime: atTime(daysFromNow(2), 14, 0),  endTime: atTime(daysFromNow(2), 15, 0),  color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calEmma.id,   title: 'Art Class',                location: 'Community Center',  startTime: atTime(daysFromNow(3), 16, 0),  endTime: atTime(daysFromNow(3), 17, 0),  color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calJordan.id, title: 'Doctor Checkup',           startTime: atTime(daysFromNow(4), 10, 0),  endTime: atTime(daysFromNow(4), 11, 0),  color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'No School: Teacher Workday', allDay: true, startTime: atTime(daysFromNow(4), 0, 0), endTime: atTime(daysFromNow(5), 0, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'Neighborhood BBQ',         startTime: atTime(daysFromNow(6), 12, 0),  endTime: atTime(daysFromNow(6), 15, 0),  color: '#EC4899', createdBy: alex.id },
+    { calendarSourceId: calEmma.id,   title: "Sleepover at Mia's",       allDay: true, startTime: atTime(daysFromNow(6), 0, 0), endTime: atTime(daysFromNow(7), 0, 0), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calSophie.id, title: 'Birthday Party for Lucas', startTime: atTime(daysFromNow(7), 14, 0),  endTime: atTime(daysFromNow(7), 16, 0),  color: '#F59E0B', createdBy: jordan.id },
+    // ── Two to three weeks out ──────────────────────────────────────────────
+    { calendarSourceId: calAlex.id,   title: 'Work Conference',          location: 'Chicago',           allDay: true, startTime: atTime(daysFromNow(9), 0, 0), endTime: atTime(daysFromNow(12), 0, 0), color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calEmma.id,   title: 'Field Trip: Science Museum', allDay: true, startTime: atTime(daysFromNow(11), 0, 0), endTime: atTime(daysFromNow(12), 0, 0), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calSophie.id, title: 'Dentist',                  startTime: atTime(daysFromNow(12), 9, 0),  endTime: atTime(daysFromNow(12), 9, 45), color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calJordan.id, title: 'Girls Night Out',          startTime: atTime(daysFromNow(12), 19, 0), endTime: atTime(daysFromNow(12), 22, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'Family Movie Night',       startTime: atTime(daysFromNow(13), 19, 0), endTime: atTime(daysFromNow(13), 21, 0), color: '#EC4899', createdBy: alex.id },
+    // ── Spring break and a weekend trip ─────────────────────────────────────
+    { calendarSourceId: calFamily.id, title: 'Beach Trip',               location: 'Coastline',         allDay: true, startTime: atTime(daysFromNow(16), 0, 0), endTime: atTime(daysFromNow(19), 0, 0), color: '#EC4899', createdBy: alex.id },
+    { calendarSourceId: calEmma.id,   title: 'Summer Camp Registration Opens', startTime: atTime(daysFromNow(18), 10, 0), endTime: atTime(daysFromNow(18), 10, 30), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calAlex.id,   title: 'Back to Office',           startTime: atTime(daysFromNow(20), 9, 0),  endTime: atTime(daysFromNow(20), 17, 0), color: '#3B82F6', createdBy: alex.id },
+    // ── Four to five weeks out ──────────────────────────────────────────────
+    { calendarSourceId: calSophie.id, title: 'Soccer Tryouts',           location: 'Community Park',    startTime: atTime(daysFromNow(22), 16, 0), endTime: atTime(daysFromNow(22), 17, 30), color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calJordan.id, title: 'Bake Sale (parent volunteer)', location: 'Maple Elementary', startTime: atTime(daysFromNow(23), 8, 0), endTime: atTime(daysFromNow(23), 10, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calAlex.id,   title: 'Car Service',              location: 'Auto Shop',         startTime: atTime(daysFromNow(24), 8, 0),  endTime: atTime(daysFromNow(24), 9, 0),  color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calFamily.id, title: "Grandpa Joe's Birthday Dinner", startTime: atTime(daysFromNow(25), 18, 0), endTime: atTime(daysFromNow(25), 20, 0), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calEmma.id,   title: 'Piano Recital',            location: 'School Auditorium', startTime: atTime(daysFromNow(26), 18, 0), endTime: atTime(daysFromNow(26), 19, 30), color: '#10B981', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'Community Fun Run',        allDay: true, startTime: atTime(daysFromNow(27), 0, 0), endTime: atTime(daysFromNow(28), 0, 0), color: '#EC4899', createdBy: alex.id },
+    { calendarSourceId: calSophie.id, title: 'Field Day',                location: 'Maple Elementary',  allDay: true, startTime: atTime(daysFromNow(30), 0, 0), endTime: atTime(daysFromNow(31), 0, 0), color: '#F59E0B', createdBy: jordan.id },
+    { calendarSourceId: calAlex.id,   title: 'Team Lunch',               startTime: atTime(daysFromNow(31), 12, 0), endTime: atTime(daysFromNow(31), 13, 0), color: '#3B82F6', createdBy: alex.id },
+    { calendarSourceId: calJordan.id, title: 'Dentist',                  startTime: atTime(daysFromNow(33), 14, 0), endTime: atTime(daysFromNow(33), 14, 45), color: '#EC4899', createdBy: jordan.id },
+    { calendarSourceId: calFamily.id, title: 'Camping Weekend',          location: 'State Park',        allDay: true, startTime: atTime(daysFromNow(34), 0, 0), endTime: atTime(daysFromNow(36), 0, 0), color: '#EC4899', createdBy: alex.id },
+  ]);
+
+  console.log(`  Created 53 events (48 one-off + 5 recurring)`);
 
   // ─── CALENDAR NOTES ───────────────────────────────────────────────────────
   console.log('Creating calendar notes...');
@@ -686,9 +736,26 @@ async function seed() {
     { name: 'Pancakes',                  dayOfWeek: 'sunday',    mealType: 'breakfast', weekOf: nextWeekStart, recipeId: recipePancakes.id, createdBy: alex.id },
     { name: 'Grilled Chicken Salad',     dayOfWeek: 'monday',    mealType: 'dinner',    weekOf: nextWeekStart, createdBy: alex.id },
     { name: 'Taco Tuesday',              dayOfWeek: 'tuesday',   mealType: 'dinner',    weekOf: nextWeekStart, recipeId: recipeTacos.id,    createdBy: jordan.id },
+    // ── This week: fill in breakfasts, lunches, a Sunday dinner + snacks so
+    //    the meal planner reads as a full week for screenshots ──────────────
+    { name: 'Grilled cheese & tomato soup', dayOfWeek: 'sunday',    mealType: 'lunch',     weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Roast Chicken & Veggies',   dayOfWeek: 'sunday',    mealType: 'dinner',    weekOf: thisWeek, createdBy: alex.id },
+    { name: 'Turkey sandwiches',         dayOfWeek: 'monday',    mealType: 'lunch',     weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Scrambled eggs & toast',    dayOfWeek: 'tuesday',   mealType: 'breakfast', weekOf: thisWeek, createdBy: alex.id },
+    { name: 'Leftover spaghetti',        dayOfWeek: 'tuesday',   mealType: 'lunch',     weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Oatmeal & berries',         dayOfWeek: 'wednesday', mealType: 'breakfast', weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Chicken salad wraps',       dayOfWeek: 'wednesday', mealType: 'lunch',     weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Yogurt parfaits',           dayOfWeek: 'thursday',  mealType: 'breakfast', weekOf: thisWeek, createdBy: emma.id },
+    { name: 'Mac & cheese',              dayOfWeek: 'thursday',  mealType: 'lunch',     weekOf: thisWeek, createdBy: sophie.id },
+    { name: 'Fruit smoothies',           dayOfWeek: 'friday',    mealType: 'breakfast', weekOf: thisWeek, createdBy: alex.id },
+    { name: 'PB&J and apple slices',     dayOfWeek: 'friday',    mealType: 'lunch',     weekOf: thisWeek, createdBy: emma.id },
+    { name: 'Cheese & crackers',         dayOfWeek: 'friday',    mealType: 'snack',     weekOf: thisWeek, createdBy: sophie.id },
+    { name: 'Weekend Pancakes',          dayOfWeek: 'saturday',  mealType: 'breakfast', weekOf: thisWeek, recipeId: recipePancakes.id, createdBy: alex.id },
+    { name: 'Quesadillas',               dayOfWeek: 'saturday',  mealType: 'lunch',     weekOf: thisWeek, createdBy: jordan.id },
+    { name: 'Popcorn',                   dayOfWeek: 'saturday',  mealType: 'snack',     weekOf: thisWeek, createdBy: emma.id },
   ].map((m) => ({ ...m, date: seedMealDate(m.weekOf, m.dayOfWeek) })) as (typeof schema.meals.$inferInsert)[]);
 
-  console.log(`  Created 12 meal plans across this + next week`);
+  console.log(`  Created 27 meal plans across this + next week`);
 
   // ─── MAINTENANCE REMINDERS ────────────────────────────────────────────────
   console.log('Creating maintenance reminders...');
@@ -720,15 +787,83 @@ async function seed() {
   // ─── GOALS ────────────────────────────────────────────────────────────────
   console.log('Creating goals...');
 
-  await db.insert(schema.goals).values([
-    { name: 'Weekly Allowance', description: 'Earn your weekly spending money',   pointCost: 50,  emoji: '💰', priority: 1, recurring: true,  recurrencePeriod: 'weekly' },
-    { name: 'Ice Cream Trip',   description: 'Family trip to the ice cream shop', pointCost: 100, emoji: '🍦', priority: 2, recurring: false },
-    { name: 'Movie Night Pick', description: 'Pick the movie for family movie night', pointCost: 75, emoji: '🎬', priority: 3, recurring: false },
-    { name: 'New LEGO Set',     description: 'Earn a new LEGO set',               pointCost: 300, emoji: '🧱', priority: 4, recurring: false },
-    { name: 'Sleepover',        description: 'Host a sleepover with friends',     pointCost: 200, emoji: '🛏️', priority: 5, recurring: false },
-  ]);
+  const goalsResult = await db
+    .insert(schema.goals)
+    .values([
+      { name: 'Weekly Allowance', description: 'Earn your weekly spending money',   pointCost: 50,  emoji: '💰', priority: 1, recurring: true,  recurrencePeriod: 'weekly' },
+      { name: 'Ice Cream Trip',   description: 'Family trip to the ice cream shop', pointCost: 100, emoji: '🍦', priority: 2, recurring: false },
+      { name: 'Movie Night Pick', description: 'Pick the movie for family movie night', pointCost: 75, emoji: '🎬', priority: 3, recurring: false },
+      { name: 'New LEGO Set',     description: 'Earn a new LEGO set',               pointCost: 300, emoji: '🧱', priority: 4, recurring: false },
+      { name: 'Sleepover',        description: 'Host a sleepover with friends',     pointCost: 200, emoji: '🛏️', priority: 5, recurring: false },
+    ])
+    .returning();
+
+  const goalAllowance  = goalsResult[0]!;
+  const goalMovieNight = goalsResult[2]!;
 
   console.log(`  Created 5 goals`);
+
+  // ─── GOAL ACHIEVEMENTS (earned-points history) ────────────────────────────
+  // The weekly allowance is recurring, so each child earns it once per week —
+  // one row per (goal, child, week-start). Emma has hit it the last few weeks,
+  // Sophie most of them. Emma has also earned the one-off Movie Night Pick this
+  // cycle. periodStart mirrors getGoalPeriodKey(): recurring = start of week
+  // (Sunday), non-recurring = the goal's lastResetAt day (seeded "now").
+  console.log('Creating goal achievements...');
+
+  const goalAchievementRows: (typeof schema.goalAchievements.$inferInsert)[] = [];
+  for (const n of [0, 1, 2, 3]) {
+    goalAchievementRows.push({
+      goalId: goalAllowance.id,
+      userId: emma.id,
+      periodStart: ymd(startOfWeek(daysAgo(n * 7))),
+      achievedAt: atTime(daysAgo(n * 7), 18, 0),
+    });
+  }
+  for (const n of [0, 1, 2]) {
+    goalAchievementRows.push({
+      goalId: goalAllowance.id,
+      userId: sophie.id,
+      periodStart: ymd(startOfWeek(daysAgo(n * 7))),
+      achievedAt: atTime(daysAgo(n * 7), 18, 30),
+    });
+  }
+  goalAchievementRows.push({
+    goalId: goalMovieNight.id,
+    userId: emma.id,
+    periodStart: ymd(NOW),
+    achievedAt: atTime(daysAgo(2), 17, 0),
+  });
+
+  await db.insert(schema.goalAchievements).values(goalAchievementRows);
+
+  console.log(`  Created ${goalAchievementRows.length} goal achievements`);
+
+  // ─── BABYSITTER INFO ──────────────────────────────────────────────────────
+  console.log('Creating babysitter info...');
+
+  await db.insert(schema.babysitterInfo).values([
+    // Emergency contacts
+    { section: 'emergency_contact', sortOrder: 0, content: { name: 'Alex Parker',   relationship: 'Dad (cell)',              phone: '(555) 234-1010', isPrimary: 'true' } },
+    { section: 'emergency_contact', sortOrder: 1, content: { name: 'Jordan Parker', relationship: 'Mom (cell)',              phone: '(555) 234-1011', isPrimary: 'true' } },
+    { section: 'emergency_contact', sortOrder: 2, content: { name: 'Grandma Helen', relationship: 'Grandmother, 5 min away',  phone: '(555) 234-2020', isPrimary: 'false' } },
+    { section: 'emergency_contact', sortOrder: 3, content: { name: 'Poison Control', relationship: '24/7 hotline',            phone: '(800) 222-1222', isPrimary: 'false' } },
+    // House info (WiFi password + door code marked sensitive = PIN to reveal)
+    { section: 'house_info', sortOrder: 0, content: { label: 'Address',         value: '42 Maple Street, Springfield, IL' } },
+    { section: 'house_info', sortOrder: 1, content: { label: 'WiFi Network',    value: 'ParkerFamily' } },
+    { section: 'house_info', sortOrder: 2, content: { label: 'WiFi Password',   value: 'sunflower-2231' }, isSensitive: true },
+    { section: 'house_info', sortOrder: 3, content: { label: 'Front Door Code', value: '4297' }, isSensitive: true },
+    { section: 'house_info', sortOrder: 4, content: { label: 'Trash Day',       value: 'Friday morning, bins by the curb' } },
+    // Children
+    { section: 'child_info', sortOrder: 0, content: { name: 'Emma',   age: '11', allergies: 'None',                                medications: 'None', bedtime: '8:30 PM', notes: 'Reads before lights out. Nightlight stays on.' } },
+    { section: 'child_info', sortOrder: 1, content: { name: 'Sophie', age: '8',  allergies: 'Peanuts (EpiPen in kitchen drawer)', medications: 'None', bedtime: '7:30 PM', notes: 'Needs her stuffed otter to sleep. Story after teeth brushing.' } },
+    // House rules
+    { section: 'house_rule', sortOrder: 0, content: { rule: 'Screens off one hour before bedtime.',                    importance: 'high' } },
+    { section: 'house_rule', sortOrder: 1, content: { rule: 'Snacks are okay from the pantry, no candy after dinner.', importance: 'medium' } },
+    { section: 'house_rule', sortOrder: 2, content: { rule: 'Keep the back door locked and the pool gate closed.',     importance: 'high' } },
+  ]);
+
+  console.log(`  Created 14 babysitter info entries`);
 
   // ─── WISH LISTS (per-member items) ────────────────────────────────────────
   console.log('Creating wish lists...');


### PR DESCRIPTION
Enriches the demo seed so marketing/docs screenshots look realistic instead of sparse. All dates stay relative via the existing helpers (evergreen).

- **~50 calendar events** (was ~15): all-day, timed, and multi-day, spread from ~2 weeks back to ~5 weeks ahead, across all four members plus the shared Family calendar, alongside the existing recurring RRULE events. Month / multi-week / week views now look busy but believable.
- **Fuller meal plan** (27 entries): breakfast/lunch/dinner on most of the coming week, plus a couple snacks; existing recipe links preserved.
- **`goal_achievements`**: earned-points history so the Goals page shows progress bars and history.
- **`babysitter_info`**: contacts, house info, per-child notes, and rules so Babysitter mode renders (WiFi password and door code flagged sensitive).

Photos are loaded separately at runtime (they need image bytes on disk), not from the seed. `tsc --noEmit` clean.