### PR TITLE
fix(dashboard): stop widgets blanking on every background poll

### DIFF
--- a/src/lib/hooks/useFetch.ts
+++ b/src/lib/hooks/useFetch.ts
@@ -36,10 +36,18 @@ export function useFetch<T>(options: UseFetchOptions<T>): UseFetchResult<T> {
   // Only show loading spinner on true cold fetches (no cached data available)
   const [loading, setLoading] = useState(!cached);
   const [error, setError] = useState<string | null>(null);
+  // The URL we've already loaded data for. Used to keep background POLLS silent
+  // (stale-while-revalidate) — the spinner is only for a cold first load of a
+  // URL. We can't rely on navCache for this: its TTL is 60s, far shorter than
+  // poll intervals (minutes), so on every poll the cache is already gone and the
+  // widget would blank. Reset implicitly when the URL changes (new endpoint =
+  // cold load), preserving the spinner on filter/param changes.
+  const loadedUrlRef = useRef<string | null>(cached ? url : null);
 
   const fetchData = useCallback(async () => {
-    // Don't flash a spinner if we already have something to show (SWR)
-    if (!navCacheGet(url)) setLoading(true);
+    // Spinner only on a cold first load of this URL; background polls keep the
+    // current data on screen instead of blanking every widget.
+    if (loadedUrlRef.current !== url && !navCacheGet(url)) setLoading(true);
     try {
       setError(null);
       const response = await fetch(url);
@@ -47,6 +55,7 @@ export function useFetch<T>(options: UseFetchOptions<T>): UseFetchResult<T> {
       const json = await response.json();
       const result = transformRef.current ? transformRef.current(json) : (json as T);
       navCacheSet(url, result);
+      loadedUrlRef.current = url;
       // Structural-shared polling: when the new payload is byte-identical
       // to what's already in state, return the previous reference so React
       // skips re-renders for every consumer of this data. Big win on weak


### PR DESCRIPTION
**The whole dashboard flashed + rebuilt every ~5 minutes.** `useFetch` suppressed its loading spinner only while `navCacheGet(url)` held data — but the nav cache TTL is **60s** and widget poll intervals are **minutes**, so on every poll the cache had already expired, `navCacheGet` returned nothing, and `setLoading(true)` blanked every widget simultaneously (skeleton → refetch → rebuild).

**Fix:** track whether the current URL has already loaded (`loadedUrlRef`) and only show the spinner on a *cold first load* of a URL. Background polls now keep current data on screen (proper stale-while-revalidate); a URL/param change still shows the cold-load spinner. One change in the shared `useFetch`, so it fixes every widget + subpage. Structural-sharing (skip re-render on identical payloads) is unchanged, so unchanged polls are fully silent. `tsc` + polling tests green.