### PR TITLE
chore(release): 1.14.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.14.4] – 2026-08-19
+
 ### Calendar
 - **Synced calendar events now populate the same multi-year range the calendar shows.** Google, iCloud, and CalDAV events were only synced for a rolling ~90 days back / 1 year forward, so once the calendar's visible window widened (see 1.14.3), synced events beyond that horizon could be missing even though local events at the same dates appeared. Sync now covers about 1 year back and 2 years forward to match. (Recurring series still populate as far as each provider expands them at sync time.)
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.14.3"
+version: "1.14.4"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.14.4.

**Calendar** — synced Google/iCloud/CalDAV events now populate the same multi-year range the calendar displays (#254), completing the #250/#251 fix so synced events past the old ~1yr sync horizon no longer go missing.

Bumps package.json + ha-app/config.yaml + migrates the CHANGELOG. Tag after merge fires the HA image build.