### PR TITLE
fix(calendar): re-auth discovers newly-subscribed Google calendars

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Re-authenticating Google now picks up newly-subscribed calendars.** Once Google was connected, re-authenticating only refreshed the calendars Prism already knew about — so a calendar you subscribed to *afterward* never appeared, and the only workaround was to fully disconnect and reconnect. Re-auth now also discovers and adds any new calendars (skipping ones you've deleted from Prism before), so subscribing to a calendar and re-authenticating brings it in.
+
 ## [1.15.0] – 2026-08-20
 
 ### Privacy

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -108,7 +108,15 @@ export async function GET(request: Request) {
         }).where(eq(calendarSources.id, source.id));
       }
 
-      // Update showInEventModal based on current accessRole
+      // Discover calendars added since the initial connect (e.g. one you
+      // subscribed to later). Re-auth previously only refreshed tokens for
+      // known calendars and never picked up new ones, so a newly-subscribed
+      // calendar would never appear. Mirror the fresh-connect path here:
+      // update showInEventModal for existing, and insert genuinely new ones.
+      const [reauthDismissed] = await db.select().from(settings)
+        .where(eq(settings.key, 'dismissedGoogleCalendarIds'));
+      const reauthDismissedIds: string[] = (reauthDismissed?.value as string[]) || [];
+
       for (const calendar of reAuthCalendars) {
         const isWritable = calendar.accessRole === 'writer' || calendar.accessRole === 'owner';
         const existing = await db.query.calendarSources.findFirst({
@@ -123,7 +131,25 @@ export async function GET(request: Request) {
             .update(calendarSources)
             .set({ showInEventModal: isWritable, updatedAt: new Date() })
             .where(eq(calendarSources.id, existing.id));
+          continue;
         }
+        // New calendar — skip if the user previously deleted it from Prism.
+        if (reauthDismissedIds.includes(calendar.id)) continue;
+        const calendarName = (calendar.summary || 'Untitled Calendar').slice(0, 255);
+        await db.insert(calendarSources).values({
+          userId: auth.userId,
+          provider: 'google',
+          sourceCalendarId: calendar.id,
+          dashboardCalendarName: calendarName,
+          displayName: calendarName,
+          color: calendar.backgroundColor || undefined,
+          enabled: true,
+          showInEventModal: isWritable,
+          accessToken: encryptedAccessToken,
+          refreshToken: encryptedRefreshToken,
+          tokenExpiresAt,
+          accountEmail,
+        });
       }
 
       logActivity({


### PR DESCRIPTION
## Symptom
Subscribing to a new Google calendar and then re-authenticating in Prism doesn't surface it — the calendar never appears, even though it's visible in Google under the connected account.

## Cause
The re-auth branch of the Google OAuth callback (`src/app/api/auth/google/callback/route.ts`) only **updates existing** calendar sources (tokens + `showInEventModal`) and returns. It never **inserts new** calendars. Only the initial-connect path discovers/adds calendars, and the periodic sync only reconciles known sources. So a calendar subscribed to after the first connect is never picked up by re-auth or sync — the only workaround was a full disconnect/reconnect.

## Fix
In the re-auth branch, after updating existing sources, also insert genuinely new calendars — mirroring the fresh-connect discovery: skip ones in the dismissed list, insert new ones `enabled` with `showInEventModal` per access role. Now re-authenticating brings in newly-subscribed calendars.

## Checks
`tsc` clean, eslint clean. No app-code changes beyond the callback.