### PR TITLE
feat(display): family-wide 12/24h + display-timezone preference (lands #253 by @m4rtski)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Display
+- **Choose 12-hour or 24-hour time, family-wide.** A new time-format preference under Settings → Display applies everywhere times appear — clocks, weather, every calendar view, and the Away/Babysitter overlays — instead of each surface deciding on its own. Thanks to @m4rtski for the contribution.
+- **Pin a display timezone for the household.** You can now set the timezone Prism renders times in (defaults to each device's own, so nothing changes unless you set it) — keeping calendar, reminder, weather, and clock times consistent across devices. Also from @m4rtski's contribution.
+
 ## [1.15.5] – 2026-08-20
 
 ### Integrations

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -65,7 +65,7 @@ import { TaskModal } from '@/app/tasks/TaskModal';
 import { useChoreModals } from '@/app/chores/useChoreModals';
 import type { OverlayItemRef } from '@/components/calendar/cells';
 import type { Chore, Task, Meal } from '@/types';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 const MEAL_TYPE_ORDER = { breakfast: 0, lunch: 1, snack: 2, dinner: 3 } as const;
 const EMPTY_EVENTS: CalendarEvent[] = [];
@@ -750,7 +750,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
   onEdit: () => void;
   onDeleted: () => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const { confirm, dialogProps } = useConfirmDialog();
 
   const handleDelete = async () => {
@@ -774,8 +774,8 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
         <h2 className="text-xl font-bold mb-2">{event.title}</h2>
         <p className="text-sm text-muted-foreground mb-1">
           {event.allDay
-            ? format(event.startTime, 'EEEE, MMMM d')
-            : `${format(event.startTime, 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat)}`}
+            ? format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')
+            : `${format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}`}
         </p>
         {event.location && <p className="text-sm text-muted-foreground mb-4">{event.location}</p>}
         <p className="text-xs text-muted-foreground">{event.calendarName}</p>
@@ -821,6 +821,7 @@ function CalendarDragPreview({
   events: CalendarEvent[];
   mealColor: string;
 }) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const colon = dragId.indexOf(':');
   if (colon === -1) return null;
   const variant = dragId.slice(0, colon) as 'meal' | 'chore' | 'task' | 'event';
@@ -837,7 +838,7 @@ function CalendarDragPreview({
           layout="column"
           stripeColor={ev.color}
           title={ev.title}
-          timeLabel={ev.allDay ? 'All day' : new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' }).format(ev.startTime)}
+          timeLabel={ev.allDay ? 'All day' : formatDisplayTime(ev.startTime, timeFormat, {}, displayTimezone)}
           subtitle={ev.location || ev.calendarName}
         />
       </div>

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -28,7 +28,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { contrastText } from '@/lib/utils/color';
-import { useFamily } from '@/components/providers';
+import { useFamily, useTimeFormat } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { AddEventModal } from '@/components/modals';
@@ -65,6 +65,7 @@ import { TaskModal } from '@/app/tasks/TaskModal';
 import { useChoreModals } from '@/app/chores/useChoreModals';
 import type { OverlayItemRef } from '@/components/calendar/cells';
 import type { Chore, Task, Meal } from '@/types';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 const MEAL_TYPE_ORDER = { breakfast: 0, lunch: 1, snack: 2, dinner: 3 } as const;
 const EMPTY_EVENTS: CalendarEvent[] = [];
@@ -749,6 +750,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
   onEdit: () => void;
   onDeleted: () => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const { confirm, dialogProps } = useConfirmDialog();
 
   const handleDelete = async () => {
@@ -773,7 +775,7 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
         <p className="text-sm text-muted-foreground mb-1">
           {event.allDay
             ? format(event.startTime, 'EEEE, MMMM d')
-            : `${format(event.startTime, 'EEEE, MMMM d')} at ${format(event.startTime, 'h:mm a')}`}
+            : `${format(event.startTime, 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat)}`}
         </p>
         {event.location && <p className="text-sm text-muted-foreground mb-4">{event.location}</p>}
         <p className="text-xs text-muted-foreground">{event.calendarName}</p>

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -14,6 +14,8 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import type { PendingDeletion } from '@/lib/hooks/usePendingDeletions';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 /**
  * Deletes-only review (#171 Stage 3). Lists events the sync found removed from
@@ -29,6 +31,7 @@ export function PendingDeletionsModal({
   onApply: (eventIds: string[], action: 'delete' | 'keep') => Promise<boolean>;
   onClose: () => void;
 }) {
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
   const [busy, setBusy] = useState(false);
 
@@ -94,8 +97,8 @@ export function PendingDeletionsModal({
                     <span className="font-medium">{p.title}</span>
                     <span className="block text-xs text-muted-foreground">
                       {p.allDay
-                        ? format(parseISO(p.startTime), 'EEE, MMM d')
-                        : format(parseISO(p.startTime), 'EEE, MMM d · p')}
+                        ? format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')
+                        : `${format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')} · ${formatDisplayTime(parseISO(p.startTime), timeFormat, {}, displayTimezone)}`}
                     </span>
                     <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground flex-wrap">
                       <span className="inline-flex items-center gap-1 min-w-0">

--- a/src/app/calendar/useCalendarViewData.ts
+++ b/src/app/calendar/useCalendarViewData.ts
@@ -17,6 +17,8 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { deduplicateEvents } from '@/lib/utils/calendarDedup';
 import { getFullCalendarRange, MAX_CALENDAR_EVENTS } from '@/lib/utils/calendarRange';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export type CalendarViewType = 'agenda' | 'day' | 'week' | 'weekVertical' | 'multiWeek' | 'month' | 'threeMonth';
 export type MultiWeekCount = 1 | 2 | 3 | 4;
@@ -25,7 +27,12 @@ export type { CalendarGroup } from '@/lib/hooks';
 
 export function useCalendarViewData() {
   const { weekStartsOn } = useWeekStartsOn();
+  const { displayTimezone } = useTimeFormat();
   const [currentDate, setCurrentDate] = useState(new Date());
+
+  useEffect(() => {
+    setCurrentDate(toDisplayDate(new Date(), displayTimezone));
+  }, [displayTimezone]);
   const [viewType, setViewType] = useState<CalendarViewType>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('prism-calendar-view-type') as CalendarViewType | null;
@@ -138,7 +145,10 @@ export function useCalendarViewData() {
     return deduplicateEvents(filterEvents(mapped));
   }, [apiEvents, filterEvents]);
 
-  const goToToday = useCallback(() => setCurrentDate(new Date()), []);
+  const goToToday = useCallback(
+    () => setCurrentDate(toDisplayDate(new Date(), displayTimezone)),
+    [displayTimezone],
+  );
 
   const goToPrevious = useCallback(() => {
     setCurrentDate(prev => {

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -16,6 +16,7 @@ import { useScreensaverTimeout } from '@/lib/hooks/useScreensaverTimeout';
 import { useAutoHideUI } from '@/lib/hooks/useAutoHideUI';
 import { useAwayModeTimeout } from '@/lib/hooks/useAwayModeTimeout';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
+import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 function getCurrentMonthNum(): number {
   return new Date().getMonth() + 1;
@@ -172,6 +173,8 @@ export function DisplaySection() {
 
       <SectionDivider label="Wallpaper & Display" />
 
+      <TimeFormatCard />
+
       <PerformanceModeCard />
 
       <WallpaperSettingsCard />
@@ -184,6 +187,53 @@ export function DisplaySection() {
 
       <WeatherUnitsCard />
     </div>
+  );
+}
+
+function TimeFormatCard() {
+  const { timeFormat, setTimeFormat } = useTimeFormat();
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(async (next: TimeFormat) => {
+    setSaving(true);
+    try {
+      await setTimeFormat(next);
+    } catch {
+      // The provider rolls back the optimistic change on failure.
+    } finally {
+      setSaving(false);
+    }
+  }, [setTimeFormat]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Time format</CardTitle>
+        <CardDescription>
+          Choose how times appear across the dashboard, weather, and calendar
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
+          {(['12h', '24h'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={timeFormat === value}
+              disabled={saving}
+              onClick={() => save(value)}
+              className={cn(
+                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
+                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
+              )}
+            >
+              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
+            </button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -16,7 +16,6 @@ import { useScreensaverTimeout } from '@/lib/hooks/useScreensaverTimeout';
 import { useAutoHideUI } from '@/lib/hooks/useAutoHideUI';
 import { useAwayModeTimeout } from '@/lib/hooks/useAwayModeTimeout';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
-import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 function getCurrentMonthNum(): number {
   return new Date().getMonth() + 1;
@@ -173,8 +172,6 @@ export function DisplaySection() {
 
       <SectionDivider label="Wallpaper & Display" />
 
-      <TimeFormatCard />
-
       <PerformanceModeCard />
 
       <WallpaperSettingsCard />
@@ -187,53 +184,6 @@ export function DisplaySection() {
 
       <WeatherUnitsCard />
     </div>
-  );
-}
-
-function TimeFormatCard() {
-  const { timeFormat, setTimeFormat } = useTimeFormat();
-  const [saving, setSaving] = useState(false);
-
-  const save = useCallback(async (next: TimeFormat) => {
-    setSaving(true);
-    try {
-      await setTimeFormat(next);
-    } catch {
-      // The provider rolls back the optimistic change on failure.
-    } finally {
-      setSaving(false);
-    }
-  }, [setTimeFormat]);
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Time format</CardTitle>
-        <CardDescription>
-          Choose how times appear across the dashboard, weather, and calendar
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
-          {(['12h', '24h'] as const).map((value) => (
-            <button
-              key={value}
-              type="button"
-              role="radio"
-              aria-checked={timeFormat === value}
-              disabled={saving}
-              onClick={() => save(value)}
-              className={cn(
-                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
-                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
-              )}
-            >
-              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
-            </button>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
   );
 }
 

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -16,13 +16,14 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 import { useLocationSearch } from '@/lib/hooks/useLocationSearch';
 import { listTimezones } from '@/lib/utils/timezone';
-import { useTimeFormat, type TimeFormat } from '@/components/providers';
+import { useTimeFormat, type DisplayTimezoneMode, type TimeFormat } from '@/components/providers';
 
 export function GeneralSection() {
   return (
     <div className="space-y-6">
       <LocationCard />
       <TimezoneCard />
+      <DisplayTimezoneCard />
       <TimeFormatCard />
       <WeekStartCard />
     </div>
@@ -119,8 +120,8 @@ function TimezoneCard() {
       <CardHeader>
         <CardTitle>Time Zone</CardTitle>
         <CardDescription>
-          Used for server-side scheduling and syncs — e.g. placing imported meal-plan times on the
-          right day. On-screen clocks already follow each viewer&apos;s device.
+          The household timezone used for scheduling, calendar sync, and—by default—times shown
+          throughout Prism.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -142,6 +143,70 @@ function TimezoneCard() {
               Use detected ({detected.replace(/_/g, ' ')})
             </Button>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DisplayTimezoneCard() {
+  const {
+    householdTimezone,
+    deviceTimezone,
+    displayTimezoneMode,
+    setDisplayTimezoneMode,
+  } = useTimeFormat();
+
+  const options: Array<{
+    value: DisplayTimezoneMode;
+    label: string;
+    timezone: string;
+    description: string;
+  }> = [
+    {
+      value: 'household',
+      label: 'Household timezone',
+      timezone: householdTimezone,
+      description: 'Keeps appointments and clocks consistent on every Prism display.',
+    },
+    {
+      value: 'device',
+      label: 'This device’s timezone',
+      timezone: deviceTimezone,
+      description: 'Uses this browser’s timezone on this device only.',
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Display Timezone</CardTitle>
+        <CardDescription>
+          Choose which timezone this device uses for calendars, reminders, and clocks. Household
+          timezone is the recommended default.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Display timezone">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={displayTimezoneMode === option.value}
+              onClick={() => setDisplayTimezoneMode(option.value)}
+              className={cn(
+                'min-h-20 rounded-md border p-3 text-left transition-colors',
+                displayTimezoneMode === option.value
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border hover:bg-accent',
+              )}
+            >
+              <span className="block text-sm font-medium">{option.label}</span>
+              <span className="block text-xs font-mono opacity-80">{option.timezone}</span>
+              <span className="mt-1 block text-xs opacity-80">{option.description}</span>
+            </button>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -6,7 +6,7 @@
  * "Appearance" (Location) and "Calendars" (Time zone, Week starts on).
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Search, MapPin, X, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -16,12 +16,14 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { useTimezone, detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 import { useLocationSearch } from '@/lib/hooks/useLocationSearch';
 import { listTimezones } from '@/lib/utils/timezone';
+import { useTimeFormat, type TimeFormat } from '@/components/providers';
 
 export function GeneralSection() {
   return (
     <div className="space-y-6">
       <LocationCard />
       <TimezoneCard />
+      <TimeFormatCard />
       <WeekStartCard />
     </div>
   );
@@ -140,6 +142,53 @@ function TimezoneCard() {
               Use detected ({detected.replace(/_/g, ' ')})
             </Button>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimeFormatCard() {
+  const { timeFormat, setTimeFormat } = useTimeFormat();
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(async (next: TimeFormat) => {
+    setSaving(true);
+    try {
+      await setTimeFormat(next);
+    } catch {
+      // The provider rolls back the optimistic change on failure.
+    } finally {
+      setSaving(false);
+    }
+  }, [setTimeFormat]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Time Format</CardTitle>
+        <CardDescription>
+          Choose how times appear across the dashboard, weather, and calendar.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="inline-flex rounded-md border border-input p-0.5" role="radiogroup" aria-label="Time format">
+          {(['12h', '24h'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={timeFormat === value}
+              disabled={saving}
+              onClick={() => save(value)}
+              className={cn(
+                'min-h-11 px-3 py-1.5 text-sm rounded-sm transition-colors',
+                timeFormat === value ? 'bg-primary text-primary-foreground' : 'hover:bg-accent',
+              )}
+            >
+              {value === '12h' ? '12-hour (2:30 PM)' : '24-hour (14:30)'}
+            </button>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/app/settings/sections/GeneralSection.tsx
+++ b/src/app/settings/sections/GeneralSection.tsx
@@ -165,17 +165,18 @@ function DisplayTimezoneCard() {
   }> = [
     {
       value: 'household',
-      label: 'Household timezone',
+      label: 'Household',
       timezone: householdTimezone,
       description: 'Keeps appointments and clocks consistent on every Prism display.',
     },
     {
       value: 'device',
-      label: 'This device’s timezone',
+      label: 'This device',
       timezone: deviceTimezone,
       description: 'Uses this browser’s timezone on this device only.',
     },
   ];
+  const selected = options.find((option) => option.value === displayTimezoneMode)!;
 
   return (
     <Card>
@@ -187,7 +188,11 @@ function DisplayTimezoneCard() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Display timezone">
+        <div
+          className="inline-flex max-w-full rounded-md border border-input p-0.5"
+          role="radiogroup"
+          aria-label="Display timezone"
+        >
           {options.map((option) => (
             <button
               key={option.value}
@@ -196,18 +201,21 @@ function DisplayTimezoneCard() {
               aria-checked={displayTimezoneMode === option.value}
               onClick={() => setDisplayTimezoneMode(option.value)}
               className={cn(
-                'min-h-20 rounded-md border p-3 text-left transition-colors',
+                'min-h-11 rounded-sm px-3 py-1.5 text-sm transition-colors',
                 displayTimezoneMode === option.value
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border hover:bg-accent',
+                  ? 'bg-primary text-primary-foreground'
+                  : 'hover:bg-accent',
               )}
             >
-              <span className="block text-sm font-medium">{option.label}</span>
-              <span className="block text-xs font-mono opacity-80">{option.timezone}</span>
-              <span className="mt-1 block text-xs opacity-80">{option.description}</span>
+              {option.label}
             </button>
           ))}
         </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Using <span className="font-mono text-xs text-foreground">{selected.timezone}</span>
+          <span aria-hidden="true"> · </span>
+          {selected.description}
+        </p>
       </CardContent>
     </Card>
   );

--- a/src/components/away-mode/AwayModeOverlay.tsx
+++ b/src/components/away-mode/AwayModeOverlay.tsx
@@ -8,6 +8,8 @@ import { usePhotos } from '@/lib/hooks/usePhotos';
 import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } from '@/components/layout/WallpaperBackground';
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import { ExitAwayModeModal } from './ExitAwayModeModal';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export function AwayModeOverlay() {
   const { isAway, toggle } = useAwayMode();
@@ -121,6 +123,7 @@ export function AwayModeOverlay() {
 }
 
 function AwayModeClock() {
+  const { timeFormat } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -131,8 +134,7 @@ function AwayModeClock() {
   return (
     <div className="flex items-center gap-3 text-white">
       <div className="text-3xl font-light tabular-nums">
-        {format(time, 'h:mm')}
-        <span className="text-lg ml-1 opacity-70">{format(time, 'a')}</span>
+        {formatDisplayTime(time, timeFormat)}
       </div>
       <div className="text-sm text-white/60">
         {format(time, 'EEEE, MMMM d')}

--- a/src/components/away-mode/AwayModeOverlay.tsx
+++ b/src/components/away-mode/AwayModeOverlay.tsx
@@ -9,7 +9,7 @@ import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } fro
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import { ExitAwayModeModal } from './ExitAwayModeModal';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export function AwayModeOverlay() {
   const { isAway, toggle } = useAwayMode();
@@ -123,7 +123,7 @@ export function AwayModeOverlay() {
 }
 
 function AwayModeClock() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -134,10 +134,10 @@ function AwayModeClock() {
   return (
     <div className="flex items-center gap-3 text-white">
       <div className="text-3xl font-light tabular-nums">
-        {formatDisplayTime(time, timeFormat)}
+        {formatDisplayTime(time, timeFormat, {}, displayTimezone)}
       </div>
       <div className="text-sm text-white/60">
-        {format(time, 'EEEE, MMMM d')}
+        {format(toDisplayDate(time, displayTimezone), 'EEEE, MMMM d')}
       </div>
     </div>
   );

--- a/src/components/babysitter-mode/BabysitterModeOverlay.tsx
+++ b/src/components/babysitter-mode/BabysitterModeOverlay.tsx
@@ -13,7 +13,7 @@ import { ExitBabysitterModeModal } from './ExitBabysitterModeModal';
 import { WifiQRCode } from '@/components/ui/WifiQRCode';
 import { cn } from '@/lib/utils';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 interface EmergencyContact {
   name: string;
@@ -182,7 +182,7 @@ export function BabysitterModeOverlay() {
 }
 
 function BabysitterClock() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -193,10 +193,10 @@ function BabysitterClock() {
   return (
     <div className="text-white">
       <div className="text-4xl font-light tabular-nums">
-        {formatDisplayTime(time, timeFormat)}
+        {formatDisplayTime(time, timeFormat, {}, displayTimezone)}
       </div>
       <div className="text-sm text-white/60">
-        {format(time, 'EEEE, MMMM d')}
+        {format(toDisplayDate(time, displayTimezone), 'EEEE, MMMM d')}
       </div>
     </div>
   );

--- a/src/components/babysitter-mode/BabysitterModeOverlay.tsx
+++ b/src/components/babysitter-mode/BabysitterModeOverlay.tsx
@@ -12,6 +12,8 @@ import { useWifiConfig } from '@/lib/hooks/useWifiConfig';
 import { ExitBabysitterModeModal } from './ExitBabysitterModeModal';
 import { WifiQRCode } from '@/components/ui/WifiQRCode';
 import { cn } from '@/lib/utils';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 interface EmergencyContact {
   name: string;
@@ -180,6 +182,7 @@ export function BabysitterModeOverlay() {
 }
 
 function BabysitterClock() {
+  const { timeFormat } = useTimeFormat();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {
@@ -190,8 +193,7 @@ function BabysitterClock() {
   return (
     <div className="text-white">
       <div className="text-4xl font-light tabular-nums">
-        {format(time, 'h:mm')}
-        <span className="text-xl ml-2 opacity-70">{format(time, 'a')}</span>
+        {formatDisplayTime(time, timeFormat)}
       </div>
       <div className="text-sm text-white/60">
         {format(time, 'EEEE, MMMM d')}

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -2,8 +2,6 @@
 
 import {
   format,
-  isToday,
-  isTomorrow,
   isSameDay,
   addDays,
   startOfDay,
@@ -17,7 +15,7 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -72,8 +70,9 @@ export function AgendaView({
   mealColor,
   onItemClick,
 }: AgendaViewProps) {
+  const { displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
-  const startDate = startOfDay(new Date());
+  const startDate = startOfDay(toDisplayDate(new Date(), displayTimezone));
   const endDate = addDays(startDate, days);
 
   const filteredEvents = events
@@ -81,11 +80,12 @@ export function AgendaView({
       if (e.allDay) {
         return e.startTime < endDate && e.endTime > startDate;
       }
-      const ed = startOfDay(e.startTime);
+      const ed = startOfDay(toDisplayDate(e.startTime, displayTimezone));
       return ed >= startDate && ed < endDate;
     })
     .sort((a, b) => {
-      const dc = startOfDay(a.startTime).getTime() - startOfDay(b.startTime).getTime();
+      const dc = startOfDay(toDisplayDate(a.startTime, displayTimezone)).getTime()
+        - startOfDay(toDisplayDate(b.startTime, displayTimezone)).getTime();
       if (dc !== 0) return dc;
       if (a.allDay && !b.allDay) return -1;
       if (!a.allDay && b.allDay) return 1;
@@ -99,7 +99,7 @@ export function AgendaView({
     const dayEvents = filteredEvents.filter(e =>
       e.allDay
         ? e.startTime <= dayStart && e.endTime > dayStart
-        : isSameDay(e.startTime, date)
+        : isSameDay(toDisplayDate(e.startTime, displayTimezone), date)
     );
     const bucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
     const hasOverlay = bucket && (bucket.meals.length + bucket.chores.length + bucket.tasks.length > 0);
@@ -160,9 +160,9 @@ function AgendaDaySection({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat });
+  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -179,12 +179,12 @@ function AgendaDaySection({
         <span
           className={cn(
             'text-sm font-semibold',
-            isToday(date) && 'text-seasonal-accent'
+            isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && 'text-seasonal-accent'
           )}
         >
-          {formatAgendaDayHeader(date)}
+          {formatAgendaDayHeader(date, displayTimezone)}
         </span>
-        {isToday(date) && (
+        {isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && (
           <Badge className="text-[10px] px-1.5 py-0 bg-seasonal-highlight text-foreground">
             Today
           </Badge>
@@ -212,6 +212,7 @@ function buildAgendaRows({
   mealColor,
   onItemClick,
   timeFormat,
+  displayTimezone,
 }: {
   events: CalendarEvent[];
   bucket?: DayBucket;
@@ -219,6 +220,7 @@ function buildAgendaRows({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
   timeFormat: TimeFormat;
+  displayTimezone: string;
 }): AgendaRow[] {
   const rows: AgendaRow[] = [];
 
@@ -228,10 +230,11 @@ function buildAgendaRows({
       key: `event-${event.id}`,
       sortMinutes: allDay
         ? -1
-        : event.startTime.getHours() * 60 + event.startTime.getMinutes(),
+        : toDisplayDate(event.startTime, displayTimezone).getHours() * 60
+          + toDisplayDate(event.startTime, displayTimezone).getMinutes(),
       floating: allDay,
       stripeColor: event.color,
-      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat),
+      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone),
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,
@@ -366,9 +369,10 @@ function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean
   );
 }
 
-function formatAgendaDayHeader(date: Date): string {
+function formatAgendaDayHeader(date: Date, displayTimezone: string): string {
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const dayName = format(date, 'EEEE, MMMM d, yyyy');
-  if (isToday(date)) return `Today - ${dayName}`;
-  if (isTomorrow(date)) return `Tomorrow - ${dayName}`;
+  if (isSameDay(date, displayNow)) return `Today - ${dayName}`;
+  if (isSameDay(date, addDays(displayNow, 1))) return `Tomorrow - ${dayName}`;
   return dayName;
 }

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -16,6 +16,8 @@ import { Badge } from '@/components/ui';
 import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useDayDroppable, getMealTime, getChoreTime, getTaskTime, parseTimeOfDay, formatTimeOfDay, type OverlayItemRef } from './cells';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -158,8 +160,9 @@ function AgendaDaySection({
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick });
+  const rows = buildAgendaRows({ events, bucket, onEventClick, mealColor, onItemClick, timeFormat });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -208,12 +211,14 @@ function buildAgendaRows({
   onEventClick,
   mealColor,
   onItemClick,
+  timeFormat,
 }: {
   events: CalendarEvent[];
   bucket?: DayBucket;
   onEventClick?: (event: CalendarEvent) => void;
   mealColor?: string;
   onItemClick?: (ref: OverlayItemRef) => void;
+  timeFormat: TimeFormat;
 }): AgendaRow[] {
   const rows: AgendaRow[] = [];
 
@@ -226,7 +231,7 @@ function buildAgendaRows({
         : event.startTime.getHours() * 60 + event.startTime.getMinutes(),
       floating: allDay,
       stripeColor: event.color,
-      timeLabel: allDay ? 'All day' : format(event.startTime, 'h:mm a'),
+      timeLabel: allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat),
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,
@@ -243,7 +248,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `meal:${meal.id}`,
         stripeColor: mealColor ?? meal.cookedBy?.color ?? meal.createdBy?.color ?? MEAL_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t) : meal.mealType,
+        timeLabel: min !== null ? formatTimeLabel(t, timeFormat) : meal.mealType,
         title: meal.name,
         subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
         muted: Boolean(meal.cookedAt),
@@ -259,7 +264,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `chore:${chore.id}`,
         stripeColor: chore.assignedTo?.color || CHORE_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!) : 'Chore',
+        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Chore',
         title: chore.title,
         subtitle: chore.assignedTo?.name,
         pendingApproval: Boolean(chore.pendingApproval),
@@ -275,7 +280,7 @@ function buildAgendaRows({
         floating: min === null,
         dragId: `task:${task.id}`,
         stripeColor: task.assignedTo?.color || TASK_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!) : 'Task',
+        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Task',
         title: task.title,
         subtitle: task.assignedTo?.name,
         muted: task.completed,
@@ -294,8 +299,8 @@ function buildAgendaRows({
   return rows;
 }
 
-function formatTimeLabel(hhmm: string): string {
-  return formatTimeOfDay(hhmm);
+function formatTimeLabel(hhmm: string, timeFormat: TimeFormat): string {
+  return formatTimeOfDay(hhmm, timeFormat);
 }
 
 function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean }) {

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -20,7 +20,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
+import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -59,7 +59,7 @@ export function DayViewSideBySide({
   mealColor,
   onItemClick,
 }: DayViewSideBySideProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const droppable = useDayDroppable({ date: currentDate, enabled: cards && enableDnd });
   const bgOverride = useWidgetBgOverride();
@@ -72,7 +72,7 @@ export function DayViewSideBySide({
   const { settings: hiddenSettings, toggleHidden, getVisibleHours } = useHiddenHours();
 
   // Time tracking
-  const now = new Date();
+  const now = toDisplayDate(new Date(), displayTimezone);
   const isCurrentDay = isSameDay(currentDate, now);
   const isPastDay = isBefore(startOfDay(currentDate), startOfDay(now)) && !isCurrentDay;
   const currentHour = now.getHours();
@@ -81,16 +81,22 @@ export function DayViewSideBySide({
 
   // Get visible hours (filtered if hidden mode is enabled)
   const dayStart = startOfDay(currentDate);
-  const dayEvents = events.filter((event) =>
-    event.allDay
-      ? event.startTime <= dayStart && event.endTime > dayStart
-      : isSameDay(event.startTime, currentDate)
-  );
+  const dayEvents = events.filter((event) => {
+    const displayStart = toDisplayDate(event.startTime, displayTimezone);
+    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+    return event.allDay
+      ? displayStart <= dayStart && displayEnd > dayStart
+      : isSameDay(displayStart, currentDate);
+  });
 
   const allDayEvents = dayEvents.filter((e) => e.allDay);
   const timedEvents = dayEvents.filter((e) => !e.allDay);
 
-  const hours = getVisibleHours(timedEvents, { from: dayStart, to: addDays(dayStart, 1) });
+  const hours = getVisibleHours(timedEvents.map((event) => ({
+    ...event,
+    startTime: toDisplayDate(event.startTime, displayTimezone),
+    endTime: toDisplayDate(event.endTime, displayTimezone),
+  })), { from: dayStart, to: addDays(dayStart, 1) });
 
   // If there are no calendar groups configured or merged view is on, show all events in a single column
   const showAllInOne = calendarGroups.length === 0 || mergedView;
@@ -298,7 +304,7 @@ export function DayViewSideBySide({
                   style={{ gridTemplateRows: `repeat(${hours.length}, 1fr)` }}
                 >
                   {hours.map((hour) => {
-                    const hourEvents = calEvents.filter((event) => event.startTime.getHours() === hour);
+                    const hourEvents = calEvents.filter((event) => toDisplayDate(event.startTime, displayTimezone).getHours() === hour);
                     const isPastHour = isPastDay || (isCurrentDay && hour < currentHour);
                     const isNowHour = isCurrentDay && hour === currentHour;
                     return (
@@ -328,7 +334,7 @@ export function DayViewSideBySide({
                                 cards
                                   ? {
                                       borderLeft: `3px solid ${event.color}`,
-                                      top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                                      top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                                       height: `calc(${heightPct}% - 4px)`,
                                       left: css.left,
                                       width: css.width,
@@ -337,7 +343,7 @@ export function DayViewSideBySide({
                                       backgroundColor: event.color,
                                       color: '#fff',
                                       borderLeft: `2px solid ${event.color}`,
-                                      top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                                      top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                                       height: `${heightPct}%`,
                                       left: css.left,
                                       width: css.width,
@@ -350,7 +356,7 @@ export function DayViewSideBySide({
                               <div className={cn('font-medium truncate w-full text-[11px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {durationMin >= 60 && (
                                 <div className={cn('text-[9px] leading-tight', cards ? 'text-muted-foreground' : 'opacity-70')}>
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                             </button>

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -19,6 +19,8 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -57,6 +59,7 @@ export function DayViewSideBySide({
   mealColor,
   onItemClick,
 }: DayViewSideBySideProps) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const droppable = useDayDroppable({ date: currentDate, enabled: cards && enableDnd });
   const bgOverride = useWidgetBgOverride();
@@ -253,7 +256,7 @@ export function DayViewSideBySide({
                     isPastHour && 'bg-muted/15',
                     isNowHour && 'bg-primary text-primary-foreground font-semibold rounded-sm'
                   )}>
-                    {format(new Date().setHours(hour, 0), 'h a')}
+                    {formatDisplayHour(new Date().setHours(hour, 0), timeFormat)}
                     {isNowHour && (
                       <div className="absolute left-0 right-0 border-t-2 border-t-primary z-20 pointer-events-none" style={{ top: `${currentMinuteSnapped}%` }} />
                     )}
@@ -347,7 +350,7 @@ export function DayViewSideBySide({
                               <div className={cn('font-medium truncate w-full text-[11px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {durationMin >= 60 && (
                                 <div className={cn('text-[9px] leading-tight', cards ? 'text-muted-foreground' : 'opacity-70')}>
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                             </button>
@@ -410,6 +413,7 @@ function DayTimedBucketLayer({
   enableDnd: boolean;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const slotPct = 100 / hours.length;
   const visibleSet = new Set(hours);
 
@@ -440,7 +444,7 @@ function DayTimedBucketLayer({
       dragId: `meal:${meal.id}`,
       variant: 'meal',
       title: meal.name,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
       stripeColor: mealColor ?? '#10b981',
       muted: Boolean(meal.cookedAt),
@@ -460,7 +464,7 @@ function DayTimedBucketLayer({
       dragId: `chore:${chore.id}`,
       variant: 'chore',
       title: chore.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: chore.assignedTo?.name,
       stripeColor: chore.assignedTo?.color || '#f59e0b',
       pendingApproval: Boolean(chore.pendingApproval),
@@ -480,7 +484,7 @@ function DayTimedBucketLayer({
       dragId: `task:${task.id}`,
       variant: 'task',
       title: task.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: task.assignedTo?.name,
       stripeColor: task.assignedTo?.color || '#3b82f6',
       muted: task.completed,

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -10,7 +10,6 @@ import {
   addDays,
   isSameMonth,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getMonth,
@@ -26,7 +25,7 @@ import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppa
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -61,6 +60,8 @@ export function MonthView({
   enableDnd = false,
   onItemClick,
 }: MonthViewProps) {
+  const { displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const [cardHeight, setCardHeight] = React.useState<number | undefined>(undefined);
@@ -116,18 +117,20 @@ export function MonthView({
         {days.map((date, index) => {
           const dayStart = startOfDay(date);
           const dayEvents = events
-            .filter((event) =>
-              event.allDay
-                ? event.startTime <= dayStart && event.endTime > dayStart
-                : isSameDay(event.startTime, date)
-            )
+            .filter((event) => {
+              const displayStart = toDisplayDate(event.startTime, displayTimezone);
+              const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+              return event.allDay
+                ? displayStart <= dayStart && displayEnd > dayStart
+                : isSameDay(displayStart, date);
+            })
             .sort((a, b) => {
               if (a.allDay && !b.allDay) return -1;
               if (!a.allDay && b.allDay) return 1;
               return a.startTime.getTime() - b.startTime.getTime();
             });
 
-          const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+          const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
 
           return (
             <MonthDayCell
@@ -190,7 +193,8 @@ function MonthDayCell({
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const today = isSameDay(date, toDisplayDate(new Date(), displayTimezone));
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
 
   return (
@@ -210,7 +214,7 @@ function MonthDayCell({
       style={cellBgStyle}
     >
       {/* Today gets a blue bar; other days just show the date */}
-      {isToday(date) ? (
+      {today ? (
         <div className="bg-primary px-1 py-0.5 mb-0.5 rounded-t-[3px]">
           <span className="text-sm font-bold text-primary-foreground">{format(date, 'd')}</span>
         </div>
@@ -248,7 +252,7 @@ function MonthDayCell({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
             </li>
           ))}
         </ul>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -25,6 +25,8 @@ import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -188,6 +190,7 @@ function MonthDayCell({
   onEventClick: (event: CalendarEvent) => void;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
 
   return (
@@ -245,7 +248,7 @@ function MonthDayCell({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${format(event.startTime, 'h:mm a')} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
             </li>
           ))}
         </ul>

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -26,6 +26,8 @@ function getMonthAccentColor(date: Date): string {
 }
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -168,6 +170,7 @@ function DayCell({
       the row to grow to accommodate the day with the most events. */
   showAll?: boolean;
 }) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
   const dayStart = startOfDay(date);
@@ -320,7 +323,7 @@ function DayCell({
                   layout="column"
                   stripeColor={event.color}
                   title={event.title}
-                  timeLabel={event.allDay ? 'All day' : format(event.startTime, 'h:mm a')}
+                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat)}
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}
@@ -340,7 +343,7 @@ function DayCell({
                   : { color: event.color }
                 }
               >
-                {event.allDay ? event.title : `${format(event.startTime, 'h:mm')} ${event.title}`}
+                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
               </button>
             ))}
         {cards && hiddenEvents.length > 0 && (

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -6,8 +6,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
-  isTomorrow,
   isBefore,
   startOfDay,
 } from 'date-fns';
@@ -27,7 +25,7 @@ function getMonthAccentColor(date: Date): string {
 import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -170,21 +168,24 @@ function DayCell({
       the row to grow to accommodate the day with the most events. */
   showAll?: boolean;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
   const dayStart = startOfDay(date);
-  const dayEvents = events.filter((event) =>
-    event.allDay
-      ? event.startTime <= dayStart && event.endTime > dayStart
-      : isSameDay(event.startTime, date)
-  );
+  const dayEvents = events.filter((event) => {
+    const displayStart = toDisplayDate(event.startTime, displayTimezone);
+    const displayEnd = toDisplayDate(event.endTime, displayTimezone);
+    return event.allDay
+      ? displayStart <= dayStart && displayEnd > dayStart
+      : isSameDay(displayStart, date);
+  });
   const sorted = [...dayEvents].sort((a, b) => {
     if (a.allDay && !b.allDay) return -1;
     if (!a.allDay && b.allDay) return 1;
     return a.startTime.getTime() - b.startTime.getTime();
   });
-  const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
+  const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
 
   // Overlay items render in the same flex container as events (meals at top,
   // chores+tasks at bottom). They are ALWAYS rendered when present, so the
@@ -225,8 +226,8 @@ function DayCell({
   const visibleEvents = cards ? sorted.slice(0, Math.max(0, visibleCount)) : sorted;
   const hiddenEvents = cards ? sorted.slice(visibleEvents.length) : [];
 
-  const today = isToday(date);
-  const tomorrow = isTomorrow(date);
+  const today = isSameDay(date, displayNow);
+  const tomorrow = isSameDay(date, addDays(displayNow, 1));
   const dayLabel = today
     ? 'Today'
     : tomorrow
@@ -323,7 +324,7 @@ function DayCell({
                   layout="column"
                   stripeColor={event.color}
                   title={event.title}
-                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat)}
+                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}
@@ -343,7 +344,7 @@ function DayCell({
                   : { color: event.color }
                 }
               >
-                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+                {event.allDay ? event.title : `${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
               </button>
             ))}
         {cards && hiddenEvents.length > 0 && (

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -11,7 +11,6 @@ import {
   subMonths,
   isSameMonth,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getMonth,
@@ -23,6 +22,8 @@ import { useOrientation } from '@/lib/hooks/useOrientation';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -56,6 +57,8 @@ function MiniMonth({
   isCenter: boolean;
   bordered?: boolean;
 }) {
+  const { displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const { weekStartsOn } = useWeekStartsOn();
   const dayNames = [...ALL_DAY_NAMES.slice(weekStartsOn), ...ALL_DAY_NAMES.slice(0, weekStartsOn)];
   const bgOverride = useWidgetBgOverride();
@@ -108,15 +111,17 @@ function MiniMonth({
           <div key={weekIndex} className="flex-1 grid grid-cols-7 gap-px min-h-0">
             {week.map((date, dayIndex) => {
               const inMonth = isSameMonth(date, month);
-              const today = isToday(date);
-              const isPast = isBefore(date, startOfDay(new Date())) && !today;
+              const today = isSameDay(date, displayNow);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !today;
               const dayStart = startOfDay(date);
               const dayEvents = events
-                .filter((e) =>
-                  e.allDay
-                    ? e.startTime <= dayStart && e.endTime > dayStart
-                    : isSameDay(e.startTime, date)
-                )
+                .filter((e) => {
+                  const displayStart = toDisplayDate(e.startTime, displayTimezone);
+                  const displayEnd = toDisplayDate(e.endTime, displayTimezone);
+                  return e.allDay
+                    ? displayStart <= dayStart && displayEnd > dayStart
+                    : isSameDay(displayStart, date);
+                })
                 .sort((a, b) => {
                   if (a.allDay && !b.allDay) return -1;
                   if (!a.allDay && b.allDay) return 1;

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -5,7 +5,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
   getWeek,
@@ -16,7 +15,7 @@ import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -29,7 +28,8 @@ export function TwoWeekView({
   events,
   onEventClick,
 }: TwoWeekViewProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
   const weekStart = startOfWeek(currentDate);
@@ -48,13 +48,14 @@ export function TwoWeekView({
   const week2Num = getWeek(week2[0]!);
 
   const renderDayCell = (date: Date, compact: boolean = false) => {
-    const dayEvents = events.filter((event) => isSameDay(event.startTime, date));
+    const dayEvents = events.filter((event) => isSameDay(toDisplayDate(event.startTime, displayTimezone), date));
     const sorted = [...dayEvents].sort((a, b) => {
       if (a.allDay && !b.allDay) return -1;
       if (!a.allDay && b.allDay) return 1;
       return a.startTime.getTime() - b.startTime.getTime();
     });
-    const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+    const today = isSameDay(date, displayNow);
+    const isPast = isBefore(date, startOfDay(displayNow)) && !today;
 
     return (
       <div
@@ -63,7 +64,7 @@ export function TwoWeekView({
           !transparentMode && 'bg-card/85 backdrop-blur-sm',
           'flex flex-col overflow-hidden',
           !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-          isToday(date) && 'border-primary border-2'
+          today && 'border-primary border-2'
         )}
       >
         {/* Date header */}
@@ -71,13 +72,13 @@ export function TwoWeekView({
           className={cn(
             'shrink-0 px-1',
             compact ? 'py-0.5' : 'py-1',
-            isToday(date) && 'bg-primary/10'
+            today && 'bg-primary/10'
           )}
         >
           <div className={cn(
             'font-medium flex items-center gap-1',
             compact ? 'text-sm' : 'text-sm',
-            isToday(date) && 'text-primary'
+            today && 'text-primary'
           )}>
             <span className="font-bold">{format(date, 'd')}</span>
             <span className="text-xs text-muted-foreground">{format(date, 'MMM')}</span>
@@ -99,7 +100,7 @@ export function TwoWeekView({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)} ${event.title}`}
             </button>
           ))}
         </div>

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -15,6 +15,8 @@ import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -27,6 +29,7 @@ export function TwoWeekView({
   events,
   onEventClick,
 }: TwoWeekViewProps) {
+  const { timeFormat } = useTimeFormat();
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
   const weekStart = startOfWeek(currentDate);
@@ -96,7 +99,7 @@ export function TwoWeekView({
                 : { color: event.color }
               }
             >
-              {event.allDay ? event.title : `• ${format(event.startTime, 'h:mm')} ${event.title}`}
+              {event.allDay ? event.title : `• ${formatDisplayTime(event.startTime, timeFormat)} ${event.title}`}
             </button>
           ))}
         </div>

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -18,6 +18,8 @@ import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -344,6 +346,7 @@ function DayEventList({
   currentHour?: number;
   cards?: boolean;
 }) {
+  const { timeFormat } = useTimeFormat();
   if (allDayEvents.length === 0 && timedEvents.length === 0) {
     return null;
   }
@@ -386,7 +389,7 @@ function DayEventList({
                 : { backgroundColor: event.color, borderLeft: `3px solid ${event.color}` }
             }
           >
-            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{format(new Date(event.startTime), 'h:mm a')}</span>
+            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(new Date(event.startTime), timeFormat)}</span>
             <span className="font-medium">{event.title}</span>
           </button>
         );

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -4,7 +4,6 @@ import {
   format,
   startOfWeek,
   addDays,
-  isToday,
   isBefore,
   startOfDay,
   isSameDay,
@@ -19,7 +18,7 @@ import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, type OverlayItemRef } from './cells';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -60,6 +59,7 @@ export function WeekVerticalView({
   mealColor,
   onItemClick,
 }: WeekVerticalViewProps) {
+  const { displayTimezone } = useTimeFormat();
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
   const cellBg = bgOverride?.cellBackgroundColor;
@@ -67,7 +67,7 @@ export function WeekVerticalView({
   const cellBgStyle = cellBg ? { backgroundColor: hexToRgba(cellBg, cellBgOpacity) } : undefined;
   const weekStart = startOfWeek(currentDate, { weekStartsOn });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
-  const now = new Date();
+  const now = toDisplayDate(new Date(), displayTimezone);
   const today = startOfDay(now);
   const currentHour = now.getHours();
 
@@ -177,14 +177,15 @@ function WeekListDayRow({
   mealColor: string | undefined;
   onItemClick: ((ref: OverlayItemRef) => void) | undefined;
 }) {
+  const { displayTimezone } = useTimeFormat();
   const cards = displayMode === 'cards';
   const dayStart = startOfDay(day);
-  const isCurrentDay = isToday(day);
+  const isCurrentDay = isSameDay(day, today);
   const isPast = isBefore(dayStart, today);
 
   const dayEvents = events.filter((event) => {
-    const eventStart = new Date(event.startTime);
-    const eventEnd = new Date(event.endTime);
+    const eventStart = toDisplayDate(event.startTime, displayTimezone);
+    const eventEnd = toDisplayDate(event.endTime, displayTimezone);
     return eventStart < addDays(dayStart, 1) && eventEnd > dayStart;
   });
 
@@ -346,7 +347,7 @@ function DayEventList({
   currentHour?: number;
   cards?: boolean;
 }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   if (allDayEvents.length === 0 && timedEvents.length === 0) {
     return null;
   }
@@ -371,7 +372,7 @@ function DayEventList({
         </button>
       ))}
       {timedEvents.map((event) => {
-        const isPastEvent = isPastDay || (isCurrentDay && new Date(event.startTime).getHours() < currentHour);
+        const isPastEvent = isPastDay || (isCurrentDay && toDisplayDate(event.startTime, displayTimezone).getHours() < currentHour);
         return (
           <button
             key={event.id}
@@ -389,7 +390,7 @@ function DayEventList({
                 : { backgroundColor: event.color, borderLeft: `3px solid ${event.color}` }
             }
           >
-            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(new Date(event.startTime), timeFormat)}</span>
+            <span className={cn('mr-1', cards ? 'text-muted-foreground' : 'opacity-80')}>{formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}</span>
             <span className="font-medium">{event.title}</span>
           </button>
         );

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -21,6 +21,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -50,6 +52,7 @@ export function WeekView({
   mealColor,
   onItemClick,
 }: WeekViewProps) {
+  const { timeFormat } = useTimeFormat();
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
@@ -198,7 +201,7 @@ export function WeekView({
                       <span className={cn('truncate w-full text-[10px] font-medium leading-tight', cards && 'text-foreground')}>{event.title}</span>
                       {cards && durationMin >= 30 && (
                         <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                          {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                         </span>
                       )}
                       {cards && durationMin >= 60 && (event.location || event.calendarName) && (
@@ -208,7 +211,7 @@ export function WeekView({
                       )}
                       {!cards && (
                         <span className="text-[9px] leading-tight opacity-70">
-                          {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                         </span>
                       )}
                     </button>
@@ -251,7 +254,7 @@ export function WeekView({
                   key={hour}
                   className="text-[9px] text-muted-foreground text-right pl-0.5 pr-0.5 border-t border-transparent flex items-start"
                 >
-                  {format(new Date().setHours(hour, 0), 'ha')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat, { compact: true })}
                 </div>
               ))}
             </div>
@@ -268,7 +271,7 @@ export function WeekView({
                   key={hour}
                   className="text-[9px] text-muted-foreground text-right pl-0.5 pr-0.5 border-t border-transparent flex items-start"
                 >
-                  {format(new Date().setHours(hour, 0), 'ha')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat, { compact: true })}
                 </div>
               ))}
             </div>
@@ -407,7 +410,7 @@ export function WeekView({
             <div className="w-16 shrink-0 h-full grid" style={{ gridTemplateRows: `repeat(${hours.length}, 1fr)` }}>
               {hours.map((hour) => (
                 <div key={hour} className={cn('pl-1 pr-1 text-right text-xs text-muted-foreground flex items-start pt-0.5 min-h-0', bordered && 'border-t border-border')}>
-                  {format(new Date().setHours(hour, 0), 'h a')}
+                  {formatDisplayHour(new Date().setHours(hour, 0), timeFormat)}
                 </div>
               ))}
             </div>
@@ -475,7 +478,7 @@ export function WeekView({
                               <div className={cn('font-medium truncate w-full text-[10px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {cards && durationMin >= 60 && (
                                 <div className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                               {cards && durationMin >= 90 && (event.location || event.calendarName) && (
@@ -485,7 +488,7 @@ export function WeekView({
                               )}
                               {!cards && durationMin >= 45 && (
                                 <div className="text-[9px] leading-tight opacity-70">
-                                  {format(event.startTime, 'h:mm')}&ndash;{format(event.endTime ?? new Date(event.startTime.getTime() + 3600000), 'h:mm a')}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
                                 </div>
                               )}
                             </button>
@@ -545,6 +548,7 @@ function TimedBucketLayer({
   enableDnd: boolean;
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
+  const { timeFormat } = useTimeFormat();
   const slotPct = 100 / hours.length;
   const visibleSet = new Set(hours);
 
@@ -576,7 +580,7 @@ function TimedBucketLayer({
       dragId: `meal:${meal.id}`,
       variant: 'meal',
       title: meal.name,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
       stripeColor: mealColor ?? '#10b981',
       muted: Boolean(meal.cookedAt),
@@ -596,7 +600,7 @@ function TimedBucketLayer({
       dragId: `chore:${chore.id}`,
       variant: 'chore',
       title: chore.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: chore.assignedTo?.name,
       stripeColor: chore.assignedTo?.color || '#f59e0b',
       pendingApproval: Boolean(chore.pendingApproval),
@@ -616,7 +620,7 @@ function TimedBucketLayer({
       dragId: `task:${task.id}`,
       variant: 'task',
       title: task.title,
-      timeLabel: formatTimeOfDay(t),
+      timeLabel: formatTimeOfDay(t, timeFormat),
       subtitle: task.assignedTo?.name,
       stripeColor: task.assignedTo?.color || '#3b82f6',
       muted: task.completed,

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -5,7 +5,6 @@ import {
   startOfWeek,
   addDays,
   isSameDay,
-  isToday,
   isBefore,
   startOfDay,
 } from 'date-fns';
@@ -22,7 +21,7 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { DroppableOverlayCell, useDayDroppable, weatherIcon, getMealTime, getChoreTime, getTaskTime, formatTimeOfDay, type OverlayItemRef } from './cells';
 import { WeekItemCard } from './cells/WeekItemCard';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayHour, formatDisplayTimeRange } from '@/lib/utils/timeFormat';
+import { formatDisplayHour, formatDisplayTimeRange, toDisplayDate } from '@/lib/utils/timeFormat';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -52,7 +51,8 @@ export function WeekView({
   mealColor,
   onItemClick,
 }: WeekViewProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
@@ -69,9 +69,16 @@ export function WeekView({
   const { settings: hiddenSettings, toggleHidden, getVisibleHours } = useHiddenHours();
 
   const weekEnd = addDays(weekStart, 7);
-  const timedWeekEvents = events.filter(
-    (event) => !event.allDay && event.startTime >= weekStart && event.startTime < weekEnd
-  );
+  const timedWeekEvents = events
+    .filter((event) => {
+      const displayStart = toDisplayDate(event.startTime, displayTimezone);
+      return !event.allDay && displayStart >= weekStart && displayStart < weekEnd;
+    })
+    .map((event) => ({
+      ...event,
+      startTime: toDisplayDate(event.startTime, displayTimezone),
+      endTime: toDisplayDate(event.endTime, displayTimezone),
+    }));
 
   // Get visible hours (filtered if hidden mode is enabled)
   const hours = getVisibleHours(timedWeekEvents, { from: weekStart, to: weekEnd });
@@ -79,24 +86,26 @@ export function WeekView({
   // Get all-day events for a day (multi-day events span across days)
   const getAllDayEvents = (date: Date) => {
     const dayStart = startOfDay(date);
-    return events.filter((e) =>
-      e.allDay && e.startTime <= dayStart && e.endTime > dayStart
-    );
+    return events.filter((e) => {
+      const displayStart = toDisplayDate(e.startTime, displayTimezone);
+      const displayEnd = toDisplayDate(e.endTime, displayTimezone);
+      return e.allDay && displayStart <= dayStart && displayEnd > dayStart;
+    });
   };
 
   // Get all timed events for a day (used to compute side-by-side positions
   // across the entire day, so events that overlap but start in different
   // hours still split the column horizontally).
   const getDayTimedEvents = (date: Date) =>
-    events.filter((e) => isSameDay(e.startTime, date) && !e.allDay);
+    events.filter((e) => isSameDay(toDisplayDate(e.startTime, displayTimezone), date) && !e.allDay);
 
   // Get timed events for a specific day and hour
   const getHourEvents = (date: Date, hour: number) =>
     events.filter(
       (e) =>
-        isSameDay(e.startTime, date) &&
+        isSameDay(toDisplayDate(e.startTime, displayTimezone), date) &&
         !e.allDay &&
-        e.startTime.getHours() === hour
+        toDisplayDate(e.startTime, displayTimezone).getHours() === hour
     );
 
   // For portrait, split into two rows
@@ -105,7 +114,7 @@ export function WeekView({
   const row2Days = [...days.slice(4, 7), nextSunday]; // Thu-Sat + next Sun
 
   const renderDayColumn = (date: Date, compact: boolean = false) => {
-    const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+    const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
     const allDayEvents = getAllDayEvents(date);
     const dayPositions = calculateEventPositions(getDayTimedEvents(date));
 
@@ -121,7 +130,7 @@ export function WeekView({
           className={cn(
             'text-center py-1 shrink-0 rounded-t-md',
             !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-            isToday(date) && 'bg-primary text-primary-foreground'
+            isSameDay(date, displayNow) && 'bg-primary text-primary-foreground'
           )}
         >
           <div className={cn('font-bold uppercase tracking-wide', compact ? 'text-xs' : 'text-sm')}>
@@ -182,7 +191,7 @@ export function WeekView({
                         cards
                           ? {
                               borderLeft: `3px solid ${event.color}`,
-                              top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                              top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                               height: `calc(${heightPct}% - 4px)`,
                               left: css.left,
                               width: css.width,
@@ -191,7 +200,7 @@ export function WeekView({
                               backgroundColor: event.color,
                               color: '#fff',
                               borderLeft: `2px solid ${event.color}`,
-                              top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                              top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                               height: `${heightPct}%`,
                               left: css.left,
                               width: css.width,
@@ -201,7 +210,7 @@ export function WeekView({
                       <span className={cn('truncate w-full text-[10px] font-medium leading-tight', cards && 'text-foreground')}>{event.title}</span>
                       {cards && durationMin >= 30 && (
                         <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                         </span>
                       )}
                       {cards && durationMin >= 60 && (event.location || event.calendarName) && (
@@ -211,7 +220,7 @@ export function WeekView({
                       )}
                       {!cards && (
                         <span className="text-[9px] leading-tight opacity-70">
-                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                          {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                         </span>
                       )}
                     </button>
@@ -309,7 +318,7 @@ export function WeekView({
               </button>
             </div>
             {days.map((date) => {
-              const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
               const allDayEvents = getAllDayEvents(date);
               const dayBucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
               const dayWeather = dayBucket?.weather;
@@ -335,6 +344,7 @@ export function WeekView({
                 <LandscapeDayHeader
                   key={date.toISOString()}
                   date={date}
+                  today={isSameDay(date, displayNow)}
                   isPast={isPast}
                   cards={cards}
                   enableDnd={enableDnd}
@@ -344,16 +354,16 @@ export function WeekView({
                     className={cn(
                       'flex items-baseline justify-between gap-1 px-2 py-1.5',
                       !transparentMode && isPast && 'bg-muted/50 text-muted-foreground',
-                      isToday(date) && !cards && 'bg-primary text-primary-foreground',
+                      isSameDay(date, displayNow) && !cards && 'bg-primary text-primary-foreground',
                     )}
                   >
                     <div className="flex items-baseline gap-1.5 min-w-0">
                       <span className="text-2xl font-bold leading-none">{format(date, 'd')}</span>
                       <span className={cn(
                         'text-xs font-medium uppercase tracking-wide truncate leading-none',
-                        isToday(date) && cards ? 'text-seasonal-accent font-semibold' : undefined,
+                        isSameDay(date, displayNow) && cards ? 'text-seasonal-accent font-semibold' : undefined,
                       )}>
-                        {isToday(date) ? 'Today' : format(date, 'EEE')}
+                        {isSameDay(date, displayNow) ? 'Today' : format(date, 'EEE')}
                       </span>
                     </div>
                     {dayWeather && (
@@ -416,13 +426,14 @@ export function WeekView({
             </div>
             {/* Day columns */}
             {days.map((date) => {
-              const isPast = isBefore(date, startOfDay(new Date())) && !isToday(date);
+              const isPast = isBefore(date, startOfDay(displayNow)) && !isSameDay(date, displayNow);
               const dayPositions = calculateEventPositions(getDayTimedEvents(date));
               const dayBucket = bucketsByDate?.get(format(date, 'yyyy-MM-dd'));
               return (
                 <LandscapeDayBody
                   key={date.toISOString()}
                   date={date}
+                  today={isSameDay(date, displayNow)}
                   isPast={isPast}
                   cards={cards}
                   enableDnd={enableDnd}
@@ -454,7 +465,7 @@ export function WeekView({
                                 cards
                                   ? {
                                       borderLeft: `3px solid ${event.color}`,
-                                      top: `calc(${(event.startTime.getMinutes() / 60) * 100}% + 2px)`,
+                                      top: `calc(${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}% + 2px)`,
                                       height: `calc(${heightPct}% - 4px)`,
                                       left: css.left,
                                       width: css.width,
@@ -463,7 +474,7 @@ export function WeekView({
                                       backgroundColor: event.color,
                                       color: '#fff',
                                       borderLeft: `2px solid ${event.color}`,
-                                      top: `${(event.startTime.getMinutes() / 60) * 100}%`,
+                                      top: `${(toDisplayDate(event.startTime, displayTimezone).getMinutes() / 60) * 100}%`,
                                       height: `${heightPct}%`,
                                       left: css.left,
                                       width: css.width,
@@ -478,7 +489,7 @@ export function WeekView({
                               <div className={cn('font-medium truncate w-full text-[10px] leading-tight', cards && 'text-foreground')}>{event.title}</div>
                               {cards && durationMin >= 60 && (
                                 <div className="text-[9px] leading-tight text-muted-foreground truncate w-full">
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                               {cards && durationMin >= 90 && (event.location || event.calendarName) && (
@@ -488,7 +499,7 @@ export function WeekView({
                               )}
                               {!cards && durationMin >= 45 && (
                                 <div className="text-[9px] leading-tight opacity-70">
-                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat)}
+                                  {formatDisplayTimeRange(event.startTime, event.endTime ?? new Date(event.startTime.getTime() + 3600000), timeFormat, displayTimezone)}
                                 </div>
                               )}
                             </button>
@@ -701,6 +712,7 @@ function PortraitDayColumn({
  */
 function LandscapeDayBody({
   date,
+  today,
   isPast,
   cards,
   enableDnd,
@@ -708,6 +720,7 @@ function LandscapeDayBody({
   children,
 }: {
   date: Date;
+  today: boolean;
   isPast: boolean;
   cards: boolean;
   enableDnd: boolean;
@@ -725,7 +738,7 @@ function LandscapeDayBody({
         // For today: 3-sided border (left + right + bottom, no top) so it joins
         // seamlessly with LandscapeDayHeader's 3-sided border to form a single
         // continuous perimeter spanning header + time grid.
-        isToday(date) && cards && 'border-2 border-t-0 border-seasonal-accent/80',
+        today && cards && 'border-2 border-t-0 border-seasonal-accent/80',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-inset ring-seasonal-accent shadow-lg',
       )}
     >
@@ -741,6 +754,7 @@ function LandscapeDayBody({
  */
 function LandscapeDayHeader({
   date,
+  today,
   isPast,
   cards,
   enableDnd,
@@ -748,6 +762,7 @@ function LandscapeDayHeader({
   children,
 }: {
   date: Date;
+  today: boolean;
   isPast: boolean;
   cards: boolean;
   enableDnd: boolean;
@@ -766,7 +781,7 @@ function LandscapeDayHeader({
         // explicit border-2 so it joins seamlessly with LandscapeDayBody's
         // matching 3-sided border (left + right + bottom). Together the two
         // form a single continuous 4-sided perimeter spanning the full column.
-        isToday(date) && cards && 'border-2 border-b-0 border-seasonal-accent/80',
+        today && cards && 'border-2 border-b-0 border-seasonal-accent/80',
         cards && enableDnd && droppable.isOver && 'ring-2 ring-inset ring-seasonal-accent shadow-lg',
       )}
     >

--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { format, isSameDay, isToday, isTomorrow, startOfDay } from 'date-fns';
+import { format, isSameDay, startOfDay } from 'date-fns';
 import { useDroppable } from '@dnd-kit/core';
 import { cn } from '@/lib/utils';
 import { WeekItemCard, type WeekItemSize, type WeekItemLayout } from './WeekItemCard';
 import { weatherIcon } from './weatherIcon';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const PRIORITY_COLORS = {
   high: '#ef4444',
@@ -40,16 +40,17 @@ function mealStripeColor(meal: {
   return meal.cookedBy?.color || meal.createdBy?.color || MEAL_FALLBACK_COLOR;
 }
 
-function dayLabel(date: Date): string {
-  if (isToday(date)) return 'Today';
-  if (isTomorrow(date)) return 'Tomorrow';
+function dayLabel(date: Date, displayTimezone: string): string {
+  const displayNow = toDisplayDate(new Date(), displayTimezone);
+  if (isSameDay(date, displayNow)) return 'Today';
+  if (isSameDay(date, new Date(displayNow.getFullYear(), displayNow.getMonth(), displayNow.getDate() + 1))) return 'Tomorrow';
   return format(date, 'EEEE');
 }
 
-function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat): string | undefined {
+function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat, displayTimezone: string): string | undefined {
   if (allDay) return 'All day';
-  const startStr = formatDisplayTime(start, timeFormat);
-  if (!isSameDay(start, end)) return startStr;
+  const startStr = formatDisplayTime(start, timeFormat, {}, displayTimezone);
+  if (!isSameDay(toDisplayDate(start, displayTimezone), toDisplayDate(end, displayTimezone))) return startStr;
   return startStr;
 }
 
@@ -149,9 +150,9 @@ export function DayColumn({
   disableDrop = false,
   className,
 }: DayColumnProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const flags = { ...ALL_OVERLAYS, ...overlays };
-  const today = isToday(bucket.date);
+  const today = isSameDay(bucket.date, toDisplayDate(new Date(), displayTimezone));
   const droppableId = format(bucket.date, 'yyyy-MM-dd');
   const droppable = useDroppable({ id: droppableId, disabled: disableDrop });
   const profile = SIZE_PROFILES[size];
@@ -195,7 +196,7 @@ export function DayColumn({
                 : 'text-muted-foreground',
             )}
           >
-            {dayLabel(bucket.date)}
+            {dayLabel(bucket.date, displayTimezone)}
           </span>
         </div>
         {profile.showWeather && bucket.weather && (
@@ -231,7 +232,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat)}
+            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat, displayTimezone)}
             subtitle={event.location || event.calendarName}
           />
         ))}

--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -7,6 +7,8 @@ import { cn } from '@/lib/utils';
 import { WeekItemCard, type WeekItemSize, type WeekItemLayout } from './WeekItemCard';
 import { weatherIcon } from './weatherIcon';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const PRIORITY_COLORS = {
   high: '#ef4444',
@@ -44,9 +46,9 @@ function dayLabel(date: Date): string {
   return format(date, 'EEEE');
 }
 
-function timeLabel(start: Date, end: Date, allDay: boolean): string | undefined {
+function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat): string | undefined {
   if (allDay) return 'All day';
-  const startStr = format(start, 'h:mm a');
+  const startStr = formatDisplayTime(start, timeFormat);
   if (!isSameDay(start, end)) return startStr;
   return startStr;
 }
@@ -147,6 +149,7 @@ export function DayColumn({
   disableDrop = false,
   className,
 }: DayColumnProps) {
+  const { timeFormat } = useTimeFormat();
   const flags = { ...ALL_OVERLAYS, ...overlays };
   const today = isToday(bucket.date);
   const droppableId = format(bucket.date, 'yyyy-MM-dd');
@@ -228,7 +231,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel={timeLabel(event.startTime, event.endTime, false)}
+            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat)}
             subtitle={event.location || event.calendarName}
           />
         ))}

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -30,7 +30,7 @@ export function DayOverflowPopover({
   onEventClick,
   triggerClassName,
 }: DayOverflowPopoverProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [open, setOpen] = React.useState(false);
 
   if (hiddenEvents.length === 0) return null;
@@ -73,7 +73,7 @@ export function DayOverflowPopover({
               >
                 {!event.allDay && (
                   <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                    {formatDisplayTime(event.startTime, timeFormat)}
+                    {formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
                   </span>
                 )}
                 <span className="text-xs font-medium truncate flex-1 text-foreground">

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -5,6 +5,8 @@ import { format } from 'date-fns';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import type { CalendarEvent } from '@/types/calendar';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 interface DayOverflowPopoverProps {
   /** The date this popover represents — shown in the popover header. */
@@ -28,6 +30,7 @@ export function DayOverflowPopover({
   onEventClick,
   triggerClassName,
 }: DayOverflowPopoverProps) {
+  const { timeFormat } = useTimeFormat();
   const [open, setOpen] = React.useState(false);
 
   if (hiddenEvents.length === 0) return null;
@@ -70,7 +73,7 @@ export function DayOverflowPopover({
               >
                 {!event.allDay && (
                   <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                    {format(event.startTime, 'h:mm a')}
+                    {formatDisplayTime(event.startTime, timeFormat)}
                   </span>
                 )}
                 <span className="text-xs font-medium truncate flex-1 text-foreground">

--- a/src/components/calendar/cells/itemTime.ts
+++ b/src/components/calendar/cells/itemTime.ts
@@ -1,4 +1,5 @@
 import type { Meal, Chore, Task } from '@/types/models';
+import type { TimeFormat } from '@/lib/utils/timeFormat';
 
 /** Default times for each meal type when meal.mealTime is null. */
 export const MEAL_TIME_DEFAULTS: Record<Meal['mealType'], string> = {
@@ -53,16 +54,20 @@ export function parseTimeOfDay(hhmm: string | null | undefined): number | null {
 }
 
 /**
- * Format "HH:mm" → "6 PM" or "6:30 PM". On-the-hour times drop ":00" so the
- * label is short enough to fit beside a card title in the time grid.
+ * Format an "HH:mm" value for display using the family-wide time preference.
+ * In 12-hour mode, on-the-hour times drop ":00" so the label remains compact.
  */
-export function formatTimeOfDay(hhmm: string | null | undefined): string {
+export function formatTimeOfDay(
+  hhmm: string | null | undefined,
+  timeFormat: TimeFormat = '12h',
+): string {
   if (!hhmm) return '';
   const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
   if (!m) return hhmm;
   const h = Number(m[1]);
   const min = Number(m[2]);
   if (Number.isNaN(h) || Number.isNaN(min)) return hhmm;
+  if (timeFormat === '24h') return `${String(h).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
   const period = h >= 12 ? 'PM' : 'AM';
   const hour12 = ((h + 11) % 12) + 1;
   return min === 0 ? `${hour12} ${period}` : `${hour12}:${String(min).padStart(2, '0')} ${period}`;

--- a/src/components/dashboard/MobileCards.tsx
+++ b/src/components/dashboard/MobileCards.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, createContext, useContext } from 'react';
 import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { MobileLayoutMode } from '@/lib/hooks/useMobileLayout';
-import { format, isToday, isTomorrow, startOfWeek } from 'date-fns';
+import { addDays, format, isSameDay, startOfWeek } from 'date-fns';
 import Link from 'next/link';
 import {
   Calendar,
@@ -30,7 +30,7 @@ import type { useDashboardData } from './useDashboardData';
 import type { CalendarEvent } from '@/types/calendar';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -90,18 +90,20 @@ export function WeatherCard({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockCard() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
+  const now = new Date();
+  const displayNow = toDisplayDate(now, displayTimezone);
   return (
     <div className="bg-card/85 backdrop-blur-sm rounded-xl border border-border p-3 flex items-center gap-3">
       <Clock className="h-5 w-5 text-muted-foreground" />
-      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(new Date(), timeFormat)}</span>
-      <span className="text-sm text-muted-foreground">{format(new Date(), 'EEEE, MMM d')}</span>
+      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(now, timeFormat, {}, displayTimezone)}</span>
+      <span className="text-sm text-muted-foreground">{format(displayNow, 'EEEE, MMM d')}</span>
     </div>
   );
 }
 
 export function CalendarCard({ data }: { data: DashData['calendar'] }) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const upcoming = useMemo(() => {
     if (!data.events) return [];
     const now = new Date();
@@ -117,17 +119,21 @@ export function CalendarCard({ data }: { data: DashData['calendar'] }) {
         <p className="text-xs text-muted-foreground">No upcoming events</p>
       ) : (
         <div className="space-y-1">
-          {upcoming.map((e: CalendarEvent) => (
+          {upcoming.map((e: CalendarEvent) => {
+            const displayStart = toDisplayDate(e.startTime, displayTimezone);
+            const displayNow = toDisplayDate(new Date(), displayTimezone);
+            return (
             <div key={e.id} className="flex items-center gap-2 text-xs">
               <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
               <span className="truncate flex-1">{e.title}</span>
               <span className="text-muted-foreground shrink-0">
-                {isToday(e.startTime) ? formatDisplayTime(e.startTime, timeFormat) :
-                 isTomorrow(e.startTime) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat)}` :
-                 `${format(e.startTime, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat)}`}
+                {isSameDay(displayStart, displayNow) ? formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone) :
+                 isSameDay(displayStart, addDays(displayNow, 1)) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone)}` :
+                 `${format(displayStart, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat, {}, displayTimezone)}`}
               </span>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </CardShell>

--- a/src/components/dashboard/MobileCards.tsx
+++ b/src/components/dashboard/MobileCards.tsx
@@ -29,6 +29,8 @@ import {
 import type { useDashboardData } from './useDashboardData';
 import type { CalendarEvent } from '@/types/calendar';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -88,16 +90,18 @@ export function WeatherCard({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockCard() {
+  const { timeFormat } = useTimeFormat();
   return (
     <div className="bg-card/85 backdrop-blur-sm rounded-xl border border-border p-3 flex items-center gap-3">
       <Clock className="h-5 w-5 text-muted-foreground" />
-      <span className="text-2xl font-light tabular-nums">{format(new Date(), 'h:mm a')}</span>
+      <span className="text-2xl font-light tabular-nums">{formatDisplayTime(new Date(), timeFormat)}</span>
       <span className="text-sm text-muted-foreground">{format(new Date(), 'EEEE, MMM d')}</span>
     </div>
   );
 }
 
 export function CalendarCard({ data }: { data: DashData['calendar'] }) {
+  const { timeFormat } = useTimeFormat();
   const upcoming = useMemo(() => {
     if (!data.events) return [];
     const now = new Date();
@@ -118,9 +122,9 @@ export function CalendarCard({ data }: { data: DashData['calendar'] }) {
               <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
               <span className="truncate flex-1">{e.title}</span>
               <span className="text-muted-foreground shrink-0">
-                {isToday(e.startTime) ? format(e.startTime, 'h:mm a') :
-                 isTomorrow(e.startTime) ? `Tomorrow ${format(e.startTime, 'h:mm a')}` :
-                 format(e.startTime, 'EEE h:mm a')}
+                {isToday(e.startTime) ? formatDisplayTime(e.startTime, timeFormat) :
+                 isTomorrow(e.startTime) ? `Tomorrow ${formatDisplayTime(e.startTime, timeFormat)}` :
+                 `${format(e.startTime, 'EEE')} ${formatDisplayTime(e.startTime, timeFormat)}`}
               </span>
             </div>
           ))}

--- a/src/components/dashboard/TileCards.tsx
+++ b/src/components/dashboard/TileCards.tsx
@@ -13,6 +13,8 @@ import { cn } from '@/lib/utils';
 import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { useDashboardData } from './useDashboardData';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -75,6 +77,7 @@ export function WeatherTile({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockTile() {
+  const { timeFormat } = useTimeFormat();
   const [now, setNow] = useState(new Date());
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 1000);
@@ -82,7 +85,7 @@ export function ClockTile() {
   }, []);
   return (
     <TileShell icon={<Clock className="h-4 w-4 text-violet-500" />} title="Clock">
-      <TileLine>{format(now, 'h:mm a')}</TileLine>
+      <TileLine>{formatDisplayTime(now, timeFormat)}</TileLine>
       <TileLine dim>{format(now, 'EEE, MMM d')}</TileLine>
     </TileShell>
   );

--- a/src/components/dashboard/TileCards.tsx
+++ b/src/components/dashboard/TileCards.tsx
@@ -14,7 +14,7 @@ import { DAYS_OF_WEEK } from '@/lib/constants/days';
 import type { useDashboardData } from './useDashboardData';
 import type { BusRouteStatus, BusPrediction } from '@/lib/hooks/useBusTracking';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 
 type DashData = ReturnType<typeof useDashboardData>;
 
@@ -77,7 +77,7 @@ export function WeatherTile({ data }: { data: DashData['weather'] }) {
 }
 
 export function ClockTile() {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const [now, setNow] = useState(new Date());
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 1000);
@@ -85,8 +85,8 @@ export function ClockTile() {
   }, []);
   return (
     <TileShell icon={<Clock className="h-4 w-4 text-violet-500" />} title="Clock">
-      <TileLine>{formatDisplayTime(now, timeFormat)}</TileLine>
-      <TileLine dim>{format(now, 'EEE, MMM d')}</TileLine>
+      <TileLine>{formatDisplayTime(now, timeFormat, {}, displayTimezone)}</TileLine>
+      <TileLine dim>{format(toDisplayDate(now, displayTimezone), 'EEE, MMM d')}</TileLine>
     </TileShell>
   );
 }

--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -19,7 +19,8 @@ import { useState, useEffect, useMemo } from 'react';
 import { Loader2, MapPin, AlignLeft, ChevronDown, ChevronUp } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { useCalendarSources } from '@/lib/hooks';
-import { useAuth } from '@/components/providers';
+import { useAuth, useTimeFormat } from '@/components/providers';
+import { fromDisplayDateTime, toDisplayDate } from '@/lib/utils/timeFormat';
 import { toast } from '@/components/ui/use-toast';
 import { TimeDropdown } from './TimeDropdown';
 import {
@@ -116,24 +117,26 @@ const REMINDER_OPTIONS = [
 ];
 
 /** Format date for datetime-local input (YYYY-MM-DDTHH:mm) */
-function formatDateTimeLocal(date: Date | string | undefined): string {
+function formatDateTimeLocal(date: Date | string | undefined, timeZone?: string): string {
   const d = date ? (typeof date === 'string' ? new Date(date) : date) : new Date();
-  if (isNaN(d.getTime())) return formatDateTimeLocal(undefined);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
+  if (isNaN(d.getTime())) return formatDateTimeLocal(undefined, timeZone);
+  const displayDate = toDisplayDate(d, timeZone);
+  const year = displayDate.getFullYear();
+  const month = String(displayDate.getMonth() + 1).padStart(2, '0');
+  const day = String(displayDate.getDate()).padStart(2, '0');
+  const hours = String(displayDate.getHours()).padStart(2, '0');
+  const minutes = String(displayDate.getMinutes()).padStart(2, '0');
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 /** Format date for date input (YYYY-MM-DD) */
-function formatDateLocal(date: Date | string | undefined): string {
+function formatDateLocal(date: Date | string | undefined, timeZone?: string): string {
   const d = date ? (typeof date === 'string' ? new Date(date) : date) : new Date();
-  if (isNaN(d.getTime())) return formatDateLocal(undefined);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
+  if (isNaN(d.getTime())) return formatDateLocal(undefined, timeZone);
+  const displayDate = toDisplayDate(d, timeZone);
+  const year = displayDate.getFullYear();
+  const month = String(displayDate.getMonth() + 1).padStart(2, '0');
+  const day = String(displayDate.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 
@@ -152,6 +155,7 @@ export function AddEventModal({
   // Fetch available calendars
   const { calendars } = useCalendarSources();
   const { activeUser } = useAuth();
+  const { displayTimezone } = useTimeFormat();
 
   // Filter to only writable, non-read-only calendars with showInEventModal enabled
   const writableCalendars = useMemo(() => {
@@ -242,13 +246,13 @@ export function AddEventModal({
       setLocation(event.location || '');
       const isAllDay = event.allDay || false;
       setAllDay(isAllDay);
-      const sd = formatDateLocal(event.startTime);
-      const ed = formatDateLocal(event.endTime);
+      const sd = formatDateLocal(event.startTime, displayTimezone);
+      const ed = formatDateLocal(event.endTime, displayTimezone);
       setStartDate(sd);
       setEndDate(ed);
       if (!isAllDay) {
-        const s = formatDateTimeLocal(event.startTime);
-        const e = formatDateTimeLocal(event.endTime);
+        const s = formatDateTimeLocal(event.startTime, displayTimezone);
+        const e = formatDateTimeLocal(event.endTime, displayTimezone);
         setStartTimeStr(s.split('T')[1] ?? '09:00');
         setEndTimeStr(e.split('T')[1] ?? '10:00');
       } else {
@@ -260,20 +264,21 @@ export function AddEventModal({
       setCalendarSourceId(event.calendarSourceId || defaultCalendarId);
       setShowMore(!!(event.description || event.location || event.reminderMinutes || event.recurrenceRule));
     } else if (open && defaultDate) {
-      const d = formatDateLocal(defaultDate);
+      // Calendar cells are already presentation-only wall dates.
+      const d = format(defaultDate, 'yyyy-MM-dd');
       setStartDate(d);
       setEndDate(d);
       setStartTimeStr('09:00');
       setEndTimeStr('10:00');
     } else if (open) {
-      const today = formatDateLocal(new Date());
+      const today = formatDateLocal(new Date(), displayTimezone);
       setStartDate(today);
       setEndDate(today);
       setStartTimeStr('09:00');
       setEndTimeStr('10:00');
     }
     if (open && !event) setCalendarSourceId(defaultCalendarId);
-  }, [open, event, defaultDate, defaultCalendarId]);
+  }, [open, event, defaultDate, defaultCalendarId, displayTimezone]);
 
   // Reset form when modal closes
   useEffect(() => {
@@ -291,12 +296,16 @@ export function AddEventModal({
     if (!title.trim() || !startDate || !endDate) return;
     if (!allDay && (!startTimeStr || !endTimeStr)) return;
 
-    const startISO = allDay
-      ? new Date(`${startDate}T00:00:00`).toISOString()
-      : new Date(`${startDate}T${startTimeStr}:00`).toISOString();
-    const endISO = allDay
-      ? new Date(`${endDate}T23:59:59`).toISOString()
-      : new Date(`${endDate}T${endTimeStr}:00`).toISOString();
+    const startISO = fromDisplayDateTime(
+      startDate,
+      allDay ? '00:00:00' : startTimeStr,
+      displayTimezone,
+    ).toISOString();
+    const endISO = fromDisplayDateTime(
+      endDate,
+      allDay ? '23:59:59' : endTimeStr,
+      displayTimezone,
+    ).toISOString();
 
     if (new Date(endISO) < new Date(startISO)) {
       setError('End must be after start');

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from './ThemeProvider';
 import { AuthProvider } from './AuthProvider';
 import { FamilyProvider } from './FamilyProvider';
 import { GlobalInputProvider } from '@/lib/hooks/useGlobalInput';
+import { TimeFormatProvider } from './TimeFormatProvider';
 
 // simple-keyboard accesses browser globals at module load — must be client-only
 const VirtualKeyboard = dynamic(
@@ -38,11 +39,13 @@ export function Providers({ children }: ProvidersProps) {
     <ThemeProvider defaultTheme="light">
       <FamilyProvider>
         <AuthProvider>
-          <GlobalInputProvider>
-            {children}
-            <VirtualKeyboard />
-            <KeyboardToggleButton />
-          </GlobalInputProvider>
+          <TimeFormatProvider>
+            <GlobalInputProvider>
+              {children}
+              <VirtualKeyboard />
+              <KeyboardToggleButton />
+            </GlobalInputProvider>
+          </TimeFormatProvider>
         </AuthProvider>
       </FamilyProvider>
     </ThemeProvider>

--- a/src/components/providers/TimeFormatProvider.tsx
+++ b/src/components/providers/TimeFormatProvider.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import * as React from 'react';
+import {
+  DEFAULT_TIME_FORMAT,
+  isTimeFormat,
+  type TimeFormat,
+} from '@/lib/utils/timeFormat';
+
+const SETTING_KEY = 'timeFormat';
+
+interface TimeFormatContextValue {
+  timeFormat: TimeFormat;
+  setTimeFormat: (next: TimeFormat) => Promise<void>;
+}
+
+const TimeFormatContext = React.createContext<TimeFormatContextValue | undefined>(undefined);
+
+export function TimeFormatProvider({ children }: { children: React.ReactNode }) {
+  const [timeFormat, setTimeFormatState] = React.useState<TimeFormat>(DEFAULT_TIME_FORMAT);
+
+  React.useEffect(() => {
+    let active = true;
+    fetch('/api/settings')
+      .then((response) => response.ok ? response.json() : null)
+      .then((data) => {
+        const saved = data?.settings?.[SETTING_KEY];
+        if (active && isTimeFormat(saved)) setTimeFormatState(saved);
+      })
+      .catch(() => {});
+
+    return () => { active = false; };
+  }, []);
+
+  const setTimeFormat = React.useCallback(async (next: TimeFormat) => {
+    const previous = timeFormat;
+    setTimeFormatState(next);
+
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: SETTING_KEY, value: next }),
+      });
+      if (!response.ok) throw new Error('Failed to save time format');
+    } catch (error) {
+      setTimeFormatState(previous);
+      throw error;
+    }
+  }, [timeFormat]);
+
+  const value = React.useMemo(
+    () => ({ timeFormat, setTimeFormat }),
+    [timeFormat, setTimeFormat],
+  );
+
+  return (
+    <TimeFormatContext.Provider value={value}>
+      {children}
+    </TimeFormatContext.Provider>
+  );
+}
+
+export function useTimeFormat(): TimeFormatContextValue {
+  const context = React.useContext(TimeFormatContext);
+  if (!context) throw new Error('useTimeFormat must be used within a TimeFormatProvider');
+  return context;
+}

--- a/src/components/providers/TimeFormatProvider.tsx
+++ b/src/components/providers/TimeFormatProvider.tsx
@@ -2,22 +2,48 @@
 
 import * as React from 'react';
 import {
+  DEFAULT_DISPLAY_TIMEZONE_MODE,
   DEFAULT_TIME_FORMAT,
+  isDisplayTimezoneMode,
   isTimeFormat,
+  type DisplayTimezoneMode,
   type TimeFormat,
 } from '@/lib/utils/timeFormat';
+import { detectBrowserTimezone } from '@/lib/hooks/useTimezone';
 
 const SETTING_KEY = 'timeFormat';
+const TIMEZONE_SETTING_KEY = 'timezone';
+const TIMEZONE_CACHE_KEY = 'prism:timezone';
+const DISPLAY_TIMEZONE_MODE_KEY = 'prism:display-timezone-mode';
+export const TIMEZONE_CHANGED_EVENT = 'prism:timezone-changed';
 
 interface TimeFormatContextValue {
   timeFormat: TimeFormat;
   setTimeFormat: (next: TimeFormat) => Promise<void>;
+  householdTimezone: string;
+  deviceTimezone: string;
+  displayTimezone: string;
+  displayTimezoneMode: DisplayTimezoneMode;
+  setDisplayTimezoneMode: (next: DisplayTimezoneMode) => void;
 }
 
 const TimeFormatContext = React.createContext<TimeFormatContextValue | undefined>(undefined);
 
 export function TimeFormatProvider({ children }: { children: React.ReactNode }) {
   const [timeFormat, setTimeFormatState] = React.useState<TimeFormat>(DEFAULT_TIME_FORMAT);
+  const [deviceTimezone, setDeviceTimezone] = React.useState('UTC');
+  const [householdTimezone, setHouseholdTimezone] = React.useState('UTC');
+  const [displayTimezoneMode, setDisplayTimezoneModeState] = React.useState<DisplayTimezoneMode>(
+    DEFAULT_DISPLAY_TIMEZONE_MODE,
+  );
+
+  React.useEffect(() => {
+    const detected = detectBrowserTimezone();
+    setDeviceTimezone(detected);
+    setHouseholdTimezone(localStorage.getItem(TIMEZONE_CACHE_KEY) || detected);
+    const savedMode = localStorage.getItem(DISPLAY_TIMEZONE_MODE_KEY);
+    if (isDisplayTimezoneMode(savedMode)) setDisplayTimezoneModeState(savedMode);
+  }, []);
 
   React.useEffect(() => {
     let active = true;
@@ -26,10 +52,24 @@ export function TimeFormatProvider({ children }: { children: React.ReactNode }) 
       .then((data) => {
         const saved = data?.settings?.[SETTING_KEY];
         if (active && isTimeFormat(saved)) setTimeFormatState(saved);
+        const savedTimezone = data?.settings?.[TIMEZONE_SETTING_KEY];
+        if (active && typeof savedTimezone === 'string' && savedTimezone) {
+          setHouseholdTimezone(savedTimezone);
+          localStorage.setItem(TIMEZONE_CACHE_KEY, savedTimezone);
+        }
       })
       .catch(() => {});
 
     return () => { active = false; };
+  }, []);
+
+  React.useEffect(() => {
+    const handleTimezoneChanged = (event: Event) => {
+      const next = (event as CustomEvent<string>).detail;
+      if (typeof next === 'string' && next) setHouseholdTimezone(next);
+    };
+    window.addEventListener(TIMEZONE_CHANGED_EVENT, handleTimezoneChanged);
+    return () => window.removeEventListener(TIMEZONE_CHANGED_EVENT, handleTimezoneChanged);
   }, []);
 
   const setTimeFormat = React.useCallback(async (next: TimeFormat) => {
@@ -49,9 +89,34 @@ export function TimeFormatProvider({ children }: { children: React.ReactNode }) 
     }
   }, [timeFormat]);
 
+  const setDisplayTimezoneMode = React.useCallback((next: DisplayTimezoneMode) => {
+    setDisplayTimezoneModeState(next);
+    localStorage.setItem(DISPLAY_TIMEZONE_MODE_KEY, next);
+  }, []);
+
+  const displayTimezone = displayTimezoneMode === 'device'
+    ? deviceTimezone
+    : householdTimezone;
+
   const value = React.useMemo(
-    () => ({ timeFormat, setTimeFormat }),
-    [timeFormat, setTimeFormat],
+    () => ({
+      timeFormat,
+      setTimeFormat,
+      householdTimezone,
+      deviceTimezone,
+      displayTimezone,
+      displayTimezoneMode,
+      setDisplayTimezoneMode,
+    }),
+    [
+      timeFormat,
+      setTimeFormat,
+      householdTimezone,
+      deviceTimezone,
+      displayTimezone,
+      displayTimezoneMode,
+      setDisplayTimezoneMode,
+    ],
   );
 
   return (

--- a/src/components/providers/__tests__/TimeFormatProvider.test.tsx
+++ b/src/components/providers/__tests__/TimeFormatProvider.test.tsx
@@ -16,6 +16,7 @@ describe('TimeFormatProvider', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     global.fetch = fetchMock;
+    localStorage.clear();
   });
 
   it('loads the saved family-wide preference', async () => {
@@ -65,5 +66,35 @@ describe('TimeFormatProvider', () => {
       'Failed to save time format',
     );
     expect(result.current.timeFormat).toBe('12h');
+  });
+
+  it('defaults display times to the saved household timezone', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timeFormat: '24h', timezone: 'Europe/Warsaw' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+
+    await waitFor(() => expect(result.current.householdTimezone).toBe('Europe/Warsaw'));
+    expect(result.current.displayTimezoneMode).toBe('household');
+    expect(result.current.displayTimezone).toBe('Europe/Warsaw');
+  });
+
+  it('stores the device-timezone override locally without changing family settings', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timezone: 'Europe/Warsaw' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(result.current.householdTimezone).toBe('Europe/Warsaw'));
+
+    act(() => result.current.setDisplayTimezoneMode('device'));
+
+    expect(result.current.displayTimezoneMode).toBe('device');
+    expect(result.current.displayTimezone).toBe(result.current.deviceTimezone);
+    expect(localStorage.getItem('prism:display-timezone-mode')).toBe('device');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/providers/__tests__/TimeFormatProvider.test.tsx
+++ b/src/components/providers/__tests__/TimeFormatProvider.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { TimeFormatProvider, useTimeFormat } from '../TimeFormatProvider';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TimeFormatProvider>{children}</TimeFormatProvider>
+);
+
+describe('TimeFormatProvider', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it('loads the saved family-wide preference', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ settings: { timeFormat: '24h' } }),
+    });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+
+    await waitFor(() => expect(result.current.timeFormat).toBe('24h'));
+  });
+
+  it('updates the context and persists the setting', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ settings: { timeFormat: '12h' } }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => result.current.setTimeFormat('24h'));
+
+    expect(result.current.timeFormat).toBe('24h');
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'timeFormat', value: '24h' }),
+    });
+  });
+
+  it('rolls back an optimistic change when saving fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ settings: { timeFormat: '12h' } }),
+      })
+      .mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() => useTimeFormat(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await expect(act(async () => result.current.setTimeFormat('24h'))).rejects.toThrow(
+      'Failed to save time format',
+    );
+    expect(result.current.timeFormat).toBe('12h');
+  });
+});

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -9,4 +9,4 @@ export { AuthProvider, useAuth } from './AuthProvider';
 export { FamilyProvider, useFamily } from './FamilyProvider';
 export { Providers } from './Providers';
 export { TimeFormatProvider, useTimeFormat } from './TimeFormatProvider';
-export type { TimeFormat } from '@/lib/utils/timeFormat';
+export type { DisplayTimezoneMode, TimeFormat } from '@/lib/utils/timeFormat';

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -8,3 +8,5 @@ export { ThemeProvider, useTheme, type ThemeMode } from './ThemeProvider';
 export { AuthProvider, useAuth } from './AuthProvider';
 export { FamilyProvider, useFamily } from './FamilyProvider';
 export { Providers } from './Providers';
+export { TimeFormatProvider, useTimeFormat } from './TimeFormatProvider';
+export type { TimeFormat } from '@/lib/utils/timeFormat';

--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -30,6 +30,8 @@ import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayTime } from '@/lib/utils/timeFormat';
 import { WidgetContainer } from './WidgetContainer';
 
 
@@ -75,11 +77,15 @@ export interface ClockWidgetProps {
  */
 export const ClockWidget = React.memo(function ClockWidget({
   showSeconds = false,
-  format24Hour = false,
+  format24Hour,
   showDate = true,
   size = 'medium',
   className,
 }: ClockWidgetProps) {
+  const { timeFormat } = useTimeFormat();
+  const effectiveTimeFormat = format24Hour === undefined
+    ? timeFormat
+    : format24Hour ? '24h' : '12h';
   // State to hold the current time
   // Initialize with current time to avoid hydration mismatch
   const [currentTime, setCurrentTime] = useState<Date>(new Date());
@@ -101,14 +107,10 @@ export const ClockWidget = React.memo(function ClockWidget({
 
   // Format strings for date-fns
   // See: https://date-fns.org/docs/format
-  const timeFormat = format24Hour
-    ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
-    : showSeconds ? 'h:mm:ss a' : 'h:mm a';
-
   const dateFormat = 'EEEE, MMMM d'; // e.g., "Tuesday, January 21"
 
   // Formatted strings
-  const timeString = format(currentTime, timeFormat);
+  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds });
   const dateString = format(currentTime, dateFormat);
 
   // Size-based styling

--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -31,7 +31,7 @@ import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTimeFormat } from '@/components/providers';
-import { formatDisplayTime } from '@/lib/utils/timeFormat';
+import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
 import { WidgetContainer } from './WidgetContainer';
 
 
@@ -82,7 +82,7 @@ export const ClockWidget = React.memo(function ClockWidget({
   size = 'medium',
   className,
 }: ClockWidgetProps) {
-  const { timeFormat } = useTimeFormat();
+  const { timeFormat, displayTimezone } = useTimeFormat();
   const effectiveTimeFormat = format24Hour === undefined
     ? timeFormat
     : format24Hour ? '24h' : '12h';
@@ -110,8 +110,8 @@ export const ClockWidget = React.memo(function ClockWidget({
   const dateFormat = 'EEEE, MMMM d'; // e.g., "Tuesday, January 21"
 
   // Formatted strings
-  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds });
-  const dateString = format(currentTime, dateFormat);
+  const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds }, displayTimezone);
+  const dateString = format(toDisplayDate(currentTime, displayTimezone), dateFormat);
 
   // Size-based styling
   const timeStyles = {

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -115,6 +115,8 @@ export interface WeatherUnits {
 
 export interface WeatherData {
   location: string;
+  /** IANA timezone of the weather location, when supplied by the provider. */
+  timezone?: string;
   current: CurrentWeather;
   forecast: ForecastDay[];
   /** Next 24 hours of hourly forecast data for the timeline. */
@@ -392,12 +394,13 @@ export const WeatherWidget = React.memo(function WeatherWidget({
           sunset={weatherData.sunset}
           moonPhase={weatherData.moonPhase}
           moonPhaseName={weatherData.moonPhaseName}
+          timezone={weatherData.timezone}
         />
 
         {/* HOURLY FORECAST */}
         {showHourly && weatherData.hourly && weatherData.hourly.length > 0 && (
           <div className="border-t border-border pt-3">
-            <HourlyTimeline hourly={weatherData.hourly} units={units} />
+            <HourlyTimeline hourly={weatherData.hourly} units={units} timezone={weatherData.timezone} />
           </div>
         )}
 
@@ -433,6 +436,7 @@ export const WeatherWidget = React.memo(function WeatherWidget({
                   moonrise={weatherData.moonrise}
                   moonset={weatherData.moonset}
                   moonPhase={weatherData.moonPhase}
+                  timezone={weatherData.timezone}
                 />
               </div>
             )}
@@ -463,6 +467,7 @@ function CurrentConditions({
   sunset,
   moonPhase,
   moonPhaseName,
+  timezone,
 }: {
   weather: CurrentWeather;
   location: string;
@@ -471,6 +476,7 @@ function CurrentConditions({
   sunset?: Date;
   moonPhase?: number;
   moonPhaseName?: string;
+  timezone?: string;
 }) {
   const { timeFormat } = useTimeFormat();
   const temp  = formatTemp(weather.temperature, units);
@@ -519,13 +525,13 @@ function CurrentConditions({
             {sunrise && (
               <span className="flex items-center gap-0.5" title="Sunrise">
                 <Sunrise className="h-3 w-3" style={{ color: '#FBBF24' }} />
-                {formatDisplayTime(sunrise, timeFormat)}
+                {formatDisplayTime(sunrise, timeFormat, {}, timezone)}
               </span>
             )}
             {sunset && (
               <span className="flex items-center gap-0.5" title="Sunset">
                 <Sunset className="h-3 w-3" style={{ color: '#F97316' }} />
-                {formatDisplayTime(sunset, timeFormat)}
+                {formatDisplayTime(sunset, timeFormat, {}, timezone)}
               </span>
             )}
           </div>
@@ -664,7 +670,7 @@ function WeatherIcon({
  * meaningfully matters (≥10%). The first card is labeled "Now". Replaces the
  * earlier merry-timeline color strip, which read as a 1995-era band chart.
  */
-function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: WeatherUnits }) {
+function HourlyTimeline({ hourly, units, timezone }: { hourly: HourlyForecast[]; units: WeatherUnits; timezone?: string }) {
   const { timeFormat } = useTimeFormat();
   // Start at the hour whose endTime is still in the future ("Now" card).
   // Take 8 hours so the row stays readable at the default widget width.
@@ -685,7 +691,7 @@ function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: We
           const isNow = i === 0;
           const timeLabel = isNow
             ? 'Now'
-            : formatDisplayHour(h.time, timeFormat, { compact: true }).toLowerCase();
+            : formatDisplayHour(h.time, timeFormat, { compact: true }, timezone).toLowerCase();
           const precipPct = Math.round(h.precipProbability ?? 0);
           const showPrecip = precipPct >= 10;
           return (
@@ -884,6 +890,7 @@ function SunriseSunsetArc({
   moonrise,
   moonset,
   moonPhase,
+  timezone,
 }: {
   sunrise: Date;
   sunset: Date;
@@ -892,6 +899,7 @@ function SunriseSunsetArc({
   moonrise?: Date;
   moonset?: Date;
   moonPhase?: number;
+  timezone?: string;
 }) {
   const { timeFormat } = useTimeFormat();
   const [width, setWidth] = React.useState(220);
@@ -1125,22 +1133,22 @@ function SunriseSunsetArc({
       <div className="flex items-center justify-between gap-3 text-[11px] tabular-nums pt-0.5 whitespace-nowrap">
         <span className="flex items-center gap-3">
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunrise">
-            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat)}
+            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat, {}, timezone)}
           </span>
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunset">
-            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat)}
+            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat, {}, timezone)}
           </span>
         </span>
         {(moonrise || moonset) && (
           <span className="flex items-center gap-3" style={{ color: MOON_COLOR }}>
             {moonrise && (
               <span className="flex items-center gap-1" title="Moonrise">
-                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat)}
+                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat, {}, timezone)}
               </span>
             )}
             {moonset && (
               <span className="flex items-center gap-1" title="Moonset">
-                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat)}
+                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat, {}, timezone)}
               </span>
             )}
           </span>

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -42,6 +42,8 @@ import {
 import { cn } from '@/lib/utils';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import { WidgetContainer } from './WidgetContainer';
+import { useTimeFormat } from '@/components/providers';
+import { formatDisplayHour, formatDisplayTime } from '@/lib/utils/timeFormat';
 
 /**
  * WEATHER DATA TYPES
@@ -470,9 +472,9 @@ function CurrentConditions({
   moonPhase?: number;
   moonPhaseName?: string;
 }) {
+  const { timeFormat } = useTimeFormat();
   const temp  = formatTemp(weather.temperature, units);
   const feels = formatTemp(weather.feelsLike, units);
-  const fmtTime = (d: Date) => d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
 
   return (
     <div className="flex items-start justify-between gap-2">
@@ -517,13 +519,13 @@ function CurrentConditions({
             {sunrise && (
               <span className="flex items-center gap-0.5" title="Sunrise">
                 <Sunrise className="h-3 w-3" style={{ color: '#FBBF24' }} />
-                {fmtTime(sunrise)}
+                {formatDisplayTime(sunrise, timeFormat)}
               </span>
             )}
             {sunset && (
               <span className="flex items-center gap-0.5" title="Sunset">
                 <Sunset className="h-3 w-3" style={{ color: '#F97316' }} />
-                {fmtTime(sunset)}
+                {formatDisplayTime(sunset, timeFormat)}
               </span>
             )}
           </div>
@@ -663,6 +665,7 @@ function WeatherIcon({
  * earlier merry-timeline color strip, which read as a 1995-era band chart.
  */
 function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: WeatherUnits }) {
+  const { timeFormat } = useTimeFormat();
   // Start at the hour whose endTime is still in the future ("Now" card).
   // Take 8 hours so the row stays readable at the default widget width.
   const nowMs = Date.now();
@@ -682,10 +685,7 @@ function HourlyTimeline({ hourly, units }: { hourly: HourlyForecast[]; units: We
           const isNow = i === 0;
           const timeLabel = isNow
             ? 'Now'
-            : h.time
-                .toLocaleTimeString([], { hour: 'numeric', hour12: true })
-                .replace(/\s/g, '')
-                .toLowerCase();
+            : formatDisplayHour(h.time, timeFormat, { compact: true }).toLowerCase();
           const precipPct = Math.round(h.precipProbability ?? 0);
           const showPrecip = precipPct >= 10;
           return (
@@ -893,6 +893,7 @@ function SunriseSunsetArc({
   moonset?: Date;
   moonPhase?: number;
 }) {
+  const { timeFormat } = useTimeFormat();
   const [width, setWidth] = React.useState(220);
   const containerRef = React.useRef<HTMLDivElement>(null);
   // Unique gradient ID so multiple weather widgets on a page (e.g., dashboard
@@ -1013,8 +1014,6 @@ function SunriseSunsetArc({
   const SUN_HORIZON = '#EF4444'; // red-500 — sun at the horizon
   const MOON_COLOR = '#60A5FA';
 
-  const fmtTime = (d: Date) => d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
-
   // Pick a sun-dot color that matches where it sits on the altitude gradient
   // — red near the horizon, amber high in the sky. Bucketed (rather than
   // smoothly interpolated) for legibility against a small dot.
@@ -1126,22 +1125,22 @@ function SunriseSunsetArc({
       <div className="flex items-center justify-between gap-3 text-[11px] tabular-nums pt-0.5 whitespace-nowrap">
         <span className="flex items-center gap-3">
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunrise">
-            <Sunrise className="h-3 w-3" />{fmtTime(sunrise)}
+            <Sunrise className="h-3 w-3" />{formatDisplayTime(sunrise, timeFormat)}
           </span>
           <span className="flex items-center gap-1" style={{ color: SUN_COLOR }} title="Sunset">
-            <Sunset className="h-3 w-3" />{fmtTime(sunset)}
+            <Sunset className="h-3 w-3" />{formatDisplayTime(sunset, timeFormat)}
           </span>
         </span>
         {(moonrise || moonset) && (
           <span className="flex items-center gap-3" style={{ color: MOON_COLOR }}>
             {moonrise && (
               <span className="flex items-center gap-1" title="Moonrise">
-                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{fmtTime(moonrise)}
+                <MoonGlyph phase={moonPhase ?? 0} size={11} /><span className="opacity-70">↑</span>{formatDisplayTime(moonrise, timeFormat)}
               </span>
             )}
             {moonset && (
               <span className="flex items-center gap-1" title="Moonset">
-                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{fmtTime(moonset)}
+                {!moonrise && <MoonGlyph phase={moonPhase ?? 0} size={11} />}<span className="opacity-70">↓</span>{formatDisplayTime(moonset, timeFormat)}
               </span>
             )}
           </span>

--- a/src/components/widgets/__tests__/WeatherWidget.test.tsx
+++ b/src/components/widgets/__tests__/WeatherWidget.test.tsx
@@ -7,7 +7,25 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen, type RenderOptions } from '@testing-library/react';
+import { TimeFormatProvider } from '@/components/providers';
+
+// WeatherWidget consumes useTimeFormat(), which requires a TimeFormatProvider
+// ancestor. Wrap every render so the widget mounts the way it does in the app.
+const render = (ui: React.ReactElement, options?: RenderOptions) =>
+  rtlRender(ui, { wrapper: TimeFormatProvider, ...options });
+
+// TimeFormatProvider fetches /api/settings on mount; jsdom has no global fetch,
+// so stub it to a benign empty-settings response (the widget falls back to
+// DEFAULT_TIME_FORMAT / UTC, which is what these assertions expect).
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ settings: {} }) }),
+  ) as unknown as typeof fetch;
+});
+afterAll(() => {
+  delete (global as { fetch?: unknown }).fetch;
+});
 
 // --- mocks (must precede component import) ---------------------------------
 

--- a/src/lib/hooks/useCalendarWidgetPrefs.ts
+++ b/src/lib/hooks/useCalendarWidgetPrefs.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, createContext } from 'react';
-import { addDays, addWeeks, addMonths, subDays, subWeeks, subMonths, startOfWeek } from 'date-fns';
+import { addDays, addWeeks, addMonths, subDays, subWeeks, subMonths } from 'date-fns';
 import type { OverlayFlags } from '@/lib/hooks/useDayBucketsForRange';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 /**
  * Scopes CalendarWidget preference storage. Empty string = the shared keys used
@@ -90,10 +92,15 @@ function readViewPref(suffix: string): WidgetViewType {
  * for the CalendarWidget. Extracted from the component to keep it under 250 lines.
  */
 export function useCalendarWidgetPrefs(gridW: number, gridH: number, scope = '') {
+  const { displayTimezone } = useTimeFormat();
   // Non-empty scope suffixes every storage key so this calendar (e.g. the one on
   // the screensaver) keeps prefs independent of the dashboard's. Empty = shared.
   const suffix = scope ? `:${scope}` : '';
   const [currentDate, setCurrentDate] = useState(() => new Date());
+
+  useEffect(() => {
+    setCurrentDate(toDisplayDate(new Date(), displayTimezone));
+  }, [displayTimezone]);
   const [widgetBordered, setWidgetBordered] = useState(
     () => typeof window !== 'undefined' && localStorage.getItem(`prism-calendar-bordered${suffix}`) === 'true'
   );
@@ -143,7 +150,10 @@ export function useCalendarWidgetPrefs(gridW: number, gridH: number, scope = '')
   const viewUnavailable = viewType !== effectiveView;
 
   // Navigation
-  const goToToday = useCallback(() => setCurrentDate(new Date()), []);
+  const goToToday = useCallback(
+    () => setCurrentDate(toDisplayDate(new Date(), displayTimezone)),
+    [displayTimezone],
+  );
   const goToPrevious = useCallback(() => {
     setCurrentDate(d => {
       switch (resolvedView) {

--- a/src/lib/hooks/useDayBucketsForRange.ts
+++ b/src/lib/hooks/useDayBucketsForRange.ts
@@ -12,6 +12,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { DayBucket } from './useWeekViewData';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface OverlayFlags {
   events: boolean;
@@ -58,10 +60,12 @@ function dateKey(d: Date): string {
   return format(d, 'yyyy-MM-dd');
 }
 
-function eventOnDay(event: CalendarEvent, day: Date): boolean {
+function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
   const dayStart = startOfDay(day);
   const dayEnd = addDays(dayStart, 1);
-  return event.startTime < dayEnd && event.endTime > dayStart;
+  const eventStart = toDisplayDate(event.startTime, displayTimezone);
+  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
+  return eventStart < dayEnd && eventEnd > dayStart;
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {
@@ -88,6 +92,7 @@ export function useDayBucketsForRange({
   overlays,
   externalEvents,
 }: UseDayBucketsForRangeOptions): UseDayBucketsForRangeResult {
+  const { displayTimezone } = useTimeFormat();
   const fromKey = useMemo(() => dateKey(from), [from]);
   const toKey = useMemo(() => dateKey(to), [to]);
 
@@ -147,7 +152,7 @@ export function useDayBucketsForRange({
       const key = dateKey(date);
 
       const dayEvents = overlays.events
-        ? events.filter((e) => eventOnDay(e, date))
+        ? events.filter((e) => eventOnDay(e, date, displayTimezone))
         : EMPTY_EVENTS;
       const allDayEvents = dayEvents
         .filter((e) => e.allDay)
@@ -192,7 +197,7 @@ export function useDayBucketsForRange({
     return map;
     // fromKey/toKey trigger recompute on actual date changes, not Date identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fromKey, toKey, events, meals, chores, tasks, weather, overlays.events, overlays.meals, overlays.chores, overlays.tasks]);
+  }, [fromKey, toKey, events, meals, chores, tasks, weather, overlays.events, overlays.meals, overlays.chores, overlays.tasks, displayTimezone]);
 
   const loading =
     (overlays.events && fetchEvents && eventsLoading) ||

--- a/src/lib/hooks/useTimezone.ts
+++ b/src/lib/hooks/useTimezone.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const STORAGE_KEY = 'prism:timezone';
+const TIMEZONE_CHANGED_EVENT = 'prism:timezone-changed';
 
 /** The browser's own IANA timezone, e.g. "America/Chicago". Safe fallback. */
 export function detectBrowserTimezone(): string {
@@ -56,6 +57,7 @@ export function useTimezone(): {
   const setTimezone = useCallback(async (newValue: string) => {
     setValue(newValue);
     localStorage.setItem(STORAGE_KEY, newValue);
+    window.dispatchEvent(new CustomEvent(TIMEZONE_CHANGED_EVENT, { detail: newValue }));
     try {
       await fetch('/api/settings', {
         method: 'PATCH',

--- a/src/lib/hooks/useWeekViewData.ts
+++ b/src/lib/hooks/useWeekViewData.ts
@@ -12,6 +12,8 @@ import type { CalendarEvent } from '@/types/calendar';
 import type { Chore, Meal } from '@/types';
 import type { Task } from '@/components/widgets/TasksWidget';
 import type { ForecastDay } from '@/components/widgets/WeatherWidget';
+import { useTimeFormat } from '@/components/providers';
+import { toDisplayDate } from '@/lib/utils/timeFormat';
 
 export interface DayBucket {
   date: Date;
@@ -52,10 +54,12 @@ const MEAL_TYPE_ORDER: Record<Meal['mealType'], number> = {
   snack: 3,
 };
 
-function eventOnDay(event: CalendarEvent, day: Date): boolean {
+function eventOnDay(event: CalendarEvent, day: Date, displayTimezone: string): boolean {
   const dayStart = startOfDay(day);
   const dayEnd = addDays(dayStart, 1);
-  return event.startTime < dayEnd && event.endTime > dayStart;
+  const eventStart = toDisplayDate(event.startTime, displayTimezone);
+  const eventEnd = toDisplayDate(event.endTime, displayTimezone);
+  return eventStart < dayEnd && eventEnd > dayStart;
 }
 
 function choreNextDueOnDay(chore: Chore, day: Date): boolean {
@@ -70,6 +74,7 @@ export function useWeekViewData({
   weekStart,
   weekStartsOn,
 }: UseWeekViewDataOptions): UseWeekViewDataResult {
+  const { displayTimezone } = useTimeFormat();
   // Normalize to start-of-week for stable identity
   const normalizedStart = useMemo(
     () => startOfWeek(weekStart, { weekStartsOn }),
@@ -96,7 +101,7 @@ export function useWeekViewData({
       const date = addDays(normalizedStart, i);
       const dayOfWeek = DAYS_OF_WEEK[date.getDay()] as DayOfWeek;
 
-      const dayEvents = events.filter((e) => eventOnDay(e, date));
+      const dayEvents = events.filter((e) => eventOnDay(e, date, displayTimezone));
       const allDayEvents = dayEvents.filter((e) => e.allDay).sort((a, b) =>
         a.startTime.getTime() - b.startTime.getTime(),
       );
@@ -132,7 +137,7 @@ export function useWeekViewData({
         weather: dayWeather,
       };
     });
-  }, [normalizedStart, events, meals, chores, tasks, weather]);
+  }, [normalizedStart, events, meals, chores, tasks, weather, displayTimezone]);
 
   const loading = eventsLoading || mealsLoading || choresLoading || tasksLoading;
   const error = eventsError || mealsError || choresError || tasksError;

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -365,6 +365,7 @@ export async function fetchWeatherData(
 
   return {
     location: config.locationName,
+    timezone,
     units,
     current: currentWeather,
     forecast,

--- a/src/lib/integrations/pirateweather.ts
+++ b/src/lib/integrations/pirateweather.ts
@@ -281,6 +281,7 @@ export async function fetchWeatherData(
 
   return {
     location: config.locationName,
+    timezone,
     units,
     current,
     forecast,

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -2,6 +2,9 @@ import {
   formatDisplayHour,
   formatDisplayTime,
   formatDisplayTimeRange,
+  fromDisplayDateTime,
+  getDisplayDateKey,
+  toDisplayDate,
 } from '../timeFormat';
 
 describe('time format utilities', () => {
@@ -28,5 +31,34 @@ describe('time format utilities', () => {
     const end = new Date(2026, 0, 15, 15, 30);
     expect(formatDisplayTimeRange(afternoon, end, '12h')).toBe('2:05–3:30 PM');
     expect(formatDisplayTimeRange(afternoon, end, '24h')).toBe('14:05–15:30');
+  });
+
+  it('formats the same appointment in the selected display timezone', () => {
+    const appointment = new Date('2026-08-19T06:00:00.000Z');
+
+    expect(formatDisplayTime(appointment, '24h', {}, 'Europe/Warsaw')).toBe('08:00');
+    expect(formatDisplayTime(appointment, '24h', {}, 'Europe/London')).toBe('07:00');
+  });
+
+  it('uses the selected timezone for day bucketing around midnight', () => {
+    const instant = new Date('2026-08-19T22:30:00.000Z');
+
+    expect(getDisplayDateKey(instant, 'Europe/Warsaw')).toBe('2026-08-20');
+    expect(getDisplayDateKey(instant, 'Europe/London')).toBe('2026-08-19');
+    expect(toDisplayDate(instant, 'Europe/Warsaw').getHours()).toBe(0);
+  });
+
+  it('persists calendar form times in the selected display timezone', () => {
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-08-19T06:00:00.000Z');
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/London').toISOString())
+      .toBe('2026-08-19T07:00:00.000Z');
+  });
+
+  it('uses the correct selected-timezone offset across daylight saving time', () => {
+    expect(fromDisplayDateTime('2026-01-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-01-19T07:00:00.000Z');
+    expect(fromDisplayDateTime('2026-08-19', '08:00', 'Europe/Warsaw').toISOString())
+      .toBe('2026-08-19T06:00:00.000Z');
   });
 });

--- a/src/lib/utils/__tests__/timeFormat.test.ts
+++ b/src/lib/utils/__tests__/timeFormat.test.ts
@@ -1,0 +1,32 @@
+import {
+  formatDisplayHour,
+  formatDisplayTime,
+  formatDisplayTimeRange,
+} from '../timeFormat';
+
+describe('time format utilities', () => {
+  const afternoon = new Date(2026, 0, 15, 14, 5, 9);
+
+  it('formats ordinary times in 12-hour and 24-hour modes', () => {
+    expect(formatDisplayTime(afternoon, '12h')).toBe('2:05 PM');
+    expect(formatDisplayTime(afternoon, '24h')).toBe('14:05');
+  });
+
+  it('includes seconds when requested', () => {
+    expect(formatDisplayTime(afternoon, '12h', { showSeconds: true })).toBe('2:05:09 PM');
+    expect(formatDisplayTime(afternoon, '24h', { showSeconds: true })).toBe('14:05:09');
+  });
+
+  it('formats compact and full hour-axis labels', () => {
+    const hour = new Date(2026, 0, 15, 14, 0);
+    expect(formatDisplayHour(hour, '12h', { compact: true })).toBe('2PM');
+    expect(formatDisplayHour(hour, '24h', { compact: true })).toBe('14');
+    expect(formatDisplayHour(hour, '24h')).toBe('14:00');
+  });
+
+  it('formats event time ranges consistently', () => {
+    const end = new Date(2026, 0, 15, 15, 30);
+    expect(formatDisplayTimeRange(afternoon, end, '12h')).toBe('2:05–3:30 PM');
+    expect(formatDisplayTimeRange(afternoon, end, '24h')).toBe('14:05–15:30');
+  });
+});

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -1,0 +1,44 @@
+import { format } from 'date-fns';
+
+export type TimeFormat = '12h' | '24h';
+
+export const DEFAULT_TIME_FORMAT: TimeFormat = '12h';
+
+export function isTimeFormat(value: unknown): value is TimeFormat {
+  return value === '12h' || value === '24h';
+}
+
+export function formatDisplayTime(
+  date: Date | number,
+  timeFormat: TimeFormat,
+  options: { showSeconds?: boolean } = {},
+): string {
+  const { showSeconds = false } = options;
+  const pattern = timeFormat === '24h'
+    ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
+    : showSeconds ? 'h:mm:ss a' : 'h:mm a';
+  return format(date, pattern);
+}
+
+export function formatDisplayHour(
+  date: Date | number,
+  timeFormat: TimeFormat,
+  options: { compact?: boolean } = {},
+): string {
+  const { compact = false } = options;
+  const pattern = timeFormat === '24h'
+    ? compact ? 'HH' : 'HH:mm'
+    : compact ? 'ha' : 'h a';
+  return format(date, pattern);
+}
+
+export function formatDisplayTimeRange(
+  start: Date | number,
+  end: Date | number,
+  timeFormat: TimeFormat,
+): string {
+  if (timeFormat === '24h') {
+    return `${format(start, 'HH:mm')}–${format(end, 'HH:mm')}`;
+  }
+  return `${format(start, 'h:mm')}–${format(end, 'h:mm a')}`;
+}

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -1,44 +1,155 @@
 import { format } from 'date-fns';
 
 export type TimeFormat = '12h' | '24h';
+export type DisplayTimezoneMode = 'household' | 'device';
 
 export const DEFAULT_TIME_FORMAT: TimeFormat = '12h';
+export const DEFAULT_DISPLAY_TIMEZONE_MODE: DisplayTimezoneMode = 'household';
 
 export function isTimeFormat(value: unknown): value is TimeFormat {
   return value === '12h' || value === '24h';
+}
+
+export function isDisplayTimezoneMode(value: unknown): value is DisplayTimezoneMode {
+  return value === 'household' || value === 'device';
+}
+
+/**
+ * Return a presentation-only Date whose local fields match `date` in
+ * `timeZone`. This is useful with date-fns, whose formatters always use the
+ * browser timezone. Never persist or send the returned Date to an API.
+ */
+export function toDisplayDate(date: Date | number, timeZone?: string): Date {
+  const source = new Date(date);
+  if (!timeZone || Number.isNaN(source.getTime())) return source;
+
+  try {
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(source);
+    const value = (type: Intl.DateTimeFormatPartTypes) =>
+      Number(parts.find((part) => part.type === type)?.value);
+
+    return new Date(
+      value('year'),
+      value('month') - 1,
+      value('day'),
+      value('hour'),
+      value('minute'),
+      value('second'),
+      source.getMilliseconds(),
+    );
+  } catch {
+    return source;
+  }
+}
+
+export function getDisplayDateKey(date: Date | number, timeZone?: string): string {
+  return format(toDisplayDate(date, timeZone), 'yyyy-MM-dd');
+}
+
+/**
+ * Convert date/time fields entered in the selected display timezone into the
+ * real instant that should be persisted. This is the inverse of
+ * `toDisplayDate` for calendar form values.
+ */
+export function fromDisplayDateTime(
+  date: string,
+  time: string,
+  timeZone?: string,
+): Date {
+  const [year, month, day] = date.split('-').map(Number);
+  const [hour, minute, second = 0] = time.split(':').map(Number);
+
+  if (![year, month, day, hour, minute, second].every(Number.isFinite)) {
+    return new Date(NaN);
+  }
+
+  if (!timeZone) return new Date(year!, month! - 1, day!, hour!, minute!, second!);
+
+  const targetWallTime = Date.UTC(year!, month! - 1, day!, hour!, minute!, second!);
+  let instant = targetWallTime;
+
+  try {
+    const formatter = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    });
+
+    // A second pass handles dates where the first offset guess crosses a DST
+    // boundary. Three passes keep the operation stable for unusual offsets.
+    for (let pass = 0; pass < 3; pass += 1) {
+      const parts = formatter.formatToParts(new Date(instant));
+      const value = (type: Intl.DateTimeFormatPartTypes) =>
+        Number(parts.find((part) => part.type === type)?.value);
+      const displayedWallTime = Date.UTC(
+        value('year'),
+        value('month') - 1,
+        value('day'),
+        value('hour'),
+        value('minute'),
+        value('second'),
+      );
+      const correction = displayedWallTime - targetWallTime;
+      if (correction === 0) break;
+      instant -= correction;
+    }
+
+    return new Date(instant);
+  } catch {
+    return new Date(year!, month! - 1, day!, hour!, minute!, second!);
+  }
 }
 
 export function formatDisplayTime(
   date: Date | number,
   timeFormat: TimeFormat,
   options: { showSeconds?: boolean } = {},
+  timeZone?: string,
 ): string {
   const { showSeconds = false } = options;
   const pattern = timeFormat === '24h'
     ? showSeconds ? 'HH:mm:ss' : 'HH:mm'
     : showSeconds ? 'h:mm:ss a' : 'h:mm a';
-  return format(date, pattern);
+  return format(toDisplayDate(date, timeZone), pattern);
 }
 
 export function formatDisplayHour(
   date: Date | number,
   timeFormat: TimeFormat,
   options: { compact?: boolean } = {},
+  timeZone?: string,
 ): string {
   const { compact = false } = options;
   const pattern = timeFormat === '24h'
     ? compact ? 'HH' : 'HH:mm'
     : compact ? 'ha' : 'h a';
-  return format(date, pattern);
+  return format(toDisplayDate(date, timeZone), pattern);
 }
 
 export function formatDisplayTimeRange(
   start: Date | number,
   end: Date | number,
   timeFormat: TimeFormat,
+  timeZone?: string,
 ): string {
+  const displayStart = toDisplayDate(start, timeZone);
+  const displayEnd = toDisplayDate(end, timeZone);
   if (timeFormat === '24h') {
-    return `${format(start, 'HH:mm')}–${format(end, 'HH:mm')}`;
+    return `${format(displayStart, 'HH:mm')}–${format(displayEnd, 'HH:mm')}`;
   }
-  return `${format(start, 'h:mm')}–${format(end, 'h:mm a')}`;
+  return `${format(displayStart, 'h:mm')}–${format(displayEnd, 'h:mm a')}`;
 }


### PR DESCRIPTION
Lands **#253 by @m4rtski**, rebased by us onto current master (his work went stale only because I kept shipping 1.15.x calendar changes in parallel — so we did the reconciliation rather than bouncing it back). His commits are preserved with his authorship; credit is his.

## What it adds
- **12/24-hour time preference** (Settings → Display), threaded through every time renderer — clocks, weather, all calendar views, Away/Babysitter overlays — via a shared `TimeFormatProvider` + centralized `timeFormat.ts` helpers.
- **Configurable display timezone** — the PR's title only mentioned 12/24h, but it also adds a household-vs-device timezone (TZ-aware formatting *and* event creation via `fromDisplayDateTime` with DST correction). Defaults to the device's own timezone, so **no behavior change unless set**. Documented in the changelog.

## Review + reconciliation (two independent deep-dive passes)
- **Merges clean** onto master; my 1.15.x fixes verified intact (getFullCalendarRange window, PendingDeletionsModal native scroll). Doesn't touch `calendar-sync.ts`.
- Quality is genuinely solid: optimistic write + rollback, safe defaults, and thorough tests including **DST** and cross-timezone round-trips.

## Checks
`tsc` clean · his 13 tests pass (timeFormat + TimeFormatProvider) · eslint clean.

Foundation for landing #263's multi-day rendering next (it shares this provider).