### PR TITLE
docs+ci: log calendar/meals changes; wire optional PAT into screenshots workflow

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -113,6 +113,10 @@ jobs:
       - name: Open a PR with the refreshed screenshots
         uses: peter-evans/create-pull-request@v6
         with:
+          # Prefer a repo PAT (SCREENSHOTS_PAT) so the PR is opened by a real user
+          # and its CI runs automatically. Falls back to GITHUB_TOKEN if the secret
+          # is not set (in which case the PR needs a close/reopen to trigger checks).
+          token: ${{ secrets.SCREENSHOTS_PAT || github.token }}
           branch: chore/refresh-screenshots
           delete-branch: true
           add-paths: docs/demos/*.png
@@ -124,5 +128,6 @@ jobs:
 
             Review the image diffs, then merge.
 
-            Note: this PR is opened with `GITHUB_TOKEN`, so the merge checks may not run automatically.
-            Close and reopen it (or push an empty commit) to trigger them, or merge with admin rights.
+            If a `SCREENSHOTS_PAT` repo secret is configured, this PR is opened by it and CI runs
+            automatically. Otherwise it falls back to `GITHUB_TOKEN`, whose PRs do not trigger CI:
+            close and reopen this PR (or push an empty commit) to run the checks.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to Prism are documented in this file.
 ### Dashboard
 - **The built-in templates were rebuilt around real composition principles.** Each board now leads with one hero (usually the calendar), sizes every widget to its natural shape (birthdays runs tall rather than wide, the clock stays small, weather gets room for its sun/moon detail) and arranges them into a couple of balanced zones instead of an even grid packed with too many panels. The new lineup is **Family Central, Calendar Focus, Command Center, Meal Planner, School Mornings**, and a photo-forward **Ambient** whose glassy clock and weather float over your wallpaper.
 
+### Calendar
+- **Meals now sit at the bottom of each day cell in cards mode.** The events lead the cell, and the day's chores, tasks, and meals are grouped in a delineated band pinned to the bottom (meals last), so the schedule and the day's plan read as separate zones.
+
+### Meals
+- **Meal-type icons render everywhere, including thin clients.** The breakfast, lunch, and dinner icons now use Prism's self-hosted emoji images, so they display on kiosk and thin-client browsers that cannot render a color-emoji font, instead of showing blank.
+
 ### Screensaver
 - **Refreshed screensaver templates.** The calendar (or tonight's meals) is the hero; the clock, weather and messages are small, aligned accents floating over one clean photo region, calmer and less cluttered, with everything sitting fully on-screen.
 
@@ -14,7 +20,7 @@ All notable changes to Prism are documented in this file.
 - **Sunrise, sunset, moonrise and moonset now show their times** along the sun/moon arc. The arc and the hourly timeline appear only when the widget is tall enough to draw them cleanly, so a short widget no longer clips them.
 
 ### Community layouts
-- **Redesigned the community-layouts gallery.** The preview boards now float on a wallpaper-style field with cleaner cards, a header with a live count, calmer search and size filters, and a clear **Apply layout** button, so browsing and applying a shared layout is easier to scan. The bundled community layouts were also regenerated to the current grid so they apply correctly.
+- **Redesigned the community-layouts gallery.** The preview boards now float on a wallpaper-style field with cleaner cards, a header with a live count, calmer search, and a **Landscape / Portrait** orientation filter (which defaults to the board you are editing), so browsing and applying a shared layout is easier to scan. The bundled community layouts were also regenerated to the current grid so they apply correctly. Sharing your own layout opens a pre-filled submission form.
 
 ### Layout editor
 - **"Save As" confirmations are no longer trapped** behind the editor overlay, when a dashboard name already exists you can now see and act on the confirm/cancel prompt.

--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -109,7 +109,7 @@ On phones, calendar views collapse to Agenda only: no view switcher, no chevrons
 The **View Options** gear (next to the view dropdown) lets you switch between two ways of laying out events within each day cell:
 
 - **Inline**: compact rows of event titles. Original look. Highest event density per cell.
-- **Cards**: each day becomes a small card with meals at top, events in the middle, chores+tasks at bottom. A dynamic capacity probe respects your font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped.
+- **Cards**: each day becomes a small card. The events lead the cell, and the day's chores, tasks, and meals are grouped in a delineated band pinned to the bottom (meals last), so the schedule and the day's plan read as separate zones. A dynamic capacity probe respects your font scale and viewport. Overflow folds into a "+N more" popover so nothing is silently clipped.
 
 Cards mode is what unlocks drag-and-drop and overlays.
 


### PR DESCRIPTION
Closes the loose ends after the calendar + screenshot work.

## Docs / logs
- **CHANGELOG**: added **Calendar** (meals now at the bottom of each cards-mode day cell) and **Meals** (meal-type icons render on thin clients) entries, and corrected the community-gallery entry to describe the **orientation** filter (it previously said "size filters").
- **`CALENDAR.md`**: updated the cards-mode cell description to "events lead, planning band at the bottom" (was the stale meals-at-top order).

## Screenshots workflow PAT
- `create-pull-request` now uses `${{ secrets.SCREENSHOTS_PAT || github.token }}`. If a `SCREENSHOTS_PAT` repo secret is set, the auto-opened screenshot PR is authored by a real user and **its CI runs automatically** (no more close/reopen). Falls back to `GITHUB_TOKEN` if the secret is absent.

**Action needed to activate:** create a fine-grained PAT with Contents + Pull requests write on this repo, add it as the repo secret `SCREENSHOTS_PAT`. (Details in the follow-up message.)