### PR TITLE
chore(release): 1.15.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.0] – 2026-08-20
+
 ### Privacy
 - **Anonymous update check (on by default, one switch to turn off).** Once a week Prism now checks whether a newer version is available and, in the same request, adds one anonymous install to a count the maintainer uses to gauge real usage. Exactly four fields are sent — a random per-install id, the version, docker-vs-Home-Assistant, and CPU architecture — with **no IP address, no personal data, and no usage tracking**. See the exact payload any time under Settings → About, disable it there with one switch, or hard-disable it for the whole install with `PRISM_DISABLE_TELEMETRY=true`. Update notices are quiet: they appear only in Settings (never on the dashboard) and only for minor/major releases, never patches. Full details in the [Anonymous update check](features/TELEMETRY.md) guide.
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.14.4"
+version: "1.15.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.14.4",
+  "version": "1.15.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.0.

**Privacy** — opt-out anonymous update check + install counter (#249). Weekly anonymous check-in (random id, version, docker-vs-HA, arch — no IP/PII), disclosed at first-run, one-click off in Settings, HA addon toggle, PRISM_DISABLE_TELEMETRY kill-switch. Collector URL baked into official images only.

**Calendar** — event location stored as text, not varchar(255) (#256), fixing sync failures for events with long multi-venue locations. Includes migration 0022 (auto-applied by migrate.js).

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG. Tag after merge fires the HA image build (which also bakes in the telemetry collector URL).