### PR TITLE
fix(calendar): make Review removals list natively scrollable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Calendar
+- **The "Review removals" window now scrolls to show every item.** When the sync holds a lot of removed events for review (Delete vs. Keep in your local calendar), the list is now natively scrollable — including drag-to-scroll on touch wall displays — and the Delete/Keep buttons stay pinned at the bottom, so a long list is fully reachable instead of clipped.
+
 ## [1.15.3] – 2026-08-20
 
 ### Calendar

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -5,7 +5,6 @@ import { format, parseISO } from 'date-fns';
 import { AlertTriangle, ArrowRight, Home } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Dialog,
   DialogContent,
@@ -53,7 +52,7 @@ export function PendingDeletionsModal({
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
@@ -61,7 +60,7 @@ export function PendingDeletionsModal({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-3 py-1">
+        <div className="space-y-3 py-1 flex-1 min-h-0 flex flex-col">
           <p className="text-sm text-muted-foreground">
             These events were removed from their source calendar and held for review.{' '}
             <span className="font-medium text-foreground">Delete</span> removes them from Prism too.{' '}
@@ -82,7 +81,9 @@ export function PendingDeletionsModal({
             Select all ({selected.size}/{pending.length})
           </label>
 
-          <ScrollArea className="max-h-[45vh] pr-3">
+          {/* Native scroll (not Radix ScrollArea) so the list drag-scrolls on
+              touch wall displays and can't clip when the list is long. */}
+          <div className="flex-1 min-h-0 overflow-y-auto pr-3 -mr-1">
             <div className="space-y-1">
               {pending.map((p) => (
                 <label
@@ -114,7 +115,7 @@ export function PendingDeletionsModal({
                 </label>
               ))}
             </div>
-          </ScrollArea>
+          </div>
         </div>
 
         <DialogFooter className="gap-2">


### PR DESCRIPTION
## Symptom
The calendar sync's "Review removals" window (Delete vs. Keep-in-local) can't be scrolled on a touch wall display, so a long list is cut off and unreachable.

## Cause
The list was wrapped in Radix `ScrollArea` with `max-h-[45vh]`. Radix `ScrollArea` clips overflow when it can't establish a scroll height and doesn't drag-scroll reliably on touch, so items past the cap were hidden with no way to reach them.

## Fix
- Swap `ScrollArea` for a native `overflow-y-auto` container (drag-scrolls on touch out of the box).
- Make `DialogContent` a `flex flex-col` capped at `max-h-[85vh]`, with the list area `flex-1 min-h-0`, so the list fills the available space and scrolls while the header and Delete/Keep footer stay pinned.

Only `PendingDeletionsModal` used this pattern. `tsc` clean, eslint clean.