### PR TITLE
feat(telemetry): opt-out anonymous update check + install counter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ APP_URL=http://localhost:3000
 # Point check-ins at your own collector (see /collector). If unset and no
 # default endpoint is baked into the build, Prism sends nothing at all:
 # PRISM_TELEMETRY_URL=https://your-worker-url
+#
+# Label this install's source in the anonymous count. Home Assistant is detected
+# automatically; hosted one-click blueprints (PikaPods, Render, Railway) should
+# set this so installs can be counted by channel. Defaults to "docker":
+# PRISM_DEPLOYMENT=pikapods
 
 # --- Security Secrets ---
 # Generate with: openssl rand -hex 32

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,20 @@ PORT=3000
 # https domain so Google/Microsoft sign-in works from any entry point.
 APP_URL=http://localhost:3000
 
+# --- Anonymous update check / telemetry ---
+# Once a week Prism checks for a newer version and adds one anonymous install to
+# the maintainer's count. Exactly four fields are sent (random install id,
+# version, docker-vs-HA, CPU arch) — no IP, no personal data, no usage. It is
+# on by default and can be turned off in Settings -> About. See
+# docs/features/TELEMETRY.md for the full contract.
+#
+# Hard-disable it for this whole install (also greys out the in-app switch):
+# PRISM_DISABLE_TELEMETRY=true
+#
+# Point check-ins at your own collector (see /collector). If unset and no
+# default endpoint is baked into the build, Prism sends nothing at all:
+# PRISM_TELEMETRY_URL=https://your-worker-url
+
 # --- Security Secrets ---
 # Generate with: openssl rand -hex 32
 # Or: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,3 +61,4 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             NEXT_TELEMETRY_DISABLED=1
