### PR TITLE
fix(calendar): wide static fetch window so future events don't vanish (#250)

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -31,6 +31,7 @@ import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { formatEventRow } from '@/lib/utils/formatters';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
+import { MAX_CALENDAR_EVENTS } from '@/lib/utils/calendarRange';
 
 // Cache events for 5 minutes
 const EVENTS_CACHE_TTL = 5 * 60;
@@ -70,7 +71,7 @@ export async function GET(request: NextRequest) {
     const endDateStr = searchParams.get('endDate');
     const calendarId = searchParams.get('calendarId');
     const allDay = searchParams.get('allDay');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '100'), 500);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '100'), MAX_CALENDAR_EVENTS);
     const offset = parseInt(searchParams.get('offset') || '0');
 
     // Validate required date range
@@ -180,6 +181,15 @@ export async function GET(request: NextRequest) {
         .orderBy(asc(events.startTime))
         .limit(limit)
         .offset(offset);
+
+      // If a fetch fills the row ceiling, events may be silently omitted — the
+      // exact failure mode of #250. Surface it in logs rather than dropping
+      // events quietly, so the cap can be raised or the fetch paginated.
+      if (results.length >= limit) {
+        console.warn(
+          `[events] fetch hit the ${limit}-row ceiling for ${startDateStr}..${endDateStr}; some events may be omitted.`,
+        );
+      }
 
       // Format response
       // Color priority: event color > user color > calendar color > default

--- a/src/app/calendar/useCalendarViewData.ts
+++ b/src/app/calendar/useCalendarViewData.ts
@@ -15,6 +15,7 @@ import {
 import { useCalendarEvents, useCalendarFilter } from '@/lib/hooks';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { deduplicateEvents } from '@/lib/utils/calendarDedup';
+import { getFullCalendarRange, MAX_CALENDAR_EVENTS } from '@/lib/utils/calendarRange';
 import type { CalendarEvent } from '@/types/calendar';
 
 export type CalendarViewType = 'agenda' | 'day' | 'week' | 'weekVertical' | 'multiWeek' | 'month' | 'threeMonth';
@@ -108,7 +109,16 @@ export function useCalendarViewData() {
   }, [overlays]);
 
   const { selectedCalendarIds, toggleCalendar, filterEvents, calendarGroups } = useCalendarFilter();
-  const { events: apiEvents, loading, error, refresh: refreshEvents } = useCalendarEvents({ daysToShow: 60 });
+  // Fetch a wide, static window (Jan 1 last year … Dec 31 +2yr) rather than a
+  // rolling today-anchored one, so events don't vanish from the views once
+  // they're more than a couple months out (#250). Fixed window => navigation
+  // reuses one cached dataset instead of refetching on every prev/next.
+  const fetchRange = useMemo(() => getFullCalendarRange(new Date()), []);
+  const { events: apiEvents, loading, error, refresh: refreshEvents } = useCalendarEvents({
+    rangeStart: fetchRange.start,
+    rangeEnd: fetchRange.end,
+    limit: MAX_CALENDAR_EVENTS,
+  });
 
   const events: CalendarEvent[] = useMemo(() => {
     const mapped = apiEvents.map((event) => ({

--- a/src/lib/hooks/useCalendarEvents.ts
+++ b/src/lib/hooks/useCalendarEvents.ts
@@ -13,8 +13,17 @@ import { useVisibilityPolling } from '@/lib/hooks/useVisibilityPolling';
 import { navCacheGet, navCacheSet } from '@/lib/utils/navCache';
 
 interface UseCalendarEventsOptions {
-  /** Number of days to fetch events for */
+  /** Number of days to fetch events for (used only when rangeStart/rangeEnd are omitted). */
   daysToShow?: number;
+  /**
+   * Explicit fetch window. When both are provided they override the
+   * today-anchored daysToShow window — used by the full calendar page so events
+   * far from today (past a rolling horizon) don't disappear from the views.
+   */
+  rangeStart?: Date;
+  rangeEnd?: Date;
+  /** Max events to request. Defaults to 500; the calendar page raises this. */
+  limit?: number;
   /** Auto-refresh interval in milliseconds (0 = disabled) */
   refreshInterval?: number;
   /** Start with demo data before API loads */
@@ -39,15 +48,26 @@ interface UseCalendarEventsResult {
 export function useCalendarEvents(
   options: UseCalendarEventsOptions = {}
 ): UseCalendarEventsResult {
-  const { daysToShow = 7, refreshInterval = 5 * 60 * 1000, useDemoFallback = true, autoSyncMinutes = 10, enabled = true } = options;
+  const { daysToShow = 7, rangeStart, rangeEnd, limit = 500, refreshInterval = 5 * 60 * 1000, useDemoFallback = true, autoSyncMinutes = 10, enabled = true } = options;
 
-  // Stable cache key for today's date range — same across remounts within the same day
+  // The request URL doubles as the cache key. When an explicit range is given
+  // it wins; otherwise fall back to the today-anchored daysToShow window.
+  // Stable across remounts within the same day (deps are primitives).
+  const rangeStartMs = rangeStart?.getTime();
+  const rangeEndMs = rangeEnd?.getTime();
   const cacheKey = useMemo(() => {
-    const today = startOfDay(new Date());
-    const startDate = startOfDay(subDays(today, 30));
-    const endDate = endOfDay(addDays(today, daysToShow));
-    return `/api/events?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}&limit=500`;
-  }, [daysToShow]);
+    let startDate: Date;
+    let endDate: Date;
+    if (rangeStartMs !== undefined && rangeEndMs !== undefined) {
+      startDate = new Date(rangeStartMs);
+      endDate = new Date(rangeEndMs);
+    } else {
+      const today = startOfDay(new Date());
+      startDate = startOfDay(subDays(today, 30));
+      endDate = endOfDay(addDays(today, daysToShow));
+    }
+    return `/api/events?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}&limit=${limit}`;
+  }, [daysToShow, rangeStartMs, rangeEndMs, limit]);
 
   const cached = navCacheGet<CalendarEvent[]>(cacheKey);
   const [events, setEvents] = useState<CalendarEvent[]>(() => cached ?? []);
@@ -63,13 +83,9 @@ export function useCalendarEvents(
     try {
       setError(null);
 
-      const today = startOfDay(new Date());
-      const startDate = startOfDay(subDays(today, 30));
-      const endDate = endOfDay(addDays(today, daysToShow));
-
-      const response = await fetch(
-        `/api/events?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}&limit=500`
-      );
+      // cacheKey IS the request URL (same window + limit), so the fetch can
+      // never diverge from what's cached.
+      const response = await fetch(cacheKey);
 
       if (!response.ok) {
         if (response.status === 401) {
@@ -124,7 +140,7 @@ export function useCalendarEvents(
     } finally {
       setLoading(false);
     }
-  }, [daysToShow, useDemoFallback, cacheKey]);
+  }, [cacheKey]);
 
   /**
    * Trigger calendar sync

--- a/src/lib/utils/__tests__/calendarRange.test.ts
+++ b/src/lib/utils/__tests__/calendarRange.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression test for #250: the calendar fetch window must reach far enough
+ * past today that events a couple months+ out don't vanish from the views.
+ */
+import { getFullCalendarRange, MAX_CALENDAR_EVENTS } from '../calendarRange';
+
+describe('getFullCalendarRange', () => {
+  it('spans Jan 1 of last year through Dec 31 two years out', () => {
+    const { start, end } = getFullCalendarRange(new Date(2026, 7, 18)); // 2026-08-18
+
+    expect(start.getFullYear()).toBe(2025);
+    expect(start.getMonth()).toBe(0); // January
+    expect(start.getDate()).toBe(1);
+
+    expect(end.getFullYear()).toBe(2028);
+    expect(end.getMonth()).toBe(11); // December
+    expect(end.getDate()).toBe(31);
+  });
+
+  it('covers the exact event that used to disappear (today + ~2 months)', () => {
+    const today = new Date(2026, 7, 18);
+    const { start, end } = getFullCalendarRange(today);
+    const oldCutoffEvent = new Date(2026, 9, 17); // 2026-10-17, the reported boundary
+
+    expect(oldCutoffEvent >= start && oldCutoffEvent <= end).toBe(true);
+  });
+
+  it('has headroom well above a busy family instance count', () => {
+    expect(MAX_CALENDAR_EVENTS).toBeGreaterThanOrEqual(5000);
+  });
+});

--- a/src/lib/utils/calendarRange.ts
+++ b/src/lib/utils/calendarRange.ts
@@ -1,0 +1,30 @@
+import { startOfYear, endOfYear, subYears, addYears } from 'date-fns';
+
+/**
+ * Maximum events a single calendar fetch will return. Sized well above a busy
+ * family's instance count across {@link getFullCalendarRange} so the window can
+ * never silently truncate; the API logs a warning if a fetch ever hits it.
+ */
+export const MAX_CALENDAR_EVENTS = 5000;
+
+/**
+ * The date window the full calendar page fetches: from Jan 1 of last year
+ * through Dec 31 two years out (~4 years, anchored to calendar-year
+ * boundaries).
+ *
+ * Why a wide *static* window instead of one that tracks the viewed month:
+ *   - Postgres range scans over years are sub-millisecond (indexed on start
+ *     time), and recurring events are stored as individual instance rows —
+ *     there is no client-side recurrence expansion to blow up — so a wide
+ *     window costs little.
+ *   - A fixed window keeps navigation instant: paging months reuses one cached
+ *     dataset instead of refetching (and flickering) on every prev/next.
+ *   - It fixes the class of bug where events past a rolling horizon silently
+ *     vanished from every view (#250).
+ */
+export function getFullCalendarRange(today: Date): { start: Date; end: Date } {
+  return {
+    start: startOfYear(subYears(today, 1)),
+    end: endOfYear(addYears(today, 2)),
+  };
+}


### PR DESCRIPTION
Fixes #250 — local (and synced) events disappearing ~2 months out.

## Root cause
The calendar fetched a **rolling, today-anchored window** and never moved it with navigation:

```ts
// useCalendarEvents.ts (old)
const startDate = startOfDay(subDays(today, 30));       // 30 days back
const endDate   = endOfDay(addDays(today, daysToShow));  // 60 days forward
```

`useCalendarViewData` requested `daysToShow: 60`, so the app only ever loaded events in `[today − 30d, today + 60d]`. From 2026‑08‑17 that upper bound is exactly **2026‑10‑16** — the reporter's cutoff. Because the window ignored `currentDate`, paging a view past the horizon rendered an empty grid, and this hit **every view** (Month, MultiWeek, Agenda, ThreeMonth) and **both local and synced** events — the report framed it as local only because those were used to probe the boundary.

## Fix
Fetch a **wide static window** instead of a rolling one:

- `useCalendarEvents` now accepts an explicit `{ rangeStart, rangeEnd, limit }`; the request URL doubles as the nav-cache key so the fetch can never diverge from what's cached. The old `daysToShow` path is untouched for other callers.
- `useCalendarViewData` fetches **Jan 1 of last year → Dec 31 two years out** (`getFullCalendarRange`, ~4 years). A fixed window means navigation reuses one cached dataset — no refetch/flicker on every prev/next.
- The events API row cap goes **500 → 5000** (`MAX_CALENDAR_EVENTS`), and it **warn-logs if a fetch ever fills the cap** rather than silently dropping events (the same failure mode as this bug).

## Why a wide window is cheap
Recurring events are stored as **individual instance rows** (Google `singleEvents=true`; CalDAV expanded at sync) — there's no client-side RRULE expansion to blow up — so the wider fetch is just an indexed Postgres range scan (sub‑ms) plus a modestly larger, cached payload (~1 MB at a few thousand events).

## Known follow-up (not blocking)
A *synced CalDAV* series only populates as far out as that integration expanded at sync time, so the far end of the window reflects the sync horizon. Local + Google events populate the full range. Extending the CalDAV sync horizon is a separate small change.

## Checks
`tsc --noEmit` clean · eslint clean (no new warnings) · new `calendarRange.test.ts` (3/3) asserts the window and that the exact today+2mo event is now covered.
