### PR TITLE
fix(oauth): fall back to APP_URL when redirect_uri resolves to a private IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,13 @@ NODE_ENV=production
 PORT=3000
 
 # Public URL where users access the dashboard.
-# If using HTTPS (recommended): https://your-domain.com or https://your-server-ip
+# If using HTTPS (recommended): https://your-domain.com
 # The setup wizard will help you configure this correctly.
+# Also used as the OAuth redirect fallback: redirect URIs are normally derived
+# from the request, but if a request arrives over a private IP / plain HTTP
+# (e.g. reaching Prism directly on the LAN), the callback falls back to this
+# public HTTPS URL — which providers like Google require. Set it to your real
+# https domain so Google/Microsoft sign-in works from any entry point.
 APP_URL=http://localhost:3000
 
 # --- Security Secrets ---

--- a/src/lib/integrations/__tests__/resolveRedirectUri.test.ts
+++ b/src/lib/integrations/__tests__/resolveRedirectUri.test.ts
@@ -1,0 +1,67 @@
+import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
+
+/** Minimal stand-in for the parts of Request that resolveRedirectUri reads. */
+function req(url: string, headers: Record<string, string> = {}): Request {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    url,
+    headers: { get: (k: string) => lower[k.toLowerCase()] ?? null },
+  } as unknown as Request;
+}
+
+const CB = '/api/auth/google/callback';
+
+describe('resolveRedirectUri', () => {
+  const original = process.env.APP_URL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = original;
+  });
+
+  it('derives an https public host from forwarded headers (unchanged)', () => {
+    process.env.APP_URL = 'https://elsewhere.example.com';
+    const r = req('http://prism-app:3000/api/auth/google', {
+      'x-forwarded-host': 'prism.example.com',
+      'x-forwarded-proto': 'https',
+    });
+    // A valid public https origin is respected, not overridden by APP_URL —
+    // this preserves the multi-host behaviour (#124).
+    expect(resolveRedirectUri(r, CB)).toBe('https://prism.example.com/api/auth/google/callback');
+  });
+
+  it('falls back to APP_URL when reached directly on a private IP over http', () => {
+    process.env.APP_URL = 'https://prism.example.com';
+    const r = req('http://192.168.1.5:3000/api/auth/google', { host: '192.168.1.5:3000' });
+    expect(resolveRedirectUri(r, CB)).toBe('https://prism.example.com/api/auth/google/callback');
+  });
+
+  it('falls back even when the private host is served over https', () => {
+    process.env.APP_URL = 'https://prism.example.com';
+    const r = req('http://10.0.0.4:3000/api/auth/google', {
+      host: '10.0.0.4:3000',
+      'x-forwarded-proto': 'https',
+    });
+    expect(resolveRedirectUri(r, CB)).toBe('https://prism.example.com/api/auth/google/callback');
+  });
+
+  it('keeps the derived value when APP_URL is unset', () => {
+    delete process.env.APP_URL;
+    const r = req('http://192.168.1.5:3000/api/auth/google', { host: '192.168.1.5:3000' });
+    expect(resolveRedirectUri(r, CB)).toBe('http://192.168.1.5:3000/api/auth/google/callback');
+  });
+
+  it('keeps the derived value when APP_URL is itself non-public (dev localhost)', () => {
+    process.env.APP_URL = 'http://localhost:3000';
+    const r = req('http://192.168.1.5:3000/api/auth/google', { host: '192.168.1.5:3000' });
+    expect(resolveRedirectUri(r, CB)).toBe('http://192.168.1.5:3000/api/auth/google/callback');
+  });
+
+  it('does not override a plain-http public host unless APP_URL is public https', () => {
+    process.env.APP_URL = 'https://prism.example.com';
+    // Public hostname but plain http (no TLS / no forwarded-proto) — providers
+    // still need https, so the public fallback applies.
+    const r = req('http://prism.example.org/api/auth/google', { host: 'prism.example.org' });
+    expect(resolveRedirectUri(r, CB)).toBe('https://prism.example.com/api/auth/google/callback');
+  });
+});

