### PR TITLE
fix(calendar): meals to cell bottom in multi-week & month cards views

### DIFF
--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -328,6 +328,10 @@ function DayCardsCell({
           <DayOverflowPopover date={date} hiddenEvents={hidden} onEventClick={onEventClick} />
         </div>
       )}
+      {/* Thin divider between events and the meals/chores/tasks overlay row. */}
+      {bucket && overlayItemCount > 0 && (visible.length > 0 || hidden.length > 0) && (
+        <div className="my-0.5 shrink-0 border-t border-border/40" aria-hidden />
+      )}
       {bucket && (
         <div onClick={(e) => e.stopPropagation()}>
           <DroppableOverlayCell

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -306,18 +306,6 @@ function DayCell({
           compact ? 'px-1 pb-1' : 'px-1.5 pb-1.5',
         )}
       >
-        {cards && bucket && bucket.meals.length > 0 && (
-          <DroppableOverlayCell
-            date={date}
-            bucket={bucket}
-            size={cardSize}
-            layout="column"
-            enableDnd={enableDnd}
-            include={{ meals: true, chores: false, tasks: false }}
-            mealColor={mealColor}
-            onItemClick={onItemClick}
-          />
-        )}
         {cards
           ? visibleEvents.map((event) => {
               // Only locally-managed events are safe to drag; external (Google,
@@ -362,6 +350,13 @@ function DayCell({
             onEventClick={onEventClick}
           />
         )}
+        {/* Skylight-style: events lead; a thin divider separates the day's
+            planning group (chores, tasks, then meals pinned at the very bottom). */}
+        {cards && bucket
+          && (bucket.meals.length + bucket.chores.length + bucket.tasks.length) > 0
+          && (visibleEvents.length > 0 || hiddenEvents.length > 0) && (
+          <div className="my-0.5 shrink-0 border-t border-border/40" aria-hidden />
+        )}
         {cards && bucket && (bucket.chores.length > 0 || bucket.tasks.length > 0) && (
           <DroppableOverlayCell
             date={date}
@@ -370,6 +365,18 @@ function DayCell({
             layout="column"
             enableDnd={enableDnd}
             include={{ meals: false, chores: true, tasks: true }}
+            onItemClick={onItemClick}
+          />
+        )}
+        {cards && bucket && bucket.meals.length > 0 && (
+          <DroppableOverlayCell
+            date={date}
+            bucket={bucket}
+            size={cardSize}
+            layout="column"
+            enableDnd={enableDnd}
+            include={{ meals: true, chores: false, tasks: false }}
+            mealColor={mealColor}
             onItemClick={onItemClick}
           />
         )}


### PR DESCRIPTION
Follow-up to #218. That PR moved meals in `DayColumn`/`OverlayItemsCell`, but the **multi-week and month cards views compose their day cells directly**, so meals were still rendering at the top there (caught in the regenerated screenshot).

- **`MultiWeekView`**: the meals overlay moved from above the events to the bottom of the cell, below chores/tasks, with a thin divider separating events from the planning group.
- **`MonthView`**: added the matching thin divider before the meals/chores/tasks overlay row (meals already sort last via #218).

Result across cards views: **events → divider → chores/tasks → meals (bottom)**. tsc clean.