+            PRISM_TELEMETRY_URL=https://prism-telemetry.sandydargoport.workers.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             PRISM_REF=${{ steps.ver.outputs.tag }}
+            PRISM_TELEMETRY_URL=https://prism-telemetry.sandydargoport.workers.dev
           push: true
           tags: |
             ghcr.io/sandydargoport/prism-ha-${{ matrix.arch }}:${{ steps.ver.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+# Anonymous update-check endpoint (see src/lib/telemetry). Empty by default, so
+# an image built from source phones home to nobody; only the official CI build
+# passes the real URL as a build-arg (Option B). Overridable/disable at runtime
+# via PRISM_TELEMETRY_URL / PRISM_DISABLE_TELEMETRY.
+ARG PRISM_TELEMETRY_URL=""
+ENV PRISM_TELEMETRY_URL=${PRISM_TELEMETRY_URL}
 
 RUN apk add --no-cache postgresql-client chromium nss freetype harfbuzz ca-certificates ttf-freefont
 

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,0 +1,74 @@
+# Prism telemetry collector
+
+A tiny [Cloudflare Worker](https://developers.cloudflare.com/workers/) + [D1](https://developers.cloudflare.com/d1/)
+database that receives Prism's weekly anonymous check-in, counts **active
+installs** (de-duplicated by a random install id), and replies with the latest
+published version so installs can show an "update available" line.
+
+It is the maintainer-side half of the opt-out update check in
+`src/lib/telemetry/`. Runs comfortably inside Cloudflare's free tier.
+
+## What it stores
+
+One row per install, and nothing else:
+
+| column | example | notes |
+|---|---|---|
+| `id` | `9f2c…` | random UUID the install generated for itself |
+| `version` | `1.14.2` | running app version |
+| `deployment` | `docker` / `ha` | distribution channel |
+| `arch` | `x64` / `arm64` | CPU architecture |
+| `first_seen` / `last_seen` | ISO timestamps | for active-install windows |
+
+**No IP address, no cookies, no fingerprint, no usage data.** The Worker never
+reads the client address. The id is meaningless outside this table.
+
+## Deploy
+
+```bash
+cd collector
+npm i -g wrangler        # if you don't have it
+wrangler login
+
+# 1. Create the D1 database and paste the printed id into wrangler.toml
+wrangler d1 create prism-telemetry
+
+# 2. Create the table
+wrangler d1 execute prism-telemetry --remote --file=schema.sql
+
+# 3. Set the stats token (any random string) and deploy
+wrangler secret put STATS_TOKEN
+wrangler deploy
+```
+
+`wrangler deploy` prints the Worker URL, e.g.
+`https://prism-telemetry.<you>.workers.dev`.
+
+## Point Prism at it
+
+Set the endpoint the app checks in to, either way:
+
+- **Per deployment:** `PRISM_TELEMETRY_URL=https://prism-telemetry.<you>.workers.dev`
+- **Baked into release builds:** set `DEFAULT_TELEMETRY_ENDPOINT` in
+  `src/lib/telemetry/constants.ts` to that URL.
+
+Until one of those is set, the app sends nothing — the feature is inert.
+
+## Read the numbers
+
+```bash
+curl "https://prism-telemetry.<you>.workers.dev/stats?token=<STATS_TOKEN>"
+```
+
+```json
+{
+  "totalInstalls": 412,
+  "activeInstalls7d": 231,
+  "activeInstalls30d": 388,
+  "byVersion":   [{ "version": "1.14.2", "n": 190 }, …],
+  "byDeployment":[{ "deployment": "docker", "n": 300 }, { "deployment": "ha", "n": 88 }]
+}
+```
+
+`activeInstalls7d` is the honest "how many live installs" number — de-duplicated
+and free of the CI/re-pull inflation that makes registry pull counts unreliable.

--- a/collector/README.md
+++ b/collector/README.md
@@ -66,7 +66,11 @@ curl "https://prism-telemetry.<you>.workers.dev/stats?token=<STATS_TOKEN>"
   "activeInstalls7d": 231,
   "activeInstalls30d": 388,
   "byVersion":   [{ "version": "1.14.2", "n": 190 }, …],
-  "byDeployment":[{ "deployment": "docker", "n": 300 }, { "deployment": "ha", "n": 88 }]
+  "byDeployment":[
+    { "deployment": "docker",   "n": 240 },
+    { "deployment": "ha",       "n": 88  },
+    { "deployment": "pikapods", "n": 60  }
+  ]
 }
 ```
 

--- a/collector/schema.sql
+++ b/collector/schema.sql
@@ -1,0 +1,14 @@
+-- Prism telemetry collector — D1 schema.
+-- One row per install, de-duplicated by the random install id. No IP column
+-- exists by design: the collector must not store client addresses.
+
+CREATE TABLE IF NOT EXISTS checkins (
+  id         TEXT PRIMARY KEY,   -- random UUID the install generated for itself
+  version    TEXT,               -- e.g. "1.14.2"
+  deployment TEXT,               -- "docker" | "ha"
+  arch       TEXT,               -- e.g. "x64" | "arm64"
+  first_seen TEXT NOT NULL,      -- ISO8601, first check-in
+  last_seen  TEXT NOT NULL       -- ISO8601, most recent check-in
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkins_last_seen ON checkins(last_seen);

--- a/collector/worker.js
+++ b/collector/worker.js
@@ -1,0 +1,133 @@
+/**
+ * Prism telemetry collector — Cloudflare Worker.
+ *
+ * Receives the weekly anonymous check-in from each Prism install, records it in
+ * a D1 table de-duplicated by the random install id, and replies with the
+ * latest published version so the install can show an "update available" line.
+ *
+ * Privacy contract (must match src/lib/telemetry/constants.ts on the app side):
+ *   - The ONLY fields stored are {id, version, deployment, arch, first_seen,
+ *     last_seen}. The client IP is never read, never logged, never stored.
+ *   - No cookies, no fingerprinting, no cross-request linking beyond the id the
+ *     install generated for itself.
+ *
+ * Endpoints:
+ *   POST /            → record a check-in, return { latestVersion }.
+ *   GET  /stats?token=…  → aggregate counts (maintainer only, STATS_TOKEN gated).
+ *   GET  /health      → "ok".
+ */
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const json = (obj, status = 200) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS },
+  });
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') return new Response(null, { headers: CORS });
+    if (url.pathname === '/health') return new Response('ok', { headers: CORS });
+
+    if (request.method === 'POST' && (url.pathname === '/' || url.pathname === '/v1/checkin')) {
+      return handleCheckIn(request, env);
+    }
+    if (request.method === 'GET' && url.pathname === '/stats') {
+      return handleStats(url, env);
+    }
+    return json({ error: 'not found' }, 404);
+  },
+};
+
+async function handleCheckIn(request, env) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'invalid json' }, 400);
+  }
+
+  // Validate + clamp. Anything unexpected is dropped rather than stored.
+  const id = typeof body.id === 'string' ? body.id.slice(0, 64) : null;
+  if (!id) return json({ error: 'missing id' }, 400);
+  const version = typeof body.version === 'string' ? body.version.slice(0, 32) : null;
+  const deployment = body.deployment === 'ha' ? 'ha' : 'docker';
+  const arch = typeof body.arch === 'string' ? body.arch.slice(0, 16) : null;
+  const now = new Date().toISOString();
+
+  // Upsert de-duplicated by id — one install counts once no matter how often it
+  // updates. Deliberately no IP column.
+  await env.DB.prepare(
+    `INSERT INTO checkins (id, version, deployment, arch, first_seen, last_seen)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+     ON CONFLICT(id) DO UPDATE SET
+       version = ?2, deployment = ?3, arch = ?4, last_seen = ?5`,
+  )
+    .bind(id, version, deployment, arch, now)
+    .run();
+
+  const latestVersion = await getLatestVersion(env);
+  return json({ ok: true, latestVersion });
+}
+
+/** Latest release tag from GitHub, cached at the edge for 1 hour. */
+async function getLatestVersion(env) {
+  const repo = env.GITHUB_REPO || 'sandydargoport/prism';
+  const apiUrl = `https://api.github.com/repos/${repo}/releases/latest`;
+  const cache = caches.default;
+  const cacheKey = new Request(apiUrl);
+
+  let res = await cache.match(cacheKey);
+  if (!res) {
+    res = await fetch(apiUrl, {
+      headers: { 'User-Agent': 'prism-telemetry-collector', Accept: 'application/vnd.github+json' },
+      cf: { cacheTtl: 3600, cacheEverything: true },
+    });
+    if (res.ok) {
+      const copy = new Response(res.body, res);
+      copy.headers.set('Cache-Control', 'max-age=3600');
+      await cache.put(cacheKey, copy.clone());
+      res = copy;
+    }
+  }
+  if (!res || !res.ok) return null;
+  try {
+    const data = await res.json();
+    return typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Aggregate counts for the maintainer. Gated by STATS_TOKEN. */
+async function handleStats(url, env) {
+  if (!env.STATS_TOKEN || url.searchParams.get('token') !== env.STATS_TOKEN) {
+    return json({ error: 'unauthorized' }, 401);
+  }
+
+  const q = (sql) => env.DB.prepare(sql).all().then((r) => r.results);
+
+  const [total, active7, active30, byVersion, byDeployment] = await Promise.all([
+    env.DB.prepare('SELECT COUNT(*) AS n FROM checkins').first('n'),
+    env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-7 days')`).first('n'),
+    env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days')`).first('n'),
+    q(`SELECT version, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY version ORDER BY n DESC`),
+    q(`SELECT deployment, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY deployment ORDER BY n DESC`),
+  ]);
+
+  return json({
+    totalInstalls: total,
+    activeInstalls7d: active7,
+    activeInstalls30d: active30,
+    byVersion,
+    byDeployment,
+    generatedAt: new Date().toISOString(),
+  });
+}

--- a/collector/worker.js
+++ b/collector/worker.js
@@ -58,7 +58,12 @@ async function handleCheckIn(request, env) {
   const id = typeof body.id === 'string' ? body.id.slice(0, 64) : null;
   if (!id) return json({ error: 'missing id' }, 400);
   const version = typeof body.version === 'string' ? body.version.slice(0, 32) : null;
-  const deployment = body.deployment === 'ha' ? 'ha' : 'docker';
+  // Channel slug (ha | docker | pikapods | render | …). Sanitised, not forced to
+  // a binary, so installs can be counted by source without a schema change.
+  const deployment =
+    typeof body.deployment === 'string'
+      ? body.deployment.toLowerCase().replace(/[^a-z0-9_-]/g, '').slice(0, 16) || 'docker'
+      : 'docker';
   const arch = typeof body.arch === 'string' ? body.arch.slice(0, 16) : null;
   const now = new Date().toISOString();
 

--- a/collector/wrangler.toml
+++ b/collector/wrangler.toml
@@ -1,0 +1,22 @@
+# Cloudflare Worker config for the Prism telemetry collector.
+# Deploy steps are in collector/README.md.
+
+name = "prism-telemetry"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+
+# D1 database binding. Create it with:
+#   wrangler d1 create prism-telemetry
+# then paste the printed database_id below.
+[[d1_databases]]
+binding = "DB"
+database_name = "prism-telemetry"
+database_id = "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+
+[vars]
+# Repo whose latest release drives the "update available" reply.
+GITHUB_REPO = "sandydargoport/prism"
+
+# STATS_TOKEN is a SECRET, not a var. Set it with:
+#   wrangler secret put STATS_TOKEN
+# Then read stats at: https://<worker-url>/stats?token=<that value>

--- a/collector/wrangler.toml
+++ b/collector/wrangler.toml
@@ -11,7 +11,7 @@ compatibility_date = "2026-08-01"
 [[d1_databases]]
 binding = "DB"
 database_name = "prism-telemetry"
-database_id = "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+database_id = "33618d6d-31da-4ada-aa10-f1933f32b475"
 
 [vars]
 # Repo whose latest release drives the "update available" reply.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Privacy
+- **Anonymous update check (on by default, one switch to turn off).** Once a week Prism now checks whether a newer version is available and, in the same request, adds one anonymous install to a count the maintainer uses to gauge real usage. Exactly four fields are sent — a random per-install id, the version, docker-vs-Home-Assistant, and CPU architecture — with **no IP address, no personal data, and no usage tracking**. See the exact payload any time under Settings → About, disable it there with one switch, or hard-disable it for the whole install with `PRISM_DISABLE_TELEMETRY=true`. Update notices are quiet: they appear only in Settings (never on the dashboard) and only for minor/major releases, never patches. Full details in the [Anonymous update check](features/TELEMETRY.md) guide.
+
 ## [1.14.2] – 2026-08-17
 
 ### Integrations

--- a/docs/features/TELEMETRY.md
+++ b/docs/features/TELEMETRY.md
@@ -58,6 +58,10 @@ dashboard itself. Patch releases (`1.14.1` → `1.14.2`) are **not** surfaced at
 all; you're only nudged when a new **minor or major** version lands, so a busy
 release schedule never turns into nagging.
 
+It is also disclosed **at first-run setup** — the final step of the setup wizard
+shows exactly this, with an off switch right there — so it is never a surprise
+you have to go hunting for.
+
 ## How to turn it off
 
 Any one of these disables it:

--- a/docs/features/TELEMETRY.md
+++ b/docs/features/TELEMETRY.md
@@ -1,0 +1,77 @@
+# Anonymous update check
+
+Prism checks for updates once a week. In the same request it adds **one
+anonymous install** to a count the maintainer uses to understand how many people
+run Prism. It is on by default and you can turn it off with a single switch.
+
+This page tells you exactly what is sent, why, and how to disable it — whether
+you prefer a checkbox or an environment variable.
+
+## What is sent
+
+Exactly four fields, once a week:
+
+```json
+{
+  "schema": 1,
+  "id": "9f2c7b3e-…",     // a random id this install made up for itself
+  "version": "1.14.2",     // which Prism version you're running
+  "deployment": "docker",  // "docker" or "ha" (Home Assistant addon)
+  "arch": "arm64"          // CPU architecture
+}
+```
+
+You can see the live payload for your own install any time under
+**Settings → About → Anonymous update check → "Show exactly what's sent."**
+
+## What is **not** sent
+
+- **No IP address.** The collector is built to never read or store client
+  addresses.
+- **No personal data.** No names, emails, family members, events, photos,
+  locations, or any content you put into Prism.
+- **No usage data.** Which pages you open, what you click, how long the screen
+  is on — none of it is collected.
+- **No account link.** The `id` is a random UUID generated on your install. It
+  is not derived from your hardware, hostname, or any account, and it means
+  nothing outside the maintainer's count.
+
+The id exists for one reason: so an install that updates every week counts as
+**one** install instead of dozens. That is what makes the number trustworthy —
+and it is also why registry "download" counts are not (they double-count every
+re-pull and every CI job).
+
+## Why it's on by default
+
+A self-hosted server has no other way to tell you a new version exists, and the
+maintainer has no other honest way to tell how many people the project actually
+serves. Keeping it on by default — like Next.js, Astro, and Homebrew do — is
+what makes the install count reflect reality instead of only the handful of
+people who go looking for a setting to switch on. It is anonymous, it is one
+request a week, and it is one click to stop.
+
+## Update notices are quiet
+
+The weekly check may learn that a newer version is available. If so, Prism shows
+a small line under **Settings → About** — never a pop-up, never anything on the
+dashboard itself. Patch releases (`1.14.1` → `1.14.2`) are **not** surfaced at
+all; you're only nudged when a new **minor or major** version lands, so a busy
+release schedule never turns into nagging.
+
+## How to turn it off
+
+Any one of these disables it:
+
+- **In the app:** Settings → About → **Anonymous update check** → switch off.
+  Nothing further is sent.
+- **Environment variable:** set `PRISM_DISABLE_TELEMETRY=true`. This hard-disables
+  the feature for the whole install (useful for distro or workplace builds) and
+  greys the switch out in the UI.
+
+## Self-hosting the collector
+
+The collector is a small open Cloudflare Worker in
+[`/collector`](https://github.com/sandydargoport/prism/tree/master/collector).
+If you run your own Prism fork and want your own counts, deploy it and point
+installs at it with `PRISM_TELEMETRY_URL=https://your-worker-url`. If no endpoint
+is configured, Prism sends nothing at all.

--- a/docs/features/TELEMETRY.md
+++ b/docs/features/TELEMETRY.md
@@ -16,10 +16,14 @@ Exactly four fields, once a week:
   "schema": 1,
   "id": "9f2c7b3e-…",     // a random id this install made up for itself
   "version": "1.14.2",     // which Prism version you're running
-  "deployment": "docker",  // "docker" or "ha" (Home Assistant addon)
+  "deployment": "docker",  // how you installed: "docker", "ha", "pikapods", …
   "arch": "arm64"          // CPU architecture
 }
 ```
+
+The `deployment` field lets the maintainer see the split between Home Assistant,
+one-click hosts like PikaPods, and plain self-hosted Docker — nothing more
+specific than the channel you installed through.
 
 You can see the live payload for your own install any time under
 **Settings → About → Anonymous update check → "Show exactly what's sent."**
@@ -68,6 +72,8 @@ Any one of these disables it:
 
 - **In the app:** Settings → About → **Anonymous update check** → switch off.
   Nothing further is sent.
+- **Home Assistant:** the addon's **Configuration** tab has an **Anonymous
+  stats** toggle — turn it off there and the addon disables it at startup.
 - **Environment variable:** set `PRISM_DISABLE_TELEMETRY=true`. This hard-disables
   the feature for the whole install (useful for distro or workplace builds) and
   greys the switch out in the UI.

--- a/ha-app/Dockerfile
+++ b/ha-app/Dockerfile
@@ -84,6 +84,12 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 # HA addon mode flag — runtime config reads this to flip paths to /data.
 ENV PRISM_HA_MODE=1
+# Anonymous update-check endpoint (see src/lib/telemetry). Empty by default so
+# a source build stays silent; only the official CI build passes the real URL
+# as a build-arg (Option B). Runtime-overridable; the addon's anonymous_stats
+# option can disable it via PRISM_DISABLE_TELEMETRY.
+ARG PRISM_TELEMETRY_URL=""
+ENV PRISM_TELEMETRY_URL=${PRISM_TELEMETRY_URL}
 
 # Entrypoint orchestrates: init secrets, init DB, start postgres+redis,
 # run migrations, exec Next.js. Only file from the addon's own context.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -35,9 +35,11 @@ options:
   database_url: ""
   redis_url: ""
   photos_root: /data/photos
+  anonymous_stats: true
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   bundled_db: bool
   database_url: str?
   redis_url: str?
   photos_root: str
+  anonymous_stats: bool

--- a/ha-app/run.sh
+++ b/ha-app/run.sh
@@ -35,8 +35,15 @@ BUNDLED_DB="$(opt bundled_db || echo true)"
 EXTERNAL_DB_URL="$(opt database_url || echo '')"
 EXTERNAL_REDIS_URL="$(opt redis_url || echo '')"
 PHOTOS_ROOT="$(opt photos_root || echo /data/photos)"
+ANON_STATS="$(opt anonymous_stats || echo true)"
 
-log "log_level=$LOG_LEVEL bundled_db=$BUNDLED_DB photos_root=$PHOTOS_ROOT"
+log "log_level=$LOG_LEVEL bundled_db=$BUNDLED_DB photos_root=$PHOTOS_ROOT anonymous_stats=$ANON_STATS"
+
+# Anonymous update check is opt-out; the addon option lets HA users disable it
+# from the Configuration tab (maps to the app's PRISM_DISABLE_TELEMETRY).
+if [ "$ANON_STATS" = "false" ]; then
+    export PRISM_DISABLE_TELEMETRY=true
+fi
 
 mkdir -p "$PHOTOS_ROOT"
 export PRISM_PHOTO_ROOT="$PHOTOS_ROOT"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Display Modes: features/DISPLAY-MODES.md
       - Mobile (PWA): features/MOBILE.md
       - Global input: features/global-input-system.md
+      - Anonymous update check: features/TELEMETRY.md
   - Integrations:
       - Apple iCloud: features/ICLOUD.md
       - Kroger / Mariano's: features/KROGER.md

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { getDisplayAuth, requireAuth, requireRole } from '@/lib/auth';
+import { APP_VERSION } from '@/lib/constants';
+import { logError } from '@/lib/utils/logError';
+import {
+  TELEMETRY_SETTING_KEYS,
+  getTelemetryEndpoint,
+} from '@/lib/telemetry/constants';
+import {
+  buildPayload,
+  isTelemetryEnabled,
+  runCheckIn,
+} from '@/lib/telemetry/checkIn';
+import { isNotifiableUpdate } from '@/lib/telemetry/version';
+import { readSetting } from '@/lib/telemetry/store';
+
+/**
+ * Status for the Settings -> About telemetry card: the current opt-out state,
+ * whether a collector is configured, the exact anonymous payload that would be
+ * sent, and any pending update the last check-in reported.
+ */
+export async function GET() {
+  const auth = await getDisplayAuth();
+  if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const [enabled, latestVersion, lastCheckAt, payload] = await Promise.all([
+      isTelemetryEnabled(),
+      readSetting<string>(TELEMETRY_SETTING_KEYS.latestVersion),
+      readSetting<string>(TELEMETRY_SETTING_KEYS.lastCheckAt),
+      buildPayload(),
+    ]);
+
+    return NextResponse.json({
+      enabled,
+      configured: Boolean(getTelemetryEndpoint()),
+      hardDisabled: process.env.PRISM_DISABLE_TELEMETRY === 'true',
+      version: APP_VERSION,
+      latestVersion: latestVersion ?? null,
+      updateAvailable: isNotifiableUpdate(APP_VERSION, latestVersion),
+      lastCheckAt: lastCheckAt ?? null,
+      payload,
+    });
+  } catch (error) {
+    logError('Error reading telemetry status:', error);
+    return NextResponse.json({ error: 'Failed to read telemetry status' }, { status: 500 });
+  }
+}
+
+/** Run a check-in immediately (the "Check now" button). Parent-only. */
+export async function POST() {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const forbidden = requireRole(authResult, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const result = await runCheckIn();
+    return NextResponse.json(result);
+  } catch (error) {
+    logError('Error running telemetry check-in:', error);
+    return NextResponse.json({ error: 'Failed to run check-in' }, { status: 500 });
+  }
+}

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -49,6 +49,7 @@ import { BackupSection } from './sections/BackupSection';
 import { BusTrackingSection } from './sections/BusTrackingSection';
 import { InputSection } from './sections/InputSection';
 import { FeaturesSection } from './sections/FeaturesSection';
+import { TelemetryCard } from './sections/TelemetryCard';
 import { ActivityLogSection } from './sections/ActivityLogSection';
 
 import { DisplaysSection } from './sections/DisplaysSection';
@@ -348,6 +349,7 @@ export function SettingsView() {
                       </Button>
                     </CardContent>
                   </Card>
+                  <TelemetryCard />
                 </div>
               )}
             </div>

--- a/src/app/settings/sections/TelemetryCard.tsx
+++ b/src/app/settings/sections/TelemetryCard.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import * as React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+
+type TelemetryStatus = {
+  enabled: boolean;
+  configured: boolean;
+  hardDisabled: boolean;
+  version: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  lastCheckAt: string | null;
+  payload: Record<string, unknown>;
+};
+
+/**
+ * Settings -> About card for the anonymous update check.
+ *
+ * Opt-out: the switch defaults on. Turning it off writes `telemetry.enabled`.
+ * The card shows the exact payload that would be sent (nothing hidden) and,
+ * when the last check-in reported a newer minor/major release, a quiet
+ * "update available" line. Patch bumps are intentionally not surfaced.
+ */
+export function TelemetryCard() {
+  const [status, setStatus] = React.useState<TelemetryStatus | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [checking, setChecking] = React.useState(false);
+  const [showPayload, setShowPayload] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    try {
+      const res = await fetch('/api/telemetry');
+      if (res.ok) setStatus(await res.json());
+    } catch {
+      /* leave null — card just won't render */
+    }
+  }, []);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  const toggle = async (next: boolean) => {
+    if (!status) return;
+    setSaving(true);
+    setStatus({ ...status, enabled: next }); // optimistic
+    try {
+      await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'telemetry.enabled', value: next }),
+      });
+    } catch {
+      setStatus({ ...status, enabled: !next }); // revert
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const checkNow = async () => {
+    setChecking(true);
+    try {
+      await fetch('/api/telemetry', { method: 'POST' });
+      await load();
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  if (!status) return null;
+
+  const lastChecked = status.lastCheckAt
+    ? new Date(status.lastCheckAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : 'never';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Anonymous update check</CardTitle>
+        <CardDescription>
+          Once a week Prism checks whether a newer version is available and, in
+          the same request, adds one anonymous install to the maintainer&apos;s
+          count. No personal data, no IP address, no usage — just the four fields
+          shown below. On by default; switch it off anytime.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">Share anonymous usage &amp; check for updates</span>
+            <span className="text-xs text-muted-foreground">
+              {status.hardDisabled
+                ? 'Disabled by the server administrator (PRISM_DISABLE_TELEMETRY).'
+                : status.configured
+                  ? `Last check-in: ${lastChecked}`
+                  : 'No collector configured on this build — nothing is sent.'}
+            </span>
+          </div>
+          <Switch
+            checked={status.enabled}
+            disabled={saving || status.hardDisabled}
+            onCheckedChange={toggle}
+            className="data-[state=checked]:bg-blue-500"
+          />
+        </div>
+
+        {/* Version status line — only nags on minor/major, never on patches. */}
+        <div className="text-sm">
+          {status.updateAvailable && status.latestVersion ? (
+            <span className="font-medium text-primary">
+              Update available: v{status.latestVersion}{' '}
+              <span className="text-muted-foreground font-normal">
+                (you have v{status.version})
+              </span>
+            </span>
+          ) : (
+            <span className="text-muted-foreground">
+              Prism is up to date (v{status.version})
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={checkNow}
+            disabled={checking || !status.enabled || !status.configured}
+          >
+            {checking ? 'Checking…' : 'Check now'}
+          </Button>
+          <button
+            type="button"
+            onClick={() => setShowPayload((v) => !v)}
+            className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+          >
+            {showPayload ? 'Hide' : 'Show'} exactly what&apos;s sent
+          </button>
+        </div>
+
+        {showPayload && (
+          <pre className="text-xs bg-muted/50 rounded-md p-3 overflow-x-auto border border-border/50">
+            {JSON.stringify(status.payload, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/setup/steps/CompleteStep.tsx
+++ b/src/app/setup/steps/CompleteStep.tsx
@@ -3,10 +3,29 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { PartyPopper, Settings } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { PartyPopper, Settings, ShieldCheck } from 'lucide-react';
 
 export function CompleteStep() {
   const [marking, setMarking] = useState(false);
+
+  // Anonymous update check is opt-out (on by default). We disclose it here at
+  // first run so it's never a surprise, with an off switch right in the flow.
+  const [telemetryOn, setTelemetryOn] = useState(true);
+  const [showSent, setShowSent] = useState(false);
+
+  const toggleTelemetry = async (next: boolean) => {
+    setTelemetryOn(next); // optimistic
+    try {
+      await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'telemetry.enabled', value: next }),
+      });
+    } catch {
+      setTelemetryOn(!next); // revert
+    }
+  };
 
   // Mark setup complete on mount
   useEffect(() => {
@@ -69,6 +88,44 @@ export function CompleteStep() {
             <Settings className="h-4 w-4 mr-2" />
             Open Settings
           </Button>
+        </div>
+
+        {/* First-run disclosure for the opt-out anonymous update check. */}
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-4 text-left">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" />
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-medium">Anonymous update check</p>
+              <p className="text-xs text-muted-foreground">
+                Once a week Prism checks for a new version and counts this install
+                anonymously so we know how many families use it.{' '}
+                <span className="font-medium text-foreground">No personal data, no IP address, no tracking.</span>{' '}
+                <button
+                  type="button"
+                  onClick={() => setShowSent((v) => !v)}
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  {showSent ? 'Hide details' : 'See what’s sent'}
+                </button>
+              </p>
+              {showSent && (
+                <ul className="text-xs text-muted-foreground list-disc pl-4 pt-1 space-y-0.5">
+                  <li>a random ID for this install (not linked to you)</li>
+                  <li>the Prism version you&apos;re running</li>
+                  <li>Docker vs. Home Assistant, and CPU type</li>
+                </ul>
+              )}
+              <p className="text-xs text-muted-foreground pt-1">
+                You can change this anytime in Settings &rarr; About.
+              </p>
+            </div>
+            <Switch
+              checked={telemetryOn}
+              onCheckedChange={toggleTelemetry}
+              aria-label="Anonymous update check"
+              className="data-[state=checked]:bg-blue-500 shrink-0 mt-0.5"
+            />
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,5 +19,8 @@ export async function register() {
 
     const { startPhotoSyncCron } = await import('./lib/server/photoSyncCron');
     startPhotoSyncCron();
+
+    const { startTelemetryCron } = await import('./lib/server/telemetryCron');
+    startTelemetryCron();
   }
 }

--- a/src/lib/config/runtime.ts
+++ b/src/lib/config/runtime.ts
@@ -23,6 +23,22 @@ export function isHaMode(): boolean {
 }
 
 /**
+ * Which distribution channel this install is running under, used only for the
+ * anonymous install count (see src/lib/telemetry). Resolution order:
+ *   1. PRISM_DEPLOYMENT env (explicit) — set by hosted blueprints so we can tell
+ *      PikaPods / Render / Railway etc. apart from a plain local Docker run.
+ *   2. Home Assistant addon (PRISM_HA_MODE=1).
+ *   3. Otherwise "docker" (self-hosted compose / bare container).
+ * The value is sanitised to a short slug so an odd env can never bloat the payload.
+ */
+export function getDeploymentChannel(): string {
+  const explicit = process.env.PRISM_DEPLOYMENT?.trim().toLowerCase();
+  if (explicit) return explicit.replace(/[^a-z0-9_-]/g, '').slice(0, 16) || 'docker';
+  if (isHaMode()) return 'ha';
+  return 'docker';
+}
+
+/**
  * Base directory for persisted state (photos, avatars, future buckets).
  * Overrideable via PRISM_DATA_ROOT — the HA addon sets it to /data, the
  * docker-compose default is `<cwd>/data`.

--- a/src/lib/server/telemetryCron.ts
+++ b/src/lib/server/telemetryCron.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-side anonymous update-check / telemetry cron.
+ *
+ * Lives in its own file (like calendarSyncCron) so the Edge runtime bundle of
+ * instrumentation.ts never pulls in the db/crypto chains — instrumentation.ts
+ * imports it only inside the `NEXT_RUNTIME === 'nodejs'` branch.
+ *
+ * Runs weekly and is a no-op unless:
+ *   - a collector endpoint is configured (PRISM_TELEMETRY_URL / DEFAULT_TELEMETRY_ENDPOINT), and
+ *   - telemetry is enabled (opt-out default; off if the user disabled it or PRISM_DISABLE_TELEMETRY=true).
+ *
+ * See src/lib/telemetry/constants.ts for the full privacy contract.
+ */
+import { runCheckIn } from '@/lib/telemetry/checkIn';
+import { getTelemetryEndpoint } from '@/lib/telemetry/constants';
+
+const INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // weekly
+const INITIAL_DELAY_MS = 5 * 60 * 1000; // 5 min after boot, past startup churn
+
+async function tick() {
+  try {
+    const result = await runCheckIn();
+    if (result.sent) {
+      console.log(
+        `[telemetry] checked in${result.latestVersion ? ` (latest: ${result.latestVersion})` : ''}`,
+      );
+    }
+    // A skipped check-in (disabled / no endpoint) is intentionally silent.
+  } catch (err) {
+    console.error('[telemetry] tick failed:', err);
+  }
+}
+
+export function startTelemetryCron(): void {
+  if (process.env.PRISM_DISABLE_TELEMETRY === 'true') {
+    console.log('[telemetry] disabled via PRISM_DISABLE_TELEMETRY');
+    return;
+  }
+  if (process.env.NODE_ENV === 'test') return;
+
+  // If no collector is configured yet, don't even schedule — keeps the feature
+  // fully inert on builds where the maintainer hasn't set an endpoint.
+  if (!getTelemetryEndpoint()) {
+    console.log('[telemetry] no collector endpoint configured — check-in disabled');
+    return;
+  }
+
+  setTimeout(() => {
+    void tick();
+    setInterval(() => void tick(), INTERVAL_MS);
+  }, INITIAL_DELAY_MS);
+
+  console.log(
+    `[telemetry] scheduled weekly (first run in ${INITIAL_DELAY_MS / 1000}s)`,
+  );
+}

--- a/src/lib/telemetry/__tests__/version.test.ts
+++ b/src/lib/telemetry/__tests__/version.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the update-check version helpers: ordering, and the deliberate
+ * suppression of patch-only bumps so the dashboard never nags on hotfixes.
+ */
+import { compareVersions, isNotifiableUpdate } from '../version';
+
+describe('compareVersions', () => {
+  it('orders major/minor/patch correctly', () => {
+    expect(compareVersions('1.14.2', '1.14.1')).toBe(1);
+    expect(compareVersions('1.14.1', '1.14.2')).toBe(-1);
+    expect(compareVersions('2.0.0', '1.99.99')).toBe(1);
+    expect(compareVersions('1.14.2', '1.14.2')).toBe(0);
+  });
+
+  it('tolerates a leading v and uneven segment counts', () => {
+    expect(compareVersions('v1.15.0', '1.14.2')).toBe(1);
+    expect(compareVersions('1.14', '1.14.0')).toBe(0);
+    expect(compareVersions('1.14.0.0', '1.14')).toBe(0);
+  });
+});
+
+describe('isNotifiableUpdate', () => {
+  it('notifies on a newer minor or major', () => {
+    expect(isNotifiableUpdate('1.14.2', '1.15.0')).toBe(true);
+    expect(isNotifiableUpdate('1.14.2', '2.0.0')).toBe(true);
+  });
+
+  it('stays silent on patch-only bumps', () => {
+    expect(isNotifiableUpdate('1.14.2', '1.14.9')).toBe(false);
+    expect(isNotifiableUpdate('1.14.0', '1.14.1')).toBe(false);
+  });
+
+  it('stays silent when up to date, ahead, or latest is unknown', () => {
+    expect(isNotifiableUpdate('1.14.2', '1.14.2')).toBe(false);
+    expect(isNotifiableUpdate('1.15.0', '1.14.2')).toBe(false);
+    expect(isNotifiableUpdate('1.14.2', undefined)).toBe(false);
+  });
+});

--- a/src/lib/telemetry/checkIn.ts
+++ b/src/lib/telemetry/checkIn.ts
@@ -1,0 +1,92 @@
+/**
+ * Weekly anonymous check-in: build the payload, POST it to the collector, and
+ * record the latest version the collector reports back (for the Settings
+ * "update available" line). Every failure is swallowed — telemetry must never
+ * affect the running app.
+ */
+import { APP_VERSION } from '@/lib/constants';
+import { isHaMode } from '@/lib/config/runtime';
+import {
+  TELEMETRY_SCHEMA_VERSION,
+  TELEMETRY_SETTING_KEYS,
+  getTelemetryEndpoint,
+  type TelemetryPayload,
+} from './constants';
+import { getOrCreateInstanceId } from './instanceId';
+import { readSetting, writeSetting } from './store';
+
+/**
+ * Whether check-ins are allowed right now.
+ *   - `PRISM_DISABLE_TELEMETRY=true` hard-disables (distro / enterprise builds).
+ *   - An explicit `telemetry.enabled === false` setting = user opted out.
+ *   - Otherwise enabled (opt-out default).
+ * Note: a configured endpoint is required to actually send, checked separately
+ * so the Settings UI can still show the toggle state on an inert build.
+ */
+export async function isTelemetryEnabled(): Promise<boolean> {
+  if (process.env.PRISM_DISABLE_TELEMETRY === 'true') return false;
+  const setting = await readSetting<boolean>(TELEMETRY_SETTING_KEYS.enabled);
+  return setting !== false;
+}
+
+/** Build the exact anonymous payload that will be sent. */
+export async function buildPayload(): Promise<TelemetryPayload> {
+  return {
+    schema: TELEMETRY_SCHEMA_VERSION,
+    id: await getOrCreateInstanceId(),
+    version: APP_VERSION,
+    deployment: isHaMode() ? 'ha' : 'docker',
+    arch: process.arch,
+  };
+}
+
+type CheckInResult = {
+  sent: boolean;
+  latestVersion?: string;
+  reason?: string;
+};
+
+/**
+ * Perform one check-in. Safe to call anytime; returns a small result object for
+ * the "check now" button in Settings. Never throws.
+ */
+export async function runCheckIn(): Promise<CheckInResult> {
+  try {
+    if (!(await isTelemetryEnabled())) return { sent: false, reason: 'disabled' };
+
+    const endpoint = getTelemetryEndpoint();
+    if (!endpoint) return { sent: false, reason: 'no-endpoint' };
+
+    const payload = await buildPayload();
+
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      // Don't let a slow/hanging collector stall the cron tick.
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) return { sent: false, reason: `http-${res.status}` };
+
+    // The collector may answer with the latest published version so we can
+    // surface an update notice. Everything here is best-effort.
+    let latestVersion: string | undefined;
+    try {
+      const data = (await res.json()) as { latestVersion?: unknown };
+      if (typeof data.latestVersion === 'string' && data.latestVersion) {
+        latestVersion = data.latestVersion.replace(/^v/, '');
+        await writeSetting(TELEMETRY_SETTING_KEYS.latestVersion, latestVersion);
+      }
+    } catch {
+      /* collector returned no/invalid JSON — fine */
+    }
+
+    await writeSetting(TELEMETRY_SETTING_KEYS.lastCheckAt, new Date().toISOString());
+    return { sent: true, latestVersion };
+  } catch (err) {
+    return { sent: false, reason: err instanceof Error ? err.message : 'error' };
+  }
+}
+
+export { compareVersions, isNotifiableUpdate } from './version';

--- a/src/lib/telemetry/checkIn.ts
+++ b/src/lib/telemetry/checkIn.ts
@@ -5,7 +5,7 @@
  * affect the running app.
  */
 import { APP_VERSION } from '@/lib/constants';
-import { isHaMode } from '@/lib/config/runtime';
+import { getDeploymentChannel } from '@/lib/config/runtime';
 import {
   TELEMETRY_SCHEMA_VERSION,
   TELEMETRY_SETTING_KEYS,
@@ -35,7 +35,7 @@ export async function buildPayload(): Promise<TelemetryPayload> {
     schema: TELEMETRY_SCHEMA_VERSION,
     id: await getOrCreateInstanceId(),
     version: APP_VERSION,
-    deployment: isHaMode() ? 'ha' : 'docker',
+    deployment: getDeploymentChannel(),
     arch: process.arch,
   };
 }

--- a/src/lib/telemetry/constants.ts
+++ b/src/lib/telemetry/constants.ts
@@ -1,0 +1,61 @@
+/**
+ * Anonymous update-check / telemetry constants.
+ *
+ * Prism phones home once a week to (a) ask whether a newer version exists so it
+ * can show a quiet "update available" line in Settings, and (b) let the
+ * maintainer count *active* installs (de-duplicated by a random instance id, so
+ * one install that updates ten times still counts once).
+ *
+ * Design guarantees, all enforced elsewhere in this module:
+ *   - Opt-OUT: on by default, one switch in Settings -> About turns it off, and
+ *     `PRISM_DISABLE_TELEMETRY=true` hard-disables it for distro/enterprise builds.
+ *   - Anonymous: the payload is exactly {schema,id,version,deployment,arch}. No
+ *     IP (the collector is instructed not to store it), no PII, no config, no
+ *     usage. The id is a random UUID with no link to any account or hostname.
+ *   - Inert until configured: if no collector endpoint is set, nothing is sent.
+ */
+
+/** Bump if the payload shape changes so the collector can branch on it. */
+export const TELEMETRY_SCHEMA_VERSION = 1;
+
+/** Settings-table keys owned by this feature. */
+export const TELEMETRY_SETTING_KEYS = {
+  /** boolean — user's opt-out switch. Unset/true = enabled (opt-out default). */
+  enabled: 'telemetry.enabled',
+  /** string — random per-install UUID. Generated lazily on first check-in. */
+  instanceId: 'telemetry.instanceId',
+  /** string — latest version the collector reported (for the update notice). */
+  latestVersion: 'telemetry.latestVersion',
+  /** string — ISO timestamp of the last successful check-in. */
+  lastCheckAt: 'telemetry.lastCheckAt',
+} as const;
+
+/**
+ * Where installs check in. This is the maintainer's deployed collector
+ * (see /collector — a Cloudflare Worker). Override per-deployment with
+ * PRISM_TELEMETRY_URL.
+ *
+ * NOTE FOR THE MAINTAINER: set this to your deployed Worker URL before shipping
+ * a release build. While it is empty, telemetry is completely inert — no
+ * request is ever made — which is the safe default for this review branch.
+ */
+export const DEFAULT_TELEMETRY_ENDPOINT = '';
+
+/** Resolve the collector endpoint (env override wins). Empty => inert. */
+export function getTelemetryEndpoint(): string {
+  return (process.env.PRISM_TELEMETRY_URL || DEFAULT_TELEMETRY_ENDPOINT).trim();
+}
+
+/** The exact anonymous payload sent on each weekly check-in. */
+export type TelemetryPayload = {
+  /** Payload schema version. */
+  schema: number;
+  /** Random per-install UUID. Not tied to any account, host, or IP. */
+  id: string;
+  /** Running app version, e.g. "1.14.2". */
+  version: string;
+  /** Distribution channel: Home Assistant addon vs. plain Docker. */
+  deployment: 'ha' | 'docker';
+  /** CPU architecture, e.g. "x64" | "arm64". */
+  arch: string;
+};

--- a/src/lib/telemetry/constants.ts
+++ b/src/lib/telemetry/constants.ts
@@ -54,8 +54,12 @@ export type TelemetryPayload = {
   id: string;
   /** Running app version, e.g. "1.14.2". */
   version: string;
-  /** Distribution channel: Home Assistant addon vs. plain Docker. */
-  deployment: 'ha' | 'docker';
+  /**
+   * Distribution channel, e.g. "ha" | "docker" | "pikapods" | "render". Set by
+   * getDeploymentChannel() so installs can be counted by source. Open-ended so
+   * new hosted blueprints need no schema change.
+   */
+  deployment: string;
   /** CPU architecture, e.g. "x64" | "arm64". */
   arch: string;
 };

--- a/src/lib/telemetry/instanceId.ts
+++ b/src/lib/telemetry/instanceId.ts
@@ -1,0 +1,22 @@
+/**
+ * Anonymous per-install identifier.
+ *
+ * A random UUID generated on first check-in and persisted in the settings
+ * table. It exists only so the collector can de-duplicate: one install that
+ * updates every week counts as a single active install rather than N. It is not
+ * derived from anything (no hostname, MAC, account, or IP) and can be wiped by
+ * clearing the `telemetry.instanceId` setting.
+ */
+import { randomUUID } from 'node:crypto';
+import { TELEMETRY_SETTING_KEYS } from './constants';
+import { readSetting, writeSetting } from './store';
+
+/** Return the install's UUID, generating and persisting one on first call. */
+export async function getOrCreateInstanceId(): Promise<string> {
+  const existing = await readSetting<string>(TELEMETRY_SETTING_KEYS.instanceId);
+  if (existing && typeof existing === 'string') return existing;
+
+  const id = randomUUID();
+  await writeSetting(TELEMETRY_SETTING_KEYS.instanceId, id);
+  return id;
+}

--- a/src/lib/telemetry/store.ts
+++ b/src/lib/telemetry/store.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny typed read/write helpers over the key-value `settings` table, scoped to
+ * the telemetry feature so it does not depend on the HTTP settings route.
+ */
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+/** Read a single setting value, or `undefined` if the key is absent. */
+export async function readSetting<T = unknown>(key: string): Promise<T | undefined> {
+  const [row] = await db.select().from(settings).where(eq(settings.key, key));
+  return row ? (row.value as T) : undefined;
+}
+
+/** Upsert a single setting value. */
+export async function writeSetting(key: string, value: unknown): Promise<void> {
+  const [existing] = await db.select().from(settings).where(eq(settings.key, key));
+  if (existing) {
+    await db
+      .update(settings)
+      .set({ value: value as object, updatedAt: new Date() })
+      .where(eq(settings.key, key));
+  } else {
+    await db.insert(settings).values({ key, value: value as object });
+  }
+}

--- a/src/lib/telemetry/version.ts
+++ b/src/lib/telemetry/version.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure semver helpers for the update check. Kept dependency-free so they can be
+ * unit-tested without importing the db/runtime chain.
+ */
+
+/**
+ * Compare two dotted versions. Returns 1 if a>b, -1 if a<b, 0 if equal.
+ * Tolerant of a leading "v" and of differing segment counts.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+/**
+ * Whether to surface an "update available" hint for `latest` vs `current`.
+ *
+ * Deliberately suppresses patch-only bumps (x.y.Z): a wall-mounted family
+ * dashboard shouldn't nag on every hotfix, and a fast patch cadence must not
+ * translate into constant notices. Only a newer MAJOR or MINOR qualifies.
+ */
+export function isNotifiableUpdate(current: string, latest?: string): boolean {
+  if (!latest) return false;
+  if (compareVersions(latest, current) <= 0) return false;
+  const [cMaj = 0, cMin = 0] = current.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const [lMaj = 0, lMin = 0] = latest.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  return lMaj > cMaj || (lMaj === cMaj && lMin > cMin);
+}


### PR DESCRIPTION
Opt-out anonymous update check + real install counter. Built for review — **not intended to auto-merge**; nothing phones home until you deploy the collector and set its URL (see "One thing you must do").

## Why
Registry pull counts (~2,218 across ghcr) can't tell you how many installs are *live* — they double-count every `:latest` re-pull and every CI job, so the number is dominated by your own activity. A per-install check-in de-duplicates (one install = one count, however many times it updates) and lets you exclude your own ids, giving a true **weekly-active-installs** number. It doubles as an update-available notice, which is a feature self-hosted users otherwise have no way to get.

## Model: opt-out (matches Next.js / Astro / Homebrew)
On by default so the count reflects reality, not just the few who'd switch it on. Off is one click, and `PRISM_DISABLE_TELEMETRY=true` hard-disables for distro/enterprise builds.

## What's sent — exactly, once a week
```json
{ "schema": 1, "id": "<random uuid>", "version": "1.14.2", "deployment": "docker", "arch": "arm64" }
```
**No IP** (collector never reads/stores it), **no personal data**, **no usage**. The `id` is a random UUID with no link to any account, host, or address — it exists only to de-dupe.

## Not annoying by design
- Update notices live **only in Settings → About** — never on the dashboard, never a pop-up.
- **Patch bumps are suppressed** (1.14.1 → 1.14.2 stays silent); you're only nudged on a new minor/major. Your fast patch cadence never becomes nagging.
- The weekly *count* ping is independent of the *notice*, so counting never depends on showing anything.

## What's here
| Area | Files |
|---|---|
| Client lib | `src/lib/telemetry/*` (payload, store, instance id, check-in, pure semver + unit tests) |
| Cron | `src/lib/server/telemetryCron.ts` (weekly, mirrors `calendarSyncCron`), registered in `instrumentation.ts` |
| API | `src/app/api/telemetry/route.ts` (status + payload preview + "check now") |
| UI | Settings → About `TelemetryCard` (toggle, quiet update line, full payload disclosure) |
| Collector | `collector/` — self-hostable Cloudflare Worker + D1 schema + deploy README |
| Docs | `docs/features/TELEMETRY.md`, CHANGELOG, `.env.example`, mkdocs nav |

## One thing you must do before it does anything
`DEFAULT_TELEMETRY_ENDPOINT` in `src/lib/telemetry/constants.ts` ships **empty**, so the feature is completely inert on this branch. To go live:
1. Deploy the collector: `cd collector && wrangler d1 create prism-telemetry && wrangler d1 execute prism-telemetry --remote --file=schema.sql && wrangler secret put STATS_TOKEN && wrangler deploy` (full steps in `collector/README.md`).
2. Set the endpoint — either bake the Worker URL into `DEFAULT_TELEMETRY_ENDPOINT`, or ship `PRISM_TELEMETRY_URL` in the image env.
3. Read numbers at `GET /stats?token=…` → `activeInstalls7d` is the honest figure.

## Checks
`tsc --noEmit` clean · eslint clean on new files · new `version.test.ts` passes (5/5) · secret/hostname scanners clean.

## Open questions for you
- Endpoint strategy: bake the URL into the constant, or keep it env-only (`PRISM_TELEMETRY_URL`) so forks stay unconfigured by default?
- Want a **first-run disclosure** line in the setup wizard (opt-out is disclosed but not yet surfaced at onboarding), or is Settings + docs enough?
