### PR TITLE
chore(release): 1.14.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.14.1] – 2026-08-17
+
+### Dashboard
+- **The dashboard no longer flashes and rebuilds every few minutes.** Background data refreshes now happen silently — the dashboard stays on screen and updates in place, instead of every widget briefly blanking to a loading skeleton on each refresh.
+
+### Calendar
+- **The agenda view lists all of your events.** It no longer caps each day at five and hides the rest behind a "+N more" line — since the agenda scrolls, every event across the next 30 days is shown.
+- **The "+N more" button on the month and multi-week views is an easier touch target.** Tapping it still opens a popup listing that day's hidden events; the button is now bigger and simpler to hit on a wall display.
+
 ## [1.14.0] – 2026-08-17
 
 ### Dashboard

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.14.0"
+version: "1.14.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release. Post-1.14.0 fixes verified on the wall display:
- Dashboard no longer flashes/rebuilds on the ~5-minute background refresh (#241)
- Agenda view shows all events, no per-day cap (#242, #243)
- '+N more' overflow button is an easier touch target (#244)

Bumps package.json + ha-app/config.yaml and migrates the Unreleased changelog under the 1.14.1 heading.