### PR TITLE
fix(keyboard): make the on-screen keyboard work inside modal dialogs

### DIFF
--- a/src/components/input/VirtualKeyboard.tsx
+++ b/src/components/input/VirtualKeyboard.tsx
@@ -202,6 +202,12 @@ export function VirtualKeyboard() {
       style={{
         height: '38vh', minHeight: 320, maxHeight: 480,
         display: visible ? undefined : 'none',
+        // A Radix *modal* dialog (e.g. the Add-Message compose box) sets
+        // pointer-events:none on everything outside its content. This keyboard
+        // portals to <body>, outside the dialog, so without this it becomes
+        // inert — taps fall straight through to the dialog backdrop and close it
+        // instead of typing. Force interactivity so keys work over a modal.
+        pointerEvents: 'auto',
       }}
       // Keep focus on the active input when a key is tapped. simple-keyboard
       // swallows the BUBBLING pointerdown before it reaches this container, so

--- a/src/components/modals/AddMessageModal.tsx
+++ b/src/components/modals/AddMessageModal.tsx
@@ -287,19 +287,21 @@ export function AddMessageModal({
             <div className="flex items-center gap-2">
               <Clock className="h-3.5 w-3.5 text-muted-foreground" />
               <Label htmlFor="expiresIn" className="text-sm whitespace-nowrap">Expires after</Label>
-              <Select value={expiresIn} onValueChange={setExpiresIn}>
-                <SelectTrigger id="expiresIn" className="h-8 w-[130px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="never">Never</SelectItem>
-                  <SelectItem value="12h">12 hours</SelectItem>
-                  <SelectItem value="1d">1 day</SelectItem>
-                  <SelectItem value="2d">2 days</SelectItem>
-                  <SelectItem value="3d">3 days</SelectItem>
-                  <SelectItem value="7d">7 days</SelectItem>
-                </SelectContent>
-              </Select>
+              {/* Native select: Radix Select's tap-to-commit is unreliable on
+                  the touch wall display; the OS picker is rock-solid on touch. */}
+              <select
+                id="expiresIn"
+                value={expiresIn}
+                onChange={(e) => setExpiresIn(e.target.value)}
+                className="h-8 w-[130px] rounded-md border border-input bg-background px-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <option value="never">Never</option>
+                <option value="12h">12 hours</option>
+                <option value="1d">1 day</option>
+                <option value="2d">2 days</option>
+                <option value="3d">3 days</option>
+                <option value="7d">7 days</option>
+              </select>
             </div>
           </div>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -22,6 +22,7 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { isVirtualKeyboardTarget } from '@/lib/input/keyboardTarget';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -62,9 +63,7 @@ const DialogContent = React.forwardRef<
       // the dialog and be lost. Ignore interactions that originate in the keyboard.
       onInteractOutside={(e) => {
         const t = (e.detail?.originalEvent?.target ?? null) as Element | null;
-        if (t && typeof t.closest === 'function' && t.closest('[data-virtual-keyboard]')) {
-          e.preventDefault();
-        }
+        if (isVirtualKeyboardTarget(t)) e.preventDefault();
         onInteractOutside?.(e);
       }}
       className={cn(

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { cn } from '@/lib/utils';
+import { isVirtualKeyboardTarget } from '@/lib/input/keyboardTarget';
 
 const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
@@ -22,9 +23,7 @@ const PopoverContent = React.forwardRef<
       // closes the popover. Ignore interactions originating in the keyboard.
       onInteractOutside={(e) => {
         const t = (e.detail?.originalEvent?.target ?? null) as Element | null;
-        if (t && typeof t.closest === 'function' && t.closest('[data-virtual-keyboard]')) {
-          e.preventDefault();
-        }
+        if (isVirtualKeyboardTarget(t)) e.preventDefault();
         onInteractOutside?.(e);
       }}
       className={cn(

--- a/src/lib/hooks/useGlobalInput.tsx
+++ b/src/lib/hooks/useGlobalInput.tsx
@@ -12,6 +12,7 @@ import React, {
 import { useIsMobile } from './useIsMobile';
 import { useSpeechRecognition } from './useSpeechRecognition';
 import { toast } from '@/components/ui/use-toast';
+import { isVirtualKeyboardTarget } from '@/lib/input/keyboardTarget';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -48,7 +49,7 @@ function shouldShowKeyboard(el: Element): boolean {
 }
 
 function isInsideKeyboard(el: Element): boolean {
-  return !!el.closest('[data-virtual-keyboard]');
+  return isVirtualKeyboardTarget(el);
 }
 
 function getScrollParent(el: Element): Element | Window {
@@ -300,12 +301,17 @@ export function GlobalInputProvider({ children }: { children: React.ReactNode })
 
     const onFocusOut = (e: FocusEvent) => {
       const next = e.relatedTarget as Element | null;
+      const from = e.target as Element | null;
+      // Only react when the element LOSING focus is the input we're tracking.
+      // Otherwise this global handler fires on every unrelated focus move — e.g.
+      // Radix Select cycling focus across its options — and repeatedly hides the
+      // keyboard / restores scroll, which nudges the list under the finger and
+      // makes option taps land a row off ("sometimes clicks past it").
+      if (from !== activeInputRef.current && from !== activeContentEditableRef.current) return;
+      // Focus moved to a focusable keyboard control — keep the keyboard open.
       if (next && isInsideKeyboard(next)) return;
-      // Tapping a virtual-keyboard key blurs the input (its keys are
-      // non-focusable divs, so relatedTarget is null). Restore focus to the
-      // active field and keep the keyboard open, rather than tearing it down —
-      // this is the touch-safe fix for the recurring first-tap-dismiss bug that
-      // preventDefault (swallowed by simple-keyboard) never reliably solved.
+      // Tapping a (non-focusable) key blurs the input with a null relatedTarget.
+      // Restore focus and keep the keyboard open instead of tearing it down.
       if (pointerOnKeyboardRef.current) {
         const el = activeContentEditableRef.current ?? activeInputRef.current;
         if (el) { el.focus({ preventScroll: true }); return; }

--- a/src/lib/input/keyboardTarget.ts
+++ b/src/lib/input/keyboardTarget.ts
@@ -1,0 +1,22 @@
+/**
+ * True if `el` is (or just was) part of the on-screen virtual keyboard.
+ *
+ * Uses `closest('[data-virtual-keyboard]')` for attached nodes, then falls back
+ * to simple-keyboard's own per-key markers (`data-skbtn` attribute / `hg-button`
+ * class). The fallback matters because toggling Shift/symbols makes
+ * simple-keyboard re-render and DETACH the tapped key: on the orphaned node
+ * `closest()` returns null, so the dialog/focus dismissal guards would wrongly
+ * treat the tap as "outside the keyboard" and close the dialog / hide the
+ * keyboard. The marker checks read straight off the element and survive
+ * detachment.
+ */
+export function isVirtualKeyboardTarget(el: Element | null | undefined): boolean {
+  if (!el || typeof (el as Element).closest !== 'function') return false;
+  const e = el as Element;
+  if (e.closest('[data-virtual-keyboard]')) return true;
+  if (typeof e.hasAttribute === 'function' && e.hasAttribute('data-skbtn')) return true;
+  const cls = typeof e.className === 'string' ? e.className : '';
+  if (cls.includes('hg-button') || cls.includes('simple-keyboard') || cls.includes('hg-theme')) return true;
+  if (e.closest('.simple-keyboard')) return true;
+  return false;
+}


### PR DESCRIPTION
Fixes the long-standing on-screen-keyboard failures in the message compose box, found via on-device tracing:

- **Keyboard inert over a modal dialog** → taps fell through to the backdrop and closed it. A Radix *modal* Dialog sets `pointer-events:none` outside its content, and the keyboard portals to `<body>`. Fix: `pointerEvents:'auto'` on the keyboard container.
- **Shift dismissed the keyboard** → tapping Shift re-renders/detaches the key, so `closest('[data-virtual-keyboard]')` failed and it read as an outside tap. Fix: new `isVirtualKeyboardTarget()` matches simple-keyboard's own `data-skbtn`/`hg-button` markers (survives detachment); wired into dialog + popover `onInteractOutside` and `useGlobalInput`.
- **Dropdown taps 'clicked past'** → the global `focusout` handler fired on unrelated focus churn (Radix Select cycling options), thrashing keyboard/scroll. Fix: only react when the *tracked input* blurs.
- **Expires dropdown** → swapped the Radix Select for a native `<select>`; Radix Select tap-to-commit is unreliable on the touch kiosk.

Verified on the actual wall display: typing, Shift/capitals, and the dropdown all work. Touch-only behavior; `tsc`+lint clean.