### PR TITLE
fix(keyboard): stop first key tap from dismissing the virtual keyboard

### DIFF
--- a/src/components/input/VirtualKeyboard.tsx
+++ b/src/components/input/VirtualKeyboard.tsx
@@ -203,14 +203,18 @@ export function VirtualKeyboard() {
         height: '38vh', minHeight: 320, maxHeight: 480,
         display: visible ? undefined : 'none',
       }}
-      onPointerDown={e => { e.stopPropagation(); e.preventDefault(); }}
-      // simple-keyboard stops the pointerdown before it reaches this container,
-      // so the preventDefault above never runs and the active input loses focus
-      // on any key tap (Shift/symbols) — the global focusout handler then reads
-      // that as "done" and hides the keyboard. The mousedown still bubbles here;
-      // preventing its default keeps focus on the input so tapping keys no longer
-      // dismisses the keyboard. (#125)
-      onMouseDown={e => { e.preventDefault(); }}
+      // Keep focus on the active input when a key is tapped. simple-keyboard
+      // swallows the BUBBLING pointerdown before it reaches this container, so
+      // the old bubble-phase preventDefault never ran on touch — the first tap
+      // blurred the input, the global focusout handler hid the keyboard, and the
+      // character was lost (mouse worked only because a bubbling mousedown still
+      // arrived). Preventing default in the CAPTURE phase runs BEFORE
+      // simple-keyboard's own handler, so it reliably stops the blur on touch and
+      // mouse alike. simple-keyboard still receives the event (preventDefault
+      // cancels only the focus/compat-event default, not propagation), so the key
+      // press still registers. (#125)
+      onPointerDownCapture={e => { e.preventDefault(); }}
+      onMouseDownCapture={e => { e.preventDefault(); }}
     >
       <div
         ref={containerRef}


### PR DESCRIPTION
**Bug:** on a touch display (seen on the Messages subpage), tapping a blank field opens the on-screen keyboard, but the **first key tap immediately folds it away and prints nothing**.

**Cause:** tapping a key blurs the active input → the global `focusout` handler (`useGlobalInput`) hides the keyboard. simple-keyboard's keys are non-focusable divs, so `relatedTarget` is null and the 'focus moved into keyboard' guard doesn't apply. The prior fix preventDefaulted the *bubbling* mousedown, but simple-keyboard swallows the bubbling pointerdown and touch emits no usable mousedown — so it never fired on touch.

**Fix:** preventDefault in the **capture** phase (`onPointerDownCapture` + `onMouseDownCapture`), which runs *before* simple-keyboard's handler, keeping the input focused on touch and mouse. simple-keyboard still gets the event (propagation untouched), so the keypress registers. `tsc` clean.