### PR TITLE
fix(calendar): widen agenda overlay-bucket range to match its 30-day view

### DIFF
--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -106,8 +106,9 @@ export const CalendarWidget = React.memo(function CalendarWidget({
         to: endOfWeek(monthEnd, { weekStartsOn }),
       };
     }
-    // agenda — 14 day window
-    return { from: currentDate, to: addDays(currentDate, 13) };
+    // agenda — 30 day window (matches AgendaView days below, so cards-mode
+    // meal/chore/task overlays are loaded for every day the agenda shows)
+    return { from: currentDate, to: addDays(currentDate, 29) };
   }, [resolvedView, resolvedWeekCount, currentDate, weekStartsOn]);
 
   const overlaysActive = cardsMode;


### PR DESCRIPTION
Follow-up to #242. The widget agenda now displays 30 days, but its overlay (meals/chores/tasks) bucket range was still 14 days, so in cards mode days 15–30 showed events with no overlays. Widened the agenda bucket range to 30 days to match. `tsc` clean.