### PR TITLE
chore(release): 1.15.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.2] – 2026-08-20
+
 ### Calendar
 - **Google calendars you've hidden in your list are now discoverable, and hiding one in Google no longer removes it from Prism.** Prism now sees all your Google calendars regardless of their visibility in your Google sidebar. Newly-discovered hidden calendars are added switched **off**, so they're available in Manage Calendars without cluttering your dashboard — and your on/off choices in Prism are now independent of Google's list, so tidying up your Google sidebar won't make calendars vanish from your board.
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.1"
+version: "1.15.2"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.2.

**Calendar** — Google calendars hidden in your list are now discoverable, and hiding one in Google no longer removes it from Prism (#260). New hidden calendars come in disabled; on/off is controlled in Prism's Manage Calendars, decoupled from Google's list visibility.

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG.