### PR TITLE
chore(release): 1.14.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.14.3] – 2026-08-18
+
+### Calendar
+- **Events more than ~2 months out no longer disappear from the calendar.** The calendar only loaded a rolling window around today (about 30 days back and 60 days forward), so events further out silently dropped from every view — Month, Agenda, and the rest — and paging ahead showed empty grids. This was purely a display limit: the events were always saved and simply reappear once you update. The calendar now loads a much wider window (Jan 1 of last year through the end of two years out), so future events stay visible while navigation stays fast. Thanks to @JoshuaPostema for the precise report (#250).
+
 ## [1.14.2] – 2026-08-17
 
 ### Integrations

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.14.2"
+version: "1.14.3"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.14.3.

**Calendar** — events more than ~2 months out no longer disappear from the calendar views (#250, fixed in #251). Widens the fetch window from a rolling ~30d-back/60d-forward window to Jan 1 last year → end of +2 years. Display-only fix; no data was lost.

Bumps package.json + ha-app/config.yaml + migrates the CHANGELOG Unreleased section. Tag pushed after merge fires the HA image build.