### PR TITLE
feat(calendar): float cards-mode planning group to the cell bottom

### DIFF
--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -328,9 +328,10 @@ function DayCardsCell({
           <DayOverflowPopover date={date} hiddenEvents={hidden} onEventClick={onEventClick} />
         </div>
       )}
-      {/* Thin divider between events and the meals/chores/tasks overlay row. */}
+      {/* Overlay row floats to the bottom of the cell (Skylight-style), with the
+          whitespace above delineating it from the events. */}
       {bucket && overlayItemCount > 0 && (visible.length > 0 || hidden.length > 0) && (
-        <div className="my-0.5 shrink-0 border-t border-border/40" aria-hidden />
+        <div className="mt-auto shrink-0 border-t border-border/40 pt-0.5" aria-hidden />
       )}
       {bucket && (
         <div onClick={(e) => e.stopPropagation()}>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -328,13 +328,16 @@ function DayCardsCell({
           <DayOverflowPopover date={date} hiddenEvents={hidden} onEventClick={onEventClick} />
         </div>
       )}
-      {/* Overlay row floats to the bottom of the cell (Skylight-style), with the
-          whitespace above delineating it from the events. */}
-      {bucket && overlayItemCount > 0 && (visible.length > 0 || hidden.length > 0) && (
-        <div className="mt-auto shrink-0 border-t border-border/40 pt-0.5" aria-hidden />
-      )}
+      {/* Meals/chores/tasks overlay floats to the bottom of the cell, inside a
+          faint theme-aware band (when populated) that delineates it from events. */}
       {bucket && (
-        <div onClick={(e) => e.stopPropagation()}>
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'mt-auto',
+            overlayItemCount > 0 && 'rounded-md bg-black/[0.04] px-1 py-0.5 dark:bg-white/[0.05]',
+          )}
+        >
           <DroppableOverlayCell
             date={date}
             bucket={bucket}

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -335,7 +335,7 @@ function DayCardsCell({
           onClick={(e) => e.stopPropagation()}
           className={cn(
             'mt-auto',
-            overlayItemCount > 0 && 'rounded-md bg-black/[0.04] px-1 py-0.5 dark:bg-white/[0.05]',
+            overlayItemCount > 0 && 'rounded-md bg-muted/60 px-1.5 py-1 ring-1 ring-border/50',
           )}
         >
           <DroppableOverlayCell

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -350,36 +350,35 @@ function DayCell({
             onEventClick={onEventClick}
           />
         )}
-        {/* Skylight-style: events lead; the day's planning group (chores,
-            tasks, then meals) floats to the bottom of the cell via mt-auto, so
-            the whitespace above it delineates it from the events. */}
-        {cards && bucket
-          && (bucket.meals.length + bucket.chores.length + bucket.tasks.length) > 0
-          && (visibleEvents.length > 0 || hiddenEvents.length > 0) && (
-          <div className="mt-auto shrink-0 border-t border-border/40 pt-0.5" aria-hidden />
-        )}
-        {cards && bucket && (bucket.chores.length > 0 || bucket.tasks.length > 0) && (
-          <DroppableOverlayCell
-            date={date}
-            bucket={bucket}
-            size={cardSize}
-            layout="column"
-            enableDnd={enableDnd}
-            include={{ meals: false, chores: true, tasks: true }}
-            onItemClick={onItemClick}
-          />
-        )}
-        {cards && bucket && bucket.meals.length > 0 && (
-          <DroppableOverlayCell
-            date={date}
-            bucket={bucket}
-            size={cardSize}
-            layout="column"
-            enableDnd={enableDnd}
-            include={{ meals: true, chores: false, tasks: false }}
-            mealColor={mealColor}
-            onItemClick={onItemClick}
-          />
+        {/* Skylight-style: events lead; the day's planning group (chores, tasks,
+            then meals) floats to the bottom of the cell (mt-auto) inside a faint
+            theme-aware band that delineates it from the events. */}
+        {cards && bucket && (bucket.meals.length + bucket.chores.length + bucket.tasks.length) > 0 && (
+          <div className="mt-auto flex flex-col gap-1 rounded-md bg-black/[0.04] p-1 dark:bg-white/[0.05]">
+            {(bucket.chores.length > 0 || bucket.tasks.length > 0) && (
+              <DroppableOverlayCell
+                date={date}
+                bucket={bucket}
+                size={cardSize}
+                layout="column"
+                enableDnd={enableDnd}
+                include={{ meals: false, chores: true, tasks: true }}
+                onItemClick={onItemClick}
+              />
+            )}
+            {bucket.meals.length > 0 && (
+              <DroppableOverlayCell
+                date={date}
+                bucket={bucket}
+                size={cardSize}
+                layout="column"
+                enableDnd={enableDnd}
+                include={{ meals: true, chores: false, tasks: false }}
+                mealColor={mealColor}
+                onItemClick={onItemClick}
+              />
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -350,12 +350,13 @@ function DayCell({
             onEventClick={onEventClick}
           />
         )}
-        {/* Skylight-style: events lead; a thin divider separates the day's
-            planning group (chores, tasks, then meals pinned at the very bottom). */}
+        {/* Skylight-style: events lead; the day's planning group (chores,
+            tasks, then meals) floats to the bottom of the cell via mt-auto, so
+            the whitespace above it delineates it from the events. */}
         {cards && bucket
           && (bucket.meals.length + bucket.chores.length + bucket.tasks.length) > 0
           && (visibleEvents.length > 0 || hiddenEvents.length > 0) && (
-          <div className="my-0.5 shrink-0 border-t border-border/40" aria-hidden />
+          <div className="mt-auto shrink-0 border-t border-border/40 pt-0.5" aria-hidden />
         )}
         {cards && bucket && (bucket.chores.length > 0 || bucket.tasks.length > 0) && (
           <DroppableOverlayCell

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -354,7 +354,7 @@ function DayCell({
             then meals) floats to the bottom of the cell (mt-auto) inside a faint
             theme-aware band that delineates it from the events. */}
         {cards && bucket && (bucket.meals.length + bucket.chores.length + bucket.tasks.length) > 0 && (
-          <div className="mt-auto flex flex-col gap-1 rounded-md bg-black/[0.04] p-1 dark:bg-white/[0.05]">
+          <div className="mt-auto flex flex-col gap-1 rounded-md bg-muted/60 p-1.5 ring-1 ring-border/50">
             {(bucket.chores.length > 0 || bucket.tasks.length > 0) && (
               <DroppableOverlayCell
                 date={date}


### PR DESCRIPTION
Refines the Skylight layout: the day's planning group (chores → tasks → meals) now uses `mt-auto` to float to the **bottom edge** of each cards-mode cell, so the whitespace above it delineates it from the events, rather than the group following the events directly. Applies to `MultiWeekView` and `MonthView`. tsc clean.

Deployed to the review instance for a look before merge.