### PR TITLE
fix(screenshots): round 2 review fixes + meal emoji on thin clients

### DIFF
--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -212,8 +212,9 @@ const SCREENSHOTS: CaptureSpec[] = [
   {
     name: 'tasks',
     url: '/tasks',
-    description: 'Tasks page with multiple lists',
-    settleMs: 1000,
+    description: 'Tasks grouped by person',
+    settleMs: 1500,
+    setup: groupByPerson,
   },
 
   // ─── Chores ────────────────────────────────────────────────
@@ -244,8 +245,9 @@ const SCREENSHOTS: CaptureSpec[] = [
   {
     name: 'wishes',
     url: '/wishes',
-    description: 'Wish lists with claim tracking',
-    settleMs: 1000,
+    description: 'Wish lists grouped by person, with claim tracking',
+    settleMs: 1500,
+    setup: groupByPerson,
   },
 
   // ─── Photos ────────────────────────────────────────────────
@@ -299,6 +301,24 @@ async function loginAsAlex(page: Page) {
   }
 }
 
+/**
+ * Switch a list page (Tasks, Wishes) into group-by-person view via its "Group"
+ * filter dropdown, so the screenshot shows per-member columns. Best-effort: if
+ * the control isn't found the page is left in its default flat view.
+ */
+async function groupByPerson(page: Page): Promise<void> {
+  try {
+    // The FilterDropdown trigger's accessible name is its label ("Group").
+    await page.getByRole('button', { name: /^Group/ }).first().click({ timeout: 6000 });
+    // Options render as Radix menuitemcheckbox rows labelled "None" / "Person".
+    await page.getByRole('menuitemcheckbox', { name: /^Person$/ }).first().click({ timeout: 3000 });
+    await page.keyboard.press('Escape').catch(() => {});
+    await page.waitForTimeout(1000);
+  } catch {
+    // Leave the page in its default view.
+  }
+}
+
 /** Fetch a handful of Bing daily wallpapers (landscape + a few portrait). */
 async function fetchBingWallpapers(): Promise<{ name: string; buffer: Buffer }[]> {
   const bases: string[] = [];
@@ -312,8 +332,10 @@ async function fetchBingWallpapers(): Promise<{ name: string; buffer: Buffer }[]
     }
   }
   const jobs: { url: string; name: string }[] = [];
+  // Landscape and portrait must come from DISJOINT bases, or the same image
+  // shows up twice (once cropped landscape, once cropped portrait).
   bases.slice(0, 8).forEach((ub, i) => jobs.push({ url: `https://www.bing.com${ub}_1920x1080.jpg`, name: `demo-land-${i}.jpg` }));
