### PR TITLE
fix(screensaver): calendar view popover, options menu & hide-hours usable

### DIFF
--- a/src/app/calendar/ViewOptionsMenu.tsx
+++ b/src/app/calendar/ViewOptionsMenu.tsx
@@ -161,7 +161,7 @@ export function ViewOptionsMenu({
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-64 p-2">
+      <PopoverContent align="end" className="w-64 p-2 z-[10000]" data-screensaver-keep>
         <div className="space-y-3">
           <section>
             <p className="mb-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -136,6 +136,7 @@ export function DayViewSideBySide({
             <div className="w-16 flex-shrink-0 flex items-center justify-center">
               <button
                 onClick={toggleHidden}
+                data-screensaver-keep
                 className={cn(
                   'p-1.5 rounded-full transition-colors',
                   hiddenSettings.enabled

--- a/src/components/widgets/CalendarWidgetControls.tsx
+++ b/src/components/widgets/CalendarWidgetControls.tsx
@@ -201,7 +201,7 @@ function ViewPopover({
             <ChevronDown className="h-3 w-3 opacity-60 shrink-0" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-32 p-1" data-screensaver-keep>
+        <PopoverContent align="end" className="w-32 p-1 z-[10000]" data-screensaver-keep>
           {VIEW_OPTIONS.map((opt) => {
             const isActive = opt.value === viewType;
             const isAvailable = availableViews.includes(opt.value);


### PR DESCRIPTION
Follow-up to #228/#231. Two remaining gaps kept calendar controls unusable on the screensaver:

- **Popovers opened *behind* the overlay.** The view popover and options menu (`PopoverContent`, `z-50`) portal to `<body>`, so they rendered underneath the `z-[9999]` screensaver — invisible/untappable. Raised to `z-[10000]`, and marked the options menu `data-screensaver-keep` (the view popover already was).
- **Hide-hours dismissed.** The toggle in `DayViewSideBySide` had no `data-screensaver-keep`, so tapping it exited. Marked it.

Now every calendar control — view list, ▲▼ cycle, Today/prev/next, options menu, hide-hours — operates in place on the screensaver; tapping elsewhere still exits. `tsc` clean.