### PR TITLE
fix(screenshots): wait for images before capture

### DIFF
--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -253,7 +253,7 @@ const SCREENSHOTS: CaptureSpec[] = [
     name: 'photos',
     url: '/photos',
     description: 'Photo gallery',
-    settleMs: 1500,
+    settleMs: 3500,
   },
 
   // ─── Travel Map ────────────────────────────────────────────
@@ -509,6 +509,24 @@ async function captureOnce(browser: Browser, spec: CaptureSpec): Promise<void> {
     // extra settle for animations + render finalization. Pass through the
     // spec's settleMs override; otherwise the function default applies.
     await waitForContentReady(page, spec.settleMs);
+
+    // Wait for any <img> (photo thumbnails, recipe images, avatars) to finish
+    // loading. waitForContentReady only tracks spinners/skeletons, not images,
+    // so without this the Photos gallery can capture blank thumbnails.
+    await page.evaluate(async () => {
+      const imgs = Array.from(document.images);
+      await Promise.all(
+        imgs.map((img) =>
+          img.complete && img.naturalWidth > 0
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => {
+                img.addEventListener('load', () => resolve(), { once: true });
+                img.addEventListener('error', () => resolve(), { once: true });
+                setTimeout(() => resolve(), 8000);
+              }),
+        ),
+      );
+    });
 
     const outPath = path.join(OUT_DIR, `${spec.name}.png`);
     await page.screenshot({ path: outPath, fullPage: false });


### PR DESCRIPTION
The first Refresh Screenshots run (#215) captured the Photos gallery with **blank thumbnails**: the settle wait polls for spinners/skeletons but not `<img>` loading, so the screenshot fired before the thumbnail fetches finished.

Fix: before each screenshot, wait for every `<img>` on the page to finish loading (or error/timeout at 8s), and give the Photos page a longer settle. This also protects any other image-backed pages (recipes, avatars).

After this merges, re-running the workflow updates #215 with correct photo thumbnails. `tsc` clean.