### PR TITLE
feat(calendar): pin meals to the bottom of each cards-mode day cell

### DIFF
--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -205,22 +205,6 @@ export function DayColumn({
         )}
       </div>
 
-      {showMeals &&
-        bucket.meals.map((meal) => (
-          <WeekItemCard
-            key={`meal-${meal.id}`}
-            variant="meal"
-            size={profile.itemSize}
-            layout={itemLayout}
-            stripeColor={mealStripeColor(meal)}
-            title={meal.name}
-            timeLabel={meal.mealType}
-            subtitle={meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined}
-            muted={Boolean(meal.cookedAt)}
-            dragId={disableDrop ? undefined : `meal:${meal.id}`}
-          />
-        ))}
-
       {showAllDay &&
         bucket.allDayEvents.map((event) => (
           <WeekItemCard
@@ -249,6 +233,13 @@ export function DayColumn({
           />
         ))}
 
+      {/* Skylight-style: events lead; the day's meals/chores/tasks form a
+          delineated planning group below, separated by a thin divider, with
+          meals pinned to the very bottom of the cell. */}
+      {(showChores || showTasks || showMeals) && (showAllDay || showTimed) && (
+        <div className="my-0.5 shrink-0 border-t border-border/40" aria-hidden />
+      )}
+
       {showChores &&
         bucket.chores.map((chore) => (
           <WeekItemCard
@@ -276,6 +267,22 @@ export function DayColumn({
             subtitle={task.assignedTo?.name}
             muted={task.completed}
             dragId={disableDrop ? undefined : `task:${task.id}`}
+          />
+        ))}
+
+      {showMeals &&
+        bucket.meals.map((meal) => (
+          <WeekItemCard
+            key={`meal-${meal.id}`}
+            variant="meal"
+            size={profile.itemSize}
+            layout={itemLayout}
+            stripeColor={mealStripeColor(meal)}
+            title={meal.name}
+            timeLabel={meal.mealType}
+            subtitle={meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined}
+            muted={Boolean(meal.cookedAt)}
+            dragId={disableDrop ? undefined : `meal:${meal.id}`}
           />
         ))}
 

--- a/src/components/calendar/cells/OverlayItemsCell.tsx
+++ b/src/components/calendar/cells/OverlayItemsCell.tsx
@@ -76,21 +76,6 @@ export function OverlayItemsCell({
 
   return (
     <div className={cn('flex flex-col gap-1', className)}>
-      {meals.map((meal) => (
-        <WeekItemCard
-          key={`meal-${meal.id}`}
-          variant="meal"
-          size={size}
-          layout={layout}
-          stripeColor={mealColor ?? mealStripeColor(meal)}
-          title={meal.name}
-          timeLabel={meal.mealType}
-          subtitle={meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined}
-          muted={Boolean(meal.cookedAt)}
-          dragId={enableDrag ? `meal:${meal.id}` : undefined}
-          onClick={onItemClick ? () => onItemClick({ kind: 'meal', id: meal.id }) : undefined}
-        />
-      ))}
       {chores.map((chore) => (
         <WeekItemCard
           key={`chore-${chore.id}`}
@@ -117,6 +102,22 @@ export function OverlayItemsCell({
           muted={task.completed}
           dragId={enableDrag ? `task:${task.id}` : undefined}
           onClick={onItemClick ? () => onItemClick({ kind: 'task', id: task.id }) : undefined}
+        />
+      ))}
+      {/* Meals pinned to the bottom (Skylight-style), consistent with DayColumn. */}
+      {meals.map((meal) => (
+        <WeekItemCard
+          key={`meal-${meal.id}`}
+          variant="meal"
+          size={size}
+          layout={layout}
+          stripeColor={mealColor ?? mealStripeColor(meal)}
+          title={meal.name}
+          timeLabel={meal.mealType}
+          subtitle={meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined}
+          muted={Boolean(meal.cookedAt)}
+          dragId={enableDrag ? `meal:${meal.id}` : undefined}
+          onClick={onItemClick ? () => onItemClick({ kind: 'meal', id: meal.id }) : undefined}
         />
       ))}
     </div>


### PR DESCRIPTION
Follows the Skylight pattern: in cards mode, **events lead** each day cell, and the day's **meals/chores/tasks form a delineated planning group below** (thin divider), with **meals pinned to the very bottom**. Previously meals rendered *above* the events, mixing the two.

- `DayColumn.tsx` (week cards): order is now all-day → timed events → divider → chores → tasks → **meals**.
- `OverlayItemsCell.tsx` (month overlay): meals moved to the bottom of the meals/chores/tasks stack for consistency.

Scope: cards mode only (inline/agenda/list stay events-only and compact, as before). tsc clean.

After merge I re-run the screenshots workflow so the calendar shots regenerate against this layout.