### PR TITLE
fix(oauth): post-auth redirects honor APP_URL instead of undocumented BASE_URL

### DIFF
--- a/src/app/api/auth/google-bus/callback/route.ts
+++ b/src/app/api/auth/google-bus/callback/route.ts
@@ -10,7 +10,7 @@ import { logError } from '@/lib/utils/logError';
 import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchGmailAccountEmail } from '@/lib/integrations/oauth-userinfo';
 
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();

--- a/src/app/api/auth/google-tasks/callback/route.ts
+++ b/src/app/api/auth/google-tasks/callback/route.ts
@@ -7,7 +7,7 @@ import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchGoogleAccountEmail } from '@/lib/integrations/oauth-userinfo';
 
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 const TEMP_TOKEN_TTL = 300; // 5 minutes
 
 interface GoogleTokens {

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -14,7 +14,7 @@ import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchGoogleAccountEmail } from '@/lib/integrations/oauth-userinfo';
 import { consumeOAuthState } from '@/lib/auth/oauthState';
 
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 
 export async function GET(request: Request) {
   const auth = await requireAuth();

--- a/src/app/api/auth/microsoft-tasks/callback/route.ts
+++ b/src/app/api/auth/microsoft-tasks/callback/route.ts
@@ -7,7 +7,7 @@ import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchMicrosoftAccountEmail } from '@/lib/integrations/oauth-userinfo';
 
 const MICROSOFT_TOKEN_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token';
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 // Must match the authorize route's scopes (Microsoft validates scope on the
 // token exchange). `User.Read` powers the "Connected as <email>" label (#100).
 const SCOPES = ['Tasks.ReadWrite', 'offline_access', 'User.Read'].join(' ');

--- a/src/app/api/auth/microsoft/callback/route.ts
+++ b/src/app/api/auth/microsoft/callback/route.ts
@@ -10,7 +10,7 @@ import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchMicrosoftAccountEmail } from '@/lib/integrations/oauth-userinfo';
 import { consumeOAuthState } from '@/lib/auth/oauthState';
 
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 
 export async function GET(request: Request) {
   // The callback is a top-level navigation, so the Prism session cookie is

--- a/src/lib/integrations/oauthSetupRedirect.ts
+++ b/src/lib/integrations/oauthSetupRedirect.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
 
 /**
  * True when an OAuth "initiate" failure is just "credentials aren't configured


### PR DESCRIPTION
Fixes #245 (reported by @c-jw with an accurate root-cause analysis).

**Bug:** OAuth callback success/error redirects were built from `process.env.BASE_URL`, which `.env.example` never documents — only `APP_URL`. On a standard reverse-proxy install `BASE_URL` is unset, so the redirect fell back to `http://localhost:3000`, bouncing the user to an unreachable host after connecting an integration. (The OAuth handshake itself was unaffected — it derives the redirect URI from the request via `resolveRedirectUri`.)

**Fix:** prefer the documented `APP_URL`, keeping `BASE_URL` as a fallback so anyone who applied the `BASE_URL=` workaround isn't broken — `APP_URL ?? BASE_URL ?? localhost`. Applied to all five OAuth callbacks (google, google-bus, google-tasks, microsoft, microsoft-tasks) + `oauthSetupRedirect`.

**Deliberately left alone:** the three `sync-all` routes also read `BASE_URL`, but there `localhost:3000` is correct — the server calling its own API internally, not a user-facing redirect. `tsc` clean.