### PR TITLE
Fix calendar date ranges and improve multi-day rendering

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -20,7 +20,7 @@ import { db } from '@/lib/db/client';
 import { events, calendarSources, dismissedEvents } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
-import { updateCalendarEvent, deleteCalendarEvent, refreshAccessToken } from '@/lib/integrations/google-calendar';
+import { updateCalendarEvent, deleteCalendarEvent, refreshAccessToken, toGoogleAllDayRange } from '@/lib/integrations/google-calendar';
 import { pushCalDAVEventDelete } from '@/lib/services/calendar-sync';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
@@ -274,7 +274,14 @@ export async function PATCH(
         .from(calendarSources)
         .where(eq(calendarSources.id, existingEvent.calendarSourceId));
 
-      if (calendarSource?.provider === 'google' && calendarSource.accessToken) {
+      if (calendarSource?.provider === 'google') {
+        if (!calendarSource.accessToken) {
+          return NextResponse.json(
+            { error: 'Google Calendar is not authenticated. Reconnect it before editing this event.' },
+            { status: 401 }
+          );
+        }
+
         try {
           let accessToken = decrypt(calendarSource.accessToken);
 
@@ -322,8 +329,9 @@ export async function PATCH(
 
           if (newStart !== undefined || newEnd !== undefined || newAllDay !== undefined) {
             if (finalAllDay) {
-              googleUpdate.start = { date: finalStart.toISOString().split('T')[0] };
-              googleUpdate.end = { date: finalEnd.toISOString().split('T')[0] };
+              const range = toGoogleAllDayRange(finalStart, finalEnd);
+              googleUpdate.start = range.start;
+              googleUpdate.end = range.end;
             } else {
               googleUpdate.start = { dateTime: finalStart.toISOString() };
               googleUpdate.end = { dateTime: finalEnd.toISOString() };
@@ -339,7 +347,12 @@ export async function PATCH(
           );
         } catch (error) {
           logError('Failed to update event on Google Calendar:', error);
-          // Continue with local update even if Google fails
+          return NextResponse.json(
+            {
+              error: `Google Calendar could not be updated. Your local event was left unchanged: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+            { status: 502 }
+          );
         }
       }
     }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -26,7 +26,7 @@ import { eq, and, or, gte, lte, asc, isNotNull, isNull } from 'drizzle-orm';
 import { createEventSchema, validateRequest } from '@/lib/validations';
 import { getCached } from '@/lib/cache/redis';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
-import { createCalendarEvent, refreshAccessToken } from '@/lib/integrations/google-calendar';
+import { createCalendarEvent, refreshAccessToken, toGoogleAllDayRange } from '@/lib/integrations/google-calendar';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { formatEventRow } from '@/lib/utils/formatters';
 import { logActivity } from '@/lib/services/auditLog';
@@ -343,6 +343,8 @@ export async function POST(request: NextRequest) {
               .where(eq(calendarSources.id, calendarSourceId));
           }
 
+          const allDayRange = allDay ? toGoogleAllDayRange(startTime, endTime) : null;
+
           // Create event on Google Calendar
           const googleEvent = await createCalendarEvent(
             accessToken,
@@ -352,10 +354,10 @@ export async function POST(request: NextRequest) {
               description: description?.trim() || undefined,
               location: location?.trim() || undefined,
               start: allDay
-                ? { date: startTime.toISOString().split('T')[0] }
+                ? allDayRange!.start
                 : { dateTime: startTime.toISOString() },
               end: allDay
-                ? { date: endTime.toISOString().split('T')[0] }
+                ? allDayRange!.end
                 : { dateTime: endTime.toISOString() },
             }
           );

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -65,7 +65,7 @@ import { TaskModal } from '@/app/tasks/TaskModal';
 import { useChoreModals } from '@/app/chores/useChoreModals';
 import type { OverlayItemRef } from '@/components/calendar/cells';
 import type { Chore, Task, Meal } from '@/types';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 const MEAL_TYPE_ORDER = { breakfast: 0, lunch: 1, snack: 2, dinner: 3 } as const;
 const EMPTY_EVENTS: CalendarEvent[] = [];
@@ -750,7 +750,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
   onEdit: () => void;
   onDeleted: () => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const { confirm, dialogProps } = useConfirmDialog();
 
   const handleDelete = async () => {
@@ -774,8 +774,8 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
         <h2 className="text-xl font-bold mb-2">{event.title}</h2>
         <p className="text-sm text-muted-foreground mb-1">
           {event.allDay
-            ? format(event.startTime, 'EEEE, MMMM d')
-            : `${format(event.startTime, 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat)}`}
+            ? format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')
+            : `${format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}`}
         </p>
         {event.location && <p className="text-sm text-muted-foreground mb-4">{event.location}</p>}
         <p className="text-xs text-muted-foreground">{event.calendarName}</p>
@@ -821,6 +821,7 @@ function CalendarDragPreview({
   events: CalendarEvent[];
   mealColor: string;
 }) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const colon = dragId.indexOf(':');
   if (colon === -1) return null;
   const variant = dragId.slice(0, colon) as 'meal' | 'chore' | 'task' | 'event';
@@ -837,7 +838,7 @@ function CalendarDragPreview({
           layout="column"
           stripeColor={ev.color}
           title={ev.title}
-          timeLabel={ev.allDay ? 'All day' : new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' }).format(ev.startTime)}
+          timeLabel={ev.allDay ? 'All day' : formatDisplayTime(ev.startTime, timeFormat, {}, displayTimezone)}
           subtitle={ev.location || ev.calendarName}
         />
       </div>

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -543,6 +543,7 @@ export function CalendarView() {
                   bucketsByDate={overlaysActive ? filteredBucketsByDate : undefined}
                   enableDnd={overlaysActive}
                   onItemClick={handleOverlayItemClick}
+                  showMonthHeader={false}
                 />
               )}
               {viewType === 'week' && (

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -28,7 +28,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { contrastText } from '@/lib/utils/color';
-import { useFamily } from '@/components/providers';
+import { useFamily, useTimeFormat } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { AddEventModal } from '@/components/modals';
@@ -65,6 +65,7 @@ import { TaskModal } from '@/app/tasks/TaskModal';
 import { useChoreModals } from '@/app/chores/useChoreModals';
 import type { OverlayItemRef } from '@/components/calendar/cells';
 import type { Chore, Task, Meal } from '@/types';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 const MEAL_TYPE_ORDER = { breakfast: 0, lunch: 1, snack: 2, dinner: 3 } as const;
 const EMPTY_EVENTS: CalendarEvent[] = [];
@@ -749,6 +750,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
   onEdit: () => void;
   onDeleted: () => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const { confirm, dialogProps } = useConfirmDialog();
 
   const handleDelete = async () => {
@@ -773,7 +775,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
         <p className="text-sm text-muted-foreground mb-1">
           {event.allDay
             ? format(event.startTime, 'EEEE, MMMM d')
-            : `${format(event.startTime, 'EEEE, MMMM d')} at ${format(event.startTime, 'h:mm a')}`}
+            : `${format(event.startTime, 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat)}`}
         </p>
         {event.location && <p className="text-sm text-muted-foreground mb-4">{event.location}</p>}
         <p className="text-xs text-muted-foreground">{event.calendarName}</p>

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -14,6 +14,8 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import type { PendingDeletion } from '@/lib/hooks/usePendingDeletions';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 /**
  * Deletes-only review (#171 Stage 3). Lists events the sync found removed from
@@ -29,6 +31,7 @@ export function PendingDeletionsModal({
   onApply: (eventIds: string[], action: 'delete' | 'keep') => Promise<boolean>;
   onClose: () => void;
 }) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
   const [busy, setBusy] = useState(false);
 
@@ -94,8 +97,8 @@ export function PendingDeletionsModal({
                     <span className="font-medium">{p.title}</span>
                     <span className="block text-xs text-muted-foreground">
                       {p.allDay
-                        ? format(parseISO(p.startTime), 'EEE, MMM d')
-                        : format(parseISO(p.startTime), 'EEE, MMM d · p')}
+                        ? format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')
+                        : `${format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')} · ${formatDisplayTime(parseISO(p.startTime), timeFormat, {}, displayTimezone)}`}
                     </span>
                     <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground flex-wrap">
                       <span className="inline-flex items-center gap-1 min-w-0">

--- a/src/app/calendar/useCalendarViewData.ts
+++ b/src/app/calendar/useCalendarViewData.ts
@@ -17,6 +17,8 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { deduplicateEvents } from '@/lib/utils/calendarDedup';
 import { getFullCalendarRange, MAX_CALENDAR_EVENTS } from '@/lib/utils/calendarRange';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export type CalendarViewType = 'agenda' | 'day' | 'week' | 'weekVertical' | 'multiWeek' | 'month' | 'threeMonth';
 export type MultiWeekCount = 1 | 2 | 3 | 4;
@@ -25,7 +27,12 @@ export type { CalendarGroup } from '@/lib/hooks';
 
 export function useCalendarViewData() {
   const { weekStartsOn } = useWeekStartsOn();
+  const { displayTimezone } = useTimeFormat();
   const [currentDate, setCurrentDate] = useState(new Date());
+
+  useEffect(() => {
+    setCurrentDate(toDisplayDate(new Date(), displayTimezone));
+  }, [displayTimezone]);
   const [viewType, setViewType] = useState<CalendarViewType>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('prism-calendar-view-type') as CalendarViewType | null;
@@ -138,7 +145,10 @@ export function useCalendarViewData() {
     return deduplicateEvents(filterEvents(mapped));
   }, [apiEvents, filterEvents]);
 
-  const goToToday = useCallback(() => setCurrentDate(new Date()), []);
+  const goToToday = useCallback(
+    () => setCurrentDate(toDisplayDate(new Date(), displayTimezone)),
+    [displayTimezone],
+  );
 
   const goToPrevious = useCallback(() => {
     setCurrentDate(prev => {

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -16,6 +16,7 @@ import { useScreensaverTimeout } from '@/lib/hooks/useScreensaverTimeout';
 import { useAutoHideUI } from '@/lib/hooks/useAutoHideUI';
 import { useAwayModeTimeout } from '@/lib/hooks/useAwayModeTimeout';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
+import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 function getCurrentMonthNum(): number {
   return new Date().getMonth() + 1;
@@ -172,6 +173,8 @@ export function DisplaySection() {
 
       <SectionDivider label="Wallpaper & Display" />
 
+      <TimeFormatCard />
+
       <PerformanceModeCard />
 
       <WallpaperSettingsCard />
@@ -184,6 +187,53 @@ export function DisplaySection() {
 
       <WeatherUnitsCard />
     </div>
+  );
+}
+
+function TimeFormatCard() {
+  const { timeFormat, setTimeFormat } = useTimeFormat();
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(async (next: TimeFormat) => {
+    setSaving(true);
+    try {
+      await setTimeFormat(next);
+    } catch {
+      // The provider rolls back the optimistic change on failure.
+    } finally {
+      setSaving(false);
+    }
+  }, [setTimeFormat]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Time format</CardTitle>
+        <CardDescription>
+          Choose how times appear across the dashboard, weather, and calendar
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
+          {(['12h', '24h'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={timeFormat === value}
+              disabled={saving}
+              onClick={() => save(value)}
+              className={cn(
+                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
+                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
+              )}
+            >
+              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
+            </button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -16,7 +16,6 @@ import { useScreensaverTimeout } from '@/lib/hooks/useScreensaverTimeout';
 import { useAutoHideUI } from '@/lib/hooks/useAutoHideUI';
 import { useAwayModeTimeout } from '@/lib/hooks/useAwayModeTimeout';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
-import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 function getCurrentMonthNum(): number {
   return new Date().getMonth() + 1;
@@ -173,8 +172,6 @@ export function DisplaySection() {
 
       <SectionDivider label="Wallpaper & Display" />
 
-      <TimeFormatCard />
-
       <PerformanceModeCard />
 
       <WallpaperSettingsCard />
@@ -187,53 +184,6 @@ export function DisplaySection() {
 
       <WeatherUnitsCard />
     </div>
-  );
-}
-
-function TimeFormatCard() {
-  const { timeFormat, setTimeFormat } = useTimeFormat();
-  const [saving, setSaving] = useState(false);
-
-  const save = useCallback(async (next: TimeFormat) => {
-    setSaving(true);
-    try {
-      await setTimeFormat(next);
-    } catch {
-      // The provider rolls back the optimistic change on failure.
-    } finally {
-      setSaving(false);
-    }
-  }, [setTimeFormat]);
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Time format</CardTitle>
-        <CardDescription>
-          Choose how times appear across the dashboard, weather, and calendar
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
-          {(['12h', '24h'] as const).map((value) => (
-            <button
-              key={value}
-              type="button"
-              role="radio"
-              aria-checked={timeFormat === value}
-              disabled={saving}
-              onClick={() => save(value)}
-              className={cn(
-                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
-                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
-              )}
-            >
-              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
-            </button>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
   );
 }
 

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -16,13 +16,14 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 import { useLocationSearch } from '@/lib/hooks/useLocationSearch';
 import { listTimezones } from '@/lib/utils/timezone';
-import { useTimeFormat, type TimeFormat } from '@/components/providers';
+import { useTimeFormat, type DisplayTimezoneMode, type TimeFormat } from '@/components/providers';
 
 export function GeneralSection() {
   return (
     <div className="space-y-6">
       <LocationCard />
       <TimezoneCard />
+      <DisplayTimezoneCard />
       <TimeFormatCard />
       <WeekStartCard />
     </div>
@@ -119,8 +120,8 @@ function TimezoneCard() {
       <CardHeader>
         <CardTitle>Time Zone</CardTitle>
         <CardDescription>
-          Used for server-side scheduling and syncs — e.g. placing imported meal-plan times on the
-          right day. On-screen clocks already follow each viewer&apos;s device.
+          The household timezone used for scheduling, calendar sync, and—by default—times shown
+          throughout Prism.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -142,6 +143,70 @@ function TimezoneCard() {
               Use detected ({detected.replace(/_/g, ' ')})
             </Button>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DisplayTimezoneCard() {
+  const {
+    householdTimezone,
+    deviceTimezone,
+    displayTimezoneMode,
+    setDisplayTimezoneMode,
+  } = useTimeFormat();
+
+  const options: Array<{
+    value: DisplayTimezoneMode;
+    label: string;
+    timezone: string;
+    description: string;
+  }> = [
+    {
+      value: 'household',
+      label: 'Household timezone',
+      timezone: householdTimezone,
+      description: 'Keeps appointments and clocks consistent on every Prism display.',
+    },
+    {
+      value: 'device',
+      label: 'This device’s timezone',
+      timezone: deviceTimezone,
+      description: 'Uses this browser’s timezone on this device only.',
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Display Timezone</CardTitle>
+        <CardDescription>
+          Choose which timezone this device uses for calendars, reminders, and clocks. Household
+          timezone is the recommended default.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Display timezone">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={displayTimezoneMode === option.value}
+              onClick={() => setDisplayTimezoneMode(option.value)}
+              className={cn(
+                'min-h-20 rounded-md border p-3 text-left transition-colors',
+                displayTimezoneMode === option.value
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border hover:bg-accent',
+              )}
+            >
+              <span className="block text-sm font-medium">{option.label}</span>
+              <span className="block text-xs font-mono opacity-80">{option.timezone}</span>
+              <span className="mt-1 block text-xs opacity-80">{option.description}</span>
+            </button>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -6,7 +6,7 @@
  * "Appearance" (Location) and "Calendars" (Time zone, Week starts on).
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Search, MapPin, X, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -16,12 +16,14 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 import { useLocationSearch } from '@/lib/hooks/useLocationSearch';
 import { listTimezones } from '@/lib/utils/timezone';
+import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 export function GeneralSection() {
   return (
     <div className="space-y-6">
       <LocationCard />
       <TimezoneCard />
+      <TimeFormatCard />
       <WeekStartCard />
     </div>
   );
@@ -140,6 +142,53 @@ function TimezoneCard() {
               Use detected ({detected.replace(/_/g, ' ')})
             </Button>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimeFormatCard() {
+  const { timeFormat, setTimeFormat } = useTimeFormat();
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(async (next: TimeFormat) => {
+    setSaving(true);
+    try {
+      await setTimeFormat(next);
+    } catch {
+      // The provider rolls back the optimistic change on failure.
+    } finally {
+      setSaving(false);
+    }
+  }, [setTimeFormat]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Time Format</CardTitle>
+        <CardDescription>
+          Choose how times appear across the dashboard, weather, and calendar.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
+          {(['12h', '24h'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={timeFormat === value}
+              disabled={saving}
+              onClick={() => save(value)}
+              className={cn(
+                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
+                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
+              )}
+            >
+              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
+            </button>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -165,17 +165,18 @@ function DisplayTimezoneCard() {
   }> = [
     {
       value: 'household',
-      label: 'Household timezone',
+      label: 'Household',
       timezone: householdTimezone,
       description: 'Keeps appointments and clocks consistent on every Prism display.',
     },
     {
       value: 'device',
-      label: 'This device’s timezone',
+      label: 'This device',
       timezone: deviceTimezone,
       description: 'Uses this browser’s timezone on this device only.',
     },
   ];
+  const selected = options.find((option) => option.value === displayTimezoneMode)!;
 
   return (
     <Card>
@@ -187,7 +188,11 @@ function DisplayTimezoneCard() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Display timezone">
+        <div
+          className="inline-flex max-w-full rounded-md border border-input p-0.5"
+          role="radiogroup"
+          aria-label="Display timezone"
+        >
           {options.map((option) => (
             <button
               key={option.value}
@@ -196,18 +201,21 @@ function DisplayTimezoneCard() {
               aria-checked={displayTimezoneMode === option.value}
               onClick={() => setDisplayTimezoneMode(option.value)}
               className={cn(
-                'min-h-20 rounded-md border p-3 text-left transition-colors',
+                'min-h-11 rounded-sm px-3 py-1.5 text-sm transition-colors',
                 displayTimezoneMode === option.value
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border hover:bg-accent',
+                  ? 'bg-primary text-primary-foreground'
+                  : 'hover:bg-accent',
               )}
             >
-              <span className="block text-sm font-medium">{option.label}</span>
-              <span className="block text-xs font-mono opacity-80">{option.timezone}</span>
-              <span className="mt-1 block text-xs opacity-80">{option.description}</span>
+              {option.label}
             </button>
           ))}
         </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Using <span className="font-mono text-xs text-foreground">{selected.timezone}</span>
+          <span aria-hidden="true"> · </span>
+          {selected.description}
+        </p>
       </CardContent>
     </Card>
   );

--- a/src/components/away-mode/AwayModeOverlay.tsx
+++ b/src/components/away-mode/AwayModeOverlay.tsx
@@ -8,6 +8,8 @@ import { usePhotos } from '@/lib/hooks/usePhotos';
 import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } from '@/components/layout/WallpaperBackground';
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import { ExitAwayModeModal } from './ExitAwayModeModal';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export function AwayModeOverlay() {
   const { isAway, toggle } = useAwayMode();
@@ -121,6 +123,7 @@ export function AwayModeOverlay() {
 }
 
 function AwayModeClock() {
+  const { timeFormat } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -131,8 +134,7 @@ function AwayModeClock() {
   return (
     <div className="flex items-center gap-3 text-white">
       <div className="text-3xl font-light tabular-nums">
-        {format(time, 'h:mm')}
-        <span className="text-lg ml-1 opacity-70">{format(time, 'a')}</span>
+        {formatDisplayTime(time, timeFormat)}
       </div>
       <div className="text-sm text-white/60">
         {format(time, 'EEEE, MMMM d')}

--- a/src/components/away-mode/AwayModeOverlay.tsx
+++ b/src/components/away-mode/AwayModeOverlay.tsx
@@ -9,7 +9,7 @@ import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } fro
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import { ExitAwayModeModal } from './ExitAwayModeModal';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export function AwayModeOverlay() {
   const { isAway, toggle } = useAwayMode();
@@ -123,7 +123,7 @@ export function AwayModeOverlay() {
 }
 
 function AwayModeClock() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -134,10 +134,10 @@ function AwayModeClock() {
   return (
     <div className="flex items-center gap-3 text-white">
       <div className="text-3xl font-light tabular-nums">
-        {formatDisplayTime(time, timeFormat)}
+        {formatDisplayTime(time, timeFormat, {}, displayTimezone)}
       </div>
       <div className="text-sm text-white/60">
-        {format(time, 'EEEE, MMMM d')}
+        {format(toDisplayDate(time, displayTimezone), 'EEEE, MMMM d')}
       </div>
     </div>
   );

--- a/src/components/babysitter-mode/BabysitterModeOverlay.tsx
+++ b/src/components/babysitter-mode/BabysitterModeOverlay.tsx
@@ -13,7 +13,7 @@ import { ExitBabysitterModeModal } from './ExitBabysitterModeModal';
 import { WifiQRCode } from '@/components/ui/WifiQRCode';
 import { cn } from '@/lib/utils';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 interface EmergencyContact {
   name: string;
@@ -182,7 +182,7 @@ export function BabysitterModeOverlay() {
 }
 
 function BabysitterClock() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -193,10 +193,10 @@ function BabysitterClock() {
   return (
     <div className="text-white">
       <div className="text-4xl font-light tabular-nums">
-        {formatDisplayTime(time, timeFormat)}
+        {formatDisplayTime(time, timeFormat, {}, displayTimezone)}
       </div>
       <div className="text-sm text-white/60">
-        {format(time, 'EEEE, MMMM d')}
+        {format(toDisplayDate(time, displayTimezone), 'EEEE, MMMM d')}
       </div>
     </div>
   );

--- a/src/components/babysitter-mode/BabysitterModeOverlay.tsx
+++ b/src/components/babysitter-mode/BabysitterModeOverlay.tsx
@@ -12,6 +12,8 @@ import { useWifiConfig } from '@/lib/hooks/useWifiConfig';
 import { ExitBabysitterModeModal } from './ExitBabysitterModeModal';
 import { WifiQRCode } from '@/components/ui/WifiQRCode';
 import { cn } from '@/lib/utils';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 interface EmergencyContact {
   name: string;
@@ -180,6 +182,7 @@ export function BabysitterModeOverlay() {
 }
 
 function BabysitterClock() {
+  const { timeFormat } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -190,8 +193,7 @@ function BabysitterClock() {
   return (
     <div className="text-white">
       <div className="text-4xl font-light tabular-nums">
-        {format(time, 'h:mm')}
-        <span className="text-xl ml-2 opacity-70">{format(time, 'a')}</span>
+        {formatDisplayTime(time, timeFormat)}
       </div>
       <div className="text-sm text-white/60">
         {format(time, 'EEEE, MMMM d')}

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -2,8 +2,6 @@
 
 import {
   format,
-  isToday,
-  isTomorrow,
   isSameDay,
   addDays,
   startOfDay,
@@ -17,7 +15,7 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -72,8 +70,9 @@ export function AgendaView({
   mealColor,
   onItemClick,
 }: AgendaViewProps) {
+  const { displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
-  const startDate = startOfDay(new Date());
+  const startDate = startOfDay(toDisplayDate(new Date(), displayTimezone));
   const endDate = addDays(startDate, days);
 
   const filteredEvents = events
@@ -81,11 +80,12 @@ export function AgendaView({
       if (e.allDay) {
         return e.startTime < endDate && e.endTime > startDate;
       }
-      const ed = startOfDay(e.startTime);
+      const ed = startOfDay(toDisplayDate(e.startTime, displayTimezone));
       return ed >= startDate && ed < endDate;
     })
     .sort((a, b) => {
-      const dc = startOfDay(a.startTime).getTime() - startOfDay(b.startTime).getTime();
+      const dc = startOfDay(toDisplayDate(a.startTime, displayTimezone)).getTime()
+        - startOfDay(toDisplayDate(b.startTime, displayTimezone)).getTime();
       if (dc !== 0) return dc;
       if (a.allDay && !b.allDay) return -1;
       if (!a.allDay && b.allDay) return 1;
@@ -99,7 +99,7 @@ export function AgendaView({
     const dayEvents = filteredEvents.filter(e =>
       e.allDay
         ? e.startTime <= dayStart && e.endTime > dayStart
-        : isSameDay(e.startTime, date)
+        : isSameDay(toDisplayDate(e.startTime, displayTimezone), date)
     );
     const bucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
     const hasOverlay = bucket && (bucket.meals.length + bucket.chores.length + bucket.tasks.length > 0);
@@ -160,9 +160,9 @@ function AgendaDaySection({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat });
+  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -179,12 +179,12 @@ function AgendaDaySection({
         <span
           className={cn(
             'text-sm font-semibold',
-            isToday(date) && 'text-seasonal-accent'
+            isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && 'text-seasonal-accent'
           )}
         >
-          {formatAgendaDayHeader(date)}
+          {formatAgendaDayHeader(date, displayTimezone)}
         </span>
-        {isToday(date) && (
+        {isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && (
           <Badge className="text-[10px] px-1.5 py-0 bg-seasonal-highlight text-foreground">
             Today
           </Badge>
@@ -212,6 +212,7 @@ function buildAgendaRows({
   mealColor,
   onItemClick,
   timeFormat,
+  displayTimezone,
 }: {
   events: CalendarEvent[];
   bucket?: DayBucket;
@@ -219,6 +220,7 @@ function buildAgendaRows({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
   timeFormat: TimeFormat;
+  displayTimezone: string;
 }): AgendaRow[] {
   const rows: AgendaRow[] = [];
 
@@ -228,10 +230,11 @@ function buildAgendaRows({
       key: `event-${event.id}`,
       sortMinutes: allDay
         ? -1
-        : event.startTime.getHours() * 60 + event.startTime.getMinutes(),
+        : toDisplayDate(event.startTime, displayTimezone).getHours() * 60
+          + toDisplayDate(event.startTime, displayTimezone).getMinutes(),
       floating: allDay,
       stripeColor: event.color,
-      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat),
+      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone),
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,
@@ -366,9 +369,10 @@ function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean
   );
 }
 
-function formatAgendaDayHeader(date: Date): string {
+function formatAgendaDayHeader(date: Date, displayTimezone: string): string {
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const dayName = format(date, 'EEEE, MMMM d, yyyy');
-  if (isToday(date)) return `Today - ${dayName}`;
-  if (isTomorrow(date)) return `Tomorrow - ${dayName}`;
+  if (isSameDay(date, displayNow)) return `Today - ${dayName}`;
+  if (isSameDay(date, addDays(displayNow, 1))) return `Tomorrow - ${dayName}`;
   return dayName;
 }

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -16,6 +16,8 @@ import { Badge } from '@/components/ui';
 import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -158,8 +160,9 @@ function AgendaDaySection({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick });
+  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -208,12 +211,14 @@ function buildAgendaRows({
   onEventClick,
   mealColor,
   onItemClick,
+  timeFormat,
 }: {
   events: CalendarEvent[];
   bucket?: DayBucket;
   onEventClick?: (event: CalendarEvent) => void;
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
+  timeFormat: TimeFormat;
 }): AgendaRow[] {
   const rows: AgendaRow[] = [];
 
@@ -226,7 +231,7 @@ function buildAgendaRows({
         : event.startTime.getHours() * 60 + event.startTime.getMinutes(),
       floating: allDay,
       stripeColor: event.color,
-      timeLabel: allDay ? 'All day' : format(event.startTime, 'h:mm a'),
+      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat),
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,
@@ -243,7 +248,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `meal:${meal.id}`,
         stripeColor: mealColor ?? meal.cookedBy?.color ?? meal.createdBy?.color ?? MEAL_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t) : meal.mealType,
+        timeLabel: min !== null ? formatTimeLabel(t, timeFormat) : meal.mealType,
         title: meal.name,
         subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
         muted: Boolean(meal.cookedAt),
@@ -259,7 +264,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `chore:${chore.id}`,
         stripeColor: chore.assignedTo?.color || CHORE_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!) : 'Chore',
+        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Chore',
         title: chore.title,
         subtitle: chore.assignedTo?.name,
         pendingApproval: Boolean(chore.pendingApproval),
@@ -275,7 +280,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `task:${task.id}`,
         stripeColor: task.assignedTo?.color || TASK_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!) : 'Task',
+        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Task',
         title: task.title,
         subtitle: task.assignedTo?.name,
         muted: task.completed,
@@ -294,8 +299,8 @@ function buildAgendaRows({
   return rows;
 }
 
-function formatTimeLabel(hhmm: string): string {
-  return formatTimeOfDay(hhmm);
+function formatTimeLabel(hhmm: string, timeFormat: TimeFormat): string {
+  return formatTimeOfDay(hhmm, timeFormat);
 }
 
 function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean }) {

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -15,7 +15,7 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -73,16 +73,16 @@ export function AgendaView({
   const { displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const startDate = startOfDay(toDisplayDate(new Date(), displayTimezone));
-  const endDate = addDays(startDate, days);
 
   const filteredEvents = events
-    .filter(e => {
-      if (e.allDay) {
-        return e.startTime < endDate && e.endTime > startDate;
-      }
-      const ed = startOfDay(toDisplayDate(e.startTime, displayTimezone));
-      return ed >= startDate && ed < endDate;
-    })
+    .filter(e => Array.from({ length: days }, (_, i) => addDays(startDate, i))
+      .some(date => eventOccursOnDisplayDay(
+        e.startTime,
+        e.endTime,
+        e.allDay,
+        date,
+        displayTimezone,
+      )))
     .sort((a, b) => {
       const dc = startOfDay(toDisplayDate(a.startTime, displayTimezone)).getTime()
         - startOfDay(toDisplayDate(b.startTime, displayTimezone)).getTime();
@@ -95,12 +95,13 @@ export function AgendaView({
   const eventsByDay: Array<{ date: Date; events: CalendarEvent[]; bucket?: DayBucket }> = [];
   for (let i = 0; i < days; i++) {
     const date = addDays(startDate, i);
-    const dayStart = startOfDay(date);
-    const dayEvents = filteredEvents.filter(e =>
-      e.allDay
-        ? e.startTime <= dayStart && e.endTime > dayStart
-        : isSameDay(toDisplayDate(e.startTime, displayTimezone), date)
-    );
+    const dayEvents = filteredEvents.filter(e => eventOccursOnDisplayDay(
+      e.startTime,
+      e.endTime,
+      e.allDay,
+      date,
+      displayTimezone,
+    ));
     const bucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
     const hasOverlay = bucket && (bucket.meals.length + bucket.chores.length + bucket.tasks.length > 0);
     if (dayEvents.length > 0 || hasOverlay) {

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -15,7 +15,13 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  eventStartsOnDisplayDay,
+  formatDisplayTime,
+  toDisplayDate,
+  type TimeFormat,
+} from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -163,7 +169,7 @@ function AgendaDaySection({
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone });
+  const rows = buildAgendaRows({ date, events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -207,6 +213,7 @@ function AgendaDaySection({
 }
 
 function buildAgendaRows({
+  date,
   events,
   bucket,
   onEventClick,
@@ -215,6 +222,7 @@ function buildAgendaRows({
   timeFormat,
   displayTimezone,
 }: {
+  date: Date;
   events: CalendarEvent[];
   bucket?: DayBucket;
   onEventClick?: (event: CalendarEvent) => void;
@@ -227,15 +235,26 @@ function buildAgendaRows({
 
   for (const event of events) {
     const allDay = event.allDay;
+    const startsToday = eventStartsOnDisplayDay(
+      event.startTime,
+      event.allDay,
+      date,
+      displayTimezone,
+    );
+    const floating = allDay || !startsToday;
     rows.push({
       key: `event-${event.id}`,
-      sortMinutes: allDay
+      sortMinutes: floating
         ? -1
         : toDisplayDate(event.startTime, displayTimezone).getHours() * 60
           + toDisplayDate(event.startTime, displayTimezone).getMinutes(),
-      floating: allDay,
+      floating,
       stripeColor: event.color,
-      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone),
+      timeLabel: allDay
+        ? 'All day'
+        : startsToday
+          ? formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)
+          : 'Continues',
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -20,7 +20,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
+import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -59,7 +59,7 @@ export function DayViewSideBySide({
   mealColor,
   onItemClick,
 }: DayViewSideBySideProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const droppable = useDayDroppable({ date: currentDate, enabled: cards && enableDnd });
   const bgOverride = useWidgetBgOverride();
@@ -72,7 +72,7 @@ export function DayViewSideBySide({
   const { settings: hiddenSettings, toggleHidden, getVisibleHours } = useHiddenHours();
 
   // Time tracking
-  const now = new Date();
+  const now = toDisplayDate(new Date(), displayTimezone);
   const isCurrentDay = isSameDay(currentDate, now);
   const isPastDay = isBefore(startOfDay(currentDate), startOfDay(now)) && !isCurrentDay;
   const currentHour = now.getHours();
@@ -81,16 +81,22 @@ export function DayViewSideBySide({
 
   // Get visible hours (filtered if hidden mode is enabled)
   const dayStart = startOfDay(currentDate);
-  const dayEvents = events.filter((event) =>
-    event.allDay
-      ? event.startTime <= dayStart && event.endTime > dayStart
-      : isSameDay(event.startTime, currentDate)
-  );
+  const dayEvents = events.filter((event) => {
+    const displayStart = toDisplayDate(event.startTime, displayTimezone);
+    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+    return event.allDay
+      ? displayStart <= dayStart && displayEnd > dayStart
+      : isSameDay(displayStart, currentDate);
+  });
 
   const allDayEvents = dayEvents.filter((e) => e.allDay);
   const timedEvents = dayEvents.filter((e) => !e.allDay);
 
-  const hours = getVisibleHours(timedEvents, { from: dayStart, to: addDays(dayStart, 1) });
+  const hours = getVisibleHours(timedEvents.map((event) => ({
+    ...event,
+    startTime: toDisplayDate(event.startTime, displayTimezone),
+    endTime: toDisplayDate(event.endTime, displayTimezone),
+  })), { from: dayStart, to: addDays(dayStart, 1) });
 
   // If there are no calendar groups configured or merged view is on, show all events in a single column
   const showAllInOne = calendarGroups.length === 0 || mergedView;
@@ -298,7 +304,7 @@ export function DayViewSideBySide({
                   style={{ gridTemplateRows: `repeat(${hours.length}, 1fr)` }}
                 >
                   {hours.map((hour) => {
-                    const hourEvents = calEvents.filter((event) => event.startTime.getHours() === hour);
+                    const hourEvents = calEvents.filter((event) => toDisplayDate(event.startTime, displayTimezone).getHours() === hour);
                     const isPastHour = isPastDay || (isCurrentDay && hour < currentHour);
                     const isNowHour = isCurrentDay && hour === currentHour;
                     return (
@@ -328,7 +334,7 @@ export function DayViewSideBySide({
                                 cards
                                   ? {
                                       borderLeft: `3px solid ${event.color}`,
-                                      top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                                      top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                                       height: `calc(${heightPct}% - 4px)`,
                                       left: css.left,
                                       width: css.width,
@@ -337,7 +343,7 @@ export function DayViewSideBySide({
                                       backgroundColor: event.color,
                                       color: '#fff',
                                       borderLeft: `2px solid ${event.color}`,
-                                      top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                                      top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                                       height: `${heightPct}%`,
                                       left: css.left,
                                       width: css.width,
@@ -350,7 +356,7 @@ export function DayViewSideBySide({
                               <div className={cn('font-medium truncate w-full text-[11px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {durationMin >= 60 && (
                                 <div className={cn('text-[9px] leading-tight', cards ? 'text-muted-foreground' : 'opacity-70')}>
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                             </button>

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -19,6 +19,8 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -57,6 +59,7 @@ export function DayViewSideBySide({
   mealColor,
   onItemClick,
 }: DayViewSideBySideProps) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const droppable = useDayDroppable({ date: currentDate, enabled: cards && enableDnd });
   const bgOverride = useWidgetBgOverride();
@@ -253,7 +256,7 @@ export function DayViewSideBySide({
                     isPastHour && 'bg-muted/15',
                     isNowHour && 'bg-primary text-primary-foreground font-semibold rounded-sm'
                   )}>
-                    {format(new Date().setHours(hour, 0), 'h a')}
+                    {formatDisplayHour(new Date().setHours(hour, 0), timeFormat)}
                     {isNowHour && (
                       <div className="absolute left-0 right-0 border-t-2 border-t-primary z-20 pointer-events-none" style={{ top: `${currentMinuteSnapped}%` }} />
                     )}
@@ -347,7 +350,7 @@ export function DayViewSideBySide({
                               <div className={cn('font-medium truncate w-full text-[11px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {durationMin >= 60 && (
                                 <div className={cn('text-[9px] leading-tight', cards ? 'text-muted-foreground' : 'opacity-70')}>
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                             </button>
@@ -410,6 +413,7 @@ function DayTimedBucketLayer({
   enableDnd: boolean;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const slotPct = 100 / hours.length;
   const visibleSet = new Set(hours);
 
@@ -440,7 +444,7 @@ function DayTimedBucketLayer({
       dragId: `meal:${meal.id}`,
       variant: 'meal',
       title: meal.name,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
       stripeColor: mealColor ?? '#10b981',
       muted: Boolean(meal.cookedAt),
@@ -460,7 +464,7 @@ function DayTimedBucketLayer({
       dragId: `chore:${chore.id}`,
       variant: 'chore',
       title: chore.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: chore.assignedTo?.name,
       stripeColor: chore.assignedTo?.color || '#f59e0b',
       pendingApproval: Boolean(chore.pendingApproval),
@@ -480,7 +484,7 @@ function DayTimedBucketLayer({
       dragId: `task:${task.id}`,
       variant: 'task',
       title: task.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: task.assignedTo?.name,
       stripeColor: task.assignedTo?.color || '#3b82f6',
       muted: task.completed,

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -20,7 +20,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -81,13 +81,13 @@ export function DayViewSideBySide({
 
   // Get visible hours (filtered if hidden mode is enabled)
   const dayStart = startOfDay(currentDate);
-  const dayEvents = events.filter((event) => {
-    const displayStart = toDisplayDate(event.startTime, displayTimezone);
-    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
-    return event.allDay
-      ? displayStart <= dayStart && displayEnd > dayStart
-      : isSameDay(displayStart, currentDate);
-  });
+  const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    currentDate,
+    displayTimezone,
+  ));
 
   const allDayEvents = dayEvents.filter((e) => e.allDay);
   const timedEvents = dayEvents.filter((e) => !e.allDay);

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -20,7 +20,15 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  eventSpansMultipleDisplayDays,
+  eventStartsOnDisplayDay,
+  formatDisplayHour,
+  formatDisplayTime,
+  formatDisplayTimeRange,
+  toDisplayDate,
+} from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -89,8 +97,31 @@ export function DayViewSideBySide({
     displayTimezone,
   ));
 
-  const allDayEvents = dayEvents.filter((e) => e.allDay);
-  const timedEvents = dayEvents.filter((e) => !e.allDay);
+  // Timed events that cross midnight belong in the persistent header rather
+  // than producing an oversized block in the hourly grid on every day.
+  const allDayEvents = dayEvents.filter((event) =>
+    event.allDay || eventSpansMultipleDisplayDays(
+      event.startTime,
+      event.endTime,
+      false,
+      displayTimezone,
+    ));
+  const timedEvents = dayEvents.filter((event) =>
+    !event.allDay && !eventSpansMultipleDisplayDays(
+      event.startTime,
+      event.endTime,
+      false,
+      displayTimezone,
+    ));
+  const headerLabel = (event: CalendarEvent) =>
+    !event.allDay && eventStartsOnDisplayDay(
+      event.startTime,
+      false,
+      currentDate,
+      displayTimezone,
+    )
+      ? `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`
+      : event.title;
 
   const hours = getVisibleHours(timedEvents.map((event) => ({
     ...event,
@@ -210,7 +241,7 @@ export function DayViewSideBySide({
                               : { backgroundColor: event.color, color: '#fff', borderLeft: `2px solid ${event.color}` }
                           }
                         >
-                          {event.title}
+                          {headerLabel(event)}
                         </button>
                       ))}
                     </div>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -10,7 +10,6 @@ import {
   addDays,
   isSameMonth,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getMonth,
@@ -26,7 +25,7 @@ import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppa
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -61,6 +60,8 @@ export function MonthView({
   enableDnd = false,
   onItemClick,
 }: MonthViewProps) {
+  const { displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const [cardHeight, setCardHeight] = React.useState<number | undefined>(undefined);
@@ -116,18 +117,20 @@ export function MonthView({
         {days.map((date, index) => {
           const dayStart = startOfDay(date);
           const dayEvents = events
-            .filter((event) =>
-              event.allDay
-                ? event.startTime <= dayStart && event.endTime > dayStart
-                : isSameDay(event.startTime, date)
-            )
+            .filter((event) => {
+              const displayStart = toDisplayDate(event.startTime, displayTimezone);
+              const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+              return event.allDay
+                ? displayStart <= dayStart && displayEnd > dayStart
+                : isSameDay(displayStart, date);
+            })
             .sort((a, b) => {
               if (a.allDay && !b.allDay) return -1;
               if (!a.allDay && b.allDay) return 1;
               return a.startTime.getTime() - b.startTime.getTime();
             });
 
-          const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+          const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
 
           return (
             <MonthDayCell
@@ -190,7 +193,8 @@ function MonthDayCell({
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const today = isSameDay(date, toDisplayDate(new Date(), displayTimezone));
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
 
   return (
@@ -210,7 +214,7 @@ function MonthDayCell({
       style={cellBgStyle}
     >
       {/* Today gets a blue bar; other days just show the date */}
-      {isToday(date) ? (
+      {today ? (
         <div className="bg-primary px-1 py-0.5 mb-0.5 rounded-t-[3px]">
           <span className="text-sm font-bold text-primary-foreground">{format(date, 'd')}</span>
         </div>
@@ -248,7 +252,7 @@ function MonthDayCell({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
             </li>
           ))}
         </ul>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -25,6 +25,8 @@ import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -188,6 +190,7 @@ function MonthDayCell({
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
 
   return (
@@ -245,7 +248,7 @@ function MonthDayCell({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${format(event.startTime, 'h:mm a')} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
             </li>
           ))}
         </ul>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -25,7 +25,7 @@ import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppa
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -115,15 +115,14 @@ export function MonthView({
         style={{ gridTemplateRows: `repeat(${numWeeks}, minmax(60px, 1fr))` }}
       >
         {days.map((date, index) => {
-          const dayStart = startOfDay(date);
           const dayEvents = events
-            .filter((event) => {
-              const displayStart = toDisplayDate(event.startTime, displayTimezone);
-              const displayEnd = toDisplayDate(event.endTime, displayTimezone);
-              return event.allDay
-                ? displayStart <= dayStart && displayEnd > dayStart
-                : isSameDay(displayStart, date);
-            })
+            .filter((event) => eventOccursOnDisplayDay(
+              event.startTime,
+              event.endTime,
+              event.allDay,
+              date,
+              displayTimezone,
+            ))
             .sort((a, b) => {
               if (a.allDay && !b.allDay) return -1;
               if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -21,11 +21,11 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
-import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
+import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, SpanningEventRows, useDayDroppable, type OverlayItemRef } from './cells';
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -85,6 +85,15 @@ export function MonthView({
 
   const numWeeks = Math.ceil(days.length / 7);
   const dayNames = [...DAYS_SHORT_ARRAY.slice(weekStartsOn), ...DAYS_SHORT_ARRAY.slice(0, weekStartsOn)];
+  const spanningEvents = events
+    .filter((event) => eventSpansMultipleDisplayDays(
+      event.startTime,
+      event.endTime,
+      event.allDay,
+      displayTimezone,
+    ))
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime() || a.title.localeCompare(b.title));
+  const spanningEventSet = new Set(spanningEvents);
 
   return (
     <div className="h-full flex flex-col overflow-auto">
@@ -115,7 +124,18 @@ export function MonthView({
         style={{ gridTemplateRows: `repeat(${numWeeks}, minmax(60px, 1fr))` }}
       >
         {days.map((date, index) => {
+          const weekStartIndex = Math.floor(index / 7) * 7;
+          const rowDates = days.slice(weekStartIndex, weekStartIndex + 7);
+          const rowSpanningEvents = spanningEvents.filter((event) => rowDates.some((rowDate) =>
+            eventOccursOnDisplayDay(
+              event.startTime,
+              event.endTime,
+              event.allDay,
+              rowDate,
+              displayTimezone,
+            )));
           const dayEvents = events
+            .filter((event) => !spanningEventSet.has(event))
             .filter((event) => eventOccursOnDisplayDay(
               event.startTime,
               event.endTime,
@@ -136,6 +156,8 @@ export function MonthView({
               key={index}
               date={date}
               dayEvents={dayEvents}
+              rowDates={rowDates}
+              spanningEvents={rowSpanningEvents}
               bucket={bucketsByDate?.get(format(date, 'yyyy-MM-dd'))}
               cards={cards}
               enableDnd={enableDnd}
@@ -164,6 +186,8 @@ export function MonthView({
 function MonthDayCell({
   date,
   dayEvents,
+  rowDates,
+  spanningEvents,
   bucket,
   cards,
   enableDnd,
@@ -179,6 +203,8 @@ function MonthDayCell({
 }: {
   date: Date;
   dayEvents: CalendarEvent[];
+  rowDates: Date[];
+  spanningEvents: CalendarEvent[];
   bucket: DayBucket | undefined;
   cards: boolean;
   enableDnd: boolean;
@@ -203,7 +229,7 @@ function MonthDayCell({
       onClick={() => onDateClick(date)}
       className={cn(
         bordered && 'border border-border rounded-md',
-        'cursor-pointer overflow-hidden',
+        'relative cursor-pointer overflow-visible',
         !transparentMode && !cellBgStyle && 'bg-card/85 backdrop-blur-sm',
         'flex flex-col min-h-0',
         !isSameMonth(date, currentDate) && 'opacity-50 text-muted-foreground',
@@ -222,6 +248,13 @@ function MonthDayCell({
           {format(date, 'd')}
         </div>
       )}
+
+      <SpanningEventRows
+        date={date}
+        rowDates={rowDates}
+        events={spanningEvents}
+        onEventClick={onEventClick}
+      />
 
       {cards ? (
         <DayCardsCell

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -232,7 +232,10 @@ function MonthDayCell({
         'relative cursor-pointer overflow-visible',
         !transparentMode && !cellBgStyle && 'bg-card/85 backdrop-blur-sm',
         'flex flex-col min-h-0',
-        !isSameMonth(date, currentDate) && 'opacity-50 text-muted-foreground',
+        !isSameMonth(date, currentDate) && [
+          'text-muted-foreground',
+          '[&>*:not([data-spanning-events])]:opacity-50',
+        ],
         !transparentMode && !cellBgStyle && isPast && isSameMonth(date, currentDate) && 'bg-muted/65 text-muted-foreground',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-seasonal-accent shadow-lg',
       )}

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -21,11 +21,11 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
-import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, SpanningEventRows, useDayDroppable, type OverlayItemRef } from './cells';
+import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, InlineCalendarEvent, SpanningEventRows, useDayDroppable, type OverlayItemRef } from './cells';
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, isCalendarEventPast, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -44,6 +44,8 @@ export interface MonthViewProps {
   bucketsByDate?: Map<string, DayBucket>;
   enableDnd?: boolean;
   onItemClick?: (ref: OverlayItemRef) => void;
+  /** Show the in-view month band. Full-page calendar already has this title. */
+  showMonthHeader?: boolean;
 }
 
 /** Fallback when ResizeObserver has not yet measured (~1 frame on mount). */
@@ -59,6 +61,7 @@ export function MonthView({
   bucketsByDate,
   enableDnd = false,
   onItemClick,
+  showMonthHeader = true,
 }: MonthViewProps) {
   const { displayTimezone } = useTimeFormat();
   const displayNow = toDisplayDate(new Date(), displayTimezone);
@@ -96,22 +99,21 @@ export function MonthView({
   const spanningEventSet = new Set(spanningEvents);
 
   return (
-    <div className="h-full flex flex-col overflow-auto">
+    <div className="h-full min-h-0 flex flex-col overflow-hidden">
       {cards && <CardHeightProbe size="xs" onMeasure={setCardHeight} />}
-      {/* Month header — kept compact (py-1, text-sm) so it doesn't eat into
-          the calendar grid. The toolbar already shows the month name; this
-          band is mostly a colored anchor. */}
-      <div
-        className="shrink-0 text-center py-1 font-semibold text-sm text-white rounded-t-md mb-1 shadow-sm"
-        style={{ backgroundColor: monthColor }}
-      >
-        {format(currentDate, 'MMMM yyyy')}
-      </div>
-      <div className="shrink-0 grid grid-cols-7 gap-1 mb-1">
+      {showMonthHeader && (
+        <div
+          className="shrink-0 text-center py-1 font-semibold text-sm text-white rounded-t-md shadow-sm"
+          style={{ backgroundColor: monthColor }}
+        >
+          {format(currentDate, 'MMMM yyyy')}
+        </div>
+      )}
+      <div className="shrink-0 grid grid-cols-7 border-b border-border/70">
         {dayNames.map((name) => (
           <div
             key={name}
-            className="text-center text-xs font-medium text-muted-foreground py-1"
+            className="text-center text-xs font-medium text-muted-foreground py-1.5"
           >
             {name}
           </div>
@@ -120,8 +122,11 @@ export function MonthView({
 
       {/* Auto-scaling calendar grid */}
       <div
-        className="flex-1 shrink-0 grid grid-cols-7 gap-1"
-        style={{ gridTemplateRows: `repeat(${numWeeks}, minmax(60px, 1fr))` }}
+        className={cn(
+          'flex-1 min-h-0 grid grid-cols-7 gap-px overflow-hidden bg-border/45',
+          bordered && 'bg-border/80',
+        )}
+        style={{ gridTemplateRows: `repeat(${numWeeks}, minmax(0, 1fr))` }}
       >
         {days.map((date, index) => {
           const weekStartIndex = Math.floor(index / 7) * 7;
@@ -164,7 +169,6 @@ export function MonthView({
               cardHeight={cardHeight}
               currentDate={currentDate}
               isPast={isPast}
-              bordered={bordered}
               transparentMode={transparentMode}
               cellBgStyle={cellBgStyle}
               onDateClick={onDateClick}
@@ -194,7 +198,6 @@ function MonthDayCell({
   cardHeight,
   currentDate,
   isPast,
-  bordered,
   transparentMode,
   cellBgStyle,
   onDateClick,
@@ -211,14 +214,13 @@ function MonthDayCell({
   cardHeight: number | undefined;
   currentDate: Date;
   isPast: boolean;
-  bordered: boolean;
   transparentMode: boolean;
   cellBgStyle: React.CSSProperties | undefined;
   onDateClick: (date: Date) => void;
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
-  const { timeFormat, displayTimezone } = useTimeFormat();
+  const { displayTimezone } = useTimeFormat();
   const today = isSameDay(date, toDisplayDate(new Date(), displayTimezone));
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
 
@@ -228,29 +230,23 @@ function MonthDayCell({
       data-droppable-day={cards && enableDnd ? droppable.droppableId : undefined}
       onClick={() => onDateClick(date)}
       className={cn(
-        bordered && 'border border-border rounded-md',
         'relative cursor-pointer overflow-visible',
         !transparentMode && !cellBgStyle && 'bg-card/85 backdrop-blur-sm',
         'flex flex-col min-h-0',
-        !isSameMonth(date, currentDate) && [
-          'text-muted-foreground',
-          '[&>*:not([data-spanning-events])]:opacity-50',
-        ],
-        !transparentMode && !cellBgStyle && isPast && isSameMonth(date, currentDate) && 'bg-muted/65 text-muted-foreground',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-seasonal-accent shadow-lg',
       )}
       style={cellBgStyle}
     >
-      {/* Today gets a blue bar; other days just show the date */}
-      {today ? (
-        <div className="bg-primary px-1 py-0.5 mb-0.5 rounded-t-[3px]">
-          <span className="text-sm font-bold text-primary-foreground">{format(date, 'd')}</span>
-        </div>
-      ) : (
-        <div className="text-sm font-medium px-1 pt-1 mb-0.5">
+      <div className="flex h-7 shrink-0 items-center justify-center">
+        <span className={cn(
+          'inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs font-medium',
+          today && 'bg-primary font-bold text-primary-foreground',
+          !today && isPast && 'text-muted-foreground',
+          !today && !isSameMonth(date, currentDate) && 'text-muted-foreground/55',
+        )}>
           {format(date, 'd')}
-        </div>
-      )}
+        </span>
+      </div>
 
       <SpanningEventRows
         date={date}
@@ -272,22 +268,8 @@ function MonthDayCell({
       ) : (
         <ul className="flex-1 overflow-y-auto space-y-0.5 list-none m-0 px-1 pb-1 pt-0">
           {dayEvents.map((event) => (
-            <li
-              key={event.id}
-              onClick={(e) => {
-                e.stopPropagation();
-                onEventClick(event);
-              }}
-              className={cn(
-                'text-xs px-1 rounded truncate cursor-pointer hover:opacity-80 hover:ring-2 hover:ring-seasonal-accent/50 transition-all',
-                event.allDay ? 'py-px' : 'py-0.5'
-              )}
-              style={event.allDay
-                ? { backgroundColor: event.color, color: '#fff', borderLeft: `2px solid ${event.color}` }
-                : { color: event.color }
-              }
-            >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
+            <li key={event.id}>
+              <InlineCalendarEvent event={event} onClick={onEventClick} />
             </li>
           ))}
         </ul>
@@ -319,6 +301,7 @@ function DayCardsCell({
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { displayTimezone } = useTimeFormat();
   const overlayItemCount = bucket ? bucket.meals.length + bucket.chores.length + bucket.tasks.length : 0;
   // Reserve ~22px for the popover trigger; each overlay row is ~24px (sm card)
   // plus the cell's 4px gap-1 separator. 20px under-reserved enough that event
@@ -359,7 +342,16 @@ function DayCardsCell({
             e.stopPropagation();
             onEventClick(event);
           }}
-          className="w-full text-left text-[10px] px-1 py-0.5 rounded bg-card/85 backdrop-blur-sm border border-border/40 shadow-sm truncate hover:bg-card transition-colors leading-tight"
+          className={cn(
+            'w-full text-left text-[10px] px-1 py-0.5 rounded bg-card/85 backdrop-blur-sm border border-border/40 shadow-sm truncate hover:bg-card transition-colors leading-tight',
+            isCalendarEventPast(
+              event.startTime,
+              event.endTime,
+              event.allDay,
+              new Date(),
+              displayTimezone,
+            ) && 'opacity-55 saturate-[0.65]',
+          )}
           style={{ borderLeft: `3px solid ${event.color}` }}
         >
           <span className="font-medium text-foreground">{event.title}</span>

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -26,6 +26,8 @@ function getMonthAccentColor(date: Date): string {
 }
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -168,6 +170,7 @@ function DayCell({
       the row to grow to accommodate the day with the most events. */
   showAll?: boolean;
 }) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
   const dayStart = startOfDay(date);
@@ -320,7 +323,7 @@ function DayCell({
                   layout="column"
                   stripeColor={event.color}
                   title={event.title}
-                  timeLabel={event.allDay ? 'All day' : format(event.startTime, 'h:mm a')}
+                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat)}
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}
@@ -340,7 +343,7 @@ function DayCell({
                   : { color: event.color }
                 }
               >
-                {event.allDay ? event.title : `${format(event.startTime, 'h:mm')} ${event.title}`}
+                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
               </button>
             ))}
         {cards && hiddenEvents.length > 0 && (

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -6,8 +6,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
-  isTomorrow,
   isBefore,
   startOfDay,
 } from 'date-fns';
@@ -27,7 +25,7 @@ function getMonthAccentColor(date: Date): string {
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -170,21 +168,24 @@ function DayCell({
       the row to grow to accommodate the day with the most events. */
   showAll?: boolean;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
   const dayStart = startOfDay(date);
-  const dayEvents = events.filter((event) =>
-    event.allDay
-      ? event.startTime <= dayStart && event.endTime > dayStart
-      : isSameDay(event.startTime, date)
-  );
+  const dayEvents = events.filter((event) => {
+    const displayStart = toDisplayDate(event.startTime, displayTimezone);
+    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+    return event.allDay
+      ? displayStart <= dayStart && displayEnd > dayStart
+      : isSameDay(displayStart, date);
+  });
   const sorted = [...dayEvents].sort((a, b) => {
     if (a.allDay && !b.allDay) return -1;
     if (!a.allDay && b.allDay) return 1;
     return a.startTime.getTime() - b.startTime.getTime();
   });
-  const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
+  const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
 
   // Overlay items render in the same flex container as events (meals at top,
   // chores+tasks at bottom). They are ALWAYS rendered when present, so the
@@ -225,8 +226,8 @@ function DayCell({
   const visibleEvents = cards ? sorted.slice(0, Math.max(0, visibleCount)) : sorted;
   const hiddenEvents = cards ? sorted.slice(visibleEvents.length) : [];
 
-  const today = isToday(date);
-  const tomorrow = isTomorrow(date);
+  const today = isSameDay(date, displayNow);
+  const tomorrow = isSameDay(date, addDays(displayNow, 1));
   const dayLabel = today
     ? 'Today'
     : tomorrow
@@ -323,7 +324,7 @@ function DayCell({
                   layout="column"
                   stripeColor={event.color}
                   title={event.title}
-                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat)}
+                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}
@@ -343,7 +344,7 @@ function DayCell({
                   : { color: event.color }
                 }
               >
-                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
               </button>
             ))}
         {cards && hiddenEvents.length > 0 && (

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -15,7 +15,7 @@ import { hexToRgba } from '@/lib/utils/color';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import type { CalendarEvent } from '@/types/calendar';
-import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, WeekItemCard, useDayDroppable, weatherIcon, type OverlayItemRef } from './cells';
+import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, SpanningEventRows, WeekItemCard, useDayDroppable, weatherIcon, type OverlayItemRef } from './cells';
 
 /** HSL color for the seasonal accent of the cell's month. */
 function getMonthAccentColor(date: Date): string {
@@ -25,7 +25,7 @@ function getMonthAccentColor(date: Date): string {
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -62,6 +62,7 @@ export function MultiWeekView({
   onItemClick,
 }: MultiWeekViewProps) {
   const { weekStartsOn } = useWeekStartsOn();
+  const { displayTimezone } = useTimeFormat();
   const [cardHeight, setCardHeight] = React.useState<number | undefined>(undefined);
   const cards = displayMode === 'cards';
   const bgOverride = useWidgetBgOverride();
@@ -85,6 +86,14 @@ export function MultiWeekView({
     weeks.push(hideWeekends ? row.filter((d) => d.getDay() !== 0 && d.getDay() !== 6) : row);
   }
   const colCount = hideWeekends ? 5 : 7;
+  const spanningEvents = events
+    .filter((event) => eventSpansMultipleDisplayDays(
+      event.startTime,
+      event.endTime,
+      event.allDay,
+      displayTimezone,
+    ))
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime() || a.title.localeCompare(b.title));
 
   // In inline mode, rows size to content (events list scrolls). In cards mode
   // with multiple weeks, rows are equal-height (`1fr`) so dynamic capacity has
@@ -105,32 +114,45 @@ export function MultiWeekView({
         className={cn('grid gap-1 min-h-0', !singleWeek && 'flex-1')}
         style={{ gridTemplateRows: `repeat(${weekCount}, ${rowSizing})` }}
       >
-        {weeks.map((week, wIdx) => (
-          <div
-            key={wIdx}
-            className={cn('grid gap-1', cards && !singleWeek && 'min-h-0 h-full')}
-            style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}
-          >
-            {week.map((date, dIdx) => (
-              <DayCell
-                key={dIdx}
-                date={date}
-                events={events}
-                onEventClick={onEventClick}
-                compact={compact}
-                bordered={bordered}
-                cellBgStyle={cellBgStyle}
-                displayMode={displayMode}
-                bucket={bucketsByDate?.get(format(date, 'yyyy-MM-dd'))}
-                enableDnd={enableDnd}
-                cardHeight={cardHeight}
-                mealColor={mealColor}
-                onItemClick={onItemClick}
-                showAll={singleWeek}
-              />
-            ))}
-          </div>
-        ))}
+        {weeks.map((week, wIdx) => {
+          const rowSpanningEvents = spanningEvents.filter((event) => week.some((rowDate) =>
+            eventOccursOnDisplayDay(
+              event.startTime,
+              event.endTime,
+              event.allDay,
+              rowDate,
+              displayTimezone,
+            )));
+
+          return (
+            <div
+              key={wIdx}
+              className={cn('grid gap-1', cards && !singleWeek && 'min-h-0 h-full')}
+              style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}
+            >
+              {week.map((date, dIdx) => (
+                <DayCell
+                  key={dIdx}
+                  date={date}
+                  rowDates={week}
+                  spanningEvents={rowSpanningEvents}
+                  events={events}
+                  onEventClick={onEventClick}
+                  compact={compact}
+                  bordered={bordered}
+                  cellBgStyle={cellBgStyle}
+                  displayMode={displayMode}
+                  bucket={bucketsByDate?.get(format(date, 'yyyy-MM-dd'))}
+                  enableDnd={enableDnd}
+                  cardHeight={cardHeight}
+                  mealColor={mealColor}
+                  onItemClick={onItemClick}
+                  showAll={singleWeek}
+                />
+              ))}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -138,6 +160,8 @@ export function MultiWeekView({
 
 function DayCell({
   date,
+  rowDates,
+  spanningEvents,
   events,
   onEventClick,
   compact,
@@ -152,6 +176,8 @@ function DayCell({
   showAll = false,
 }: {
   date: Date;
+  rowDates: Date[];
+  spanningEvents: CalendarEvent[];
   events: CalendarEvent[];
   onEventClick: (event: CalendarEvent) => void;
   compact: boolean;
@@ -171,13 +197,16 @@ function DayCell({
   const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
-  const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
-    event.startTime,
-    event.endTime,
-    event.allDay,
-    date,
-    displayTimezone,
-  ));
+  const spanningEventSet = new Set(spanningEvents);
+  const dayEvents = events
+    .filter((event) => !spanningEventSet.has(event))
+    .filter((event) => eventOccursOnDisplayDay(
+      event.startTime,
+      event.endTime,
+      event.allDay,
+      date,
+      displayTimezone,
+    ));
   const sorted = [...dayEvents].sort((a, b) => {
     if (a.allDay && !b.allDay) return -1;
     if (!a.allDay && b.allDay) return 1;
@@ -243,7 +272,7 @@ function DayCell({
       ref={cards && enableDnd ? droppable.setNodeRef : undefined}
       data-droppable-day={cards && enableDnd ? droppable.droppableId : undefined}
       className={cn(
-        'flex flex-col rounded-md',
+        'relative flex flex-col overflow-visible rounded-md',
         // In 1W mode (showAll=true) the column sizes to its content. In
         // 2/3/4W modes the cell stretches to fill the equal-height row so
         // the capacity probe has a real target height.
@@ -299,6 +328,14 @@ function DayCell({
           </div>
         )}
       </div>
+
+      <SpanningEventRows
+        date={date}
+        rowDates={rowDates}
+        events={spanningEvents}
+        onEventClick={onEventClick}
+        compact={compact}
+      />
 
       {/* Cards / events. In cards mode, meals render at the top of the day's
           stack (like all-day events); chores + tasks fall to the bottom. */}

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -15,7 +15,7 @@ import { hexToRgba } from '@/lib/utils/color';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import type { CalendarEvent } from '@/types/calendar';
-import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, SpanningEventRows, WeekItemCard, useDayDroppable, weatherIcon, type OverlayItemRef } from './cells';
+import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, InlineCalendarEvent, SpanningEventRows, WeekItemCard, useDayDroppable, weatherIcon, type OverlayItemRef } from './cells';
 
 /** HSL color for the seasonal accent of the cell's month. */
 function getMonthAccentColor(date: Date): string {
@@ -25,7 +25,7 @@ function getMonthAccentColor(date: Date): string {
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, isCalendarEventPast, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -277,7 +277,6 @@ function DayCell({
         // 2/3/4W modes the cell stretches to fill the equal-height row so
         // the capacity probe has a real target height.
         cards && (showAll ? 'min-h-0' : 'min-h-0 h-full'),
-        isPast && !cellBgStyle && '[&>*:not([data-spanning-events])]:opacity-50',
         // Cards mode: every cell gets a subtle border, today gets the month's
         // seasonal-accent ring (lavender in April, etc.).
         cards && !cellBgStyle && 'border border-border bg-card/85 backdrop-blur-sm',
@@ -287,7 +286,6 @@ function DayCell({
         // Inline mode keeps the legacy bordered look.
         !cards && bordered && !cellBgStyle && 'border border-border bg-card/85',
         !cards && bordered && cellBgStyle && 'border border-border',
-        !cards && bordered && isPast && !cellBgStyle && 'bg-muted/65',
       )}
       style={{
         ...cellBgStyle,
@@ -301,6 +299,7 @@ function DayCell({
         className={cn(
           'shrink-0 flex items-start justify-between gap-1',
           compact ? 'px-1.5 py-1' : 'px-2 py-1.5',
+          isPast && 'text-muted-foreground',
         )}
       >
         <div className="flex items-baseline gap-1.5 min-w-0">
@@ -364,24 +363,23 @@ function DayCell({
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}
+                  subdued={isCalendarEventPast(
+                    event.startTime,
+                    event.endTime,
+                    event.allDay,
+                    new Date(),
+                    displayTimezone,
+                  )}
                 />
               );
             })
           : visibleEvents.map((event) => (
-              <button
+              <InlineCalendarEvent
                 key={event.id}
-                onClick={(e) => { e.stopPropagation(); onEventClick(event); }}
-                className={cn(
-                  'w-full text-left rounded truncate hover:opacity-80 hover:ring-1 hover:ring-seasonal-accent/50 transition-all',
-                  compact ? 'text-xs px-0.5 py-px' : 'text-xs px-1 py-0.5',
-                )}
-                style={event.allDay
-                  ? { backgroundColor: event.color, color: '#fff', borderLeft: `2px solid ${event.color}` }
-                  : { color: event.color }
-                }
-              >
-                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
-              </button>
+                event={event}
+                onClick={onEventClick}
+                compact={compact}
+              />
             ))}
         {cards && hiddenEvents.length > 0 && (
           <DayOverflowPopover

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -277,7 +277,7 @@ function DayCell({
         // 2/3/4W modes the cell stretches to fill the equal-height row so
         // the capacity probe has a real target height.
         cards && (showAll ? 'min-h-0' : 'min-h-0 h-full'),
-        isPast && !cellBgStyle && 'opacity-50',
+        isPast && !cellBgStyle && '[&>*:not([data-spanning-events])]:opacity-50',
         // Cards mode: every cell gets a subtle border, today gets the month's
         // seasonal-accent ring (lavender in April, etc.).
         cards && !cellBgStyle && 'border border-border bg-card/85 backdrop-blur-sm',

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -25,7 +25,7 @@ function getMonthAccentColor(date: Date): string {
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -171,14 +171,13 @@ function DayCell({
   const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
-  const dayStart = startOfDay(date);
-  const dayEvents = events.filter((event) => {
-    const displayStart = toDisplayDate(event.startTime, displayTimezone);
-    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
-    return event.allDay
-      ? displayStart <= dayStart && displayEnd > dayStart
-      : isSameDay(displayStart, date);
-  });
+  const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    date,
+    displayTimezone,
+  ));
   const sorted = [...dayEvents].sort((a, b) => {
     if (a.allDay && !b.allDay) return -1;
     if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -11,7 +11,6 @@ import {
   subMonths,
   isSameMonth,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getMonth,
@@ -23,6 +22,8 @@ import { useOrientation } from '@/lib/hooks/useOrientation';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -56,6 +57,8 @@ function MiniMonth({
   isCenter: boolean;
   bordered?: boolean;
 }) {
+  const { displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const { weekStartsOn } = useWeekStartsOn();
   const dayNames = [...ALL_DAY_NAMES.slice(weekStartsOn), ...ALL_DAY_NAMES.slice(0, weekStartsOn)];
   const bgOverride = useWidgetBgOverride();
@@ -108,15 +111,17 @@ function MiniMonth({
           <div key={weekIndex} className="flex-1 grid grid-cols-7 gap-px min-h-0">
             {week.map((date, dayIndex) => {
               const inMonth = isSameMonth(date, month);
-              const today = isToday(date);
-              const isPast = isBefore(date, startOfDay(new Date())) && !today;
+              const today = isSameDay(date, displayNow);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !today;
               const dayStart = startOfDay(date);
               const dayEvents = events
-                .filter((e) =>
-                  e.allDay
-                    ? e.startTime <= dayStart && e.endTime > dayStart
-                    : isSameDay(e.startTime, date)
-                )
+                .filter((e) => {
+                  const displayStart = toDisplayDate(e.startTime, displayTimezone);
+                  const displayEnd = toDisplayDate(e.endTime, displayTimezone);
+                  return e.allDay
+                    ? displayStart <= dayStart && displayEnd > dayStart
+                    : isSameDay(displayStart, date);
+                })
                 .sort((a, b) => {
                   if (a.allDay && !b.allDay) return -1;
                   if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -23,7 +23,8 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, toDisplayDate } from '@/lib/utils/timeFormat';
+import { SpanningEventRows } from './cells';
+import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -80,6 +81,15 @@ function MiniMonth({
   for (let i = 0; i < days.length; i += 7) {
     weeks.push(days.slice(i, i + 7));
   }
+  const spanningEvents = events
+    .filter((event) => eventSpansMultipleDisplayDays(
+      event.startTime,
+      event.endTime,
+      event.allDay,
+      displayTimezone,
+    ))
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime() || a.title.localeCompare(b.title));
+  const spanningEventSet = new Set(spanningEvents);
 
   return (
     <div className={cn(
@@ -107,13 +117,25 @@ function MiniMonth({
 
       {/* Day grid — fills remaining space */}
       <div className="flex-1 flex flex-col gap-px px-1 pb-1">
-        {weeks.map((week, weekIndex) => (
-          <div key={weekIndex} className="flex-1 grid grid-cols-7 gap-px min-h-0">
-            {week.map((date, dayIndex) => {
+        {weeks.map((week, weekIndex) => {
+          const visibleRowDates = week.filter((date) => isSameMonth(date, month));
+          const rowSpanningEvents = spanningEvents.filter((event) => visibleRowDates.some((rowDate) =>
+            eventOccursOnDisplayDay(
+              event.startTime,
+              event.endTime,
+              event.allDay,
+              rowDate,
+              displayTimezone,
+            )));
+
+          return (
+            <div key={weekIndex} className="flex-1 grid grid-cols-7 gap-px min-h-0">
+              {week.map((date, dayIndex) => {
               const inMonth = isSameMonth(date, month);
               const today = isSameDay(date, displayNow);
               const isPast = isBefore(date, startOfDay(displayNow)) && !today;
               const dayEvents = events
+                .filter((event) => !spanningEventSet.has(event))
                 .filter((event) => eventOccursOnDisplayDay(
                   event.startTime,
                   event.endTime,
@@ -132,7 +154,7 @@ function MiniMonth({
                   key={dayIndex}
                   onClick={() => onDateClick(date)}
                   className={cn(
-                    'flex flex-col rounded text-xs cursor-pointer overflow-hidden p-0.5',
+                    'relative flex flex-col rounded text-xs cursor-pointer overflow-visible p-0.5',
                     bordered && 'border border-border',
                     !inMonth && 'text-muted-foreground/40',
                     !transparentMode && isPast && inMonth && 'bg-muted/30 text-muted-foreground',
@@ -145,6 +167,16 @@ function MiniMonth({
                   )}>
                     {format(date, 'd')}
                   </span>
+                  {inMonth && (
+                    <SpanningEventRows
+                      date={date}
+                      rowDates={visibleRowDates}
+                      events={rowSpanningEvents}
+                      onEventClick={onEventClick}
+                      compact
+                      gap="1px"
+                    />
+                  )}
                   {/* Event list — scrollable within day cell */}
                   {inMonth && dayEvents.length > 0 && (
                     <ul className="flex-1 overflow-y-auto space-y-px mt-0.5 scrollbar-thin list-none m-0 p-0">
@@ -168,9 +200,10 @@ function MiniMonth({
                   )}
                 </div>
               );
-            })}
-          </div>
-        ))}
+              })}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -23,7 +23,7 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { useTimeFormat } from '@/components/providers';
-import { toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -113,15 +113,14 @@ function MiniMonth({
               const inMonth = isSameMonth(date, month);
               const today = isSameDay(date, displayNow);
               const isPast = isBefore(date, startOfDay(displayNow)) && !today;
-              const dayStart = startOfDay(date);
               const dayEvents = events
-                .filter((e) => {
-                  const displayStart = toDisplayDate(e.startTime, displayTimezone);
-                  const displayEnd = toDisplayDate(e.endTime, displayTimezone);
-                  return e.allDay
-                    ? displayStart <= dayStart && displayEnd > dayStart
-                    : isSameDay(displayStart, date);
-                })
+                .filter((event) => eventOccursOnDisplayDay(
+                  event.startTime,
+                  event.endTime,
+                  event.allDay,
+                  date,
+                  displayTimezone,
+                ))
                 .sort((a, b) => {
                   if (a.allDay && !b.allDay) return -1;
                   if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -11,8 +11,6 @@ import {
   subMonths,
   isSameMonth,
   isSameDay,
-  isBefore,
-  startOfDay,
   getMonth,
 } from 'date-fns';
 import { cn } from '@/lib/utils';
@@ -23,7 +21,7 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { useTimeFormat } from '@/components/providers';
-import { SpanningEventRows } from './cells';
+import { InlineCalendarEvent, SpanningEventRows } from './cells';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
@@ -133,7 +131,6 @@ function MiniMonth({
               {week.map((date, dayIndex) => {
               const inMonth = isSameMonth(date, month);
               const today = isSameDay(date, displayNow);
-              const isPast = isBefore(date, startOfDay(displayNow)) && !today;
               const dayEvents = events
                 .filter((event) => !spanningEventSet.has(event))
                 .filter((event) => eventOccursOnDisplayDay(
@@ -157,16 +154,16 @@ function MiniMonth({
                     'relative flex flex-col rounded text-xs cursor-pointer overflow-visible p-0.5',
                     bordered && 'border border-border',
                     !inMonth && 'text-muted-foreground/40',
-                    !transparentMode && isPast && inMonth && 'bg-muted/30 text-muted-foreground',
-                    today && 'bg-seasonal-highlight/20',
                   )}
                 >
-                  <span className={cn(
-                    'text-center text-[10px] leading-tight flex-shrink-0',
-                    today && 'font-bold text-seasonal-accent',
-                  )}>
-                    {format(date, 'd')}
-                  </span>
+                  <div className="flex h-4 flex-shrink-0 items-center justify-center">
+                    <span className={cn(
+                      'inline-flex h-4 min-w-4 items-center justify-center rounded-full px-0.5 text-[10px] leading-tight',
+                      today && 'bg-primary font-bold text-primary-foreground',
+                    )}>
+                      {format(date, 'd')}
+                    </span>
+                  </div>
                   {inMonth && (
                     <SpanningEventRows
                       date={date}
@@ -181,19 +178,13 @@ function MiniMonth({
                   {inMonth && dayEvents.length > 0 && (
                     <ul className="flex-1 overflow-y-auto space-y-px mt-0.5 scrollbar-thin list-none m-0 p-0">
                       {dayEvents.map((event) => (
-                        <li
-                          key={event.id}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onEventClick(event);
-                          }}
-                          className="text-[8px] leading-tight px-0.5 rounded truncate cursor-pointer hover:opacity-80 hover:ring-1 hover:ring-seasonal-accent/50 transition-all"
-                          style={event.allDay
-                            ? { backgroundColor: event.color + '20', borderLeft: `2px solid ${event.color}` }
-                            : { color: event.color }
-                          }
-                        >
-                          {event.allDay ? event.title : `• ${event.title}`}
+                        <li key={event.id}>
+                          <InlineCalendarEvent
+                            event={event}
+                            onClick={onEventClick}
+                            compact
+                            showTime={false}
+                          />
                         </li>
                       ))}
                     </ul>

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -5,7 +5,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getWeek,
@@ -16,7 +15,7 @@ import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -29,7 +28,8 @@ export function TwoWeekView({
   events,
   onEventClick,
 }: TwoWeekViewProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
   const weekStart = startOfWeek(currentDate);
@@ -48,13 +48,14 @@ export function TwoWeekView({
   const week2Num = getWeek(week2[0]!);
 
   const renderDayCell = (date: Date, compact: boolean = false) => {
-    const dayEvents = events.filter((event) => isSameDay(event.startTime, date));
+    const dayEvents = events.filter((event) => isSameDay(toDisplayDate(event.startTime, displayTimezone), date));
     const sorted = [...dayEvents].sort((a, b) => {
       if (a.allDay && !b.allDay) return -1;
       if (!a.allDay && b.allDay) return 1;
       return a.startTime.getTime() - b.startTime.getTime();
     });
-    const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+    const today = isSameDay(date, displayNow);
+    const isPast = isBefore(date, startOfDay(displayNow)) && !today;
 
     return (
       <div
@@ -63,7 +64,7 @@ export function TwoWeekView({
           !transparentMode && 'bg-card/85 backdrop-blur-sm',
           'flex flex-col overflow-hidden',
           !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-          isToday(date) && 'border-primary border-2'
+          today && 'border-primary border-2'
         )}
       >
         {/* Date header */}
@@ -71,13 +72,13 @@ export function TwoWeekView({
           className={cn(
             'shrink-0 px-1',
             compact ? 'py-0.5' : 'py-1',
-            isToday(date) && 'bg-primary/10'
+            today && 'bg-primary/10'
           )}
         >
           <div className={cn(
             'font-medium flex items-center gap-1',
             compact ? 'text-sm' : 'text-sm',
-            isToday(date) && 'text-primary'
+            today && 'text-primary'
           )}>
             <span className="font-bold">{format(date, 'd')}</span>
             <span className="text-xs text-muted-foreground">{format(date, 'MMM')}</span>
@@ -99,7 +100,7 @@ export function TwoWeekView({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
             </button>
           ))}
         </div>

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -15,6 +15,8 @@ import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -27,6 +29,7 @@ export function TwoWeekView({
   events,
   onEventClick,
 }: TwoWeekViewProps) {
+  const { timeFormat } = useTimeFormat();
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
   const weekStart = startOfWeek(currentDate);
@@ -96,7 +99,7 @@ export function TwoWeekView({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${format(event.startTime, 'h:mm')} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
             </button>
           ))}
         </div>

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -15,7 +15,7 @@ import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -48,7 +48,13 @@ export function TwoWeekView({
   const week2Num = getWeek(week2[0]!);
 
   const renderDayCell = (date: Date, compact: boolean = false) => {
-    const dayEvents = events.filter((event) => isSameDay(toDisplayDate(event.startTime, displayTimezone), date));
+    const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+      event.startTime,
+      event.endTime,
+      event.allDay,
+      date,
+      displayTimezone,
+    ));
     const sorted = [...dayEvents].sort((a, b) => {
       if (a.allDay && !b.allDay) return -1;
       if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -15,7 +15,12 @@ import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  eventStartsOnDisplayDay,
+  formatDisplayTime,
+  toDisplayDate,
+} from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -106,7 +111,14 @@ export function TwoWeekView({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
+              {event.allDay || !eventStartsOnDisplayDay(
+                event.startTime,
+                false,
+                date,
+                displayTimezone,
+              )
+                ? event.title
+                : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
             </button>
           ))}
         </div>

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -18,6 +18,8 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -344,6 +346,7 @@ function DayEventList({
   currentHour?: number;
   cards?: boolean;
 }) {
+  const { timeFormat } = useTimeFormat();
   if (allDayEvents.length === 0 && timedEvents.length === 0) {
     return null;
   }
@@ -386,7 +389,7 @@ function DayEventList({
                 : { backgroundColor: event.color, borderLeft: `3px solid ${event.color}` }
             }
           >
-            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{format(new Date(event.startTime), 'h:mm a')}</span>
+            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(new Date(event.startTime), timeFormat)}</span>
             <span className="font-medium">{event.title}</span>
           </button>
         );

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -4,7 +4,6 @@ import {
   format,
   startOfWeek,
   addDays,
-  isToday,
   isBefore,
   startOfDay,
   isSameDay,
@@ -19,7 +18,7 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -60,6 +59,7 @@ export function WeekVerticalView({
   mealColor,
   onItemClick,
 }: WeekVerticalViewProps) {
+  const { displayTimezone } = useTimeFormat();
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
   const cellBg = bgOverride?.cellBackgroundColor;
@@ -67,7 +67,7 @@ export function WeekVerticalView({
   const cellBgStyle = cellBg ? { backgroundColor: hexToRgba(cellBg, cellBgOpacity) } : undefined;
   const weekStart = startOfWeek(currentDate, { weekStartsOn });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
-  const now = new Date();
+  const now = toDisplayDate(new Date(), displayTimezone);
   const today = startOfDay(now);
   const currentHour = now.getHours();
 
@@ -177,14 +177,15 @@ function WeekListDayRow({
   mealColor: string | undefined;
   onItemClick: ((ref: OverlayItemRef) => void) | undefined;
 }) {
+  const { displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const dayStart = startOfDay(day);
-  const isCurrentDay = isToday(day);
+  const isCurrentDay = isSameDay(day, today);
   const isPast = isBefore(dayStart, today);
 
   const dayEvents = events.filter((event) => {
-    const eventStart = new Date(event.startTime);
-    const eventEnd = new Date(event.endTime);
+    const eventStart = toDisplayDate(event.startTime, displayTimezone);
+    const eventEnd = toDisplayDate(event.endTime, displayTimezone);
     return eventStart < addDays(dayStart, 1) && eventEnd > dayStart;
   });
 
@@ -346,7 +347,7 @@ function DayEventList({
   currentHour?: number;
   cards?: boolean;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   if (allDayEvents.length === 0 && timedEvents.length === 0) {
     return null;
   }
@@ -371,7 +372,7 @@ function DayEventList({
         </button>
       ))}
       {timedEvents.map((event) => {
-        const isPastEvent = isPastDay || (isCurrentDay && new Date(event.startTime).getHours() < currentHour);
+        const isPastEvent = isPastDay || (isCurrentDay && toDisplayDate(event.startTime, displayTimezone).getHours() < currentHour);
         return (
           <button
             key={event.id}
@@ -389,7 +390,7 @@ function DayEventList({
                 : { backgroundColor: event.color, borderLeft: `3px solid ${event.color}` }
             }
           >
-            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(new Date(event.startTime), timeFormat)}</span>
+            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}</span>
             <span className="font-medium">{event.title}</span>
           </button>
         );

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -18,7 +18,13 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  eventStartsOnDisplayDay,
+  formatDisplayTime,
+  isCalendarEventPast,
+  toDisplayDate,
+} from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -69,7 +75,6 @@ export function WeekVerticalView({
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const now = toDisplayDate(new Date(), displayTimezone);
   const today = startOfDay(now);
-  const currentHour = now.getHours();
 
   // Determine display groups (same logic as DayViewSideBySide)
   const showAllInOne = calendarGroups.length === 0 || mergedView;
@@ -124,7 +129,6 @@ export function WeekVerticalView({
           getEventsForGroup={getEventsForGroup}
           bordered={bordered}
           cellBgStyle={cellBgStyle}
-          currentHour={currentHour}
           onEventClick={onEventClick}
           showNotes={showNotes}
           notesByDate={notesByDate}
@@ -148,7 +152,6 @@ function WeekListDayRow({
   getEventsForGroup,
   bordered,
   cellBgStyle,
-  currentHour,
   onEventClick,
   showNotes,
   notesByDate,
@@ -166,7 +169,6 @@ function WeekListDayRow({
   getEventsForGroup: (dayEvents: CalendarEvent[], gid: string) => CalendarEvent[];
   bordered: boolean;
   cellBgStyle: React.CSSProperties | undefined;
-  currentHour: number;
   onEventClick: (event: CalendarEvent) => void;
   showNotes: boolean;
   notesByDate: Map<string, CalendarNote> | undefined;
@@ -192,9 +194,12 @@ function WeekListDayRow({
   ));
 
   const allDayEvents = dayEvents.filter((e) => e.allDay);
-  const timedEvents = dayEvents.filter((e) => !e.allDay).sort(
-    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-  );
+  const timedEvents = dayEvents.filter((e) => !e.allDay).sort((a, b) => {
+    const aStartsToday = eventStartsOnDisplayDay(a.startTime, false, day, displayTimezone);
+    const bStartsToday = eventStartsOnDisplayDay(b.startTime, false, day, displayTimezone);
+    if (aStartsToday !== bStartsToday) return aStartsToday ? 1 : -1;
+    return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+  });
 
   const droppable = useDayDroppable({ date: day, enabled: cards && enableDnd });
 
@@ -269,12 +274,12 @@ function WeekListDayRow({
             return (
               <div key={group.id} className="flex-1 min-w-0 border-l border-border p-1 space-y-0.5">
                 <DayEventList
+                  day={day}
                   allDayEvents={groupAllDay}
                   timedEvents={groupTimed}
                   onEventClick={onEventClick}
                   isPastDay={isPast && !isCurrentDay}
                   isCurrentDay={isCurrentDay}
-                  currentHour={currentHour}
                   cards={cards}
                 />
                 {groupBucket && (
@@ -295,12 +300,12 @@ function WeekListDayRow({
       ) : (
         <div className="flex-1 p-1.5 min-w-0 space-y-1">
           <DayEventList
+            day={day}
             allDayEvents={allDayEvents}
             timedEvents={timedEvents}
             onEventClick={onEventClick}
             isPastDay={isPast && !isCurrentDay}
             isCurrentDay={isCurrentDay}
-            currentHour={currentHour}
             cards={cards}
           />
           {bucketsByDate && (
@@ -333,20 +338,20 @@ function WeekListDayRow({
 
 /** Renders all-day events then timed events in chronological order */
 function DayEventList({
+  day,
   allDayEvents,
   timedEvents,
   onEventClick,
   isPastDay = false,
   isCurrentDay = false,
-  currentHour = 0,
   cards = false,
 }: {
+  day: Date;
   allDayEvents: CalendarEvent[];
   timedEvents: CalendarEvent[];
   onEventClick: (event: CalendarEvent) => void;
   isPastDay?: boolean;
   isCurrentDay?: boolean;
-  currentHour?: number;
   cards?: boolean;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
@@ -374,7 +379,19 @@ function DayEventList({
         </button>
       ))}
       {timedEvents.map((event) => {
-        const isPastEvent = isPastDay || (isCurrentDay && toDisplayDate(event.startTime, displayTimezone).getHours() < currentHour);
+        const startsToday = eventStartsOnDisplayDay(
+          event.startTime,
+          false,
+          day,
+          displayTimezone,
+        );
+        const isPastEvent = isPastDay || (isCurrentDay && isCalendarEventPast(
+          event.startTime,
+          event.endTime,
+          false,
+          new Date(),
+          displayTimezone,
+        ));
         return (
           <button
             key={event.id}
@@ -392,7 +409,11 @@ function DayEventList({
                 : { backgroundColor: event.color, borderLeft: `3px solid ${event.color}` }
             }
           >
-            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}</span>
+            {startsToday && (
+              <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>
+                {formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
+              </span>
+            )}
             <span className="font-medium">{event.title}</span>
           </button>
         );

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -18,7 +18,7 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -183,11 +183,13 @@ function WeekListDayRow({
   const isCurrentDay = isSameDay(day, today);
   const isPast = isBefore(dayStart, today);
 
-  const dayEvents = events.filter((event) => {
-    const eventStart = toDisplayDate(event.startTime, displayTimezone);
-    const eventEnd = toDisplayDate(event.endTime, displayTimezone);
-    return eventStart < addDays(dayStart, 1) && eventEnd > dayStart;
-  });
+  const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    day,
+    displayTimezone,
+  ));
 
   const allDayEvents = dayEvents.filter((e) => e.allDay);
   const timedEvents = dayEvents.filter((e) => !e.allDay).sort(

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -21,6 +21,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -50,6 +52,7 @@ export function WeekView({
   mealColor,
   onItemClick,
 }: WeekViewProps) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
@@ -198,7 +201,7 @@ export function WeekView({
                       <span className={cn('truncate w-full text-[10px] font-medium leading-tight', cards && 'text-foreground')}>{event.title}</span>
                       {cards && durationMin >= 30 && (
                         <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                          {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                         </span>
                       )}
                       {cards && durationMin >= 60 && (event.location || event.calendarName) && (
@@ -208,7 +211,7 @@ export function WeekView({
                       )}
                       {!cards && (
                         <span className="text-[9px] leading-tight opacity-70">
-                          {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                         </span>
                       )}
                     </button>
@@ -251,7 +254,7 @@ export function WeekView({
                   key={hour}
                   className="text-[9px] text-muted-foreground text-right pl-0.5 pr-0.5 border-t border-transparent flex items-start"
                 >
-                  {format(new Date().setHours(hour, 0), 'ha')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat, { compact: true })}
                 </div>
               ))}
             </div>
@@ -268,7 +271,7 @@ export function WeekView({
                   key={hour}
                   className="text-[9px] text-muted-foreground text-right pl-0.5 pr-0.5 border-t border-transparent flex items-start"
                 >
-                  {format(new Date().setHours(hour, 0), 'ha')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat, { compact: true })}
                 </div>
               ))}
             </div>
@@ -407,7 +410,7 @@ export function WeekView({
             <div className="w-16 shrink-0 h-full grid" style={{ gridTemplateRows: `repeat(${hours.length}, 1fr)` }}>
               {hours.map((hour) => (
                 <div key={hour} className={cn('pl-1 pr-1 text-right text-xs text-muted-foreground flex items-start pt-0.5 min-h-0', bordered && 'border-t border-border')}>
-                  {format(new Date().setHours(hour, 0), 'h a')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat)}
                 </div>
               ))}
             </div>
@@ -475,7 +478,7 @@ export function WeekView({
                               <div className={cn('font-medium truncate w-full text-[10px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {cards && durationMin >= 60 && (
                                 <div className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                               {cards && durationMin >= 90 && (event.location || event.calendarName) && (
@@ -485,7 +488,7 @@ export function WeekView({
                               )}
                               {!cards && durationMin >= 45 && (
                                 <div className="text-[9px] leading-tight opacity-70">
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                             </button>
@@ -545,6 +548,7 @@ function TimedBucketLayer({
   enableDnd: boolean;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const slotPct = 100 / hours.length;
   const visibleSet = new Set(hours);
 
@@ -576,7 +580,7 @@ function TimedBucketLayer({
       dragId: `meal:${meal.id}`,
       variant: 'meal',
       title: meal.name,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
       stripeColor: mealColor ?? '#10b981',
       muted: Boolean(meal.cookedAt),
@@ -596,7 +600,7 @@ function TimedBucketLayer({
       dragId: `chore:${chore.id}`,
       variant: 'chore',
       title: chore.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: chore.assignedTo?.name,
       stripeColor: chore.assignedTo?.color || '#f59e0b',
       pendingApproval: Boolean(chore.pendingApproval),
@@ -616,7 +620,7 @@ function TimedBucketLayer({
       dragId: `task:${task.id}`,
       variant: 'task',
       title: task.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: task.assignedTo?.name,
       stripeColor: task.assignedTo?.color || '#3b82f6',
       muted: task.completed,

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -5,7 +5,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
 } from 'date-fns';
@@ -22,7 +21,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
+import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -52,7 +51,8 @@ export function WeekView({
   mealColor,
   onItemClick,
 }: WeekViewProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
@@ -69,9 +69,16 @@ export function WeekView({
   const { settings: hiddenSettings, toggleHidden, getVisibleHours } = useHiddenHours();
 
   const weekEnd = addDays(weekStart, 7);
-  const timedWeekEvents = events.filter(
-    (event) => !event.allDay && event.startTime >= weekStart && event.startTime < weekEnd
-  );
+  const timedWeekEvents = events
+    .filter((event) => {
+      const displayStart = toDisplayDate(event.startTime, displayTimezone);
+      return !event.allDay && displayStart >= weekStart && displayStart < weekEnd;
+    })
+    .map((event) => ({
+      ...event,
+      startTime: toDisplayDate(event.startTime, displayTimezone),
+      endTime: toDisplayDate(event.endTime, displayTimezone),
+    }));
 
   // Get visible hours (filtered if hidden mode is enabled)
   const hours = getVisibleHours(timedWeekEvents, { from: weekStart, to: weekEnd });
@@ -79,24 +86,26 @@ export function WeekView({
   // Get all-day events for a day (multi-day events span across days)
   const getAllDayEvents = (date: Date) => {
     const dayStart = startOfDay(date);
-    return events.filter((e) =>
-      e.allDay && e.startTime <= dayStart && e.endTime > dayStart
-    );
+    return events.filter((e) => {
+      const displayStart = toDisplayDate(e.startTime, displayTimezone);
+      const displayEnd = toDisplayDate(e.endTime, displayTimezone);
+      return e.allDay && displayStart <= dayStart && displayEnd > dayStart;
+    });
   };
 
   // Get all timed events for a day (used to compute side-by-side positions
   // across the entire day, so events that overlap but start in different
   // hours still split the column horizontally).
   const getDayTimedEvents = (date: Date) =>
-    events.filter((e) => isSameDay(e.startTime, date) && !e.allDay);
+    events.filter((e) => isSameDay(toDisplayDate(e.startTime, displayTimezone), date) && !e.allDay);
 
   // Get timed events for a specific day and hour
   const getHourEvents = (date: Date, hour: number) =>
     events.filter(
       (e) =>
-        isSameDay(e.startTime, date) &&
+        isSameDay(toDisplayDate(e.startTime, displayTimezone), date) &&
         !e.allDay &&
-        e.startTime.getHours() === hour
+        toDisplayDate(e.startTime, displayTimezone).getHours() === hour
     );
 
   // For portrait, split into two rows
@@ -105,7 +114,7 @@ export function WeekView({
   const row2Days = [...days.slice(4, 7), nextSunday]; // Thu-Sat + next Sun
 
   const renderDayColumn = (date: Date, compact: boolean = false) => {
-    const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+    const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
     const allDayEvents = getAllDayEvents(date);
     const dayPositions = calculateEventPositions(getDayTimedEvents(date));
 
@@ -121,7 +130,7 @@ export function WeekView({
           className={cn(
             'text-center py-1 shrink-0 rounded-t-md',
             !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-            isToday(date) && 'bg-primary text-primary-foreground'
+            isSameDay(date, displayNow) && 'bg-primary text-primary-foreground'
           )}
         >
           <div className={cn('font-bold uppercase tracking-wide', compact ? 'text-xs' : 'text-sm')}>
@@ -182,7 +191,7 @@ export function WeekView({
                         cards
                           ? {
                               borderLeft: `3px solid ${event.color}`,
-                              top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                              top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                               height: `calc(${heightPct}% - 4px)`,
                               left: css.left,
                               width: css.width,
@@ -191,7 +200,7 @@ export function WeekView({
                               backgroundColor: event.color,
                               color: '#fff',
                               borderLeft: `2px solid ${event.color}`,
-                              top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                              top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                               height: `${heightPct}%`,
                               left: css.left,
                               width: css.width,
@@ -201,7 +210,7 @@ export function WeekView({
                       <span className={cn('truncate w-full text-[10px] font-medium leading-tight', cards && 'text-foreground')}>{event.title}</span>
                       {cards && durationMin >= 30 && (
                         <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                         </span>
                       )}
                       {cards && durationMin >= 60 && (event.location || event.calendarName) && (
@@ -211,7 +220,7 @@ export function WeekView({
                       )}
                       {!cards && (
                         <span className="text-[9px] leading-tight opacity-70">
-                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                         </span>
                       )}
                     </button>
@@ -309,7 +318,7 @@ export function WeekView({
               </button>
             </div>
             {days.map((date) => {
-              const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
               const allDayEvents = getAllDayEvents(date);
               const dayBucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
               const dayWeather = dayBucket?.weather;
@@ -335,6 +344,7 @@ export function WeekView({
                 <LandscapeDayHeader
                   key={date.toISOString()}
                   date={date}
+                  today={isSameDay(date, displayNow)}
                   isPast={isPast}
                   cards={cards}
                   enableDnd={enableDnd}
@@ -344,16 +354,16 @@ export function WeekView({
                     className={cn(
                       'flex items-baseline justify-between gap-1 px-2 py-1.5',
                       !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-                      isToday(date) && !cards && 'bg-primary text-primary-foreground',
+                      isSameDay(date, displayNow) && !cards && 'bg-primary text-primary-foreground',
                     )}
                   >
                     <div className="flex items-baseline gap-1.5 min-w-0">
                       <span className="text-2xl font-bold leading-none">{format(date, 'd')}</span>
                       <span className={cn(
                         'text-xs font-medium uppercase tracking-wide truncate leading-none',
-                        isToday(date) && cards ? 'text-seasonal-accent font-semibold' : undefined,
+                        isSameDay(date, displayNow) && cards ? 'text-seasonal-accent font-semibold' : undefined,
                       )}>
-                        {isToday(date) ? 'Today' : format(date, 'EEE')}
+                        {isSameDay(date, displayNow) ? 'Today' : format(date, 'EEE')}
                       </span>
                     </div>
                     {dayWeather && (
@@ -416,13 +426,14 @@ export function WeekView({
             </div>
             {/* Day columns */}
             {days.map((date) => {
-              const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
               const dayPositions = calculateEventPositions(getDayTimedEvents(date));
               const dayBucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
               return (
                 <LandscapeDayBody
                   key={date.toISOString()}
                   date={date}
+                  today={isSameDay(date, displayNow)}
                   isPast={isPast}
                   cards={cards}
                   enableDnd={enableDnd}
@@ -454,7 +465,7 @@ export function WeekView({
                                 cards
                                   ? {
                                       borderLeft: `3px solid ${event.color}`,
-                                      top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                                      top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                                       height: `calc(${heightPct}% - 4px)`,
                                       left: css.left,
                                       width: css.width,
@@ -463,7 +474,7 @@ export function WeekView({
                                       backgroundColor: event.color,
                                       color: '#fff',
                                       borderLeft: `2px solid ${event.color}`,
-                                      top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                                      top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                                       height: `${heightPct}%`,
                                       left: css.left,
                                       width: css.width,
@@ -478,7 +489,7 @@ export function WeekView({
                               <div className={cn('font-medium truncate w-full text-[10px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {cards && durationMin >= 60 && (
                                 <div className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                               {cards && durationMin >= 90 && (event.location || event.calendarName) && (
@@ -488,7 +499,7 @@ export function WeekView({
                               )}
                               {!cards && durationMin >= 45 && (
                                 <div className="text-[9px] leading-tight opacity-70">
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                             </button>
@@ -701,6 +712,7 @@ function PortraitDayColumn({
  */
 function LandscapeDayBody({
   date,
+  today,
   isPast,
   cards,
   enableDnd,
@@ -708,6 +720,7 @@ function LandscapeDayBody({
   children,
 }: {
   date: Date;
+  today: boolean;
   isPast: boolean;
   cards: boolean;
   enableDnd: boolean;
@@ -725,7 +738,7 @@ function LandscapeDayBody({
         // For today: 3-sided border (left + right + bottom, no top) so it joins
         // seamlessly with LandscapeDayHeader's 3-sided border to form a single
         // continuous perimeter spanning header + time grid.
-        isToday(date) && cards && 'border-2 border-t-0 border-seasonal-accent/80',
+        today && cards && 'border-2 border-t-0 border-seasonal-accent/80',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-inset ring-seasonal-accent shadow-lg',
       )}
     >
@@ -741,6 +754,7 @@ function LandscapeDayBody({
  */
 function LandscapeDayHeader({
   date,
+  today,
   isPast,
   cards,
   enableDnd,
@@ -748,6 +762,7 @@ function LandscapeDayHeader({
   children,
 }: {
   date: Date;
+  today: boolean;
   isPast: boolean;
   cards: boolean;
   enableDnd: boolean;
@@ -766,7 +781,7 @@ function LandscapeDayHeader({
         // explicit border-2 so it joins seamlessly with LandscapeDayBody's
         // matching 3-sided border (left + right + bottom). Together the two
         // form a single continuous 4-sided perimeter spanning the full column.
-        isToday(date) && cards && 'border-2 border-b-0 border-seasonal-accent/80',
+        today && cards && 'border-2 border-b-0 border-seasonal-accent/80',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-inset ring-seasonal-accent shadow-lg',
       )}
     >

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -21,7 +21,15 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  eventSpansMultipleDisplayDays,
+  eventStartsOnDisplayDay,
+  formatDisplayHour,
+  formatDisplayTime,
+  formatDisplayTimeRange,
+  toDisplayDate,
+} from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -72,7 +80,10 @@ export function WeekView({
   const timedWeekEvents = events
     .filter((event) => {
       const displayStart = toDisplayDate(event.startTime, displayTimezone);
-      return !event.allDay && displayStart >= weekStart && displayStart < weekEnd;
+      return !event.allDay
+        && !eventSpansMultipleDisplayDays(event.startTime, event.endTime, false, displayTimezone)
+        && displayStart >= weekStart
+        && displayStart < weekEnd;
     })
     .map((event) => ({
       ...event,
@@ -83,21 +94,40 @@ export function WeekView({
   // Get visible hours (filtered if hidden mode is enabled)
   const hours = getVisibleHours(timedWeekEvents, { from: weekStart, to: weekEnd });
 
-  // Get all-day events for a day (multi-day events span across days)
+  // Multi-day timed events share the persistent header with all-day events so
+  // they do not become oversized blocks in the hourly grid.
   const getAllDayEvents = (date: Date) => events.filter((event) =>
-    event.allDay && eventOccursOnDisplayDay(
+    (event.allDay || eventSpansMultipleDisplayDays(
       event.startTime,
       event.endTime,
-      true,
+      false,
+      displayTimezone,
+    )) && eventOccursOnDisplayDay(
+      event.startTime,
+      event.endTime,
+      event.allDay,
       date,
       displayTimezone,
     ));
+
+  const getHeaderEventLabel = (event: CalendarEvent, date: Date) =>
+    !event.allDay && eventStartsOnDisplayDay(
+      event.startTime,
+      false,
+      date,
+      displayTimezone,
+    )
+      ? `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`
+      : event.title;
 
   // Get all timed events for a day (used to compute side-by-side positions
   // across the entire day, so events that overlap but start in different
   // hours still split the column horizontally).
   const getDayTimedEvents = (date: Date) =>
-    events.filter((e) => isSameDay(toDisplayDate(e.startTime, displayTimezone), date) && !e.allDay);
+    events.filter((event) =>
+      !event.allDay
+      && !eventSpansMultipleDisplayDays(event.startTime, event.endTime, false, displayTimezone)
+      && isSameDay(toDisplayDate(event.startTime, displayTimezone), date));
 
   // Get timed events for a specific day and hour
   const getHourEvents = (date: Date, hour: number) =>
@@ -105,6 +135,7 @@ export function WeekView({
       (e) =>
         isSameDay(toDisplayDate(e.startTime, displayTimezone), date) &&
         !e.allDay &&
+        !eventSpansMultipleDisplayDays(e.startTime, e.endTime, false, displayTimezone) &&
         toDisplayDate(e.startTime, displayTimezone).getHours() === hour
     );
 
@@ -144,7 +175,7 @@ export function WeekView({
         {/* All-day events */}
         {allDayEvents.length > 0 && (
           <div className={cn('shrink-0 p-0.5 flex flex-col gap-px', !transparentMode && 'bg-card/50')}>
-            {allDayEvents.map((event, idx) => (
+            {allDayEvents.map((event) => (
               <button
                 key={event.id}
                 onClick={() => onEventClick(event)}
@@ -158,7 +189,7 @@ export function WeekView({
                     : { backgroundColor: event.color, color: '#fff', borderLeft: `2px solid ${event.color}` }
                 }
               >
-                {event.title}
+                {getHeaderEventLabel(event, date)}
               </button>
             ))}
           </div>
@@ -391,7 +422,7 @@ export function WeekView({
                               : { backgroundColor: event.color, color: '#fff', borderLeft: `2px solid ${event.color}` }
                           }
                         >
-                          {event.title}
+                          {getHeaderEventLabel(event, date)}
                         </button>
                       ))}
                     </div>

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -21,7 +21,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay, formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -84,14 +84,14 @@ export function WeekView({
   const hours = getVisibleHours(timedWeekEvents, { from: weekStart, to: weekEnd });
 
   // Get all-day events for a day (multi-day events span across days)
-  const getAllDayEvents = (date: Date) => {
-    const dayStart = startOfDay(date);
-    return events.filter((e) => {
-      const displayStart = toDisplayDate(e.startTime, displayTimezone);
-      const displayEnd = toDisplayDate(e.endTime, displayTimezone);
-      return e.allDay && displayStart <= dayStart && displayEnd > dayStart;
-    });
-  };
+  const getAllDayEvents = (date: Date) => events.filter((event) =>
+    event.allDay && eventOccursOnDisplayDay(
+      event.startTime,
+      event.endTime,
+      true,
+      date,
+      displayTimezone,
+    ));
 
   // Get all timed events for a day (used to compute side-by-side positions
   // across the entire day, so events that overlap but start in different

--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { format, isSameDay, isToday, isTomorrow, startOfDay } from 'date-fns';
+import { format, isSameDay, startOfDay } from 'date-fns';
 import { useDroppable } from '@dnd-kit/core';
 import { cn } from '@/lib/utils';
 import { WeekItemCard, type WeekItemSize, type WeekItemLayout } from './WeekItemCard';
 import { weatherIcon } from './weatherIcon';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const PRIORITY_COLORS = {
   high: '#ef4444',
@@ -40,16 +40,17 @@ function mealStripeColor(meal: {
   return meal.cookedBy?.color || meal.createdBy?.color || MEAL_FALLBACK_COLOR;
 }
 
-function dayLabel(date: Date): string {
-  if (isToday(date)) return 'Today';
-  if (isTomorrow(date)) return 'Tomorrow';
+function dayLabel(date: Date, displayTimezone: string): string {
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
+  if (isSameDay(date, displayNow)) return 'Today';
+  if (isSameDay(date, new Date(displayNow.getFullYear(), displayNow.getMonth(), displayNow.getDate() + 1))) return 'Tomorrow';
   return format(date, 'EEEE');
 }
 
-function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat): string | undefined {
+function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat, displayTimezone: string): string | undefined {
   if (allDay) return 'All day';
-  const startStr = formatDisplayTime(start, timeFormat);
-  if (!isSameDay(start, end)) return startStr;
+  const startStr = formatDisplayTime(start, timeFormat, {}, displayTimezone);
+  if (!isSameDay(toDisplayDate(start, displayTimezone), toDisplayDate(end, displayTimezone))) return startStr;
   return startStr;
 }
 
@@ -149,9 +150,9 @@ export function DayColumn({
   disableDrop = false,
   className,
 }: DayColumnProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const flags = { ...ALL_OVERLAYS, ...overlays };
-  const today = isToday(bucket.date);
+  const today = isSameDay(bucket.date, toDisplayDate(new Date(), displayTimezone));
   const droppableId = format(bucket.date, 'yyyy-MM-dd');
   const droppable = useDroppable({ id: droppableId, disabled: disableDrop });
   const profile = SIZE_PROFILES[size];
@@ -195,7 +196,7 @@ export function DayColumn({
                 : 'text-muted-foreground',
             )}
           >
-            {dayLabel(bucket.date)}
+            {dayLabel(bucket.date, displayTimezone)}
           </span>
         </div>
         {profile.showWeather && bucket.weather && (
@@ -231,7 +232,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat)}
+            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat, displayTimezone)}
             subtitle={event.location || event.calendarName}
           />
         ))}

--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -7,6 +7,8 @@ import { cn } from '@/lib/utils';
 import { WeekItemCard, type WeekItemSize, type WeekItemLayout } from './WeekItemCard';
 import { weatherIcon } from './weatherIcon';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const PRIORITY_COLORS = {
   high: '#ef4444',
@@ -44,9 +46,9 @@ function dayLabel(date: Date): string {
   return format(date, 'EEEE');
 }
 
-function timeLabel(start: Date, end: Date, allDay: boolean): string | undefined {
+function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat): string | undefined {
   if (allDay) return 'All day';
-  const startStr = format(start, 'h:mm a');
+  const startStr = formatDisplayTime(start, timeFormat);
   if (!isSameDay(start, end)) return startStr;
   return startStr;
 }
@@ -147,6 +149,7 @@ export function DayColumn({
   disableDrop = false,
   className,
 }: DayColumnProps) {
+  const { timeFormat } = useTimeFormat();
   const flags = { ...ALL_OVERLAYS, ...overlays };
   const today = isToday(bucket.date);
   const droppableId = format(bucket.date, 'yyyy-MM-dd');
@@ -228,7 +231,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel={timeLabel(event.startTime, event.endTime, false)}
+            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat)}
             subtitle={event.location || event.calendarName}
           />
         ))}

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -30,7 +30,7 @@ export function DayOverflowPopover({
   onEventClick,
   triggerClassName,
 }: DayOverflowPopoverProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [open, setOpen] = React.useState(false);
 
   if (hiddenEvents.length === 0) return null;
@@ -73,7 +73,7 @@ export function DayOverflowPopover({
               >
                 {!event.allDay && (
                   <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                    {formatDisplayTime(event.startTime, timeFormat)}
+                    {formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
                   </span>
                 )}
                 <span className="text-xs font-medium truncate flex-1 text-foreground">

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -5,6 +5,8 @@ import { format } from 'date-fns';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 interface DayOverflowPopoverProps {
   /** The date this popover represents — shown in the popover header. */
@@ -28,6 +30,7 @@ export function DayOverflowPopover({
   onEventClick,
   triggerClassName,
 }: DayOverflowPopoverProps) {
+  const { timeFormat } = useTimeFormat();
   const [open, setOpen] = React.useState(false);
 
   if (hiddenEvents.length === 0) return null;
@@ -70,7 +73,7 @@ export function DayOverflowPopover({
               >
                 {!event.allDay && (
                   <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                    {format(event.startTime, 'h:mm a')}
+                    {formatDisplayTime(event.startTime, timeFormat)}
                   </span>
                 )}
                 <span className="text-xs font-medium truncate flex-1 text-foreground">

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -6,7 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { cn } from '@/lib/utils';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, isCalendarEventPast } from '@/lib/utils/timeFormat';
 
 interface DayOverflowPopoverProps {
   /** The date this popover represents — shown in the popover header. */
@@ -68,7 +68,16 @@ export function DayOverflowPopover({
                   onEventClick(event);
                   setOpen(false);
                 }}
-                className="w-full text-left px-2 py-1 rounded bg-card hover:bg-accent transition-colors flex items-center gap-2 border border-border/40"
+                className={cn(
+                  'w-full text-left px-2 py-1 rounded bg-card hover:bg-accent transition-colors flex items-center gap-2 border border-border/40',
+                  isCalendarEventPast(
+                    event.startTime,
+                    event.endTime,
+                    event.allDay,
+                    new Date(),
+                    displayTimezone,
+                  ) && 'opacity-55 saturate-[0.65]',
+                )}
                 style={{ borderLeft: `3px solid ${event.color}` }}
               >
                 {!event.allDay && (

--- a/src/components/calendar/cells/InlineCalendarEvent.tsx
+++ b/src/components/calendar/cells/InlineCalendarEvent.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { contrastText } from '@/lib/utils/color';
+import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, isCalendarEventPast } from '@/lib/utils/timeFormat';
+
+export type InlineCalendarEventProps = {
+  event: CalendarEvent;
+  onClick: (event: CalendarEvent) => void;
+  compact?: boolean;
+  showTime?: boolean;
+  className?: string;
+};
+
+/** Shared filled-chip / timed-dot treatment for compact calendar views. */
+export function InlineCalendarEvent({
+  event,
+  onClick,
+  compact = false,
+  showTime = true,
+  className,
+}: InlineCalendarEventProps) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const past = isCalendarEventPast(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    new Date(),
+    displayTimezone
+  );
+  const time =
+    showTime && !event.allDay
+      ? formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)
+      : null;
+
+  return (
+    <button
+      type="button"
+      title={event.title}
+      onClick={(clickEvent) => {
+        clickEvent.stopPropagation();
+        onClick(event);
+      }}
+      className={cn(
+        'w-full min-w-0 truncate rounded text-left font-medium transition-[background-color,filter,opacity]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seasonal-accent',
+        compact ? 'px-0.5 py-px text-[8px] leading-tight' : 'px-1 py-0.5 text-xs leading-tight',
+        event.allDay ? 'block hover:brightness-95' : 'flex items-center gap-1 hover:bg-accent/60',
+        past && 'opacity-55 saturate-[0.65]',
+        className
+      )}
+      style={
+        event.allDay
+          ? { backgroundColor: event.color, color: contrastText(event.color) }
+          : undefined
+      }
+    >
+      {event.allDay ? (
+        event.title
+      ) : (
+        <>
+          <span
+            aria-hidden
+            className={cn('shrink-0 rounded-full', compact ? 'h-1 w-1' : 'h-1.5 w-1.5')}
+            style={{ backgroundColor: event.color }}
+          />
+          {time && <span className="shrink-0 tabular-nums text-muted-foreground">{time}</span>}
+          <span className="truncate text-foreground">{event.title}</span>
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/components/calendar/cells/InlineCalendarEvent.tsx
+++ b/src/components/calendar/cells/InlineCalendarEvent.tsx
@@ -53,7 +53,7 @@ export function InlineCalendarEvent({
       )}
       style={
         event.allDay
-          ? { backgroundColor: event.color, color: contrastText(event.color) }
+          ? { backgroundColor: event.color, color: past ? contrastText(event.color) : '#fff' }
           : undefined
       }
     >

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -89,7 +89,7 @@ export function SpanningEventRows({
             )}
             style={{
               backgroundColor: event.color,
-              color: contrastText(event.color),
+              color: past ? contrastText(event.color) : '#fff',
               width: continuesWithinRow ? `calc(100% + ${gap})` : '100%',
               clipPath:
                 continuesBeforeRow && continuesAfterRow

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -18,7 +18,9 @@ export type SpanningEventRowsProps = {
 
 /**
  * Renders the slice of each multi-day event that crosses this day cell.
- * Adjacent slices bridge the parent grid gap, creating one continuous bar.
+ * A continuing slice covers only the gap after its own cell. Adjacent slices
+ * therefore meet without overlapping, which keeps translucent/muted bars from
+ * producing darker seams at day boundaries.
  */
 export function SpanningEventRows({
   date,
@@ -41,7 +43,10 @@ export function SpanningEventRows({
   );
 
   return (
-    <div className={cn('relative z-20 flex shrink-0 flex-col', compact ? 'gap-px' : 'gap-0.5')}>
+    <div
+      data-spanning-events
+      className={cn('relative z-20 flex shrink-0 flex-col', compact ? 'gap-px' : 'gap-0.5')}
+    >
       {events.map((event) => {
         const active = occurs(event, date);
         const continuesFromPrevious = active && column > 0 && occurs(event, rowDates[column - 1]!);
@@ -75,14 +80,7 @@ export function SpanningEventRows({
             style={{
               backgroundColor: event.color,
               color: contrastText(event.color),
-              marginLeft: continuesFromPrevious ? `calc(-${gap} - 1px)` : undefined,
-              width: continuesFromPrevious && continuesToNext
-                ? `calc(100% + ${gap} + 1px + ${gap})`
-                : continuesFromPrevious
-                  ? `calc(100% + ${gap} + 1px)`
-                  : continuesToNext
-                    ? `calc(100% + ${gap})`
-                    : '100%',
+              width: continuesToNext ? `calc(100% + ${gap})` : '100%',
             }}
           >
             {!continuesFromPrevious && label}

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { isSameDay } from 'date-fns';
+import { addDays, isSameDay } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { contrastText } from '@/lib/utils/color';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { eventOccursOnDisplayDay, formatDisplayTime } from '@/lib/utils/timeFormat';
+import {
+  eventOccursOnDisplayDay,
+  formatDisplayTime,
+  isCalendarEventPast,
+} from '@/lib/utils/timeFormat';
 
 export type SpanningEventRowsProps = {
   date: Date;
@@ -34,13 +38,8 @@ export function SpanningEventRows({
   const column = rowDates.findIndex((candidate) => isSameDay(candidate, date));
   if (column < 0 || events.length === 0) return null;
 
-  const occurs = (event: CalendarEvent, target: Date) => eventOccursOnDisplayDay(
-    event.startTime,
-    event.endTime,
-    event.allDay,
-    target,
-    displayTimezone,
-  );
+  const occurs = (event: CalendarEvent, target: Date) =>
+    eventOccursOnDisplayDay(event.startTime, event.endTime, event.allDay, target, displayTimezone);
 
   return (
     <div
@@ -49,10 +48,18 @@ export function SpanningEventRows({
     >
       {events.map((event) => {
         const active = occurs(event, date);
-        const continuesFromPrevious = active && column > 0 && occurs(event, rowDates[column - 1]!);
-        const continuesToNext = active
-          && column < rowDates.length - 1
-          && occurs(event, rowDates[column + 1]!);
+        const continuesFromPrevious = active && occurs(event, addDays(date, -1));
+        const continuesToNext = active && occurs(event, addDays(date, 1));
+        const continuesWithinRow = continuesToNext && column < rowDates.length - 1;
+        const continuesBeforeRow = continuesFromPrevious && column === 0;
+        const continuesAfterRow = continuesToNext && column === rowDates.length - 1;
+        const past = isCalendarEventPast(
+          event.startTime,
+          event.endTime,
+          event.allDay,
+          new Date(),
+          displayTimezone
+        );
         const rowHeight = compact ? 'h-3.5' : 'h-5';
 
         if (!active) return <div key={event.id} aria-hidden className={rowHeight} />;
@@ -76,14 +83,25 @@ export function SpanningEventRows({
               compact ? 'h-3.5 px-0.5 text-[8px]' : 'h-5 px-1 text-xs',
               !continuesFromPrevious && 'rounded-l-md',
               !continuesToNext && 'rounded-r-md',
+              continuesBeforeRow && (compact ? 'pl-1.5' : 'pl-2'),
+              continuesAfterRow && (compact ? 'pr-1.5' : 'pr-2'),
+              past && 'opacity-55 saturate-[0.65]'
             )}
             style={{
               backgroundColor: event.color,
               color: contrastText(event.color),
-              width: continuesToNext ? `calc(100% + ${gap})` : '100%',
+              width: continuesWithinRow ? `calc(100% + ${gap})` : '100%',
+              clipPath:
+                continuesBeforeRow && continuesAfterRow
+                  ? 'polygon(0 50%, 6px 0, calc(100% - 6px) 0, 100% 50%, calc(100% - 6px) 100%, 6px 100%)'
+                  : continuesBeforeRow
+                    ? 'polygon(0 50%, 6px 0, 100% 0, 100% 100%, 6px 100%)'
+                    : continuesAfterRow
+                      ? 'polygon(0 0, calc(100% - 6px) 0, 100% 50%, calc(100% - 6px) 100%, 0 100%)'
+                      : undefined,
             }}
           >
-            {!continuesFromPrevious && label}
+            {(!continuesFromPrevious || column === 0) && label}
           </button>
         );
       })}

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { isSameDay } from 'date-fns';
+import { cn } from '@/lib/utils';
+import { contrastText } from '@/lib/utils/color';
+import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { eventOccursOnDisplayDay, formatDisplayTime } from '@/lib/utils/timeFormat';
+
+export type SpanningEventRowsProps = {
+  date: Date;
+  rowDates: Date[];
+  events: CalendarEvent[];
+  onEventClick: (event: CalendarEvent) => void;
+  compact?: boolean;
+  gap?: string;
+};
+
+/**
+ * Renders the slice of each multi-day event that crosses this day cell.
+ * Adjacent slices bridge the parent grid gap, creating one continuous bar.
+ */
+export function SpanningEventRows({
+  date,
+  rowDates,
+  events,
+  onEventClick,
+  compact = false,
+  gap = '0.25rem',
+}: SpanningEventRowsProps) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const column = rowDates.findIndex((candidate) => isSameDay(candidate, date));
+  if (column < 0 || events.length === 0) return null;
+
+  const occurs = (event: CalendarEvent, target: Date) => eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    target,
+    displayTimezone,
+  );
+
+  return (
+    <div className={cn('relative z-20 flex shrink-0 flex-col', compact ? 'gap-px' : 'gap-0.5')}>
+      {events.map((event) => {
+        const active = occurs(event, date);
+        const continuesFromPrevious = active && column > 0 && occurs(event, rowDates[column - 1]!);
+        const continuesToNext = active
+          && column < rowDates.length - 1
+          && occurs(event, rowDates[column + 1]!);
+        const rowHeight = compact ? 'h-3.5' : 'h-5';
+
+        if (!active) return <div key={event.id} aria-hidden className={rowHeight} />;
+
+        const label = event.allDay
+          ? event.title
+          : `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`;
+
+        return (
+          <button
+            key={event.id}
+            type="button"
+            title={label}
+            onClick={(clickEvent) => {
+              clickEvent.stopPropagation();
+              onEventClick(event);
+            }}
+            className={cn(
+              'relative z-20 block w-full truncate text-left font-medium leading-tight hover:brightness-95',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seasonal-accent',
+              compact ? 'h-3.5 px-0.5 text-[8px]' : 'h-5 px-1 text-xs',
+              !continuesFromPrevious && 'rounded-l-md',
+              !continuesToNext && 'rounded-r-md',
+            )}
+            style={{
+              backgroundColor: event.color,
+              color: contrastText(event.color),
+              marginLeft: continuesFromPrevious ? `calc(-${gap} - 1px)` : undefined,
+              width: continuesFromPrevious && continuesToNext
+                ? `calc(100% + ${gap} + 1px + ${gap})`
+                : continuesFromPrevious
+                  ? `calc(100% + ${gap} + 1px)`
+                  : continuesToNext
+                    ? `calc(100% + ${gap})`
+                    : '100%',
+            }}
+          >
+            {!continuesFromPrevious && label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -7,6 +7,7 @@ import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
 import {
   eventOccursOnDisplayDay,
+  eventStartsOnDisplayDay,
   formatDisplayTime,
   isCalendarEventPast,
 } from '@/lib/utils/timeFormat';
@@ -64,9 +65,15 @@ export function SpanningEventRows({
 
         if (!active) return <div key={event.id} aria-hidden className={rowHeight} />;
 
-        const label = event.allDay
-          ? event.title
-          : `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`;
+        const startsToday = eventStartsOnDisplayDay(
+          event.startTime,
+          event.allDay,
+          date,
+          displayTimezone,
+        );
+        const label = !event.allDay && startsToday
+          ? `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`
+          : event.title;
 
         return (
           <button

--- a/src/components/calendar/cells/WeekItemCard.tsx
+++ b/src/components/calendar/cells/WeekItemCard.tsx
@@ -22,6 +22,8 @@ interface WeekItemCardProps {
   subtitle?: string;
   /** Strike-through and dim, for completed/cooked items */
   muted?: boolean;
+  /** Dim without marking complete, for items whose time has passed. */
+  subdued?: boolean;
   /** Diagonal-stripe overlay for items awaiting parent approval. */
   pendingApproval?: boolean;
   /** Click handler — opens detail modal in caller */
@@ -108,6 +110,7 @@ export function WeekItemCard({
   timeLabel,
   subtitle,
   muted,
+  subdued,
   pendingApproval,
   onClick,
   ariaLabel,
@@ -166,6 +169,7 @@ export function WeekItemCard({
           dragId && 'cursor-grab active:cursor-grabbing',
           draggable.isDragging && 'opacity-60 ring-2 ring-seasonal-accent shadow-xl',
           muted && 'opacity-60',
+          subdued && 'opacity-55 saturate-[0.65]',
           styles.padding,
         )}
       >
@@ -214,6 +218,7 @@ export function WeekItemCard({
         dragId && 'cursor-grab active:cursor-grabbing',
         draggable.isDragging && 'opacity-60 ring-2 ring-seasonal-accent shadow-xl',
         muted && 'opacity-60',
+        subdued && 'opacity-55 saturate-[0.65]',
       )}
     >
       {pendingApproval && (

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -106,6 +106,41 @@ describe('SpanningEventRows', () => {
 
     expect(getByRole('button').style.color).toBe('rgb(255, 255, 255)');
   });
+
+  it('does not repeat a timed event start time on continuation days', () => {
+    const timedEvent: CalendarEvent = {
+      ...event,
+      title: 'Weekend trip',
+      allDay: false,
+      startTime: new Date('2026-08-21T16:00:00.000Z'),
+      endTime: new Date('2026-08-23T17:00:00.000Z'),
+    };
+
+    const startDay = new Date(2026, 7, 21);
+    const continuationDay = new Date(2026, 7, 22);
+    const rowDates = [startDay, continuationDay];
+    const { container } = render(
+      <div>
+        <SpanningEventRows
+          date={startDay}
+          rowDates={rowDates}
+          events={[timedEvent]}
+          onEventClick={() => {}}
+        />
+        <SpanningEventRows
+          date={continuationDay}
+          rowDates={rowDates}
+          events={[timedEvent]}
+          onEventClick={() => {}}
+        />
+      </div>
+    );
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0]!.textContent).toBe('18:00 Weekend trip');
+    expect(buttons[1]!.textContent).toBe('');
+    expect(buttons[1]!.title).toBe('Weekend trip');
+  });
 });
 
 describe('InlineCalendarEvent', () => {

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { SpanningEventRows } from '../SpanningEventRows';
+import { InlineCalendarEvent } from '../InlineCalendarEvent';
 import type { CalendarEvent } from '@/types/calendar';
 
 jest.mock('@/components/providers', () => ({
@@ -27,11 +28,7 @@ const event: CalendarEvent = {
 
 describe('SpanningEventRows', () => {
   it('bridges day gaps without overlapping adjacent event slices', () => {
-    const rowDates = [
-      new Date(2026, 7, 10),
-      new Date(2026, 7, 11),
-      new Date(2026, 7, 12),
-    ];
+    const rowDates = [new Date(2026, 7, 10), new Date(2026, 7, 11), new Date(2026, 7, 12)];
 
     const { container } = render(
       <div>
@@ -44,7 +41,7 @@ describe('SpanningEventRows', () => {
             onEventClick={() => {}}
           />
         ))}
-      </div>,
+      </div>
     );
 
     const rows = container.querySelectorAll('[data-spanning-events]');
@@ -58,5 +55,71 @@ describe('SpanningEventRows', () => {
     expect(buttons[0]!.style.width).toBe('calc(100% + 0.25rem)');
     expect(buttons[1]!.style.width).toBe('calc(100% + 0.25rem)');
     expect(buttons[2]!.style.width).toBe('100%');
+  });
+
+  it('shows continuation edges and repeats the label after a week wrap', () => {
+    const wrappingEvent: CalendarEvent = {
+      ...event,
+      startTime: new Date('2026-08-09T00:00:00.000Z'),
+      endTime: new Date('2026-08-18T00:00:00.000Z'),
+    };
+    const rowDates = Array.from({ length: 7 }, (_, index) => new Date(2026, 7, 10 + index));
+
+    const { container } = render(
+      <div>
+        {rowDates.map((date) => (
+          <SpanningEventRows
+            key={date.toISOString()}
+            date={date}
+            rowDates={rowDates}
+            events={[wrappingEvent]}
+            onEventClick={() => {}}
+          />
+        ))}
+      </div>
+    );
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(7);
+    expect(buttons[0]!.textContent).toBe('Family trip');
+    expect(buttons[0]!.className).not.toContain('rounded-l-md');
+    expect(buttons[0]!.style.clipPath).toContain('0 50%');
+    expect(buttons[6]!.className).not.toContain('rounded-r-md');
+    expect(buttons[6]!.style.clipPath).toContain('100% 50%');
+  });
+});
+
+describe('InlineCalendarEvent', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-20T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('uses a neutral timed-event label and event-colour dot', () => {
+    const timedEvent: CalendarEvent = {
+      ...event,
+      allDay: false,
+      startTime: new Date('2026-08-20T14:00:00.000Z'),
+      endTime: new Date('2026-08-20T15:00:00.000Z'),
+    };
+
+    const { getByRole } = render(<InlineCalendarEvent event={timedEvent} onClick={() => {}} />);
+    const button = getByRole('button');
+    const dot = button.querySelector('[aria-hidden]') as HTMLElement;
+
+    expect(button.className).toContain('text-left');
+    expect(button.style.backgroundColor).toBe('');
+    expect(dot.style.backgroundColor).toBe('rgb(91, 127, 234)');
+  });
+
+  it('subdues a completed event without striking it through', () => {
+    const { getByRole } = render(<InlineCalendarEvent event={event} onClick={() => {}} />);
+    const button = getByRole('button');
+
+    expect(button.className).toContain('opacity-55');
+    expect(button.className).not.toContain('line-through');
   });
 });

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { SpanningEventRows } from '../SpanningEventRows';
+import type { CalendarEvent } from '@/types/calendar';
+
+jest.mock('@/components/providers', () => ({
+  useTimeFormat: () => ({
+    timeFormat: '24h',
+    displayTimezone: 'Europe/Warsaw',
+  }),
+}));
+
+const event: CalendarEvent = {
+  id: 'multi-day',
+  title: 'Family trip',
+  startTime: new Date('2026-08-10T00:00:00.000Z'),
+  endTime: new Date('2026-08-13T00:00:00.000Z'),
+  allDay: true,
+  color: '#5b7fea',
+  calendarName: 'Family',
+  calendarId: 'family',
+};
+
+describe('SpanningEventRows', () => {
+  it('bridges day gaps without overlapping adjacent event slices', () => {
+    const rowDates = [
+      new Date(2026, 7, 10),
+      new Date(2026, 7, 11),
+      new Date(2026, 7, 12),
+    ];
+
+    const { container } = render(
+      <div>
+        {rowDates.map((date) => (
+          <SpanningEventRows
+            key={date.toISOString()}
+            date={date}
+            rowDates={rowDates}
+            events={[event]}
+            onEventClick={() => {}}
+          />
+        ))}
+      </div>,
+    );
+
+    const rows = container.querySelectorAll('[data-spanning-events]');
+    const buttons = container.querySelectorAll('button');
+
+    expect(rows).toHaveLength(3);
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]!.style.marginLeft).toBe('');
+    expect(buttons[1]!.style.marginLeft).toBe('');
+    expect(buttons[2]!.style.marginLeft).toBe('');
+    expect(buttons[0]!.style.width).toBe('calc(100% + 0.25rem)');
+    expect(buttons[1]!.style.width).toBe('calc(100% + 0.25rem)');
+    expect(buttons[2]!.style.width).toBe('100%');
+  });
+});

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -87,6 +87,25 @@ describe('SpanningEventRows', () => {
     expect(buttons[6]!.className).not.toContain('rounded-r-md');
     expect(buttons[6]!.style.clipPath).toContain('100% 50%');
   });
+
+  it('uses white text for a future spanning event', () => {
+    const futureEvent: CalendarEvent = {
+      ...event,
+      startTime: new Date('2099-08-10T00:00:00.000Z'),
+      endTime: new Date('2099-08-13T00:00:00.000Z'),
+    };
+
+    const { getByRole } = render(
+      <SpanningEventRows
+        date={new Date(2099, 7, 10)}
+        rowDates={[new Date(2099, 7, 10)]}
+        events={[futureEvent]}
+        onEventClick={() => {}}
+      />
+    );
+
+    expect(getByRole('button').style.color).toBe('rgb(255, 255, 255)');
+  });
 });
 
 describe('InlineCalendarEvent', () => {
@@ -121,5 +140,17 @@ describe('InlineCalendarEvent', () => {
 
     expect(button.className).toContain('opacity-55');
     expect(button.className).not.toContain('line-through');
+  });
+
+  it('uses white text for a current or future filled event', () => {
+    const futureEvent: CalendarEvent = {
+      ...event,
+      startTime: new Date('2026-08-21T00:00:00.000Z'),
+      endTime: new Date('2026-08-22T00:00:00.000Z'),
+    };
+
+    const { getByRole } = render(<InlineCalendarEvent event={futureEvent} onClick={() => {}} />);
+
+    expect(getByRole('button').style.color).toBe('rgb(255, 255, 255)');
   });
 });

--- a/src/components/calendar/cells/index.ts
+++ b/src/components/calendar/cells/index.ts
@@ -9,4 +9,5 @@ export { DroppableOverlayCell } from './DroppableOverlayCell';
 export { CardHeightProbe } from './CardHeightProbe';
 export { weatherIcon } from './weatherIcon';
 export { useDayDroppable } from './useDayDroppable';
+export { SpanningEventRows } from './SpanningEventRows';
 export { getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, MEAL_TIME_DEFAULTS } from './itemTime';

--- a/src/components/calendar/cells/index.ts
+++ b/src/components/calendar/cells/index.ts
@@ -10,4 +10,5 @@ export { CardHeightProbe } from './CardHeightProbe';
 export { weatherIcon } from './weatherIcon';
 export { useDayDroppable } from './useDayDroppable';
 export { SpanningEventRows } from './SpanningEventRows';
+export { InlineCalendarEvent } from './InlineCalendarEvent';
 export { getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, MEAL_TIME_DEFAULTS } from './itemTime';

--- a/src/components/calendar/cells/itemTime.ts
+++ b/src/components/calendar/cells/itemTime.ts
@@ -1,4 +1,5 @@
 import type { Meal, Chore, Task } from '@/types/models';
+import type { TimeFormat } from '@/lib/utils/timeFormat';
 
 /** Default times for each meal type when meal.mealTime is null. */
 export const MEAL_TIME_DEFAULTS: Record<Meal['mealType'], string> = {
@@ -53,16 +54,20 @@ export function parseTimeOfDay(hhmm: string | null | undefined): number | null {
 }
 
 /**
- * Format "HH:mm" → "6 PM" or "6:30 PM". On-the-hour times drop ":00" so the
- * label is short enough to fit beside a card title in the time grid.
+ * Format an "HH:mm" value for display using the family-wide time preference.
+ * In 12-hour mode, on-the-hour times drop ":00" so the label remains compact.
  */
-export function formatTimeOfDay(hhmm: string | null | undefined): string {
+export function formatTimeOfDay(
+  hhmm: string | null | undefined,
+  timeFormat: TimeFormat = '12h',
+): string {
   if (!hhmm) return '';
   const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
   if (!m) return hhmm;
   const h = Number(m[1]);
   const min = Number(m[2]);
   if (Number.isNaN(h) || Number.isNaN(min)) return hhmm;
+  if (timeFormat === '24h') return `${String(h).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
   const period = h >= 12 ? 'PM' : 'AM';
   const hour12 = ((h + 11) % 12) + 1;
   return min === 0 ? `${hour12} ${period}` : `${hour12}:${String(min).padStart(2, '0')} ${period}`;

--- a/src/components/dashboard/MobileCards.tsx
+++ b/src/components/dashboard/MobileCards.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, createContext, useContext } from 'react';
 import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { MobileLayoutMode } from '@/lib/hooks/useMobileLayout';
-import { format, isToday, isTomorrow, startOfWeek } from 'date-fns';
+import { addDays, format, isSameDay, startOfWeek } from 'date-fns';
 import Link from 'next/link';
 import {
   Calendar,
@@ -30,7 +30,7 @@ import type { useDashboardData } from './useDashboardData';
 import type { CalendarEvent } from '@/types/calendar';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -90,18 +90,20 @@ export function WeatherCard({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockCard() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const now = new Date();
+  const displayNow = toDisplayDate(now, displayTimezone);
   return (
     <div className="bg-card/85 backdrop-blur-sm rounded-xl border border-border p-3 flex items-center gap-3">
       <Clock className="h-5 w-5 text-muted-foreground" />
-      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(new Date(), timeFormat)}</span>
-      <span className="text-sm text-muted-foreground">{format(new Date(), 'EEEE, MMM d')}</span>
+      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(now, timeFormat, {}, displayTimezone)}</span>
+      <span className="text-sm text-muted-foreground">{format(displayNow, 'EEEE, MMM d')}</span>
     </div>
   );
 }
 
 export function CalendarCard({ data }: { data: DashData['calendar'] }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const upcoming = useMemo(() => {
     if (!data.events) return [];
     const now = new Date();
@@ -117,17 +119,21 @@ export function CalendarCard({ data }: { data: DashData['calendar'] }) {
         <p className="text-xs text-muted-foreground">No upcoming events</p>
       ) : (
         <div className="space-y-1">
-          {upcoming.map((e: CalendarEvent) => (
+          {upcoming.map((e: CalendarEvent) => {
+            const displayStart = toDisplayDate(e.startTime, displayTimezone);
+            const displayNow = toDisplayDate(new Date(), displayTimezone);
+            return (
             <div key={e.id} className="flex items-center gap-2 text-xs">
               <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
               <span className="truncate flex-1">{e.title}</span>
               <span className="text-muted-foreground shrink-0">
-                {isToday(e.startTime) ? formatDisplayTime(e.startTime, timeFormat) :
-                 isTomorrow(e.startTime) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat)}` :
-                 `${format(e.startTime, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat)}`}
+                {isSameDay(displayStart, displayNow) ? formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone) :
+                 isSameDay(displayStart, addDays(displayNow, 1)) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone)}` :
+                 `${format(displayStart, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone)}`}
               </span>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </CardShell>

--- a/src/components/dashboard/MobileCards.tsx
+++ b/src/components/dashboard/MobileCards.tsx
@@ -29,6 +29,8 @@ import {
 import type { useDashboardData } from './useDashboardData';
 import type { CalendarEvent } from '@/types/calendar';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -88,16 +90,18 @@ export function WeatherCard({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockCard() {
+  const { timeFormat } = useTimeFormat();
   return (
     <div className="bg-card/85 backdrop-blur-sm rounded-xl border border-border p-3 flex items-center gap-3">
       <Clock className="h-5 w-5 text-muted-foreground" />
-      <span className="text-2xl font-light tabular-nums">{format(new Date(), 'h:mm a')}</span>
+      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(new Date(), timeFormat)}</span>
       <span className="text-sm text-muted-foreground">{format(new Date(), 'EEEE, MMM d')}</span>
     </div>
   );
 }
 
 export function CalendarCard({ data }: { data: DashData['calendar'] }) {
+  const { timeFormat } = useTimeFormat();
   const upcoming = useMemo(() => {
     if (!data.events) return [];
     const now = new Date();
@@ -118,9 +122,9 @@ export function CalendarCard({ data }: { data: DashData['calendar'] }) {
               <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
               <span className="truncate flex-1">{e.title}</span>
               <span className="text-muted-foreground shrink-0">
-                {isToday(e.startTime) ? format(e.startTime, 'h:mm a') :
-                 isTomorrow(e.startTime) ? `Tomorrow ${format(e.startTime, 'h:mm a')}` :
-                 format(e.startTime, 'EEE h:mm a')}
+                {isToday(e.startTime) ? formatDisplayTime(e.startTime, timeFormat) :
+                 isTomorrow(e.startTime) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat)}` :
+                 `${format(e.startTime, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat)}`}
               </span>
             </div>
           ))}

--- a/src/components/dashboard/TileCards.tsx
+++ b/src/components/dashboard/TileCards.tsx
@@ -13,6 +13,8 @@ import { cn } from '@/lib/utils';
 import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { useDashboardData } from './useDashboardData';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -75,6 +77,7 @@ export function WeatherTile({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockTile() {
+  const { timeFormat } = useTimeFormat();
   const [now, setNow] = useState(new Date());
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 1000);
@@ -82,7 +85,7 @@ export function ClockTile() {
   }, []);
   return (
     <TileShell icon={<Clock className="h-4 w-4 text-violet-500" />} title="Clock">
-      <TileLine>{format(now, 'h:mm a')}</TileLine>
+      <TileLine>{formatDisplayTime(now, timeFormat)}</TileLine>
       <TileLine dim>{format(now, 'EEE, MMM d')}</TileLine>
     </TileShell>
   );

--- a/src/components/dashboard/TileCards.tsx
+++ b/src/components/dashboard/TileCards.tsx
@@ -14,7 +14,7 @@ import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { useDashboardData } from './useDashboardData';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -77,7 +77,7 @@ export function WeatherTile({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockTile() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [now, setNow] = useState(new Date());
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 1000);
@@ -85,8 +85,8 @@ export function ClockTile() {
   }, []);
   return (
     <TileShell icon={<Clock className="h-4 w-4 text-violet-500" />} title="Clock">
-      <TileLine>{formatDisplayTime(now, timeFormat)}</TileLine>
-      <TileLine dim>{format(now, 'EEE, MMM d')}</TileLine>
+      <TileLine>{formatDisplayTime(now, timeFormat, {}, displayTimezone)}</TileLine>
+      <TileLine dim>{format(toDisplayDate(now, displayTimezone), 'EEE, MMM d')}</TileLine>
     </TileShell>
   );
 }

--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -140,6 +140,26 @@ function formatDateLocal(date: Date | string | undefined, timeZone?: string): st
   return `${year}-${month}-${day}`;
 }
 
+/** Date-only events are floating calendar dates, not timezone-based instants. */
+function formatAllDayDate(date: Date | string | undefined): string {
+  const value = date ? (typeof date === 'string' ? new Date(date) : date) : new Date();
+  return value.toISOString().slice(0, 10);
+}
+
+/** Convert Google's exclusive all-day end date to the inclusive form date. */
+function formatAllDayEndDate(start: Date | string, end: Date | string): string {
+  const startValue = typeof start === 'string' ? new Date(start) : start;
+  const endValue = typeof end === 'string' ? new Date(end) : new Date(end.getTime());
+  const isExclusiveMidnight = endValue.getTime() > startValue.getTime()
+    && endValue.getUTCHours() === 0
+    && endValue.getUTCMinutes() === 0
+    && endValue.getUTCSeconds() === 0
+    && endValue.getUTCMilliseconds() === 0;
+
+  if (isExclusiveMidnight) endValue.setUTCDate(endValue.getUTCDate() - 1);
+  return formatAllDayDate(endValue);
+}
+
 /**
  * ADD EVENT MODAL COMPONENT
  */
@@ -246,8 +266,12 @@ export function AddEventModal({
       setLocation(event.location || '');
       const isAllDay = event.allDay || false;
       setAllDay(isAllDay);
-      const sd = formatDateLocal(event.startTime, displayTimezone);
-      const ed = formatDateLocal(event.endTime, displayTimezone);
+      const sd = isAllDay
+        ? formatAllDayDate(event.startTime)
+        : formatDateLocal(event.startTime, displayTimezone);
+      const ed = isAllDay
+        ? formatAllDayEndDate(event.startTime, event.endTime)
+        : formatDateLocal(event.endTime, displayTimezone);
       setStartDate(sd);
       setEndDate(ed);
       if (!isAllDay) {
@@ -296,16 +320,14 @@ export function AddEventModal({
     if (!title.trim() || !startDate || !endDate) return;
     if (!allDay && (!startTimeStr || !endTimeStr)) return;
 
-    const startISO = fromDisplayDateTime(
-      startDate,
-      allDay ? '00:00:00' : startTimeStr,
-      displayTimezone,
-    ).toISOString();
-    const endISO = fromDisplayDateTime(
-      endDate,
-      allDay ? '23:59:59' : endTimeStr,
-      displayTimezone,
-    ).toISOString();
+    // All-day values are floating dates. Keep them in UTC so their calendar
+    // date is stable and Google can receive an exclusive end date reliably.
+    const startISO = allDay
+      ? `${startDate}T00:00:00.000Z`
+      : fromDisplayDateTime(startDate, startTimeStr, displayTimezone).toISOString();
+    const endISO = allDay
+      ? `${endDate}T23:59:59.000Z`
+      : fromDisplayDateTime(endDate, endTimeStr, displayTimezone).toISOString();
 
     if (new Date(endISO) < new Date(startISO)) {
       setError('End must be after start');

--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -19,7 +19,8 @@ import { useState, useEffect, useMemo } from 'react';
 import { Loader2, MapPin, AlignLeft, ChevronDown, ChevronUp } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { useCalendarSources } from '@/lib/hooks';
-import { useAuth } from '@/components/providers';
+import { useAuth, useTimeFormat } from '@/components/providers';
+import { fromDisplayDateTime, toDisplayDate } from '@/lib/utils/timeFormat';
 import { toast } from '@/components/ui/use-toast';
 import { TimeDropdown } from './TimeDropdown';
 import {
@@ -116,24 +117,26 @@ const REMINDER_OPTIONS = [
 ];
 
 /** Format date for datetime-local input (YYYY-MM-DDTHH:mm) */
-function formatDateTimeLocal(date: Date | string | undefined): string {
+function formatDateTimeLocal(date: Date | string | undefined, timeZone?: string): string {
   const d = date ? (typeof date === 'string' ? new Date(date) : date) : new Date();
-  if (isNaN(d.getTime())) return formatDateTimeLocal(undefined);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
+  if (isNaN(d.getTime())) return formatDateTimeLocal(undefined, timeZone);
+  const displayDate = toDisplayDate(d, timeZone);
+  const year = displayDate.getFullYear();
+  const month = String(displayDate.getMonth() + 1).padStart(2, '0');
+  const day = String(displayDate.getDate()).padStart(2, '0');
+  const hours = String(displayDate.getHours()).padStart(2, '0');
+  const minutes = String(displayDate.getMinutes()).padStart(2, '0');
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 /** Format date for date input (YYYY-MM-DD) */
-function formatDateLocal(date: Date | string | undefined): string {
+function formatDateLocal(date: Date | string | undefined, timeZone?: string): string {
   const d = date ? (typeof date === 'string' ? new Date(date) : date) : new Date();
-  if (isNaN(d.getTime())) return formatDateLocal(undefined);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
+  if (isNaN(d.getTime())) return formatDateLocal(undefined, timeZone);
+  const displayDate = toDisplayDate(d, timeZone);
+  const year = displayDate.getFullYear();
+  const month = String(displayDate.getMonth() + 1).padStart(2, '0');
+  const day = String(displayDate.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 
@@ -152,6 +155,7 @@ export function AddEventModal({
   // Fetch available calendars
   const { calendars } = useCalendarSources();
   const { activeUser } = useAuth();
+  const { displayTimezone } = useTimeFormat();
 
   // Filter to only writable, non-read-only calendars with showInEventModal enabled
   const writableCalendars = useMemo(() => {
@@ -242,13 +246,13 @@ export function AddEventModal({
       setLocation(event.location || '');
       const isAllDay = event.allDay || false;
       setAllDay(isAllDay);
-      const sd = formatDateLocal(event.startTime);
-      const ed = formatDateLocal(event.endTime);
+      const sd = formatDateLocal(event.startTime, displayTimezone);
+      const ed = formatDateLocal(event.endTime, displayTimezone);
       setStartDate(sd);
       setEndDate(ed);
       if (!isAllDay) {
-        const s = formatDateTimeLocal(event.startTime);
-        const e = formatDateTimeLocal(event.endTime);
+        const s = formatDateTimeLocal(event.startTime, displayTimezone);
+        const e = formatDateTimeLocal(event.endTime, displayTimezone);
         setStartTimeStr(s.split('T')[1] ?? '09:00');
         setEndTimeStr(e.split('T')[1] ?? '10:00');
       } else {
@@ -260,20 +264,21 @@ export function AddEventModal({
       setCalendarSourceId(event.calendarSourceId || defaultCalendarId);
       setShowMore(!!(event.description || event.location || event.reminderMinutes || event.recurrenceRule));
     } else if (open && defaultDate) {
-      const d = formatDateLocal(defaultDate);
+      // Calendar cells are already presentation-only wall dates.
+      const d = format(defaultDate, 'yyyy-MM-dd');
       setStartDate(d);
       setEndDate(d);
       setStartTimeStr('09:00');
       setEndTimeStr('10:00');
     } else if (open) {
-      const today = formatDateLocal(new Date());
+      const today = formatDateLocal(new Date(), displayTimezone);
       setStartDate(today);
       setEndDate(today);
       setStartTimeStr('09:00');
       setEndTimeStr('10:00');
     }
     if (open && !event) setCalendarSourceId(defaultCalendarId);
-  }, [open, event, defaultDate, defaultCalendarId]);
+  }, [open, event, defaultDate, defaultCalendarId, displayTimezone]);
 
   // Reset form when modal closes
   useEffect(() => {
@@ -291,12 +296,16 @@ export function AddEventModal({
     if (!title.trim() || !startDate || !endDate) return;
     if (!allDay && (!startTimeStr || !endTimeStr)) return;
 
-    const startISO = allDay
-      ? new Date(`${startDate}T00:00:00`).toISOString()
-      : new Date(`${startDate}T${startTimeStr}:00`).toISOString();
-    const endISO = allDay
-      ? new Date(`${endDate}T23:59:59`).toISOString()
-      : new Date(`${endDate}T${endTimeStr}:00`).toISOString();
+    const startISO = fromDisplayDateTime(
+      startDate,
+      allDay ? '00:00:00' : startTimeStr,
+      displayTimezone,
+    ).toISOString();
+    const endISO = fromDisplayDateTime(
+      endDate,
+      allDay ? '23:59:59' : endTimeStr,
+      displayTimezone,
+    ).toISOString();
 
     if (new Date(endISO) < new Date(startISO)) {
       setError('End must be after start');

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from './ThemeProvider';
 import { AuthProvider } from './AuthProvider';
 import { FamilyProvider } from './FamilyProvider';
 import { GlobalInputProvider } from '@/lib/hooks/useGlobalInput';
+import { TimeFormatProvider } from './TimeFormatProvider';
 
 // simple-keyboard accesses browser globals at module load — must be client-only
 const VirtualKeyboard = dynamic(
@@ -38,11 +39,13 @@ export function Providers({ children }: ProvidersProps) {
     <ThemeProvider defaultTheme="light">
       <FamilyProvider>
         <AuthProvider>
-          <GlobalInputProvider>
-            {children}
-            <VirtualKeyboard />
-            <KeyboardToggleButton />
-          </GlobalInputProvider>
+          <TimeFormatProvider>
+            <GlobalInputProvider>
+              {children}
+              <VirtualKeyboard />
+              <KeyboardToggleButton />
+            </GlobalInputProvider>
+          </TimeFormatProvider>
         </AuthProvider>
       </FamilyProvider>
     </ThemeProvider>

--- a/src/components/providers/TimeFormatProvider.tsx
+++ b/src/components/providers/TimeFormatProvider.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import * as React from 'react';
+import {
+  DEFAULT_TIME_FORMAT,
+  isTimeFormat,
+  type TimeFormat,
+} from '@/lib/utils/timeFormat';
+
+const SETTING_KEY = 'timeFormat';
+
+interface TimeFormatContextValue {
+  timeFormat: TimeFormat;
+  setTimeFormat: (next: TimeFormat) => Promise<void>;
+}
+
+const TimeFormatContext = React.createContext<TimeFormatContextValue | undefined>(undefined);
+
+export function TimeFormatProvider({ children }: { children: React.ReactNode }) {
+  const [timeFormat, setTimeFormatState] = React.useState<TimeFormat>(DEFAULT_TIME_FORMAT);
+
+  React.useEffect(() => {
+    let active = true;
+    fetch('/api/settings')
+      .then((response) => response.ok ? response.json() : null)
+      .then((data) => {
+        const saved = data?.settings?.[SETTING_KEY];
+        if (active && isTimeFormat(saved)) setTimeFormatState(saved);
+      })
+      .catch(() => {});
+
+    return () => { active = false; };
+  }, []);
+
+  const setTimeFormat = React.useCallback(async (next: TimeFormat) => {
+    const previous = timeFormat;
+    setTimeFormatState(next);
+
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: SETTING_KEY, value: next }),
+      });
+      if (!response.ok) throw new Error('Failed to save time format');
+    } catch (error) {
+      setTimeFormatState(previous);
+      throw error;
+    }
+  }, [timeFormat]);
+
+  const value = React.useMemo(
+    () => ({ timeFormat, setTimeFormat }),
+    [timeFormat, setTimeFormat],
+  );
+
+  return (
+    <TimeFormatContext.Provider value={value}>
+      {children}
+    </TimeFormatContext.Provider>
+  );
+}
+
+export function useTimeFormat(): TimeFormatContextValue {
+  const context = React.useContext(TimeFormatContext);
+  if (!context) throw new Error('useTimeFormat must be used within a TimeFormatProvider');
+  return context;
+}

--- a/src/components/providers/TimeFormatProvider.tsx
+++ b/src/components/providers/TimeFormatProvider.tsx
@@ -2,22 +2,48 @@
 
 import * as React from 'react';
 import {
+  DEFAULT_DISPLAY_TIMEZONE_MODE,
   DEFAULT_TIME_FORMAT,
+  isDisplayTimezoneMode,
   isTimeFormat,
+  type DisplayTimezoneMode,
   type TimeFormat,
 } from '@/lib/utils/timeFormat';
+import { detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 
 const SETTING_KEY = 'timeFormat';
+const TIMEZONE_SETTING_KEY = 'timezone';
+const TIMEZONE_CACHE_KEY = 'prism:timezone';
+const DISPLAY_TIMEZONE_MODE_KEY = 'prism:display-timezone-mode';
+export const TIMEZONE_CHANGED_EVENT = 'prism:timezone-changed';
 
 interface TimeFormatContextValue {
   timeFormat: TimeFormat;
   setTimeFormat: (next: TimeFormat) => Promise<void>;
+  householdTimezone: string;
+  deviceTimezone: string;
+  displayTimezone: string;
+  displayTimezoneMode: DisplayTimezoneMode;
+  setDisplayTimezoneMode: (next: DisplayTimezoneMode) => void;
 }
 
 const TimeFormatContext = React.createContext<TimeFormatContextValue | undefined>(undefined);
 
 export function TimeFormatProvider({ children }: { children: React.ReactNode }) {
   const [timeFormat, setTimeFormatState] = React.useState<TimeFormat>(DEFAULT_TIME_FORMAT);
+  const [deviceTimezone, setDeviceTimezone] = React.useState('UTC');
+  const [householdTimezone, setHouseholdTimezone] = React.useState('UTC');
+  const [displayTimezoneMode, setDisplayTimezoneModeState] = React.useState<DisplayTimezoneMode>(
+    DEFAULT_DISPLAY_TIMEZONE_MODE,
+  );
+
+  React.useEffect(() => {
+    const detected = detectBrowserTimezone();
+    setDeviceTimezone(detected);
+    setHouseholdTimezone(localStorage.getItem(TIMEZONE_CACHE_KEY) || detected);
+    const savedMode = localStorage.getItem(DISPLAY_TIMEZONE_MODE_KEY);
+    if (isDisplayTimezoneMode(savedMode)) setDisplayTimezoneModeState(savedMode);
+  }, []);
 
   React.useEffect(() => {
     let active = true;
@@ -26,10 +52,24 @@ export function TimeFormatProvider({ children }: { children: React.ReactNode }) 
       .then((data) => {
         const saved = data?.settings?.[SETTING_KEY];
         if (active && isTimeFormat(saved)) setTimeFormatState(saved);
+        const savedTimezone = data?.settings?.[TIMEZONE_SETTING_KEY];
+        if (active && typeof savedTimezone === 'string' && savedTimezone) {
+          setHouseholdTimezone(savedTimezone);
+          localStorage.setItem(TIMEZONE_CACHE_KEY, savedTimezone);
+        }
       })
       .catch(() => {});
 
     return () => { active = false; };
+  }, []);
+
+  React.useEffect(() => {
+    const handleTimezoneChanged = (event: Event) => {
+      const next = (event as CustomEvent<string>).detail;
+      if (typeof next === 'string' && next) setHouseholdTimezone(next);
+    };
+    window.addEventListener(TIMEZONE_CHANGED_EVENT, handleTimezoneChanged);
+    return () => window.removeEventListener(TIMEZONE_CHANGED_EVENT, handleTimezoneChanged);
   }, []);
 
   const setTimeFormat = React.useCallback(async (next: TimeFormat) => {
@@ -49,9 +89,34 @@ export function TimeFormatProvider({ children }: { children: React.ReactNode }) 
     }
   }, [timeFormat]);
 
+  const setDisplayTimezoneMode = React.useCallback((next: DisplayTimezoneMode) => {
+    setDisplayTimezoneModeState(next);
+    localStorage.setItem(DISPLAY_TIMEZONE_MODE_KEY, next);
+  }, []);
+
+  const displayTimezone = displayTimezoneMode === 'device'
+    ? deviceTimezone
+    : householdTimezone;
+
   const value = React.useMemo(
-    () => ({ timeFormat, setTimeFormat }),
-    [timeFormat, setTimeFormat],
+    () => ({
+      timeFormat,
+      setTimeFormat,
+      householdTimezone,
+      deviceTimezone,
+      displayTimezone,
+      displayTimezoneMode,
+      setDisplayTimezoneMode,
+    }),
+    [
+      timeFormat,
+      setTimeFormat,
+      householdTimezone,
+      deviceTimezone,
+      displayTimezone,
+      displayTimezoneMode,
+      setDisplayTimezoneMode,
+    ],
   );
 
   return (

--- a/src/components/providers/__tests__/TimeFormatProvider.test.tsx
+++ b/src/components/providers/__tests__/TimeFormatProvider.test.tsx
@@ -16,6 +16,7 @@ describe('TimeFormatProvider', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     global.fetch = fetchMock;
+    localStorage.clear();
   });
 
   it('loads the saved family-wide preference', async () => {
@@ -65,5 +66,35 @@ describe('TimeFormatProvider', () => {
       'Failed to save time format',
     );
     expect(result.current.timeFormat).toBe('12h');
+  });
+
+  it('defaults display times to the saved household timezone', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timeFormat: '24h', timezone: 'Europe/Warsaw' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+
+    await waitFor(() => expect(result.current.householdTimezone).toBe('Europe/Warsaw'));
+    expect(result.current.displayTimezoneMode).toBe('household');
+    expect(result.current.displayTimezone).toBe('Europe/Warsaw');
+  });
+
+  it('stores the device-timezone override locally without changing family settings', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timezone: 'Europe/Warsaw' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(result.current.householdTimezone).toBe('Europe/Warsaw'));
+
+    act(() => result.current.setDisplayTimezoneMode('device'));
+
+    expect(result.current.displayTimezoneMode).toBe('device');
+    expect(result.current.displayTimezone).toBe(result.current.deviceTimezone);
+    expect(localStorage.getItem('prism:display-timezone-mode')).toBe('device');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/providers/__tests__/TimeFormatProvider.test.tsx
+++ b/src/components/providers/__tests__/TimeFormatProvider.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { TimeFormatProvider, useTimeFormat } from '../TimeFormatProvider';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TimeFormatProvider>{children}</TimeFormatProvider>
+);
+
+describe('TimeFormatProvider', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it('loads the saved family-wide preference', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timeFormat: '24h' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+
+    await waitFor(() => expect(result.current.timeFormat).toBe('24h'));
+  });
+
+  it('updates the context and persists the setting', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ settings: { timeFormat: '12h' } }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => result.current.setTimeFormat('24h'));
+
+    expect(result.current.timeFormat).toBe('24h');
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'timeFormat', value: '24h' }),
+    });
+  });
+
+  it('rolls back an optimistic change when saving fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ settings: { timeFormat: '12h' } }),
+      })
+      .mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await expect(act(async () => result.current.setTimeFormat('24h'))).rejects.toThrow(
+      'Failed to save time format',
+    );
+    expect(result.current.timeFormat).toBe('12h');
+  });
+});

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -9,4 +9,4 @@ export { AuthProvider, useAuth } from './AuthProvider';
 export { FamilyProvider, useFamily } from './FamilyProvider';
 export { Providers } from './Providers';
 export { TimeFormatProvider, useTimeFormat } from './TimeFormatProvider';
-export type { TimeFormat } from '@/lib/utils/timeFormat';
+export type { DisplayTimezoneMode, TimeFormat } from '@/lib/utils/timeFormat';

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -8,3 +8,5 @@ export { ThemeProvider, useTheme, type ThemeMode } from './ThemeProvider';
 export { AuthProvider, useAuth } from './AuthProvider';
 export { FamilyProvider, useFamily } from './FamilyProvider';
 export { Providers } from './Providers';
+export { TimeFormatProvider, useTimeFormat } from './TimeFormatProvider';
+export type { TimeFormat } from '@/lib/utils/timeFormat';

--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -30,6 +30,8 @@ import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 import { WidgetContainer } from './WidgetContainer';
 
 
@@ -75,11 +77,15 @@ export interface ClockWidgetProps {
  */
 export const ClockWidget = React.memo(function ClockWidget({
   showSeconds = false,
-  format24Hour = false,
+  format24Hour,
   showDate = true,
   size = 'medium',
   className,
 }: ClockWidgetProps) {
+  const { timeFormat } = useTimeFormat();
+  const effectiveTimeFormat = format24Hour === undefined
+    ? timeFormat
+    : format24Hour ? '24h' : '12h';
   // State to hold the current time
   // Initialize with current time to avoid hydration mismatch
   const [currentTime, setCurrentTime] = useState<Date>(new Date());
@@ -101,14 +107,10 @@ export const ClockWidget = React.memo(function ClockWidget({
 
   // Format strings for date-fns
   // See: https://date-fns.org/docs/format
-  const timeFormat = format24Hour
-    ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
-    : showSeconds ? 'h:mm:ss a' : 'h:mm a';
-
   const dateFormat = 'EEEE, MMMM d'; // e.g., "Tuesday, January 21"
 
   // Formatted strings
-  const timeString = format(currentTime, timeFormat);
+  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds });
   const dateString = format(currentTime, dateFormat);
 
   // Size-based styling

--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -31,7 +31,7 @@ import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 import { WidgetContainer } from './WidgetContainer';
 
 
@@ -82,7 +82,7 @@ export const ClockWidget = React.memo(function ClockWidget({
   size = 'medium',
   className,
 }: ClockWidgetProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const effectiveTimeFormat = format24Hour === undefined
     ? timeFormat
     : format24Hour ? '24h' : '12h';
@@ -110,8 +110,8 @@ export const ClockWidget = React.memo(function ClockWidget({
   const dateFormat = 'EEEE, MMMM d'; // e.g., "Tuesday, January 21"
 
   // Formatted strings
-  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds });
-  const dateString = format(currentTime, dateFormat);
+  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds }, displayTimezone);
+  const dateString = format(toDisplayDate(currentTime, displayTimezone), dateFormat);
 
   // Size-based styling
   const timeStyles = {

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -115,6 +115,8 @@ export interface WeatherUnits {
 
 export interface WeatherData {
   location: string;
+  /** IANA timezone of the weather location, when supplied by the provider. */
+  timezone?: string;
   current: CurrentWeather;
   forecast: ForecastDay[];
   /** Next 24 hours of hourly forecast data for the timeline. */
@@ -392,12 +394,13 @@ export const WeatherWidget = React.memo(function WeatherWidget({
           sunset={weatherData.sunset}
           moonPhase={weatherData.moonPhase}
           moonPhaseName={weatherData.moonPhaseName}
+          timezone={weatherData.timezone}
         />
 
         {/* HOURLY FORECAST */}
         {showHourly && weatherData.hourly && weatherData.hourly.length > 0 && (
           <div className="border-t border-border pt-3">
-            <HourlyTimeline hourly={weatherData.hourly} units={units} />
+            <HourlyTimeline hourly={weatherData.hourly} units={units} timezone={weatherData.timezone} />
           </div>
         )}
 
@@ -433,6 +436,7 @@ export const WeatherWidget = React.memo(function WeatherWidget({
                   moonrise={weatherData.moonrise}
                   moonset={weatherData.moonset}
                   moonPhase={weatherData.moonPhase}
+                  timezone={weatherData.timezone}
                 />
               </div>
             )}
@@ -463,6 +467,7 @@ function CurrentConditions({
   sunset,
   moonPhase,
   moonPhaseName,
+  timezone,
 }: {
   weather: CurrentWeather;
   location: string;
@@ -471,6 +476,7 @@ function CurrentConditions({
   sunset?: Date;
   moonPhase?: number;
   moonPhaseName?: string;
+  timezone?: string;
 }) {
   const { timeFormat } = useTimeFormat();
   const temp  = formatTemp(weather.temperature, units);
@@ -519,13 +525,13 @@ function CurrentConditions({
             {sunrise && (
               <span className="flex items-center gap-0.5" title="Sunrise">
                 <Sunrise className="h-3 w-3" style={{ color: '#FBBF24' }} />
-                {formatDisplayTime(sunrise, timeFormat)}
+                {formatDisplayTime(sunrise, timeFormat, {}, timezone)}
               </span>
             )}
             {sunset && (
               <span className="flex items-center gap-0.5" title="Sunset">
                 <Sunset className="h-3 w-3" style={{ color: '#F97316' }} />
-                {formatDisplayTime(sunset, timeFormat)}
+                {formatDisplayTime(sunset, timeFormat, {}, timezone)}
               </span>
             )}
           </div>
@@ -664,7 +670,7 @@ function WeatherIcon({
  * meaningfully matters (≥10%). The first card is labeled "Now". Replaces the
  * earlier merry-timeline color strip, which read as a 1995-era band chart.
  */
-function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: WeatherUnits }) {
+function HourlyTimeline({ hourly, units, timezone }: { hourly: HourlyForecast[]; units: WeatherUnits; timezone?: string }) {
   const { timeFormat } = useTimeFormat();
   // Start at the hour whose endTime is still in the future ("Now" card).
   // Take 8 hours so the row stays readable at the default widget width.
@@ -685,7 +691,7 @@ function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: We
           const isNow = i === 0;
           const timeLabel = isNow
             ? 'Now'
-            : formatDisplayHour(h.time, timeFormat, { compact: true }).toLowerCase();
+            : formatDisplayHour(h.time, timeFormat, { compact: true }, timezone).toLowerCase();
           const precipPct = Math.round(h.precipProbability ?? 0);
           const showPrecip = precipPct >= 10;
           return (
@@ -884,6 +890,7 @@ function SunriseSunsetArc({
   moonrise,
   moonset,
   moonPhase,
+  timezone,
 }: {
   sunrise: Date;
   sunset: Date;
@@ -892,6 +899,7 @@ function SunriseSunsetArc({
   moonrise?: Date;
   moonset?: Date;
   moonPhase?: number;
+  timezone?: string;
 }) {
   const { timeFormat } = useTimeFormat();
   const [width, setWidth] = React.useState(220);
@@ -1125,22 +1133,22 @@ function SunriseSunsetArc({
       <div className="flex items-center justify-between gap-3 text-[11px] tabular-nums pt-0.5 whitespace-nowrap">
         <span className="flex items-center gap-3">
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunrise">
-            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat)}
+            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat, {}, timezone)}
           </span>
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunset">
-            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat)}
+            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat, {}, timezone)}
           </span>
         </span>
         {(moonrise || moonset) && (
           <span className="flex items-center gap-3" style={{ color: MOON_COLOR }}>
             {moonrise && (
               <span className="flex items-center gap-1" title="Moonrise">
-                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat)}
+                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat, {}, timezone)}
               </span>
             )}
             {moonset && (
               <span className="flex items-center gap-1" title="Moonset">
-                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat)}
+                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat, {}, timezone)}
               </span>
             )}
           </span>

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -42,6 +42,8 @@ import {
 import { cn } from '@/lib/utils';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import { WidgetContainer } from './WidgetContainer';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTime } from '@/lib/utils/timeFormat';
 
 /**
  * WEATHER DATA TYPES
@@ -470,9 +472,9 @@ function CurrentConditions({
   moonPhase?: number;
   moonPhaseName?: string;
 }) {
+  const { timeFormat } = useTimeFormat();
   const temp  = formatTemp(weather.temperature, units);
   const feels = formatTemp(weather.feelsLike, units);
-  const fmtTime = (d: Date) => d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
 
   return (
     <div className="flex items-start justify-between gap-2">
@@ -517,13 +519,13 @@ function CurrentConditions({
             {sunrise && (
               <span className="flex items-center gap-0.5" title="Sunrise">
                 <Sunrise className="h-3 w-3" style={{ color: '#FBBF24' }} />
-                {fmtTime(sunrise)}
+                {formatDisplayTime(sunrise, timeFormat)}
               </span>
             )}
             {sunset && (
               <span className="flex items-center gap-0.5" title="Sunset">
                 <Sunset className="h-3 w-3" style={{ color: '#F97316' }} />
-                {fmtTime(sunset)}
+                {formatDisplayTime(sunset, timeFormat)}
               </span>
             )}
           </div>
@@ -663,6 +665,7 @@ function WeatherIcon({
  * earlier merry-timeline color strip, which read as a 1995-era band chart.
  */
 function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: WeatherUnits }) {
+  const { timeFormat } = useTimeFormat();
   // Start at the hour whose endTime is still in the future ("Now" card).
   // Take 8 hours so the row stays readable at the default widget width.
   const nowMs = Date.now();
@@ -682,10 +685,7 @@ function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: We
           const isNow = i === 0;
           const timeLabel = isNow
             ? 'Now'
-            : h.time
-                .toLocaleTimeString([], { hour: 'numeric', hour12: true })
-                .replace(/\s/g, '')
-                .toLowerCase();
+            : formatDisplayHour(h.time, timeFormat, { compact: true }).toLowerCase();
           const precipPct = Math.round(h.precipProbability ?? 0);
           const showPrecip = precipPct >= 10;
           return (
@@ -893,6 +893,7 @@ function SunriseSunsetArc({
   moonset?: Date;
   moonPhase?: number;
 }) {
+  const { timeFormat } = useTimeFormat();
   const [width, setWidth] = React.useState(220);
   const containerRef = React.useRef<HTMLDivElement>(null);
   // Unique gradient ID so multiple weather widgets on a page (e.g., dashboard
@@ -1013,8 +1014,6 @@ function SunriseSunsetArc({
   const SUN_HORIZON = '#EF4444'; // red-500 — sun at the horizon
   const MOON_COLOR = '#60A5FA';
 
-  const fmtTime = (d: Date) => d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
-
   // Pick a sun-dot color that matches where it sits on the altitude gradient
   // — red near the horizon, amber high in the sky. Bucketed (rather than
   // smoothly interpolated) for legibility against a small dot.
@@ -1126,22 +1125,22 @@ function SunriseSunsetArc({
       <div className="flex items-center justify-between gap-3 text-[11px] tabular-nums pt-0.5 whitespace-nowrap">
         <span className="flex items-center gap-3">
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunrise">
-            <Sunrise className="h-3 w-3" />{fmtTime(sunrise)}
+            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat)}
           </span>
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunset">
-            <Sunset className="h-3 w-3" />{fmtTime(sunset)}
+            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat)}
           </span>
         </span>
         {(moonrise || moonset) && (
           <span className="flex items-center gap-3" style={{ color: MOON_COLOR }}>
             {moonrise && (
               <span className="flex items-center gap-1" title="Moonrise">
-                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{fmtTime(moonrise)}
+                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat)}
               </span>
             )}
             {moonset && (
               <span className="flex items-center gap-1" title="Moonset">
-                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{fmtTime(moonset)}
+                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat)}
               </span>
             )}
           </span>

--- a/src/lib/hooks/useCalendarWidgetPrefs.ts
+++ b/src/lib/hooks/useCalendarWidgetPrefs.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, createContext } from 'react';
-import { addDays, addWeeks, addMonths, subDays, subWeeks, subMonths, startOfWeek } from 'date-fns';
+import { addDays, addWeeks, addMonths, subDays, subWeeks, subMonths } from 'date-fns';
 import type { OverlayFlags } from '@/lib/hooks/useDayBucketsForRange';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 /**
  * Scopes CalendarWidget preference storage. Empty string = the shared keys used
@@ -90,10 +92,15 @@ function readViewPref(suffix: string): WidgetViewType {
  * for the CalendarWidget. Extracted from the component to keep it under 250 lines.
  */
 export function useCalendarWidgetPrefs(gridW: number, gridH: number, scope = '') {
+  const { displayTimezone } = useTimeFormat();
   // Non-empty scope suffixes every storage key so this calendar (e.g. the one on
   // the screensaver) keeps prefs independent of the dashboard's. Empty = shared.
   const suffix = scope ? `:${scope}` : '';
   const [currentDate, setCurrentDate] = useState(() => new Date());
+
+  useEffect(() => {
+    setCurrentDate(toDisplayDate(new Date(), displayTimezone));
+  }, [displayTimezone]);
   const [widgetBordered, setWidgetBordered] = useState(
     () => typeof window !== 'undefined' && localStorage.getItem(`prism-calendar-bordered${suffix}`) === 'true'
   );
@@ -143,7 +150,10 @@ export function useCalendarWidgetPrefs(gridW: number, gridH: number, scope = '')
   const viewUnavailable = viewType !== effectiveView;
 
   // Navigation
-  const goToToday = useCallback(() => setCurrentDate(new Date()), []);
+  const goToToday = useCallback(
+    () => setCurrentDate(toDisplayDate(new Date(), displayTimezone)),
+    [displayTimezone],
+  );
   const goToPrevious = useCallback(() => {
     setCurrentDate(d => {
       switch (resolvedView) {

--- a/src/lib/hooks/useDayBucketsForRange.ts
+++ b/src/lib/hooks/useDayBucketsForRange.ts
@@ -12,6 +12,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { DayBucket } from './useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface OverlayFlags {
   events: boolean;
@@ -58,10 +60,12 @@ function dateKey(d: Date): string {
   return format(d, 'yyyy-MM-dd');
 }
 
-function eventOnDay(event: CalendarEvent, day: Date): boolean {
+function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
   const dayStart = startOfDay(day);
   const dayEnd = addDays(dayStart, 1);
-  return event.startTime < dayEnd && event.endTime > dayStart;
+  const eventStart = toDisplayDate(event.startTime, displayTimezone);
+  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
+  return eventStart < dayEnd && eventEnd > dayStart;
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {
@@ -88,6 +92,7 @@ export function useDayBucketsForRange({
   overlays,
   externalEvents,
 }: UseDayBucketsForRangeOptions): UseDayBucketsForRangeResult {
+  const { displayTimezone } = useTimeFormat();
   const fromKey = useMemo(() => dateKey(from), [from]);
   const toKey = useMemo(() => dateKey(to), [to]);
 
@@ -147,7 +152,7 @@ export function useDayBucketsForRange({
       const key = dateKey(date);
 
       const dayEvents = overlays.events
-        ? events.filter((e) => eventOnDay(e, date))
+        ? events.filter((e) => eventOnDay(e, date, displayTimezone))
         : EMPTY_EVENTS;
       const allDayEvents = dayEvents
         .filter((e) => e.allDay)
@@ -192,7 +197,7 @@ export function useDayBucketsForRange({
     return map;
     // fromKey/toKey trigger recompute on actual date changes, not Date identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fromKey, toKey, events, meals, chores, tasks, weather, overlays.events, overlays.meals, overlays.chores, overlays.tasks]);
+  }, [fromKey, toKey, events, meals, chores, tasks, weather, overlays.events, overlays.meals, overlays.chores, overlays.tasks, displayTimezone]);
 
   const loading =
     (overlays.events && fetchEvents && eventsLoading) ||

--- a/src/lib/hooks/useDayBucketsForRange.ts
+++ b/src/lib/hooks/useDayBucketsForRange.ts
@@ -13,7 +13,7 @@ import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { DayBucket } from './useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay } from '@/lib/utils/timeFormat';
 
 export interface OverlayFlags {
   events: boolean;
@@ -61,11 +61,13 @@ function dateKey(d: Date): string {
 }
 
 function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
-  const dayStart = startOfDay(day);
-  const dayEnd = addDays(dayStart, 1);
-  const eventStart = toDisplayDate(event.startTime, displayTimezone);
-  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
-  return eventStart < dayEnd && eventEnd > dayStart;
+  return eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    day,
+    displayTimezone,
+  );
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {

--- a/src/lib/hooks/useTimezone.ts
+++ b/src/lib/hooks/useTimezone.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const STORAGE_KEY = 'prism:timezone';
+const TIMEZONE_CHANGED_EVENT = 'prism:timezone-changed';
 
 /** The browser's own IANA timezone, e.g. "America/Chicago". Safe fallback. */
 export function detectBrowserTimezone(): string {
@@ -56,6 +57,7 @@ export function useTimezone(): {
   const setTimezone = useCallback(async (newValue: string) => {
     setValue(newValue);
     localStorage.setItem(STORAGE_KEY, newValue);
+    window.dispatchEvent(new CustomEvent(TIMEZONE_CHANGED_EVENT, { detail: newValue }));
     try {
       await fetch('/api/settings', {
         method: 'PATCH',

--- a/src/lib/hooks/useWeekViewData.ts
+++ b/src/lib/hooks/useWeekViewData.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { addDays, format, isSameDay, startOfDay, startOfWeek } from 'date-fns';
+import { addDays, format, isSameDay, startOfWeek } from 'date-fns';
 import { useCalendarEvents } from './useCalendarEvents';
 import { useMeals } from './useMeals';
 import { useChores } from './useChores';
@@ -13,7 +13,7 @@ import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { ForecastDay } from '@/components/widgets/WeatherWidget';
 import { useTimeFormat } from '@/components/providers';
-import { toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventOccursOnDisplayDay } from '@/lib/utils/timeFormat';
 
 export interface DayBucket {
   date: Date;
@@ -55,11 +55,13 @@ const MEAL_TYPE_ORDER: Record<Meal['mealType'], number> = {
 };
 
 function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
-  const dayStart = startOfDay(day);
-  const dayEnd = addDays(dayStart, 1);
-  const eventStart = toDisplayDate(event.startTime, displayTimezone);
-  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
-  return eventStart < dayEnd && eventEnd > dayStart;
+  return eventOccursOnDisplayDay(
+    event.startTime,
+    event.endTime,
+    event.allDay,
+    day,
+    displayTimezone,
+  );
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {

--- a/src/lib/hooks/useWeekViewData.ts
+++ b/src/lib/hooks/useWeekViewData.ts
@@ -12,6 +12,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { ForecastDay } from '@/components/widgets/WeatherWidget';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface DayBucket {
   date: Date;
@@ -52,10 +54,12 @@ const MEAL_TYPE_ORDER: Record<Meal['mealType'], number> = {
   snack: 3,
 };
 
-function eventOnDay(event: CalendarEvent, day: Date): boolean {
+function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
   const dayStart = startOfDay(day);
   const dayEnd = addDays(dayStart, 1);
-  return event.startTime < dayEnd && event.endTime > dayStart;
+  const eventStart = toDisplayDate(event.startTime, displayTimezone);
+  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
+  return eventStart < dayEnd && eventEnd > dayStart;
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {
@@ -70,6 +74,7 @@ export function useWeekViewData({
   weekStart,
   weekStartsOn,
 }: UseWeekViewDataOptions): UseWeekViewDataResult {
+  const { displayTimezone } = useTimeFormat();
   // Normalize to start-of-week for stable identity
   const normalizedStart = useMemo(
     () => startOfWeek(weekStart, { weekStartsOn }),
@@ -96,7 +101,7 @@ export function useWeekViewData({
       const date = addDays(normalizedStart, i);
       const dayOfWeek = DAYS_OF_WEEK[date.getDay()] as DayOfWeek;
 
-      const dayEvents = events.filter((e) => eventOnDay(e, date));
+      const dayEvents = events.filter((e) => eventOnDay(e, date, displayTimezone));
       const allDayEvents = dayEvents.filter((e) => e.allDay).sort((a, b) =>
         a.startTime.getTime() - b.startTime.getTime(),
       );
@@ -132,7 +137,7 @@ export function useWeekViewData({
         weather: dayWeather,
       };
     });
-  }, [normalizedStart, events, meals, chores, tasks, weather]);
+  }, [normalizedStart, events, meals, chores, tasks, weather, displayTimezone]);
 
   const loading = eventsLoading || mealsLoading || choresLoading || tasksLoading;
   const error = eventsError || mealsError || choresError || tasksError;

--- a/src/lib/integrations/__tests__/google-calendar.test.ts
+++ b/src/lib/integrations/__tests__/google-calendar.test.ts
@@ -1,4 +1,31 @@
-import { convertGoogleEventToInternal, type GoogleCalendarEvent } from '../google-calendar';
+import {
+  convertGoogleEventToInternal,
+  toGoogleAllDayRange,
+  type GoogleCalendarEvent,
+} from '../google-calendar';
+
+describe('toGoogleAllDayRange', () => {
+  it('advances an inclusive same-day end to Google’s exclusive next day', () => {
+    expect(toGoogleAllDayRange(
+      new Date('2026-08-19T00:00:00.000Z'),
+      new Date('2026-08-19T23:59:59.000Z'),
+    )).toEqual({ start: { date: '2026-08-19' }, end: { date: '2026-08-20' } });
+  });
+
+  it('preserves an end that is already an exclusive midnight boundary', () => {
+    expect(toGoogleAllDayRange(
+      new Date('2026-08-19T00:00:00.000Z'),
+      new Date('2026-08-20T00:00:00.000Z'),
+    )).toEqual({ start: { date: '2026-08-19' }, end: { date: '2026-08-20' } });
+  });
+
+  it('uses an exclusive day after the inclusive end for multi-day events', () => {
+    expect(toGoogleAllDayRange(
+      new Date('2026-08-19T00:00:00.000Z'),
+      new Date('2026-08-21T23:59:59.000Z'),
+    )).toEqual({ start: { date: '2026-08-19' }, end: { date: '2026-08-22' } });
+  });
+});
 
 describe('convertGoogleEventToInternal', () => {
   const SOURCE_ID = 'cal-source-1';
@@ -54,8 +81,8 @@ describe('convertGoogleEventToInternal', () => {
       const result = convertGoogleEventToInternal(event, SOURCE_ID);
 
       expect(result.allDay).toBe(true);
-      expect(result.startTime).toEqual(new Date('2026-03-01T00:00:00'));
-      expect(result.endTime).toEqual(new Date('2026-03-04T00:00:00'));
+      expect(result.startTime).toEqual(new Date('2026-03-01T00:00:00Z'));
+      expect(result.endTime).toEqual(new Date('2026-03-04T00:00:00Z'));
     });
   });
 

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -305,6 +305,42 @@ export async function createCalendarEvent(
 }
 
 /**
+ * Convert Prism's inclusive all-day range into Google's exclusive-end date
+ * range. Google requires a one-day event on Aug 19 to be represented as
+ * start=Aug 19, end=Aug 20.
+ */
+export function toGoogleAllDayRange(startTime: Date, endTime: Date): {
+  start: { date: string };
+  end: { date: string };
+} {
+  const dateOnly = (date: Date) => date.toISOString().slice(0, 10);
+  const addUtcDay = (date: string) => {
+    const value = new Date(`${date}T00:00:00.000Z`);
+    value.setUTCDate(value.getUTCDate() + 1);
+    return dateOnly(value);
+  };
+
+  const startDate = dateOnly(startTime);
+  const endIsExclusiveMidnight = endTime.getTime() > startTime.getTime()
+    && endTime.getUTCHours() === 0
+    && endTime.getUTCMinutes() === 0
+    && endTime.getUTCSeconds() === 0
+    && endTime.getUTCMilliseconds() === 0;
+  let endDate = endIsExclusiveMidnight
+    ? dateOnly(endTime)
+    : addUtcDay(dateOnly(endTime));
+
+  // Google rejects zero-length all-day ranges. Keep malformed/legacy local
+  // rows editable by coercing them to a single-day event.
+  if (endDate <= startDate) endDate = addUtcDay(startDate);
+
+  return {
+    start: { date: startDate },
+    end: { date: endDate },
+  };
+}
+
+/**
  * Update an event in a calendar
  */
 export async function updateCalendarEvent(
@@ -388,8 +424,8 @@ export function convertGoogleEventToInternal(
 
   if (isAllDay) {
     // All-day events use date strings (YYYY-MM-DD)
-    startTime = new Date(googleEvent.start.date + 'T00:00:00');
-    endTime = new Date(googleEvent.end.date + 'T00:00:00');
+    startTime = new Date(googleEvent.start.date + 'T00:00:00Z');
+    endTime = new Date(googleEvent.end.date + 'T00:00:00Z');
   } else {
     startTime = new Date(googleEvent.start.dateTime!);
     endTime = new Date(googleEvent.end.dateTime!);

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -365,6 +365,7 @@ export async function fetchWeatherData(
 
   return {
     location: config.locationName,
+    timezone,
     units,
     current: currentWeather,
     forecast,

--- a/src/lib/integrations/pirateweather.ts
+++ b/src/lib/integrations/pirateweather.ts
@@ -281,6 +281,7 @@ export async function fetchWeatherData(
 
   return {
     location: config.locationName,
+    timezone,
     units,
     current,
     forecast,

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -2,6 +2,9 @@ import {
   formatDisplayHour,
   formatDisplayTime,
   formatDisplayTimeRange,
+  fromDisplayDateTime,
+  getDisplayDateKey,
+  toDisplayDate,
 } from '../timeFormat';
 
 describe('time format utilities', () => {
@@ -28,5 +31,34 @@ describe('time format utilities', () => {
     const end = new Date(2026, 0, 15, 15, 30);
     expect(formatDisplayTimeRange(afternoon, end, '12h')).toBe('2:05–3:30 PM');
     expect(formatDisplayTimeRange(afternoon, end, '24h')).toBe('14:05–15:30');
+  });
+
+  it('formats the same appointment in the selected display timezone', () => {
+    const appointment = new Date('2026-08-19T06:00:00.000Z');
+
+    expect(formatDisplayTime(appointment, '24h', {}, 'Europe/Warsaw')).toBe('08:00');
+    expect(formatDisplayTime(appointment, '24h', {}, 'Europe/London')).toBe('07:00');
+  });
+
+  it('uses the selected timezone for day bucketing around midnight', () => {
+    const instant = new Date('2026-08-19T22:30:00.000Z');
+
+    expect(getDisplayDateKey(instant, 'Europe/Warsaw')).toBe('2026-08-20');
+    expect(getDisplayDateKey(instant, 'Europe/London')).toBe('2026-08-19');
+    expect(toDisplayDate(instant, 'Europe/Warsaw').getHours()).toBe(0);
+  });
+
+  it('persists calendar form times in the selected display timezone', () => {
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-08-19T06:00:00.000Z');
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/London').toISOString())
+      .toBe('2026-08-19T07:00:00.000Z');
+  });
+
+  it('uses the correct selected-timezone offset across daylight saving time', () => {
+    expect(fromDisplayDateTime('2026-01-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-01-19T07:00:00.000Z');
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-08-19T06:00:00.000Z');
   });
 });

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -1,0 +1,32 @@
+import {
+  formatDisplayHour,
+  formatDisplayTime,
+  formatDisplayTimeRange,
+} from '../timeFormat';
+
+describe('time format utilities', () => {
+  const afternoon = new Date(2026, 0, 15, 14, 5, 9);
+
+  it('formats ordinary times in 12-hour and 24-hour modes', () => {
+    expect(formatDisplayTime(afternoon, '12h')).toBe('2:05 PM');
+    expect(formatDisplayTime(afternoon, '24h')).toBe('14:05');
+  });
+
+  it('includes seconds when requested', () => {
+    expect(formatDisplayTime(afternoon, '12h', { showSeconds: true })).toBe('2:05:09 PM');
+    expect(formatDisplayTime(afternoon, '24h', { showSeconds: true })).toBe('14:05:09');
+  });
+
+  it('formats compact and full hour-axis labels', () => {
+    const hour = new Date(2026, 0, 15, 14, 0);
+    expect(formatDisplayHour(hour, '12h', { compact: true })).toBe('2PM');
+    expect(formatDisplayHour(hour, '24h', { compact: true })).toBe('14');
+    expect(formatDisplayHour(hour, '24h')).toBe('14:00');
+  });
+
+  it('formats event time ranges consistently', () => {
+    const end = new Date(2026, 0, 15, 15, 30);
+    expect(formatDisplayTimeRange(afternoon, end, '12h')).toBe('2:05–3:30 PM');
+    expect(formatDisplayTimeRange(afternoon, end, '24h')).toBe('14:05–15:30');
+  });
+});

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -1,4 +1,5 @@
 import {
+  eventOccursOnDisplayDay,
   formatDisplayHour,
   formatDisplayTime,
   formatDisplayTimeRange,
@@ -60,5 +61,34 @@ describe('time format utilities', () => {
       .toBe('2026-01-19T07:00:00.000Z');
     expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/Warsaw').toISOString())
       .toBe('2026-08-19T06:00:00.000Z');
+  });
+
+  it('keeps a Google all-day event on its date despite a positive timezone offset', () => {
+    const start = new Date('2026-08-18T00:00:00.000Z');
+    const exclusiveEnd = new Date('2026-08-19T00:00:00.000Z');
+
+    expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 18), 'Europe/Warsaw'))
+      .toBe(true);
+    expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 19), 'Europe/Warsaw'))
+      .toBe(false);
+  });
+
+  it('supports Prism all-day events with an inclusive end-of-day timestamp', () => {
+    const start = new Date('2026-08-18T00:00:00.000Z');
+    const inclusiveEnd = new Date('2026-08-18T23:59:59.999Z');
+
+    expect(eventOccursOnDisplayDay(start, inclusiveEnd, true, new Date(2026, 7, 18), 'Europe/Warsaw'))
+      .toBe(true);
+    expect(eventOccursOnDisplayDay(start, inclusiveEnd, true, new Date(2026, 7, 19), 'Europe/Warsaw'))
+      .toBe(false);
+  });
+
+  it('preserves exclusive ends for multi-day all-day events', () => {
+    const start = new Date('2026-08-18T00:00:00.000Z');
+    const exclusiveEnd = new Date('2026-08-20T00:00:00.000Z');
+
+    expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 18))).toBe(true);
+    expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 19))).toBe(true);
+    expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 20))).toBe(false);
   });
 });

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -6,6 +6,7 @@ import {
   formatDisplayTimeRange,
   fromDisplayDateTime,
   getDisplayDateKey,
+  isCalendarEventPast,
   toDisplayDate,
 } from '../timeFormat';
 
@@ -118,5 +119,35 @@ describe('time format utilities', () => {
       new Date('2026-08-24T00:00:00.000Z'),
       true,
     )).toBe(true);
+  });
+
+  it('treats an all-day event as past only after its exclusive end date', () => {
+    const start = new Date('2026-08-18T00:00:00.000Z');
+    const exclusiveEnd = new Date('2026-08-20T00:00:00.000Z');
+
+    expect(isCalendarEventPast(
+      start,
+      exclusiveEnd,
+      true,
+      new Date('2026-08-19T12:00:00.000Z'),
+      'Europe/Warsaw',
+    )).toBe(false);
+    expect(isCalendarEventPast(
+      start,
+      exclusiveEnd,
+      true,
+      new Date('2026-08-20T12:00:00.000Z'),
+      'Europe/Warsaw',
+    )).toBe(true);
+  });
+
+  it('keeps an ongoing timed event active until its actual end instant', () => {
+    const start = new Date('2026-08-20T06:00:00.000Z');
+    const end = new Date('2026-08-20T08:00:00.000Z');
+
+    expect(isCalendarEventPast(start, end, false, new Date('2026-08-20T07:00:00.000Z')))
+      .toBe(false);
+    expect(isCalendarEventPast(start, end, false, new Date('2026-08-20T08:00:00.000Z')))
+      .toBe(true);
   });
 });

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -1,5 +1,6 @@
 import {
   eventOccursOnDisplayDay,
+  eventStartsOnDisplayDay,
   eventSpansMultipleDisplayDays,
   formatDisplayHour,
   formatDisplayTime,
@@ -99,6 +100,24 @@ describe('time format utilities', () => {
     const end = new Date('2026-08-23T17:00:00.000Z');
 
     expect(eventSpansMultipleDisplayDays(start, end, false, 'Europe/Warsaw')).toBe(true);
+  });
+
+  it('shows a timed event start only on its first displayed day', () => {
+    const start = new Date('2026-08-21T16:00:00.000Z');
+
+    expect(eventStartsOnDisplayDay(start, false, new Date(2026, 7, 21), 'Europe/Warsaw'))
+      .toBe(true);
+    expect(eventStartsOnDisplayDay(start, false, new Date(2026, 7, 22), 'Europe/Warsaw'))
+      .toBe(false);
+  });
+
+  it('uses floating UTC dates for all-day event starts', () => {
+    const start = new Date('2026-08-21T00:00:00.000Z');
+
+    expect(eventStartsOnDisplayDay(start, true, new Date(2026, 7, 21), 'America/Los_Angeles'))
+      .toBe(true);
+    expect(eventStartsOnDisplayDay(start, true, new Date(2026, 7, 20), 'America/Los_Angeles'))
+      .toBe(false);
   });
 
   it('does not treat an exact-midnight end as occupying another day', () => {

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -1,5 +1,6 @@
 import {
   eventOccursOnDisplayDay,
+  eventSpansMultipleDisplayDays,
   formatDisplayHour,
   formatDisplayTime,
   formatDisplayTimeRange,
@@ -90,5 +91,32 @@ describe('time format utilities', () => {
     expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 18))).toBe(true);
     expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 19))).toBe(true);
     expect(eventOccursOnDisplayDay(start, exclusiveEnd, true, new Date(2026, 7, 20))).toBe(false);
+  });
+
+  it('classifies timed events spanning displayed dates', () => {
+    const start = new Date('2026-08-21T16:00:00.000Z');
+    const end = new Date('2026-08-23T17:00:00.000Z');
+
+    expect(eventSpansMultipleDisplayDays(start, end, false, 'Europe/Warsaw')).toBe(true);
+  });
+
+  it('does not treat an exact-midnight end as occupying another day', () => {
+    const start = new Date('2026-08-21T16:00:00.000Z');
+    const midnightEnd = new Date('2026-08-21T22:00:00.000Z');
+
+    expect(eventSpansMultipleDisplayDays(start, midnightEnd, false, 'Europe/Warsaw')).toBe(false);
+  });
+
+  it('distinguishes one-day and multi-day all-day ranges', () => {
+    expect(eventSpansMultipleDisplayDays(
+      new Date('2026-08-21T00:00:00.000Z'),
+      new Date('2026-08-22T00:00:00.000Z'),
+      true,
+    )).toBe(false);
+    expect(eventSpansMultipleDisplayDays(
+      new Date('2026-08-21T00:00:00.000Z'),
+      new Date('2026-08-24T00:00:00.000Z'),
+      true,
+    )).toBe(true);
   });
 });

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -1,0 +1,44 @@
+import { format } from 'date-fns';
+
+export type TimeFormat = '12h' | '24h';
+
+export const DEFAULT_TIME_FORMAT: TimeFormat = '12h';
+
+export function isTimeFormat(value: unknown): value is TimeFormat {
+  return value === '12h' || value === '24h';
+}
+
+export function formatDisplayTime(
+  date: Date | number,
+  timeFormat: TimeFormat,
+  options: { showSeconds?: boolean } = {},
+): string {
+  const { showSeconds = false } = options;
+  const pattern = timeFormat === '24h'
+    ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
+    : showSeconds ? 'h:mm:ss a' : 'h:mm a';
+  return format(date, pattern);
+}
+
+export function formatDisplayHour(
+  date: Date | number,
+  timeFormat: TimeFormat,
+  options: { compact?: boolean } = {},
+): string {
+  const { compact = false } = options;
+  const pattern = timeFormat === '24h'
+    ? compact ? 'HH' : 'HH:mm'
+    : compact ? 'ha' : 'h a';
+  return format(date, pattern);
+}
+
+export function formatDisplayTimeRange(
+  start: Date | number,
+  end: Date | number,
+  timeFormat: TimeFormat,
+): string {
+  if (timeFormat === '24h') {
+    return `${format(start, 'HH:mm')}–${format(end, 'HH:mm')}`;
+  }
+  return `${format(start, 'h:mm')}–${format(end, 'h:mm a')}`;
+}

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -1,44 +1,155 @@
 import { format } from 'date-fns';
 
 export type TimeFormat = '12h' | '24h';
+export type DisplayTimezoneMode = 'household' | 'device';
 
 export const DEFAULT_TIME_FORMAT: TimeFormat = '12h';
+export const DEFAULT_DISPLAY_TIMEZONE_MODE: DisplayTimezoneMode = 'household';
 
 export function isTimeFormat(value: unknown): value is TimeFormat {
   return value === '12h' || value === '24h';
+}
+
+export function isDisplayTimezoneMode(value: unknown): value is DisplayTimezoneMode {
+  return value === 'household' || value === 'device';
+}
+
+/**
+ * Return a presentation-only Date whose local fields match `date` in
+ * `timeZone`. This is useful with date-fns, whose formatters always use the
+ * browser timezone. Never persist or send the returned Date to an API.
+ */
+export function toDisplayDate(date: Date | number, timeZone?: string): Date {
+  const source = new Date(date);
+  if (!timeZone || Number.isNaN(source.getTime())) return source;
+
+  try {
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(source);
+    const value = (type: Intl.DateTimeFormatPartTypes) =>
+      Number(parts.find((part) => part.type === type)?.value);
+
+    return new Date(
+      value('year'),
+      value('month') - 1,
+      value('day'),
+      value('hour'),
+      value('minute'),
+      value('second'),
+      source.getMilliseconds(),
+    );
+  } catch {
+    return source;
+  }
+}
+
+export function getDisplayDateKey(date: Date | number, timeZone?: string): string {
+  return format(toDisplayDate(date, timeZone), 'yyyy-MM-dd');
+}
+
+/**
+ * Convert date/time fields entered in the selected display timezone into the
+ * real instant that should be persisted. This is the inverse of
+ * `toDisplayDate` for calendar form values.
+ */
+export function fromDisplayDateTime(
+  date: string,
+  time: string,
+  timeZone?: string,
+): Date {
+  const [year, month, day] = date.split('-').map(Number);
+  const [hour, minute, second = 0] = time.split(':').map(Number);
+
+  if (![year, month, day, hour, minute, second].every(Number.isFinite)) {
+    return new Date(NaN);
+  }
+
+  if (!timeZone) return new Date(year!, month! - 1, day!, hour!, minute!, second!);
+
+  const targetWallTime = Date.UTC(year!, month! - 1, day!, hour!, minute!, second!);
+  let instant = targetWallTime;
+
+  try {
+    const formatter = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    });
+
+    // A second pass handles dates where the first offset guess crosses a DST
+    // boundary. Three passes keep the operation stable for unusual offsets.
+    for (let pass = 0; pass < 3; pass += 1) {
+      const parts = formatter.formatToParts(new Date(instant));
+      const value = (type: Intl.DateTimeFormatPartTypes) =>
+        Number(parts.find((part) => part.type === type)?.value);
+      const displayedWallTime = Date.UTC(
+        value('year'),
+        value('month') - 1,
+        value('day'),
+        value('hour'),
+        value('minute'),
+        value('second'),
+      );
+      const correction = displayedWallTime - targetWallTime;
+      if (correction === 0) break;
+      instant -= correction;
+    }
+
+    return new Date(instant);
+  } catch {
+    return new Date(year!, month! - 1, day!, hour!, minute!, second!);
+  }
 }
 
 export function formatDisplayTime(
   date: Date | number,
   timeFormat: TimeFormat,
   options: { showSeconds?: boolean } = {},
+  timeZone?: string,
 ): string {
   const { showSeconds = false } = options;
   const pattern = timeFormat === '24h'
     ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
     : showSeconds ? 'h:mm:ss a' : 'h:mm a';
-  return format(date, pattern);
+  return format(toDisplayDate(date, timeZone), pattern);
 }
 
 export function formatDisplayHour(
   date: Date | number,
   timeFormat: TimeFormat,
   options: { compact?: boolean } = {},
+  timeZone?: string,
 ): string {
   const { compact = false } = options;
   const pattern = timeFormat === '24h'
     ? compact ? 'HH' : 'HH:mm'
     : compact ? 'ha' : 'h a';
-  return format(date, pattern);
+  return format(toDisplayDate(date, timeZone), pattern);
 }
 
 export function formatDisplayTimeRange(
   start: Date | number,
   end: Date | number,
   timeFormat: TimeFormat,
+  timeZone?: string,
 ): string {
+  const displayStart = toDisplayDate(start, timeZone);
+  const displayEnd = toDisplayDate(end, timeZone);
   if (timeFormat === '24h') {
-    return `${format(start, 'HH:mm')}–${format(end, 'HH:mm')}`;
+    return `${format(displayStart, 'HH:mm')}–${format(displayEnd, 'HH:mm')}`;
   }
-  return `${format(start, 'h:mm')}–${format(end, 'h:mm a')}`;
+  return `${format(displayStart, 'h:mm')}–${format(displayEnd, 'h:mm a')}`;
 }

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -108,6 +108,22 @@ export function eventSpansMultipleDisplayDays(
   return getDisplayDateKey(eventStart, timeZone) !== getDisplayDateKey(inclusiveEnd, timeZone);
 }
 
+/** Return true when an event begins on the supplied displayed calendar day. */
+export function eventStartsOnDisplayDay(
+  start: Date | number,
+  allDay: boolean,
+  day: Date,
+  timeZone?: string,
+): boolean {
+  const eventStart = new Date(start);
+  if (Number.isNaN(eventStart.getTime())) return false;
+
+  const dayKey = format(day, 'yyyy-MM-dd');
+  return allDay
+    ? getUtcDateKey(eventStart) === dayKey
+    : getDisplayDateKey(eventStart, timeZone) === dayKey;
+}
+
 /**
  * Return true when an event has completely finished from the viewer's
  * perspective. All-day ranges use their floating, exclusive end date; timed

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -55,6 +55,64 @@ export function getDisplayDateKey(date: Date | number, timeZone?: string): strin
   return format(toDisplayDate(date, timeZone), 'yyyy-MM-dd');
 }
 
+function getUtcDateKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function nextUtcDateKey(date: Date): string {
+  return getUtcDateKey(new Date(Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate() + 1,
+  )));
+}
+
+/**
+ * Test whether an event belongs to a displayed calendar day.
+ *
+ * All-day events are floating date ranges: their UTC date fields are the
+ * intended calendar dates and must not be shifted into the display timezone.
+ * Google uses an exclusive midnight end, while Prism also accepts its legacy
+ * inclusive end-of-day representation.
+ */
+export function eventOccursOnDisplayDay(
+  start: Date | number,
+  end: Date | number,
+  allDay: boolean,
+  day: Date,
+  timeZone?: string,
+): boolean {
+  const eventStart = new Date(start);
+  const eventEnd = new Date(end);
+  if (Number.isNaN(eventStart.getTime()) || Number.isNaN(eventEnd.getTime())) return false;
+
+  if (allDay) {
+    const dayKey = format(day, 'yyyy-MM-dd');
+    const startKey = getUtcDateKey(eventStart);
+    const endIsExclusiveMidnight = eventEnd > eventStart
+      && eventEnd.getUTCHours() === 0
+      && eventEnd.getUTCMinutes() === 0
+      && eventEnd.getUTCSeconds() === 0
+      && eventEnd.getUTCMilliseconds() === 0;
+    const endExclusiveKey = endIsExclusiveMidnight
+      ? getUtcDateKey(eventEnd)
+      : nextUtcDateKey(eventEnd);
+
+    return dayKey >= startKey && dayKey < endExclusiveKey;
+  }
+
+  const dayStart = new Date(day);
+  dayStart.setHours(0, 0, 0, 0);
+  const dayEnd = new Date(dayStart);
+  dayEnd.setDate(dayEnd.getDate() + 1);
+  const displayStart = toDisplayDate(eventStart, timeZone);
+  const displayEnd = toDisplayDate(eventEnd, timeZone);
+  return displayStart < dayEnd && displayEnd > dayStart;
+}
+
 /**
  * Convert date/time fields entered in the selected display timezone into the
  * real instant that should be persisted. This is the inverse of

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -70,6 +70,44 @@ function nextUtcDateKey(date: Date): string {
   )));
 }
 
+function getAllDayExclusiveEndKey(eventStart: Date, eventEnd: Date): string {
+  const startKey = getUtcDateKey(eventStart);
+  const endIsExclusiveMidnight = eventEnd > eventStart
+    && eventEnd.getUTCHours() === 0
+    && eventEnd.getUTCMinutes() === 0
+    && eventEnd.getUTCSeconds() === 0
+    && eventEnd.getUTCMilliseconds() === 0;
+  const endKey = endIsExclusiveMidnight
+    ? getUtcDateKey(eventEnd)
+    : nextUtcDateKey(eventEnd);
+
+  return endKey > startKey ? endKey : nextUtcDateKey(eventStart);
+}
+
+/** Return true when an event occupies more than one displayed calendar day. */
+export function eventSpansMultipleDisplayDays(
+  start: Date | number,
+  end: Date | number,
+  allDay: boolean,
+  timeZone?: string,
+): boolean {
+  const eventStart = new Date(start);
+  const eventEnd = new Date(end);
+  if (
+    Number.isNaN(eventStart.getTime())
+    || Number.isNaN(eventEnd.getTime())
+    || eventEnd <= eventStart
+  ) return false;
+
+  if (allDay) {
+    return getAllDayExclusiveEndKey(eventStart, eventEnd) > nextUtcDateKey(eventStart);
+  }
+
+  // An event ending exactly at midnight does not occupy the following day.
+  const inclusiveEnd = new Date(eventEnd.getTime() - 1);
+  return getDisplayDateKey(eventStart, timeZone) !== getDisplayDateKey(inclusiveEnd, timeZone);
+}
+
 /**
  * Test whether an event belongs to a displayed calendar day.
  *
@@ -92,14 +130,7 @@ export function eventOccursOnDisplayDay(
   if (allDay) {
     const dayKey = format(day, 'yyyy-MM-dd');
     const startKey = getUtcDateKey(eventStart);
-    const endIsExclusiveMidnight = eventEnd > eventStart
-      && eventEnd.getUTCHours() === 0
-      && eventEnd.getUTCMinutes() === 0
-      && eventEnd.getUTCSeconds() === 0
-      && eventEnd.getUTCMilliseconds() === 0;
-    const endExclusiveKey = endIsExclusiveMidnight
-      ? getUtcDateKey(eventEnd)
-      : nextUtcDateKey(eventEnd);
+    const endExclusiveKey = getAllDayExclusiveEndKey(eventStart, eventEnd);
 
     return dayKey >= startKey && dayKey < endExclusiveKey;
   }

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -109,6 +109,35 @@ export function eventSpansMultipleDisplayDays(
 }
 
 /**
+ * Return true when an event has completely finished from the viewer's
+ * perspective. All-day ranges use their floating, exclusive end date; timed
+ * events use their real instant. An event that is still in progress is never
+ * treated as past.
+ */
+export function isCalendarEventPast(
+  start: Date | number,
+  end: Date | number,
+  allDay: boolean,
+  now: Date | number = new Date(),
+  timeZone?: string,
+): boolean {
+  const eventStart = new Date(start);
+  const eventEnd = new Date(end);
+  const current = new Date(now);
+  if (
+    Number.isNaN(eventStart.getTime())
+    || Number.isNaN(eventEnd.getTime())
+    || Number.isNaN(current.getTime())
+  ) return false;
+
+  if (allDay) {
+    return getAllDayExclusiveEndKey(eventStart, eventEnd) <= getDisplayDateKey(current, timeZone);
+  }
+
+  return eventEnd <= current;
+}
+
+/**
  * Test whether an event belongs to a displayed calendar day.
  *
  * All-day events are floating date ranges: their UTC date fields are the


### PR DESCRIPTION
## Summary

- add a configurable display timezone so households can keep calendar, reminder, weather, and clock times consistent across devices
- preserve floating all-day date boundaries and push edited Google all-day dates back during two-way sync
- render multi-day events as continuous bars across month and multi-week calendars
- improve calendar spacing, past-event treatment, and active/future bar contrast
- show a timed multi-day event's start time only on its true first day across list, agenda, month, week, and day views

## Testing

- `npm run type-check`
- `npx jest src/lib/utils/__tests__/timeFormat.test.ts src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx --runInBand` (25 tests passed)
- production Docker build and `/api/health/ready` smoke test

## Dependency

This is stacked on #253 because the display-timezone work extends its shared time-format provider. Review the commits after `65078be`; once #253 merges, GitHub will automatically reduce this PR to the calendar-specific diff.