-  bases.slice(0, 3).forEach((ub, i) => jobs.push({ url: `https://www.bing.com${ub}_1080x1920.jpg`, name: `demo-port-${i}.jpg` }));
+  bases.slice(8, 11).forEach((ub, i) => jobs.push({ url: `https://www.bing.com${ub}_1080x1920.jpg`, name: `demo-port-${i}.jpg` }));
   const out: { name: string; buffer: Buffer }[] = [];
   for (const job of jobs) {
     try {
@@ -421,9 +443,10 @@ async function captureOnce(browser: Browser, spec: CaptureSpec): Promise<void> {
     ({ theme, calendarView, calendarWeekCount, calendarDisplayMode }) => {
       try {
         if (theme) {
-          localStorage.setItem('theme', theme);
-          document.documentElement.classList.remove('light', 'dark');
-          document.documentElement.classList.add(theme);
+          // ThemeProvider reads the 'prism-theme' key (not 'theme') and toggles
+          // only the 'dark' class on <html>.
+          localStorage.setItem('prism-theme', theme);
+          document.documentElement.classList.toggle('dark', theme === 'dark');
         }
         if (calendarView) {
           localStorage.setItem('prism-calendar-view-type', calendarView);

--- a/src/app/meals/MealsView.tsx
+++ b/src/app/meals/MealsView.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import Link from 'next/link';
+import { Emoji } from '@/components/ui/Emoji';
 import { format, addDays, isBefore, startOfDay } from 'date-fns';
 import {
   UtensilsCrossed,
@@ -151,7 +152,7 @@ export function MealsView() {
                 }}
                 className="text-xs h-7 shrink-0"
               >
-                {getMealTypeEmoji(type)} {type.charAt(0).toUpperCase() + type.slice(1)}
+                <Emoji e={getMealTypeEmoji(type)} /> {type.charAt(0).toUpperCase() + type.slice(1)}
               </Button>
             );
           })}
@@ -309,7 +310,7 @@ function MealCard({ meal, onMarkCooked, onUnmarkCooked, onEdit, onDelete, onDrop
         touchDragging && 'opacity-50 scale-95'
       )}
     >
-      <span className="text-lg shrink-0">{getMealTypeEmoji(meal.mealType)}</span>
+      <span className="text-lg shrink-0"><Emoji e={getMealTypeEmoji(meal.mealType)} /></span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <span className={cn('text-sm font-medium', isCooked && 'line-through text-muted-foreground')}>{meal.name}</span>
@@ -503,7 +504,7 @@ export function MealModal({ weekOf, meal, defaultDay, dayOptions, recipes, onClo
             <div className="flex gap-2 mt-1 flex-wrap">
               {(['breakfast', 'lunch', 'dinner', 'snack'] as const).map((type) => (
                 <Button key={type} type="button" variant={mealType === type ? 'default' : 'outline'} size="sm" onClick={() => setMealType(type)} className="capitalize">
-                  {getMealTypeEmoji(type)} {type}
+                  <Emoji e={getMealTypeEmoji(type)} /> {type}
                 </Button>
               ))}
             </div>

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -260,52 +260,27 @@ async function seed() {
   // back to ~5 weeks ahead. Colors follow each source (family/Jordan pink,
   // Alex blue, Emma green, Sophie amber).
   await db.insert(schema.events).values([
-    // ── Past two weeks (historic fill) ──────────────────────────────────────
-    { calendarSourceId: calAlex.id,   title: 'Quarterly Planning',       location: 'Office',            startTime: atTime(daysAgo(13), 9, 0),  endTime: atTime(daysAgo(13), 11, 0), color: '#3B82F6', createdBy: alex.id },
-    { calendarSourceId: calFamily.id, title: 'School Closed',            allDay: true, startTime: atTime(daysAgo(12), 0, 0), endTime: atTime(daysAgo(11), 0, 0), color: '#EC4899', createdBy: jordan.id },
+    // ── Past two weeks ──────────────────────────────────────────────────────
     { calendarSourceId: calEmma.id,   title: 'Soccer Game',              location: 'Community Park',    startTime: atTime(daysAgo(11), 10, 0), endTime: atTime(daysAgo(11), 11, 30), color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calSophie.id, title: 'Swim Lesson',              location: 'Rec Center',        startTime: atTime(daysAgo(10), 16, 0), endTime: atTime(daysAgo(10), 16, 45), color: '#F59E0B', createdBy: jordan.id },
-    { calendarSourceId: calJordan.id, title: 'Yoga Class',               location: 'Sunrise Studio',    startTime: atTime(daysAgo(9), 7, 30),  endTime: atTime(daysAgo(9), 8, 30),  color: '#EC4899', createdBy: jordan.id },
-    { calendarSourceId: calFamily.id, title: 'Farmers Market',           location: 'Town Square',       startTime: atTime(daysAgo(8), 9, 0),   endTime: atTime(daysAgo(8), 11, 0),  color: '#EC4899', createdBy: alex.id },
     { calendarSourceId: calAlex.id,   title: 'Dentist',                  location: "Dr. Smith's Office", startTime: atTime(daysAgo(6), 8, 0),  endTime: atTime(daysAgo(6), 8, 45),  color: '#3B82F6', createdBy: alex.id },
-    { calendarSourceId: calEmma.id,   title: 'Library Reading Club',     location: 'Public Library',    startTime: atTime(daysAgo(5), 15, 30), endTime: atTime(daysAgo(5), 16, 30), color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calSophie.id, title: 'Playdate with Mia',        startTime: atTime(daysAgo(4), 15, 0),  endTime: atTime(daysAgo(4), 17, 0),  color: '#F59E0B', createdBy: jordan.id },
     { calendarSourceId: calFamily.id, title: "Dinner at Grandma Helen's", startTime: atTime(daysAgo(3), 17, 30), endTime: atTime(daysAgo(3), 20, 0), color: '#EC4899', createdBy: jordan.id },
-    { calendarSourceId: calJordan.id, title: 'Volunteer at Food Bank',   location: 'Community Center',  startTime: atTime(daysAgo(2), 9, 0),   endTime: atTime(daysAgo(2), 12, 0),  color: '#EC4899', createdBy: jordan.id },
-    { calendarSourceId: calAlex.id,   title: 'Haircut',                  startTime: atTime(daysAgo(1), 12, 0),  endTime: atTime(daysAgo(1), 12, 30), color: '#3B82F6', createdBy: alex.id },
-    // ── This week and next (near-term busy) ─────────────────────────────────
+    // ── This week and next ──────────────────────────────────────────────────
     { calendarSourceId: calSophie.id, title: 'Piano Lesson',             startTime: atTime(daysFromNow(2), 16, 0),  endTime: atTime(daysFromNow(2), 16, 45), color: '#F59E0B', createdBy: jordan.id },
-    { calendarSourceId: calAlex.id,   title: 'Client Call',              startTime: atTime(daysFromNow(2), 14, 0),  endTime: atTime(daysFromNow(2), 15, 0),  color: '#3B82F6', createdBy: alex.id },
     { calendarSourceId: calEmma.id,   title: 'Art Class',                location: 'Community Center',  startTime: atTime(daysFromNow(3), 16, 0),  endTime: atTime(daysFromNow(3), 17, 0),  color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calJordan.id, title: 'Doctor Checkup',           startTime: atTime(daysFromNow(4), 10, 0),  endTime: atTime(daysFromNow(4), 11, 0),  color: '#EC4899', createdBy: jordan.id },
     { calendarSourceId: calFamily.id, title: 'No School: Teacher Workday', allDay: true, startTime: atTime(daysFromNow(4), 0, 0), endTime: atTime(daysFromNow(5), 0, 0), color: '#EC4899', createdBy: jordan.id },
     { calendarSourceId: calFamily.id, title: 'Neighborhood BBQ',         startTime: atTime(daysFromNow(6), 12, 0),  endTime: atTime(daysFromNow(6), 15, 0),  color: '#EC4899', createdBy: alex.id },
-    { calendarSourceId: calEmma.id,   title: "Sleepover at Mia's",       allDay: true, startTime: atTime(daysFromNow(6), 0, 0), endTime: atTime(daysFromNow(7), 0, 0), color: '#10B981', createdBy: jordan.id },
     { calendarSourceId: calSophie.id, title: 'Birthday Party for Lucas', startTime: atTime(daysFromNow(7), 14, 0),  endTime: atTime(daysFromNow(7), 16, 0),  color: '#F59E0B', createdBy: jordan.id },
     // ── Two to three weeks out ──────────────────────────────────────────────
     { calendarSourceId: calAlex.id,   title: 'Work Conference',          location: 'Chicago',           allDay: true, startTime: atTime(daysFromNow(9), 0, 0), endTime: atTime(daysFromNow(12), 0, 0), color: '#3B82F6', createdBy: alex.id },
     { calendarSourceId: calEmma.id,   title: 'Field Trip: Science Museum', allDay: true, startTime: atTime(daysFromNow(11), 0, 0), endTime: atTime(daysFromNow(12), 0, 0), color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calSophie.id, title: 'Dentist',                  startTime: atTime(daysFromNow(12), 9, 0),  endTime: atTime(daysFromNow(12), 9, 45), color: '#F59E0B', createdBy: jordan.id },
-    { calendarSourceId: calJordan.id, title: 'Girls Night Out',          startTime: atTime(daysFromNow(12), 19, 0), endTime: atTime(daysFromNow(12), 22, 0), color: '#EC4899', createdBy: jordan.id },
     { calendarSourceId: calFamily.id, title: 'Family Movie Night',       startTime: atTime(daysFromNow(13), 19, 0), endTime: atTime(daysFromNow(13), 21, 0), color: '#EC4899', createdBy: alex.id },
-    // ── Spring break and a weekend trip ─────────────────────────────────────
+    // ── A few weeks out ─────────────────────────────────────────────────────
     { calendarSourceId: calFamily.id, title: 'Beach Trip',               location: 'Coastline',         allDay: true, startTime: atTime(daysFromNow(16), 0, 0), endTime: atTime(daysFromNow(19), 0, 0), color: '#EC4899', createdBy: alex.id },
-    { calendarSourceId: calEmma.id,   title: 'Summer Camp Registration Opens', startTime: atTime(daysFromNow(18), 10, 0), endTime: atTime(daysFromNow(18), 10, 30), color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calAlex.id,   title: 'Back to Office',           startTime: atTime(daysFromNow(20), 9, 0),  endTime: atTime(daysFromNow(20), 17, 0), color: '#3B82F6', createdBy: alex.id },
-    // ── Four to five weeks out ──────────────────────────────────────────────
-    { calendarSourceId: calSophie.id, title: 'Soccer Tryouts',           location: 'Community Park',    startTime: atTime(daysFromNow(22), 16, 0), endTime: atTime(daysFromNow(22), 17, 30), color: '#F59E0B', createdBy: jordan.id },
-    { calendarSourceId: calJordan.id, title: 'Bake Sale (parent volunteer)', location: 'Maple Elementary', startTime: atTime(daysFromNow(23), 8, 0), endTime: atTime(daysFromNow(23), 10, 0), color: '#EC4899', createdBy: jordan.id },
-    { calendarSourceId: calAlex.id,   title: 'Car Service',              location: 'Auto Shop',         startTime: atTime(daysFromNow(24), 8, 0),  endTime: atTime(daysFromNow(24), 9, 0),  color: '#3B82F6', createdBy: alex.id },
-    { calendarSourceId: calFamily.id, title: "Grandpa Joe's Birthday Dinner", startTime: atTime(daysFromNow(25), 18, 0), endTime: atTime(daysFromNow(25), 20, 0), color: '#EC4899', createdBy: jordan.id },
     { calendarSourceId: calEmma.id,   title: 'Piano Recital',            location: 'School Auditorium', startTime: atTime(daysFromNow(26), 18, 0), endTime: atTime(daysFromNow(26), 19, 30), color: '#10B981', createdBy: jordan.id },
-    { calendarSourceId: calFamily.id, title: 'Community Fun Run',        allDay: true, startTime: atTime(daysFromNow(27), 0, 0), endTime: atTime(daysFromNow(28), 0, 0), color: '#EC4899', createdBy: alex.id },
-    { calendarSourceId: calSophie.id, title: 'Field Day',                location: 'Maple Elementary',  allDay: true, startTime: atTime(daysFromNow(30), 0, 0), endTime: atTime(daysFromNow(31), 0, 0), color: '#F59E0B', createdBy: jordan.id },
-    { calendarSourceId: calAlex.id,   title: 'Team Lunch',               startTime: atTime(daysFromNow(31), 12, 0), endTime: atTime(daysFromNow(31), 13, 0), color: '#3B82F6', createdBy: alex.id },
-    { calendarSourceId: calJordan.id, title: 'Dentist',                  startTime: atTime(daysFromNow(33), 14, 0), endTime: atTime(daysFromNow(33), 14, 45), color: '#EC4899', createdBy: jordan.id },
     { calendarSourceId: calFamily.id, title: 'Camping Weekend',          location: 'State Park',        allDay: true, startTime: atTime(daysFromNow(34), 0, 0), endTime: atTime(daysFromNow(36), 0, 0), color: '#EC4899', createdBy: alex.id },
   ]);
 
-  console.log(`  Created 53 events (48 one-off + 5 recurring)`);
+  console.log(`  Created 25 events (20 one-off + 5 recurring)`);
 
   // ─── CALENDAR NOTES ───────────────────────────────────────────────────────
   console.log('Creating calendar notes...');
@@ -787,7 +762,7 @@ async function seed() {
   // ─── GOALS ────────────────────────────────────────────────────────────────
   console.log('Creating goals...');
 
-  const goalsResult = await db
+  await db
     .insert(schema.goals)
     .values([
       { name: 'Weekly Allowance', description: 'Earn your weekly spending money',   pointCost: 50,  emoji: '💰', priority: 1, recurring: true,  recurrencePeriod: 'weekly' },
@@ -795,49 +770,9 @@ async function seed() {
       { name: 'Movie Night Pick', description: 'Pick the movie for family movie night', pointCost: 75, emoji: '🎬', priority: 3, recurring: false },
       { name: 'New LEGO Set',     description: 'Earn a new LEGO set',               pointCost: 300, emoji: '🧱', priority: 4, recurring: false },
       { name: 'Sleepover',        description: 'Host a sleepover with friends',     pointCost: 200, emoji: '🛏️', priority: 5, recurring: false },
-    ])
-    .returning();
-
-  const goalAllowance  = goalsResult[0]!;
-  const goalMovieNight = goalsResult[2]!;
+    ]);
 
   console.log(`  Created 5 goals`);
-
-  // ─── GOAL ACHIEVEMENTS (earned-points history) ────────────────────────────
-  // The weekly allowance is recurring, so each child earns it once per week —
-  // one row per (goal, child, week-start). Emma has hit it the last few weeks,
-  // Sophie most of them. Emma has also earned the one-off Movie Night Pick this
-  // cycle. periodStart mirrors getGoalPeriodKey(): recurring = start of week
-  // (Sunday), non-recurring = the goal's lastResetAt day (seeded "now").
-  console.log('Creating goal achievements...');
-
-  const goalAchievementRows: (typeof schema.goalAchievements.$inferInsert)[] = [];
-  for (const n of [0, 1, 2, 3]) {
-    goalAchievementRows.push({
-      goalId: goalAllowance.id,
-      userId: emma.id,
-      periodStart: ymd(startOfWeek(daysAgo(n * 7))),
-      achievedAt: atTime(daysAgo(n * 7), 18, 0),
-    });
-  }
-  for (const n of [0, 1, 2]) {
-    goalAchievementRows.push({
-      goalId: goalAllowance.id,
-      userId: sophie.id,
-      periodStart: ymd(startOfWeek(daysAgo(n * 7))),
-      achievedAt: atTime(daysAgo(n * 7), 18, 30),
-    });
-  }
-  goalAchievementRows.push({
-    goalId: goalMovieNight.id,
-    userId: emma.id,
-    periodStart: ymd(NOW),
-    achievedAt: atTime(daysAgo(2), 17, 0),
-  });
-
-  await db.insert(schema.goalAchievements).values(goalAchievementRows);
-
-  console.log(`  Created ${goalAchievementRows.length} goal achievements`);
 
   // ─── BABYSITTER INFO ──────────────────────────────────────────────────────
   console.log('Creating babysitter info...');


### PR DESCRIPTION
Addresses the first screenshot review. Mix of a real code fix and demo/capture tuning.

## Code fix
- **`fix(meals)`** — meal-type emoji were raw emoji chars in a `<span>` (missed by the emoji→Twemoji sweep), so they render **blank on any browser without a color-emoji font** (kiosk/thin-client Chromium, and the CI capture). Now routed through the `<Emoji>` component like the rest of the app. Fixes the empty circles on the meal planner.

## Capture script
- **Dark mode** now actually dark: the script wrote the wrong localStorage key (`theme`); the provider reads **`prism-theme`**.
- **Tasks & Wishes** are set to **group-by-person** via their Group filter.
- **No duplicate photos**: portrait wallpapers now come from Bing bases disjoint from the landscape set.

## Seed
- Removed the `goal_achievements` that made a goal show **"achieved" while the progress bars were below target** (Emma 35/50, Sophie 28/50). Goals now show honest progress.
- **Trimmed the calendar** from ~53 to ~25 events so month/week views look active but not cluttered.

Not changed: the **Send-to-Kroger** button is already present on the mobile shopping view (icon-only, the paper-airplane in the header) — it renders whenever the active list has unchecked items, not gated on mobile. Happy to add a label on mobile if you want it more obvious.

tsc + eslint clean. After merge I re-run the workflow to regenerate #215.