### PR TITLE
fix(screensaver): let taps reach widgets so calendar controls actually react

### DIFF
--- a/src/components/screensaver/Screensaver.tsx
+++ b/src/components/screensaver/Screensaver.tsx
@@ -94,16 +94,20 @@ export function Screensaver() {
         visible ? 'opacity-100' : 'opacity-0'
       }`}
     >
+      {/* Decorative layers are absolutely positioned, so in CSS paint order they
+          sit ABOVE the (statically-positioned) widget grid and would swallow every
+          tap. pointer-events-none lets taps fall through to the widgets — needed
+          for the calendar view controls to be operable on the screensaver. */}
       {src && (
         <div
-          className="absolute inset-0 bg-cover bg-center transition-opacity duration-1000"
+          className="pointer-events-none absolute inset-0 bg-cover bg-center transition-opacity duration-1000"
           style={{
             backgroundImage: `url(${src})`,
             opacity: fadingOut ? 0 : 1,
           }}
         />
       )}
-      <div className="absolute inset-0 bg-black/40" />
+      <div className="pointer-events-none absolute inset-0 bg-black/40" />
       <ScreensaverGrid />
     </div>
   );


### PR DESCRIPTION
Follow-up to #228. The view controls still didn't react to taps on the screensaver because the decorative layers (photo background + `bg-black/40` tint) are `absolute` (positioned) while the widget grid is static — so in CSS paint order they render **above** the widgets and intercept every pointer event. The tap never reached the view button, and the idle-guard saw the overlay (no `data-screensaver-keep`) as the target, so it dismissed.

Fix: `pointer-events-none` on the two decorative layers so taps fall through to the widget grid. Now the calendar view controls receive taps (and the #228 guard keeps them from dismissing); tapping any non-control area still exits. One-line-per-layer change; `tsc` clean.