### PR TITLE
feat(calendar): restore removed calendars + friendlier deleted-calendar handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **Restore a Google calendar you removed by mistake.** Deleting a Google calendar from Prism tombstones it so it won't reappear on your next sign-in — but until now there was no way to undo that. Manage calendars now has a **Removed calendars** section listing anything you've deleted, each with a **Restore** button that brings it back. (The tombstone now remembers the calendar's name, so the list is readable rather than a cryptic id.)
+
 ## [1.15.2] – 2026-08-20
 
 ### Calendar

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Calendar
+- **Deleting a calendar in Google no longer flashes a "Sync failed" error in Prism.** When you remove a calendar from Google, Prism used to surface the resulting "not found" error as an alarming sync failure for a few cycles before auto-disabling the calendar. It now handles that quietly and, once confirmed, labels the calendar **"Removed in Google — auto-disabled"** in Manage calendars so you can see why it went inactive.
 - **Restore a Google calendar you removed by mistake.** Deleting a Google calendar from Prism tombstones it so it won't reappear on your next sign-in — but until now there was no way to undo that. Manage calendars now has a **Removed calendars** section listing anything you've deleted, each with a **Restore** button that brings it back. (The tombstone now remembers the calendar's name, so the list is readable rather than a cryptic id.)
 
 ## [1.15.2] – 2026-08-20

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -7,7 +7,9 @@ import { logError } from '@/lib/utils/logError';
 import {
   exchangeCodeForTokens,
   fetchCalendarList,
+  DISMISSED_GOOGLE_CALENDARS_KEY,
 } from '@/lib/integrations/google-calendar';
+import { tombstoneIdSet } from '@/lib/services/settingsTombstone';
 import { encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
@@ -113,9 +115,7 @@ export async function GET(request: Request) {
       // known calendars and never picked up new ones, so a newly-subscribed
       // calendar would never appear. Mirror the fresh-connect path here:
       // update showInEventModal for existing, and insert genuinely new ones.
-      const [reauthDismissed] = await db.select().from(settings)
-        .where(eq(settings.key, 'dismissedGoogleCalendarIds'));
-      const reauthDismissedIds: string[] = (reauthDismissed?.value as string[]) || [];
+      const reauthDismissedSet = await tombstoneIdSet(DISMISSED_GOOGLE_CALENDARS_KEY);
 
       for (const calendar of reAuthCalendars) {
         const isWritable = calendar.accessRole === 'writer' || calendar.accessRole === 'owner';
@@ -134,7 +134,7 @@ export async function GET(request: Request) {
           continue;
         }
         // New calendar — skip if the user previously deleted it from Prism.
-        if (reauthDismissedIds.includes(calendar.id)) continue;
+        if (reauthDismissedSet.has(calendar.id)) continue;
         const calendarName = (calendar.summary || 'Untitled Calendar').slice(0, 255);
         await db.insert(calendarSources).values({
           userId: auth.userId,
@@ -168,13 +168,11 @@ export async function GET(request: Request) {
     const calendars = await fetchCalendarList(tokens.access_token);
 
     // Fetch dismissed Google calendar IDs so we don't recreate user-deleted calendars
-    const [dismissedSetting] = await db.select().from(settings)
-      .where(eq(settings.key, 'dismissedGoogleCalendarIds'));
-    const dismissedIds: string[] = (dismissedSetting?.value as string[]) || [];
+    const dismissedSet = await tombstoneIdSet(DISMISSED_GOOGLE_CALENDARS_KEY);
 
     for (const calendar of calendars) {
       // Skip calendars the user has previously deleted from Prism
-      if (dismissedIds.includes(calendar.id)) continue;
+      if (dismissedSet.has(calendar.id)) continue;
       const existing = await db.query.calendarSources.findFirst({
         where: (cs, { and, eq }) =>
           and(

--- a/src/app/api/calendars/[id]/route.ts
+++ b/src/app/api/calendars/[id]/route.ts
@@ -12,9 +12,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { db } from '@/lib/db/client';
-import { calendarSources, events, settings } from '@/lib/db/schema';
+import { calendarSources, events } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { logError } from '@/lib/utils/logError';
+import { addTombstone } from '@/lib/services/settingsTombstone';
+import { DISMISSED_GOOGLE_CALENDARS_KEY } from '@/lib/integrations/google-calendar';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -233,20 +235,14 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     // Delete the calendar (events will be cascade deleted)
     await db.delete(calendarSources).where(eq(calendarSources.id, id));
 
-    // If it's a Google calendar, add to dismissed list so it won't be recreated on re-connect
+    // If it's a Google calendar, tombstone it (with its name) so discovery won't
+    // recreate it on the next connect/re-auth. Reversible via Manage Calendars →
+    // Removed calendars → Restore.
     if (existing.provider === 'google' && existing.sourceCalendarId) {
-      const [dismissedSetting] = await db.select().from(settings)
-        .where(eq(settings.key, 'dismissedGoogleCalendarIds'));
-      const dismissed: string[] = (dismissedSetting?.value as string[]) || [];
-      if (!dismissed.includes(existing.sourceCalendarId)) {
-        dismissed.push(existing.sourceCalendarId);
-        if (dismissedSetting) {
-          await db.update(settings).set({ value: dismissed, updatedAt: new Date() })
-            .where(eq(settings.key, 'dismissedGoogleCalendarIds'));
-        } else {
-          await db.insert(settings).values({ key: 'dismissedGoogleCalendarIds', value: dismissed });
-        }
-      }
+      await addTombstone(DISMISSED_GOOGLE_CALENDARS_KEY, {
+        id: existing.sourceCalendarId,
+        name: existing.dashboardCalendarName || existing.displayName || existing.sourceCalendarId,
+      });
     }
 
     return NextResponse.json({

--- a/src/app/api/calendars/removed/route.ts
+++ b/src/app/api/calendars/removed/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { logError } from '@/lib/utils/logError';
+import { listTombstones, removeTombstone } from '@/lib/services/settingsTombstone';
+import { DISMISSED_GOOGLE_CALENDARS_KEY } from '@/lib/integrations/google-calendar';
+
+/**
+ * Removed (tombstoned) Google calendars — the ones a user deleted from Prism,
+ * which discovery skips so they don't come back on re-auth.
+ *
+ *   GET           → { removed: [{ id, name }] }
+ *   POST { id }   → clear that tombstone. The calendar is re-discovered on the
+ *                   next Google re-authentication.
+ *
+ * The GET/POST {id} contract is deliberately entity-agnostic so a photos/events
+ * "restore" surface can reuse the same shape and UI.
+ */
+export async function GET() {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const removed = await listTombstones(DISMISSED_GOOGLE_CALENDARS_KEY);
+    return NextResponse.json({ removed });
+  } catch (error) {
+    logError('Error listing removed calendars:', error);
+    return NextResponse.json({ error: 'Failed to list removed calendars' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  try {
+    const { id } = await request.json();
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+    await removeTombstone(DISMISSED_GOOGLE_CALENDARS_KEY, id);
+    return NextResponse.json({ restored: true });
+  } catch (error) {
+    logError('Error restoring calendar:', error);
+    return NextResponse.json({ error: 'Failed to restore calendar' }, { status: 500 });
+  }
+}

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { RemovedItemsManager } from '@/components/settings/RemovedItemsManager';
 import { Switch } from '@/components/ui/switch';
 import { useCalendarSources } from '@/lib/hooks';
 import { useFamily } from '@/components/providers';
@@ -32,6 +33,8 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
   // State for editing calendar display names
   const [editingCalendarId, setEditingCalendarId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
+  const [removedCalendars, setRemovedCalendars] = useState<Array<{ id: string; name: string }>>([]);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
 
   const familyCalendarColor = typeof window !== 'undefined'
     ? localStorage.getItem('prism-family-calendar-color') || '#F59E0B'
@@ -49,6 +52,43 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
     }
     fetchGroups();
   }, [calendars]);
+
+  // Load the list of removed (tombstoned) Google calendars so we can offer to
+  // restore them.
+  useEffect(() => {
+    async function fetchRemoved() {
+      try {
+        const res = await fetch('/api/calendars/removed');
+        if (res.ok) {
+          const data = await res.json();
+          setRemovedCalendars(data.removed || []);
+        }
+      } catch { /* ignore */ }
+    }
+    fetchRemoved();
+  }, [calendars]);
+
+  // Restore a removed calendar: clear its tombstone, then re-authenticate Google
+  // so discovery re-adds it (discovery only runs on connect/re-auth).
+  const handleRestoreCalendar = async (id: string) => {
+    setRestoringId(id);
+    try {
+      const res = await fetch('/api/calendars/removed', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
+      if (res.ok) {
+        setRemovedCalendars((prev) => prev.filter((c) => c.id !== id));
+        const firstGoogle = localCalendars.find((c) => c.provider === 'google');
+        window.location.href = firstGoogle
+          ? `/api/auth/google?reauth=${firstGoogle.id}&returnSection=calendars`
+          : '/api/auth/google?returnSection=calendars';
+      }
+    } finally {
+      setRestoringId(null);
+    }
+  };
 
   useEffect(() => {
     if (calendars.length > 0 && localCalendars.length === 0) {
@@ -571,6 +611,14 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
           )}
         </CardContent>
       </Card>
+
+      <RemovedItemsManager
+        title="Removed calendars"
+        description="Google calendars you deleted from Prism. Discovery won't re-add them automatically — restore one to bring it back on your next Google sign-in."
+        items={removedCalendars}
+        onRestore={handleRestoreCalendar}
+        restoringId={restoringId}
+      />
 
       {/* Calendar Groups */}
       <Card>

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -496,6 +496,14 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
                             </span>
                           </div>
                         )}
+                        {cal.syncErrors?.removedAtSource && (
+                          <div className="flex items-center gap-1 mt-1">
+                            <AlertTriangle className="h-3 w-3 text-muted-foreground shrink-0" />
+                            <span className="text-xs text-muted-foreground">
+                              Removed in Google — auto-disabled here
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                     <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/settings/RemovedItemsManager.tsx
+++ b/src/components/settings/RemovedItemsManager.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RotateCcw } from 'lucide-react';
+
+export interface RemovedItem {
+  id: string;
+  name: string;
+}
+
+/**
+ * Reusable "Removed items → Restore" card. Presentational only — the parent owns
+ * fetching and the restore action — so any sub-page (calendars now; photos or
+ * events later) can drop it in with its own { id, name }[] list and restore
+ * handler. Renders nothing when there's nothing to show, so it can sit
+ * unconditionally in a settings page and only appear when relevant.
+ */
+export function RemovedItemsManager({
+  title,
+  description,
+  items,
+  onRestore,
+  restoringId,
+}: {
+  title: string;
+  description?: string;
+  items: RemovedItem[];
+  onRestore: (id: string) => void;
+  restoringId?: string | null;
+}) {
+  if (items.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 list-none m-0 p-0">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-center justify-between gap-3 rounded-md border border-border/50 px-3 py-2"
+            >
+              <span className="text-sm truncate">{item.name}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={restoringId === item.id}
+                onClick={() => onRestore(item.id)}
+              >
+                <RotateCcw className="h-4 w-4 mr-1.5" />
+                {restoringId === item.id ? 'Restoring…' : 'Restore'}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/hooks/useCalendarEvents.ts
+++ b/src/lib/hooks/useCalendarEvents.ts
@@ -254,7 +254,7 @@ export function useCalendarSources() {
       groupName: string | null;
       groupColor: string | null;
       lastSynced: string | null;
-      syncErrors: { needsReauth?: boolean; lastError?: string; timestamp?: string } | null;
+      syncErrors: { needsReauth?: boolean; removedAtSource?: boolean; lastError?: string; timestamp?: string } | null;
       providerConfig: Record<string, unknown> | null;
       user: { id: string; name: string; color: string } | null;
     }>

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -56,6 +56,9 @@ export interface GoogleCalendarEvent {
 /**
  * Google Calendar from API
  */
+/** Settings key holding the tombstones for user-deleted Google calendars. */
+export const DISMISSED_GOOGLE_CALENDARS_KEY = 'dismissedGoogleCalendarIds';
+
 export interface GoogleCalendar {
   id: string;
   summary: string;

--- a/src/lib/services/__tests__/settingsTombstone.test.ts
+++ b/src/lib/services/__tests__/settingsTombstone.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Tests for the tombstone value coercion — the bit that must never regress,
+ * since a broken read would let deleted calendars silently reappear.
+ */
+import { normalizeTombstones } from '../settingsTombstone';
+
+describe('normalizeTombstones', () => {
+  it('reads legacy string[] as { id, name: id }', () => {
+    expect(normalizeTombstones(['cal-a@group', 'cal-b@group'])).toEqual([
+      { id: 'cal-a@group', name: 'cal-a@group' },
+      { id: 'cal-b@group', name: 'cal-b@group' },
+    ]);
+  });
+
+  it('passes through { id, name } entries', () => {
+    expect(normalizeTombstones([{ id: 'x', name: 'Cadet Orchestra' }])).toEqual([
+      { id: 'x', name: 'Cadet Orchestra' },
+    ]);
+  });
+
+  it('backfills a missing/empty name with the id', () => {
+    expect(normalizeTombstones([{ id: 'x' }, { id: 'y', name: '' }])).toEqual([
+      { id: 'x', name: 'x' },
+      { id: 'y', name: 'y' },
+    ]);
+  });
+
+  it('drops malformed entries and non-arrays', () => {
+    expect(normalizeTombstones([{ name: 'no id' }, 42, null])).toEqual([]);
+    expect(normalizeTombstones(undefined)).toEqual([]);
+    expect(normalizeTombstones('not-an-array')).toEqual([]);
+  });
+});

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -246,12 +246,16 @@ export async function syncGoogleCalendarSource(
         ...(shouldAutoDisable ? { enabled: false, showInEventModal: false } : {}),
         syncErrors: {
           lastError: is404
-            ? `Calendar not found in Google (404). Failure ${consecutive404}/${DISABLE_THRESHOLD}.`
+            ? (shouldAutoDisable
+                ? 'Removed in Google Calendar — auto-disabled here.'
+                : `Calendar not found in Google (404). Failure ${consecutive404}/${DISABLE_THRESHOLD}.`)
             : errorStr,
           consecutiveFailures,
           consecutive404,
           is404,
-          ...(shouldAutoDisable ? { autoDisabled: true, autoDisabledAt: new Date().toISOString() } : {}),
+          // On confirmed deletion, flag it so the UI can say "removed in Google"
+          // rather than leaving a mysteriously-disabled calendar.
+          ...(shouldAutoDisable ? { autoDisabled: true, autoDisabledAt: new Date().toISOString(), removedAtSource: true } : {}),
           ...(prevErrors.userOverride ? { userOverride: true } : {}),
           timestamp: new Date().toISOString(),
         },
@@ -259,7 +263,10 @@ export async function syncGoogleCalendarSource(
       })
       .where(eq(calendarSources.id, sourceId));
 
-    return emptyCounts([`Failed to fetch events: ${error}`]);
+    // A 404 means the calendar was deleted in Google — expected and handled
+    // (it counts toward auto-disable above). Don't surface it as a user-facing
+    // "Sync failed"; only real/transient errors bubble up to the sync result.
+    return emptyCounts(is404 ? [] : [`Failed to fetch events: ${error}`]);
   }
 
   // Build set of Google event IDs for deletion cleanup (excluding cancelled)

--- a/src/lib/services/settingsTombstone.ts
+++ b/src/lib/services/settingsTombstone.ts
@@ -1,0 +1,84 @@
+/**
+ * Reusable "tombstone" (soft-delete / dismissed-item) store backed by a single
+ * key in the settings table, holding a JSON array of { id, name } entries.
+ *
+ * When a user deletes a synced item that a provider would otherwise re-create on
+ * the next sync (a Google calendar, and — with a parallel store — potentially
+ * photos or other entities), we record its external id here so discovery skips
+ * it. Storing the display name alongside the id lets a "Removed items → Restore"
+ * UI show something human instead of an opaque id.
+ *
+ * Entity-agnostic on purpose: any sub-page that tombstones via a settings key
+ * can reuse this (calendars use `dismissedGoogleCalendarIds`). Table-backed
+ * tombstones (excluded_photos, dismissed_events) keep their own storage but can
+ * expose the same { id, name } + restore contract to share the UI.
+ *
+ * Backward compatible: legacy values were a bare `string[]` of ids; those are
+ * read transparently as { id, name: id } so nothing breaks pre-migration.
+ */
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+export interface TombstoneEntry {
+  id: string;
+  name: string;
+}
+
+/** Coerce a raw settings value (legacy string[] or {id,name}[]) to entries. */
+export function normalizeTombstones(raw: unknown): TombstoneEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item): TombstoneEntry | null => {
+      if (typeof item === 'string') return { id: item, name: item };
+      if (item && typeof item === 'object' && typeof (item as TombstoneEntry).id === 'string') {
+        const e = item as TombstoneEntry;
+        return { id: e.id, name: typeof e.name === 'string' && e.name ? e.name : e.id };
+      }
+      return null;
+    })
+    .filter((e): e is TombstoneEntry => e !== null);
+}
+
+async function readRaw(key: string): Promise<TombstoneEntry[]> {
+  const [row] = await db.select().from(settings).where(eq(settings.key, key));
+  return normalizeTombstones(row?.value);
+}
+
+async function writeRaw(key: string, entries: TombstoneEntry[]): Promise<void> {
+  const [existing] = await db.select().from(settings).where(eq(settings.key, key));
+  if (existing) {
+    await db.update(settings).set({ value: entries, updatedAt: new Date() }).where(eq(settings.key, key));
+  } else {
+    await db.insert(settings).values({ key, value: entries });
+  }
+}
+
+/** All tombstoned entries for this key (each { id, name }). */
+export async function listTombstones(key: string): Promise<TombstoneEntry[]> {
+  return readRaw(key);
+}
+
+/** Just the ids, as a Set — for fast "is this dismissed?" checks in discovery. */
+export async function tombstoneIdSet(key: string): Promise<Set<string>> {
+  return new Set((await readRaw(key)).map((e) => e.id));
+}
+
+/** Add (or refresh the name of) a tombstone. Idempotent on id. */
+export async function addTombstone(key: string, entry: TombstoneEntry): Promise<void> {
+  const entries = await readRaw(key);
+  const idx = entries.findIndex((e) => e.id === entry.id);
+  if (idx >= 0) {
+    entries[idx] = entry; // refresh name
+  } else {
+    entries.push(entry);
+  }
+  await writeRaw(key, entries);
+}
+
+/** Remove a tombstone by id (the "restore" primitive). No-op if absent. */
+export async function removeTombstone(key: string, id: string): Promise<void> {
+  const entries = await readRaw(key);
+  const next = entries.filter((e) => e.id !== id);
+  if (next.length !== entries.length) await writeRaw(key, next);
+}


### PR DESCRIPTION
Deleting a Google calendar in Prism tombstones it (so discovery won't re-add it on the next sign-in) — but there was no way to undo that. This adds a **Removed calendars → Restore** flow, built on a reusable foundation.

## Reusable by design
The storage differs per entity today (calendars: a settings JSON array; photos/events: dedicated tables), so rather than a risky unifying migration, the *reusable* pieces are:
- **`settingsTombstone.ts`** — an entity-agnostic `{id,name}` tombstone store over any settings key (backward-compatible with the legacy `string[]`; unit-tested).
- **`RemovedItemsManager`** — a presentational 'Removed items → Restore' card (parent owns fetch + restore).
- A consistent **`GET → {id,name}[]` / `POST {id}` restore** API contract.

Photos (`excluded_photos`) and events (`dismissed_events`) can adopt the same component + contract against their own tables later, no storage change forced.

## Calendar wiring
- Delete now stores `{id, name}` (name → readable Removed list).
- Google discovery (connect + re-auth) skips via `tombstoneIdSet()`.
- `/api/calendars/removed`: GET list, POST `{id}` clears the tombstone; the UI then re-authenticates Google so discovery re-adds it.
- `CalendarsSection` renders the Removed calendars card (only appears when there's something to restore).

## Checks
`tsc` clean · eslint clean · `settingsTombstone` coercion unit-tested (4/4, covers the legacy `string[]` path so deleted calendars can't silently reappear).