### PR TITLE
chore(release): 1.14.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.14.2] – 2026-08-17
+
+### Integrations
+- **OAuth sign-in returns you to the right place behind a reverse proxy.** After connecting Google or Microsoft (calendar, tasks, or the bus tracker), the post-connect redirect now uses your configured `APP_URL` instead of an undocumented variable that fell back to `localhost:3000` — so you land back on your dashboard's Integrations page instead of an unreachable address. The connection itself always worked; only the redirect afterward was wrong. Thanks to @c-jw for the precise report (#245).
+
 ## [1.14.1] – 2026-08-17
 
 ### Dashboard

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.14.1"
+version: "1.14.2"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release. Fixes the OAuth post-auth redirect using an undocumented BASE_URL that fell back to localhost:3000 behind a reverse proxy; now prefers APP_URL (with BASE_URL fallback), across all OAuth callbacks. Reported by @c-jw (#245), fixed in #247.