### PR TITLE
fix(calendar): make the '+N more' overflow button a proper touch target

### DIFF
--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -281,7 +281,7 @@ function DayCardsCell({
   // Reserve ~22px for the popover trigger; each overlay row is ~24px (sm card)
   // plus the cell's 4px gap-1 separator. 20px under-reserved enough that event
   // rows pushed overlay items into clipped territory on dense days.
-  const popoverHeight = 22 + overlayItemCount * 26;
+  const popoverHeight = 28 + overlayItemCount * 26;
 
   const { cellRef, fitWithOverflow, fitWithoutOverflow } = useCardCapacity({
     cardHeight,

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -192,7 +192,7 @@ function DayCell({
   const overlayRowHeight = cardHeight ?? 56;
   const cellGap = 4; // matches `gap-1` between cards in the events container
   const overlayRowsHeight = overlayItemCount * (overlayRowHeight + cellGap);
-  const popoverTriggerHeight = 22; // only present when events actually overflow
+  const popoverTriggerHeight = 28; // only present when events actually overflow
   const { cellRef, fitWithOverflow, fitWithoutOverflow } = useCardCapacity({
     cardHeight,
     headerHeight: overlayRowsHeight,

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -38,9 +38,11 @@ export function DayOverflowPopover({
         <button
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'block w-full text-left text-[10px] font-medium px-1 py-0.5 rounded',
-            'bg-muted/60 hover:bg-muted text-muted-foreground transition-colors',
-            'min-h-[20px]',
+            // Full-width + a taller min-height so it's an easy touch target on a
+            // wall display (was min-h-20px / 10px text — fiddly to tap).
+            'flex w-full items-center text-left text-[11px] font-medium px-2 py-1 rounded',
+            'bg-muted/60 hover:bg-muted active:bg-muted text-muted-foreground transition-colors',
+            'min-h-[28px]',
             triggerClassName,
           )}
         >


### PR DESCRIPTION
The month/multi-week "+N more" popover trigger (tap to see the day's hidden events) was `min-h-20px` with 10px text — hard to hit on a touch wall display. Enlarged it (`min-h-28px`, 11px text, full-width, centered, active feedback) and bumped the reserved trigger height in MonthView + MultiWeekView from 22 → 28 so the cell layout still reserves the exact space. `tsc` clean.