### PR TITLE
fix(keyboard): keep keyboard open on key tap via focusout refocus (touch-safe)

### DIFF
--- a/docs/features/global-input-system.md
+++ b/docs/features/global-input-system.md
@@ -137,13 +137,35 @@ if (lastPointerType === 'touch' && !isMobile && !suppressedForScan && virtualKey
 **`focusout`:**
 ```ts
 const next = e.relatedTarget as Element | null;
-if (next && isInsideKeyboard(next)) return; // keyboard buttons stole focus, ignore
+if (next && isInsideKeyboard(next)) return; // focus moved to a focusable keyboard control
+// Keyboard keys are non-focusable <div>s, so tapping one blurs the input with a
+// NULL relatedTarget. Detect that via the pointerdown target we tracked and
+// restore focus instead of tearing the keyboard down.
+if (pointerOnKeyboardRef.current) {
+  const el = activeContentEditableRef.current ?? activeInputRef.current;
+  if (el) { el.focus({ preventScroll: true }); return; }
+}
 activeInputRef.current = null;
 setKeyboardVisible(false);
 restoreScroll();
 ```
 
 `isInsideKeyboard(el)` checks `el.closest('[data-virtual-keyboard]')`.
+
+> **⚠️ Recurring bug — "first key tap dismisses the keyboard" (#125 → #135 → #234 → and again).**
+> Tapping a key blurs the focused input (keys are non-focusable divs → null
+> `relatedTarget`), so `focusout` hid the keyboard and the character was lost.
+> Earlier fixes tried to *prevent the blur* — `onPointerDown`/`onMouseDown`/
+> `onPointerDownCapture` `preventDefault` on the keyboard container — but
+> simple-keyboard swallows the pointerdown and touch displays emit no usable
+> mousedown, so each patch fixed only one input path (mouse, or one key group).
+> **The durable fix does not rely on preventDefault or relatedTarget:** track
+> whether the last `pointerdown` landed inside `[data-virtual-keyboard]`
+> (`pointerOnKeyboardRef`), and in `focusout` re-focus the active field when it
+> did. `setKeyboardVisible(false)` clears that flag so the ↓/Enter keys still
+> close the keyboard. If this regresses again, verify `pointerOnKeyboardRef` is
+> being set on `pointerdown` and read in `focusout` — don't add another
+> `preventDefault`.
 
 **`keydown`:** physical keyboard auto-dismiss (§9) + barcode buffer (§5).
 

--- a/src/lib/hooks/useGlobalInput.tsx
+++ b/src/lib/hooks/useGlobalInput.tsx
@@ -85,6 +85,15 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
   const suppressedForScan = useRef(false);
   const lastPointerTypeRef = useRef<'touch' | 'mouse' | 'keyboard'>('mouse');
   const textInjectedWhileOpen = useRef(false);
+  // True while the most recent pointerdown landed on the virtual keyboard. The
+  // durable guard against the recurring "first key tap dismisses the keyboard"
+  // bug (#125/#135/#234): keyboard keys are non-focusable divs, so tapping one
+  // blurs the input with a null relatedTarget and the focusout handler used to
+  // tear the keyboard down. We instead detect the keyboard-origin blur here and
+  // restore focus, independent of preventDefault (which simple-keyboard defeats)
+  // and of relatedTarget (always null for div keys). See global-input-system.md.
+  const pointerOnKeyboardRef = useRef(false);
+  const keyboardVisibleRef = useRef(false);
 
   // Read virtual keyboard setting (default enabled)
   const [virtualKeyboardEnabled, setVirtualKeyboardEnabled] = useState(true);
@@ -111,6 +120,10 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
     input.dispatchEvent(new Event('change', { bubbles: true }));
     textInjectedWhileOpen.current = true;
   }, []);
+
+  // Mirror keyboardVisible into a ref so the document event handlers (bound once)
+  // can read the live value without re-binding.
+  useEffect(() => { keyboardVisibleRef.current = keyboardVisible; }, [keyboardVisible]);
 
   // ---- audio feedback ----
   const playBeep = useCallback(async () => {
@@ -222,6 +235,10 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
     if (visible) {
       textInjectedWhileOpen.current = false;
     } else {
+      // Explicit close (↓ dismiss / Enter). Clear the keyboard-tap flag so the
+      // blur those keys trigger isn't caught by the focusout refocus guard,
+      // which would otherwise immediately reopen the keyboard.
+      pointerOnKeyboardRef.current = false;
       if (!textInjectedWhileOpen.current) restoreScroll();
       textInjectedWhileOpen.current = false;
     }
@@ -246,6 +263,8 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
       } else if (e.pointerType === 'mouse') {
         lastPointerTypeRef.current = 'mouse';
       }
+      const t = e.target;
+      pointerOnKeyboardRef.current = t instanceof Element && isInsideKeyboard(t);
     };
 
     const onFocusIn = (e: FocusEvent) => {
@@ -271,14 +290,26 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
         !suppressedForScan.current &&
         virtualKeyboardEnabled
       ) {
+        const wasVisible = keyboardVisibleRef.current;
         setKeyboardVisibleState(true);
-        scrollInputIntoView(target);
+        // Don't re-scroll when this focusin is the restore-focus that follows a
+        // keyboard key tap — the keyboard is already open and in place.
+        if (!wasVisible) scrollInputIntoView(target);
       }
     };
 
     const onFocusOut = (e: FocusEvent) => {
       const next = e.relatedTarget as Element | null;
       if (next && isInsideKeyboard(next)) return;
+      // Tapping a virtual-keyboard key blurs the input (its keys are
+      // non-focusable divs, so relatedTarget is null). Restore focus to the
+      // active field and keep the keyboard open, rather than tearing it down —
+      // this is the touch-safe fix for the recurring first-tap-dismiss bug that
+      // preventDefault (swallowed by simple-keyboard) never reliably solved.
+      if (pointerOnKeyboardRef.current) {
+        const el = activeContentEditableRef.current ?? activeInputRef.current;
+        if (el) { el.focus({ preventScroll: true }); return; }
+      }
       activeInputRef.current = null;
       activeContentEditableRef.current = null;
       setIsInputFocused(false);


### PR DESCRIPTION
The 'first key tap dismisses the on-screen keyboard' bug has recurred through #125 → #135 → #234 because every fix tried to *prevent the blur* with `preventDefault` on the keyboard container — which simple-keyboard defeats (it swallows the pointerdown) and touch has no usable mousedown, so each patch only closed one input path.

**Durable fix, independent of preventDefault/relatedTarget:** track whether the last `pointerdown` landed inside `[data-virtual-keyboard]` (`pointerOnKeyboardRef`); in `focusout`, re-focus the active field when it did, instead of hiding. `setKeyboardVisible(false)` clears the flag so ↓/Enter still close it; `onFocusIn` skips re-scroll when already visible so restore-focus doesn't jitter. Root cause + 'don't add another preventDefault' guidance added to `global-input-system.md`. `tsc` clean.

Note: touch-timing, can't be exercised in CI — verified by the maintainer on the display (Settings → Backup → Clear Cache & Reload to pick up the build).