### PR TITLE
security(scan-pii): remove real PII literals from the scanner's own files

### DIFF
--- a/scripts/prism-pii-denylist.example.txt
+++ b/scripts/prism-pii-denylist.example.txt
@@ -10,7 +10,7 @@
 # fails the push/commit if any tracked file contains one of these values. This
 # is the reliable catch for your EXACT PII anywhere in the tree, with zero false
 # positives. The built-in rules in scan-pii.sh already catch the general classes
-# (your tallacker domain, non-allowlisted emails, private/Tailscale IPs), so
+# (non-allowlisted emails, private/Tailscale IPs), so
 # this file is for the specifics they can't know.
 #
 # Format: one fixed-string entry per line. '#' comments and blank lines ignored.

--- a/scripts/scan-pii.sh
+++ b/scripts/scan-pii.sh
@@ -8,7 +8,6 @@
 #      maintainer-PII we know we care about, tuned against the tree so they do
 #      NOT trip on legitimate security code (SSRF guards use private ranges) or
 #      test fixtures (10.0.0.5, 169.254.169.254) or vendor/system emails.
-#        - the maintainer's own domain (tallacker)
 #        - any email address other than an allowlisted one
 #        - a specific private / Tailscale-CGNAT / link-local IP host in a
 #          non-test, non-SSRF-guard file (the "real LAN IP in a comment" bug)
@@ -26,7 +25,9 @@
 # Path: $PRISM_PII_DENYLIST (env var) OR ~/.config/prism-pii-denylist.txt
 # Format: one fixed-string entry per line; '#' comments and blank lines ignored.
 # MUST live outside the repo and MUST NOT be committed. Populate with:
-#   - Real LAN / Tailscale IPs (e.g. 192.168.1.236, 100.x.y.z)
+#   - Real LAN / Tailscale IPs (e.g. 192.168.x.x, 10.x.x.x, 100.x.y.z)
+#   - The real WAN/host DOMAIN(S) you use (this is the reliable catch for the
+#     specific domain — it is intentionally NOT hardcoded in this public file)
 #   - Real names of household members (first AND last)
 #   - Street address, school name, employer name
 #   - Phone numbers (anything not 555-01xx reserved-for-fiction)
@@ -52,15 +53,16 @@ EMAIL_ALLOW='(@example\.(com|org|net|edu)|@users\.noreply\.github\.com|sandydarg
 
 builtin=""
 
-# 1. The maintainer's own domain, anywhere.
-m=$(printf '%s\n' "$REPO_FILES" | xargs -d '\n' grep -inHE 'tallacker' 2>/dev/null || true)
-[ -n "$m" ] && builtin+="$m"$'\n'
+# NOTE: the maintainer's SPECIFIC domain/host literals are deliberately NOT
+# hardcoded here — this file is public and must never itself carry that PII.
+# The specific domain is caught by Layer 2 (the external denylist) everywhere,
+# and by scan-hostnames.sh generically when it appears in a comment.
 
-# 2. Any email not on the allowlist, anywhere.
+# 1. Any email not on the allowlist, anywhere.
 m=$(printf '%s\n' "$REPO_FILES" | xargs -d '\n' grep -inHoE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' 2>/dev/null | grep -viE "$EMAIL_ALLOW" || true)
 [ -n "$m" ] && builtin+="$m"$'\n'
 
-# 3. A specific private / CGNAT / link-local IP HOST (not a /CIDR range, not a
+# 2. A specific private / CGNAT / link-local IP HOST (not a /CIDR range, not a
 #    .0.0 network) in a file that is not an SSRF guard or a test fixture.
 m=$(printf '%s\n' "$REPO_FILES" | grep -vE "$IP_EXCLUDE" \
   | xargs -d '\n' grep -inHE '\b(192\.168|10\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])|169\.254)\.[0-9]{1,3}\.[0-9]{1,3}\b' 2>/dev/null \


### PR DESCRIPTION
Found while scanning the forks (per the leak follow-up): PR #224 accidentally re-introduced the exact values it protects against — the literal \`192.0.2.10\` and the maintainer domain — as **examples inside the scanner's own doc comments**. Since \`scan-pii.sh\` and the denylist template are (necessarily) excluded from their own scan, CI couldn't catch it. The lesson generalises: a file excluded from its own scan is a blind spot, and the place an example value gets typed is the comment explaining what the scanner catches.

## Fix
- **Drop the hardcoded domain rule** from \`scan-pii.sh\`. A public file must never carry the literal it's meant to detect. The specific domain is still caught by the external **denylist** (Layer 2, any file/context) and by **scan-hostnames.sh** (generically, in comments — verified against the real \`//\`-comment leak shape).
- **Genericize** the example IP in the denylist doc block → \`192.168.x.x\`.
- **Remove** the domain word from the denylist template prose.

## Verified
- \`git grep\` for \`example-host\` and \`192.0.2.10\` → **zero** hits anywhere in the tree.
- Scanners still catch injected PII: built-in rules flag an injected private IP + non-allowlisted email; the denylist + scan-hostnames flag the domain.

Note: I also confirmed \`setup-https.ps1\` and \`login/route.ts\` are already clean on current \`master\` — the fork copies are just frozen at pre-genericization commits (history-remediation territory, tracked separately).

