### PR TITLE
chore(release): 1.15.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.1] – 2026-08-20
+
 ### Calendar
 - **Re-authenticating Google now picks up newly-subscribed calendars.** Once Google was connected, re-authenticating only refreshed the calendars Prism already knew about — so a calendar you subscribed to *afterward* never appeared, and the only workaround was to fully disconnect and reconnect. Re-auth now also discovers and adds any new calendars (skipping ones you've deleted from Prism before), so subscribing to a calendar and re-authenticating brings it in.
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.0"
+version: "1.15.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.1.

**Calendar** — re-authenticating Google now discovers newly-subscribed calendars (#258), not just refreshing existing ones. Fixes calendars subscribed to after the initial connect never appearing without a full disconnect/reconnect.

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG.