### PR TITLE
feat(integrations): configure Google OAuth in the app (no .env) + auth-guard credential endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Integrations
+- **Set up Google Calendar entirely in the app — no `.env` file needed.** You can now enter your Google OAuth credentials (Client ID, Secret, Redirect URI) directly in Settings → Integrations → Google, stored encrypted in Prism's database. This unblocks Home Assistant addon and other installs where you can't edit `.env` — previously the Google card only pointed you at `.env`, so there was no way to configure it. (Microsoft already worked this way; Google now matches.)
+
+### Security
+- **The OAuth credential-save endpoints now require an admin.** `/api/setup/credentials/google` and `/api/setup/credentials/microsoft` were unauthenticated; they now require a signed-in user with settings-management permission before storing app credentials.
+
 ## [1.15.4] – 2026-08-20
 
 ### Calendar

--- a/src/app/api/setup/credentials/google/route.ts
+++ b/src/app/api/setup/credentials/google/route.ts
@@ -8,8 +8,14 @@ import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { encrypt } from '@/lib/utils/crypto';
+import { requireAuth, requireRole } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
   try {
     const body = await request.json() as {
       clientId?: string;

--- a/src/app/api/setup/credentials/microsoft/route.ts
+++ b/src/app/api/setup/credentials/microsoft/route.ts
@@ -7,8 +7,14 @@ import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { encrypt } from '@/lib/utils/crypto';
+import { requireAuth, requireRole } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
   try {
     const body = await request.json() as {
       clientId?: string;

--- a/src/app/settings/sections/integrations/cards/GoogleCredentialsForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleCredentialsForm.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+
+/**
+ * Admin form to set/rotate the Google OAuth *app* credentials — Client ID,
+ * Client Secret, Redirect URI. Saved encrypted to the DB (settings key
+ * 'credentials.google'), which takes precedence over .env — so Home Assistant
+ * addon and other no-shell installs can configure Google Calendar entirely from
+ * the UI, without touching a .env file. Write-only: the stored secret is never
+ * read back to the UI.
+ */
+export function GoogleCredentialsForm({ onSaved }: { onSaved?: () => void }) {
+  const [clientId, setClientId] = React.useState('');
+  const [clientSecret, setClientSecret] = React.useState('');
+  const defaultRedirect =
+    typeof window !== 'undefined' ? `${window.location.origin}/api/auth/google/callback` : '';
+  const [redirectUri, setRedirectUri] = React.useState(defaultRedirect);
+  const [saving, setSaving] = React.useState(false);
+
+  const canSave = clientId.trim() && clientSecret.trim() && redirectUri.trim() && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const res = await fetch('/api/setup/credentials/google', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clientId: clientId.trim(),
+          clientSecret: clientSecret.trim(),
+          redirectUri: redirectUri.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to save credentials');
+      }
+      toast({ title: 'Google credentials saved', description: 'You can now connect Google Calendar / Tasks.' });
+      setClientSecret('');
+      onSaved?.();
+    } catch (err) {
+      toast({
+        title: 'Could not save credentials',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    'h-9 w-full rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        In the{' '}
+        <a
+          href="https://console.cloud.google.com/apis/credentials"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Google Cloud Console
+        </a>
+        , enable the <span className="font-medium">Google Calendar API</span> (and{' '}
+        <span className="font-medium">Tasks API</span> if you want tasks), then create an{' '}
+        <span className="font-medium">OAuth 2.0 Client ID</span> of type{' '}
+        <span className="font-medium">Web application</span>. Add the Redirect URI below to the
+        client&apos;s <span className="font-medium">Authorized redirect URIs</span>, and add your
+        Google account as a <span className="font-medium">Test user</span> on the OAuth consent
+        screen (or publish it). Then paste the Client ID and Secret here — no{' '}
+        <code className="text-xs bg-muted px-1 py-0.5 rounded">.env</code> editing needed.
+      </p>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client ID</span>
+        <input
+          className={inputClass}
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="1234567890-abc123.apps.googleusercontent.com"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client secret</span>
+        <input
+          className={inputClass}
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          placeholder="Paste the client secret"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Redirect URI</span>
+        <input
+          className={inputClass}
+          value={redirectUri}
+          onChange={(e) => setRedirectUri(e.target.value)}
+          spellCheck={false}
+        />
+        <span className="text-[11px] text-muted-foreground">
+          Copy this exact value into your Google OAuth client&apos;s Authorized redirect URIs.
+        </span>
+      </label>
+
+      <Button size="sm" onClick={handleSave} disabled={!canSave}>
+        {saving ? 'Saving…' : 'Save credentials'}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { ProviderCardShell } from '../shared/ProviderCardShell';
 import { CollapsibleSubSection } from '../shared/CollapsibleSubSection';
+import { GoogleCredentialsForm } from './GoogleCredentialsForm';
 import type { IntegrationStatus } from '../shared/useIntegrationStatus';
 import type { ConnectionStatus } from '../shared/ConnectionStatusBadge';
 import { connectedAsLabel } from '../shared/connectedAs';
@@ -167,22 +168,26 @@ export function GoogleProviderCard({
           <CollapsibleSubSection
             id="google-setup"
             label="One-time admin setup"
-            summary="Requires a Google Cloud OAuth client"
+            summary="Enter your Google Cloud OAuth credentials"
             defaultOpen
           >
-            <p className="text-sm text-muted-foreground">
-              An admin needs to create a Google Cloud OAuth client and set{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">GOOGLE_CLIENT_ID</code>,{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">GOOGLE_CLIENT_SECRET</code>, and{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">GOOGLE_REDIRECT_URI</code> in{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">.env</code> (see{' '}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">.env.example</code>). No credentials?
-              Use{' '}
+            <GoogleCredentialsForm onSaved={() => window.location.reload()} />
+            <p className="text-xs text-muted-foreground mt-3">
+              Prefer no setup? Use{' '}
               <Link href="/calendar?manage=calendars" className="text-primary hover:underline">
                 iCal subscriptions
               </Link>{' '}
-              for keyless, read-only calendars in the meantime.
+              for keyless, read-only calendars.
             </p>
+          </CollapsibleSubSection>
+        )}
+        {configured && !connected && (
+          <CollapsibleSubSection
+            id="google-credentials"
+            label="App credentials (advanced)"
+            summary="Update the Google client ID / secret / redirect — e.g. after a secret rotates"
+          >
+            <GoogleCredentialsForm onSaved={() => window.location.reload()} />
           </CollapsibleSubSection>
         )}
         {connected && (


### PR DESCRIPTION
## Problem (from a HA add-on user)
> installed prism as a HA Add-on and love it… struggling to get Google Calendar set up. Can't figure out how to edit the google auth in the .env file with it installed through the add-on store.

They're not missing anything — **there was no in-app way to set Google credentials.** The Google card only said *"set `GOOGLE_CLIENT_ID`/`SECRET` in `.env`"*, which HA add-on (and other no-shell) installs can't do. Meanwhile the backend already reads creds **DB-first** (`credentials.google`) and a save endpoint existed — and **Microsoft already had an in-app form**. Google just never got one.

## Fix
- **`GoogleCredentialsForm`** — Client ID / Secret / Redirect URI, posts to the existing `/api/setup/credentials/google` (encrypted DB storage). Mirrors `MicrosoftCredentialsForm`, with Google-Cloud-specific guidance.
- **`GoogleProviderCard`** — replaced the `.env`-only text with the form (one-time setup) and added an advanced *rotate credentials* section. `oauth-status` is DB-aware (`getGoogleCredentials()`), so after saving, the card flips to a **Connect** button — full flow, no `.env`.
- **Security:** `/api/setup/credentials/google` and `/api/setup/credentials/microsoft` were **unauthenticated** — anyone could overwrite the stored OAuth app creds. Both now require `requireAuth` + `canModifySettings`.

Directly serves the self-serve/HA-friendly goal (#178): non-technical hosted users hit this exact wall.

## Checks
`tsc` clean · eslint clean. Verified the status endpoint is DB-aware so the configured→Connect transition works end-to-end.