### PR TITLE
chore(release): 1.15.5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.15.5] – 2026-08-20
+
 ### Integrations
 - **Set up Google Calendar entirely in the app — no `.env` file needed.** You can now enter your Google OAuth credentials (Client ID, Secret, Redirect URI) directly in Settings → Integrations → Google, stored encrypted in Prism's database. This unblocks Home Assistant addon and other installs where you can't edit `.env` — previously the Google card only pointed you at `.env`, so there was no way to configure it. (Microsoft already worked this way; Google now matches.)
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.4"
+version: "1.15.5"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release 1.15.5.

**Integrations** — configure Google OAuth entirely in the app (Settings → Integrations → Google), no .env needed — unblocks Home Assistant addon / no-shell installs (#267). **Security** — the Google/Microsoft credential-save endpoints now require an admin.

Bumps package.json + ha-app/config.yaml + migrates CHANGELOG.