### PR TITLE
fix(overlays): don't close dialogs/popovers when tapping the virtual keyboard

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -51,11 +51,22 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, onInteractOutside, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      // The on-screen virtual keyboard portals to <body>, outside this dialog.
+      // Without this guard, tapping a key counts as an "outside" interaction and
+      // Radix closes the dialog — so a keystroke into any dialog field would shut
+      // the dialog and be lost. Ignore interactions that originate in the keyboard.
+      onInteractOutside={(e) => {
+        const t = (e.detail?.originalEvent?.target ?? null) as Element | null;
+        if (t && typeof t.closest === 'function' && t.closest('[data-virtual-keyboard]')) {
+          e.preventDefault();
+        }
+        onInteractOutside?.(e);
+      }}
       className={cn(
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg',
         'translate-x-[-50%] translate-y-[-50%] gap-4',

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -11,12 +11,22 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, onInteractOutside, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      // The virtual keyboard portals to <body>, outside this popover; without
+      // this guard, tapping a key counts as an outside interaction and Radix
+      // closes the popover. Ignore interactions originating in the keyboard.
+      onInteractOutside={(e) => {
+        const t = (e.detail?.originalEvent?.target ?? null) as Element | null;
+        if (t && typeof t.closest === 'function' && t.closest('[data-virtual-keyboard]')) {
+          e.preventDefault();
+        }
+        onInteractOutside?.(e);
+      }}
       className={cn(
         'z-50 w-72 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',


### PR DESCRIPTION
**Real cause of the recurring 'keyboard folds on first tap' — found on the Messages page.** Composing a new message uses `AddMessageModal`, a Radix Dialog. The virtual keyboard portals to `<body>`, *outside* the dialog, so a key tap is an 'outside' interaction and Radix dismisses the dialog → the field unmounts (keyboard hides) and the keystroke is lost. This is why the earlier focus/blur fixes (#125/#234/#236) never helped here — the whole dialog was being torn down.

**Fix:** guard `DialogContent` + `PopoverContent` — in `onInteractOutside`, `preventDefault()` when the interaction originates inside `[data-virtual-keyboard]`. Keyboard taps no longer dismiss the overlay; genuine outside clicks still close it; any caller-supplied `onInteractOutside` still runs. Fixes every dialog/popover-with-a-field, not just the message modal. `tsc` clean.

Touch-only behavior — verified by maintainer on the display.