### PR TITLE
chore(privacy): remove maintainer PII from doc/comment examples

### DIFF
--- a/docs/code-review-modalities.md
+++ b/docs/code-review-modalities.md
@@ -24,7 +24,7 @@ Real Prism bugs in this class that survived adversarial review and were caught b
 | Toolbar icons invisible under wallpaper z-index in perf mode | Render |
 | `/api/family` POST blocked initial setup wizard | User-flow |
 | Auto-hide UI making toolbar appear "broken" | User-flow |
-| Real first names ("Eric"/"Kim") in `formatters.test.ts` fixtures | Cross-artifact (PII) |
+| Real first names in `formatters.test.ts` fixtures | Cross-artifact (PII) |
 | `scan-pii.sh` couldn't find the denylist when run via npm-spawned bash on WSL | Cross-environment (path resolution) |
 | `scan-pii.sh` ran 30+ seconds on a 50-entry denylist (per-entry loop instead of single-pass `grep -f`) | Performance / algorithmic |
 
@@ -81,7 +81,7 @@ Whole-word, fixed-string grep that fails if any tracked file contains items from
 2. (Optional) install the pre-push hook so it runs before every `git push`: `npm run scan:pii:install-hook`.
 3. Run manually anytime: `npm run scan:pii`.
 
-The denylist file MUST live outside the repo and MUST NOT be committed — committed values would defeat the purpose. The script exits cleanly (with a warning) when the file is absent, so contributors who haven't set one up don't have their pushes blocked. Why it catches what LLM review misses: an LLM has no way of knowing whether `'Eric'` is fictional or refers to the maintainer's spouse; a maintainer-curated denylist closes that gap with one deterministic grep.
+The denylist file MUST live outside the repo and MUST NOT be committed — committed values would defeat the purpose. The script exits cleanly (with a warning) when the file is absent, so contributors who haven't set one up don't have their pushes blocked. Why it catches what LLM review misses: an LLM has no way of knowing whether a given first name is fictional or refers to a real family member; a maintainer-curated denylist closes that gap with one deterministic grep.
 
 ### Placeholder / example audit — `scripts/scan-examples.sh`
 

--- a/src/app/api/location-search/route.ts
+++ b/src/app/api/location-search/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
     const results: LocationCandidate[] = [];
 
     // Postal-code path. A bare number in a fuzzy free-text search returns noisy
-    // matches (e.g. "60062" also hits a Greek municipality), so resolve postal
+    // matches (e.g. a bare US ZIP can also hit a foreign municipality), so resolve postal
     // codes authoritatively and return them directly:
     //  1. OWM's zip endpoint when a key is configured, else
     //  2. a KEYLESS Nominatim *structured* postalcode query (one clean result).


### PR DESCRIPTION
Prep for the history redaction. Two committed files used real maintainer identifiers as *examples*:
- `docs/code-review-modalities.md` named real first names as the PII example (in the doc describing the PII scanner itself — and this file is scanner-excluded, so the built-in scan never caught it).
- `src/app/api/location-search/route.ts` had a comment example that should have used a fictional value.

Genericized both. **Comment/doc only, no behavior change.** This clears the current tree so the follow-up history rewrite only has to touch old commits.
