### PR TITLE
chore(release): 1.15.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.4] – 2026-08-20
+
 ### Calendar
 - **The "Review removals" window now scrolls to show every item.** When the sync holds a lot of removed events for review (Delete vs. Keep in your local calendar), the list is now natively scrollable — including drag-to-scroll on touch wall displays — and the Delete/Keep buttons stay pinned at the bottom, so a long list is fully reachable instead of clipped.
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.3"
+version: "1.15.4"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.4.

**Calendar** — the sync's 'Review removals' window (Delete vs. Keep-in-local) is now natively scrollable, including drag-scroll on touch displays, with the action buttons pinned (#265).

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG.