### PR TITLE
fix(calendar): discover hidden Google calendars, decouple on/off from Google

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Google calendars you've hidden in your list are now discoverable, and hiding one in Google no longer removes it from Prism.** Prism now sees all your Google calendars regardless of their visibility in your Google sidebar. Newly-discovered hidden calendars are added switched **off**, so they're available in Manage Calendars without cluttering your dashboard — and your on/off choices in Prism are now independent of Google's list, so tidying up your Google sidebar won't make calendars vanish from your board.
+
 ## [1.15.1] – 2026-08-20
 
 ### Calendar

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -143,7 +143,9 @@ export async function GET(request: Request) {
           dashboardCalendarName: calendarName,
           displayName: calendarName,
           color: calendar.backgroundColor || undefined,
-          enabled: true,
+          // Calendars hidden in the user's Google list come in disabled, so
+          // they're available in Manage Calendars without cluttering the board.
+          enabled: !calendar.hidden,
           showInEventModal: isWritable,
           accessToken: encryptedAccessToken,
           refreshToken: encryptedRefreshToken,
@@ -207,7 +209,9 @@ export async function GET(request: Request) {
           dashboardCalendarName: calendarName,
           displayName: calendarName,
           color: calendar.backgroundColor || undefined,
-          enabled: true,
+          // Calendars hidden in the user's Google list come in disabled, so
+          // they're available in Manage Calendars without cluttering the board.
+          enabled: !calendar.hidden,
           showInEventModal: isWritable,
           accessToken: encryptedAccessToken,
           refreshToken: encryptedRefreshToken,

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -64,6 +64,8 @@ export interface GoogleCalendar {
   foregroundColor?: string;
   primary?: boolean;
   accessRole: string;
+  /** True when the calendar is hidden from the user's Google list view. */
+  hidden?: boolean;
 }
 
 /**
@@ -186,7 +188,12 @@ export async function refreshAccessToken(refreshToken: string): Promise<GoogleTo
  * Fetch list of calendars
  */
 export async function fetchCalendarList(accessToken: string): Promise<GoogleCalendar[]> {
-  const response = await fetch(`${GOOGLE_CALENDAR_API}/users/me/calendarList`, {
+  // showHidden=true so subscribed calendars you've hidden from your Google list
+  // are still discovered. Prism controls on/off itself (in Manage Calendars),
+  // decoupled from Google's list visibility — so hiding a calendar in Google no
+  // longer makes it vanish from Prism. Newly-discovered hidden calendars are
+  // added disabled by the callers (see enabled: !calendar.hidden).
+  const response = await fetch(`${GOOGLE_CALENDAR_API}/users/me/calendarList?showHidden=true`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },


### PR DESCRIPTION
Follow-up to #258. Makes Google calendar discovery independent of Google's list-visibility.

## Behavior
- `fetchCalendarList` now passes `showHidden=true`, so calendars hidden in your Google sidebar (commonly subscribed calendars) are discovered.
- Newly-discovered **hidden** calendars are inserted **disabled** (`enabled: !calendar.hidden`) — available in Manage Calendars, but not auto-added to the dashboard.
- Because hidden calendars now appear in the fetched list, the sync's "not found → auto-disable after 3 checks" no longer triggers just because you hid a calendar in Google. **On/off is controlled in Prism**, decoupled from Google's list — so tidying your Google sidebar won't make calendars flap on your board.

## Files
- `src/lib/integrations/google-calendar.ts` — `showHidden=true` + `hidden` field on the `GoogleCalendar` type.
- `src/app/api/auth/google/callback/route.ts` — both discovery inserts (connect + re-auth) key `enabled` off `hidden`.

## Checks
`tsc` clean, eslint clean (no new warnings).