### PR TITLE
fix(calendar): store event location as text, not varchar(255)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Fixed calendar sync failing for events with long locations.** Events whose location lists several venues (e.g. a CalDAV event with three rooms joined by `;`, ~300+ characters) exceeded the location field's 255-character limit, so every occurrence of that recurring series failed to sync and flooded the logs with errors. The location field is now unbounded (stored as `text`), matching the description field — nothing is truncated, and existing data is preserved.
+
 ## [1.14.4] – 2026-08-19
 
 ### Calendar

--- a/drizzle/0022_event_location_text.sql
+++ b/drizzle/0022_event_location_text.sql
@@ -1,0 +1,9 @@
+-- Widen events.location from varchar(255) to text.
+--
+-- Real calendar locations can exceed 255 chars — e.g. a CalDAV event whose
+-- LOCATION concatenates several venue rooms with ';' separators (300+ chars).
+-- The length check rejected the whole row, so every occurrence of such a
+-- recurring series failed to sync. text has identical storage/perf to varchar
+-- in Postgres and matches the already-text description column. varchar->text
+-- needs no table rewrite and preserves all existing values.
+ALTER TABLE "events" ALTER COLUMN "location" TYPE text;

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -291,7 +291,7 @@ CREATE TABLE IF NOT EXISTS public.events (
     external_event_id character varying(255),
     title character varying(255) NOT NULL,
     description text,
-    location character varying(255),
+    location text,
     start_time timestamp without time zone NOT NULL,
     end_time timestamp without time zone NOT NULL,
     all_day boolean DEFAULT false NOT NULL,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -148,7 +148,7 @@ export const events = pgTable('events', {
 
   title: varchar('title', { length: 255 }).notNull(),
   description: text('description'),
-  location: varchar('location', { length: 255 }),
+  location: text('location'),
 
   startTime: timestamp('start_time').notNull(),
   endTime: timestamp('end_time').notNull(),


### PR DESCRIPTION
## Symptom
Calendar sync flooding the logs with Postgres errors on a recurring CalDAV event:
```
insert into "events" ... value too long for type character varying(255)
```

## Cause
The event's `location` concatenates several venue rooms with `;` separators — 300+ characters — but `events.location` was `varchar(255)`, so Postgres rejected the whole row for **every occurrence** of the recurring series. The wider sync horizon shipped in 1.14.4 (#254) pulled the full multi-year series into range, turning an occasional failure into a flood.

## Fix
Widen `events.location` from `varchar(255)` to `text` — matching the already-`text` `description` column:
- Identical storage/performance in Postgres; `varchar→text` needs no table rewrite and preserves all existing data.
- Fixes **every** sync path (Google/CalDAV/iCal/local) with one column change, no truncation, no location data lost.
- `schema.ts` + fresh-install `02-schema.sql` + `drizzle/0022_event_location_text.sql` (auto-applied by `migrate.js` on container start).

## Deploy note
Existing installs get it via migration `0022` on next container start. For an immediate hotfix without redeploying:
```
ALTER TABLE events ALTER COLUMN location TYPE text;
```

## Checks
`tsc` clean. Schema-only — no app-code changes.