### PR TITLE
fix(calendar): widen sync horizon to match the display window

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Synced calendar events now populate the same multi-year range the calendar shows.** Google, iCloud, and CalDAV events were only synced for a rolling ~90 days back / 1 year forward, so once the calendar's visible window widened (see 1.14.3), synced events beyond that horizon could be missing even though local events at the same dates appeared. Sync now covers about 1 year back and 2 years forward to match. (Recurring series still populate as far as each provider expands them at sync time.)
+
 ## [1.14.3] – 2026-08-18
 
 ### Calendar

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -22,17 +22,23 @@ import { async as icalAsync, type VEvent, type CalendarResponse } from 'node-ica
 /**
  * Default sync window.
  *
- * Past: 90 days back so recent-past events (last quarter) keep flowing in.
- * Events OLDER than this are never touched by sync — the delete-on-remove
- * logic only operates within this window, so historic events synced under
- * an older default stay in the local DB forever.
+ * Sized to cover the calendar's display window (getFullCalendarRange: ~1yr
+ * back … ~2yr forward). If sync were narrower than the display, synced Google/
+ * CalDAV events past the sync horizon would silently not appear even though the
+ * views reach for them — the synced-calendar counterpart of #250, and worse
+ * because it's inconsistent (a local event shows at that date, a synced one
+ * doesn't). So keep sync >= the display reach.
  *
- * Future: 365 days forward so school-year, sports-season, and far-out
- * scheduled events show up. The previous ±30-day default silently dropped
- * anything beyond a month.
+ * Past: 365 days back so recent history stays in step with the views. Events
+ * OLDER than this are never touched by sync — the delete-on-remove logic only
+ * operates within this window, so historic events synced under an older default
+ * stay in the local DB forever.
+ *
+ * Future: 730 days forward so school-year, sports-season, and far-out scheduled
+ * events show up. (Was ±90d/365d, which the wider display window outran.)
  */
-const DEFAULT_TIME_MIN_MS = 90 * 24 * 60 * 60 * 1000;       // 90 days
-const DEFAULT_TIME_MAX_MS = 365 * 24 * 60 * 60 * 1000;      // 365 days
+const DEFAULT_TIME_MIN_MS = 365 * 24 * 60 * 60 * 1000;      // 1 year
+const DEFAULT_TIME_MAX_MS = 730 * 24 * 60 * 60 * 1000;      // 2 years
 
 /**
  * Check if token needs refresh (within 5 minutes of expiry)


### PR DESCRIPTION
Follow-up to #251/#250 — closes the synced-calendar half of the same bug.

## Why
#251 widened the calendar's **display** window to ~1yr back … ~2yr forward. But sync only pulled a rolling **90 days back / 365 days forward** (`DEFAULT_TIME_MIN_MS`/`MAX_MS`), so synced Google/iCloud/CalDAV events past that horizon silently didn't appear — even though local events at the same dates did. That inconsistency is exactly what would prompt a "you said #250 was fixed but my iCloud event next year still doesn't show" follow-up.

## Change
- `DEFAULT_TIME_MIN_MS`: 90d → **365d** (1 year back)
- `DEFAULT_TIME_MAX_MS`: 365d → **730d** (2 years forward)

Now sync covers the display reach. Verified Google's `fetchCalendarEvents` paginates on `nextPageToken` (maxResults 250/page), so the wider window pages through everything instead of truncating at the per-page cap.

## Trade-off (accepted)
A wider sync materializes more recurring instance rows into the DB — the "daily standup × N years" cost you flagged as not a concern. The events fetch cap (5,000, from #251) comfortably covers it.

## Known limit (unchanged)
A recurring series still only populates as far as each provider expands it at sync time; this aligns the *window*, not per-provider expansion depth.

## Checks
`tsc` clean · eslint clean (0 errors) · existing calendar-sync suite 29/29 pass.