### PR TITLE
chore(release): 1.15.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.3] – 2026-08-20
+
 ### Calendar
 - **Deleting a calendar in Google no longer flashes a "Sync failed" error in Prism.** When you remove a calendar from Google, Prism used to surface the resulting "not found" error as an alarming sync failure for a few cycles before auto-disabling the calendar. It now handles that quietly and, once confirmed, labels the calendar **"Removed in Google — auto-disabled"** in Manage calendars so you can see why it went inactive.
 - **Restore a Google calendar you removed by mistake.** Deleting a Google calendar from Prism tombstones it so it won't reappear on your next sign-in — but until now there was no way to undo that. Manage calendars now has a **Removed calendars** section listing anything you've deleted, each with a **Restore** button that brings it back. (The tombstone now remembers the calendar's name, so the list is readable rather than a cryptic id.)

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.2"
+version: "1.15.3"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.3.

**Calendar** — restore removed Google calendars (Manage calendars → Removed calendars → Restore) on a reusable tombstone helper + UI component (#262); and deleting a calendar in Google no longer flashes a "Sync failed" error — it's handled quietly and labeled "Removed in Google".

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG.