### PR TITLE
fix(deploy): ship public/ (service worker) with local deploys

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -18,6 +18,13 @@ docker cp .next/standalone/. prism-app:/app/
 docker exec --user root prism-app sh -c "rm -rf /app/.next/static && mkdir -p /app/.next/static"
 docker cp .next/static/. prism-app:/app/.next/static/
 
+# Public assets, incl. the PWA service worker. Next.js standalone output does
+# NOT bundle public/, so without this the container keeps the image's stale
+# sw.js — its precache manifest points at old chunk hashes, so browsers keep
+# serving an outdated app (and can't cleanly update) after every deploy.
+docker cp public/. prism-app:/app/public/
+docker exec --user root prism-app chown -R nextjs:nodejs /app/public
+
 # The standalone bundle ships empty data/ dirs (recipe-images, photos). The
 # docker cp above lays them over the bind-mounted /app/data, resetting it to
 # the host uid so the container user (nextjs) can no longer write uploads


### PR DESCRIPTION
`deploy-local.sh` copied `.next/` but not `public/`, so the container kept serving the image's stale `sw.js`. Its precache manifest referenced old chunk hashes, so browsers served an outdated app and couldn't cleanly update after each deploy (surfaced as 'deployed fix not taking effect'). Now the script also `docker cp public/.` into the container and chowns it, keeping the service worker consistent with the freshly built assets.