### PR TITLE
fix(screensaver): let calendar view controls work without dismissing

### DIFF
--- a/src/components/widgets/CalendarWidgetControls.tsx
+++ b/src/components/widgets/CalendarWidgetControls.tsx
@@ -77,7 +77,10 @@ export function CalendarWidgetControls({
   return (
     // Layout mirrors the calendar subpage toolbar: Today | < > | view menu |
     // gear popover. All controls share h-8 so the toolbar reads as one band.
-    <div className="flex items-stretch gap-1" onClick={(e) => e.stopPropagation()}>
+    // data-screensaver-keep: taps on these controls must NOT dismiss the
+    // screensaver overlay, so the view can be changed in place. useIdleDetection
+    // checks for this attribute before dismissing on pointer-down.
+    <div className="flex items-stretch gap-1" data-screensaver-keep onClick={(e) => e.stopPropagation()}>
       {/* Navigation (hidden in agenda-only mode) */}
       {availableViews.length > 1 && resolvedView !== 'agenda' && (
         <>
@@ -198,7 +201,7 @@ function ViewPopover({
             <ChevronDown className="h-3 w-3 opacity-60 shrink-0" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-32 p-1">
+        <PopoverContent align="end" className="w-32 p-1" data-screensaver-keep>
           {VIEW_OPTIONS.map((opt) => {
             const isActive = opt.value === viewType;
             const isAvailable = availableViews.includes(opt.value);

--- a/src/lib/hooks/useIdleDetection.ts
+++ b/src/lib/hooks/useIdleDetection.ts
@@ -98,15 +98,27 @@ export function useIdleDetection(initialTimeout?: number) {
     const moveEvents = ['mousemove', 'scroll'] as const;
     moveEvents.forEach((e) => window.addEventListener(e, resetTimer));
 
-    // Click/key/touch dismiss the screensaver AND reset the timer
+    // Click/key/touch dismiss the screensaver AND reset the timer — EXCEPT when
+    // the interaction targets an opt-in "keep-alive" control (e.g. the calendar
+    // view switcher), so those can be operated in place without exiting the
+    // screensaver. Checking the native event target covers portaled controls
+    // (like the view popover, which renders under <body>) that stopPropagation
+    // on the React tree would miss.
+    const maybeDismiss = (e: Event) => {
+      const target = e.target as Element | null;
+      if (target && typeof target.closest === 'function' && target.closest('[data-screensaver-keep]')) {
+        return;
+      }
+      dismissIdle();
+    };
     const dismissEvents = ['mousedown', 'keydown', 'touchstart'] as const;
-    dismissEvents.forEach((e) => window.addEventListener(e, dismissIdle));
+    dismissEvents.forEach((e) => window.addEventListener(e, maybeDismiss));
 
     resetTimer();
 
     return () => {
       moveEvents.forEach((e) => window.removeEventListener(e, resetTimer));
-      dismissEvents.forEach((e) => window.removeEventListener(e, dismissIdle));
+      dismissEvents.forEach((e) => window.removeEventListener(e, maybeDismiss));
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [resetTimer, dismissIdle, timeout, isPWA]);


### PR DESCRIPTION
**Problem:** on the screensaver, tapping the calendar's view switcher dismissed the overlay instead of changing the view — the first pointer-down anywhere triggers the `window` mousedown/touchstart listener in `useIdleDetection` that unmounts the screensaver ("I can only click once").

**Fix:** an opt-in `data-screensaver-keep` marker. `useIdleDetection` now checks the native event target and skips dismissal when the tap lands inside a marked control. Applied to the calendar toolbar wrapper and the view popover. Checking the *native* target (not React-tree `stopPropagation`) matters because the popover portals to `<body>`, so its option clicks would otherwise still reach `window`.

Result: Today / prev-next / the view menu / the ▲▼ cycler all change the calendar in place on the screensaver; tapping anywhere else still exits as before. No behavior change on the dashboard/subpage. `tsc` clean.