--- a/src/lib/integrations/resolveRedirectUri.ts
+++ b/src/lib/integrations/resolveRedirectUri.ts
@@ -1,3 +1,5 @@
+import { isPrivateHostname } from '@/lib/utils/safeFetch';
+
 /**
  * Resolve an OAuth redirect URI from the current request, honoring reverse-proxy
  * forwarded headers (Cloudflare Tunnel, nginx, etc.).
@@ -23,5 +25,34 @@ export function resolveRedirectUri(request: Request, callbackPath: string): stri
   const url = new URL(request.url);
   const host = xfHost ?? headers.get('host') ?? url.host;
   const proto = xfProto ?? url.protocol.replace(':', '');
-  return `${proto}://${host}${callbackPath}`;
+  const derived = `${proto}://${host}${callbackPath}`;
+
+  // OAuth providers (notably Google) reject private-IP / non-HTTPS redirect
+  // URIs. If the request resolved to one — usually because Prism was reached
+  // directly on the LAN (http://192.168.x.x:3000) instead of through its public
+  // HTTPS proxy — fall back to the configured public base URL (APP_URL) so the
+  // provider still gets a valid redirect_uri. When APP_URL is unset or itself
+  // non-public (the dev default localhost), the derived value is kept, so
+  // multi-host setups (#124) and local development are unaffected.
+  if (proto !== 'https' || isPrivateHostname(hostnameOf(host))) {
+    const base = process.env.APP_URL;
+    if (base) {
+      try {
+        const b = new URL(base);
+        if (b.protocol === 'https:' && !isPrivateHostname(b.hostname)) {
+          return new URL(callbackPath, b).toString();
+        }
+      } catch { /* malformed APP_URL — fall through to the derived value */ }
+    }
+  }
+  return derived;
+}
+
+/** Extract the bare hostname (no port, no IPv6 brackets) from a Host value. */
+function hostnameOf(host: string): string {
+  try {
+    return new URL(`http://${host}`).hostname;
+  } catch {
+    return host;
+  }
 }

--- a/src/lib/utils/safeFetch.ts
+++ b/src/lib/utils/safeFetch.ts
@@ -95,6 +95,17 @@ function unbracket(host: string): string {
 }
 
 /**
+ * True if `host` (a hostname or IP literal, port already stripped) is not
+ * publicly routable: a localhost name, RFC1918 / loopback / link-local / CGNAT
+ * IPv4, or a private IPv6. Used to decide when a request-derived OAuth redirect
+ * URI can't be handed to a public provider (e.g. Google rejects private IPs).
+ */
+export function isPrivateHostname(host: string): boolean {
+  const h = unbracket(host);
+  return isLocalhostName(h) || isPrivateIPv4(h) || isPrivateIPv6(h);
+}
+
+/**
  * Parse PRISM_ALLOWED_INTERNAL_HOSTS into a list of allowlist entries.
  * Entries may be separated by commas, spaces, or newlines — whichever reads
  * best in your .env. Each entry is a hostname, IP literal, or IPv4 CIDR range.


### PR DESCRIPTION
**Problem (hit in the wild):** Google refused sign-in with `device_id and device_name are required for private IP` because `resolveRedirectUri` derived `http://192.168.x.x:3000/api/auth/google/callback` — a private IP over HTTP, which Google (and most providers) reject. This happens whenever Prism is reached directly on the LAN instead of through its public HTTPS proxy.

**Fix:** if the request-derived origin is a private IP or plain HTTP, fall back to the configured public base URL (`APP_URL`) when that is public HTTPS. A valid public https origin is still respected (multi-host derivation from #124 preserved); local dev (`APP_URL` unset or `localhost`) is unchanged, so nothing regresses.

- Reuses vetted range logic via a new exported `isPrivateHostname` in `safeFetch.ts`.
- Documents `APP_URL`'s redirect-fallback role in `.env.example`.
- 6 unit tests for resolveRedirectUri.

Relevant to #178 (self-serve hosting): turns a hard OAuth failure into a working default once the operator sets `APP_URL` to their domain.