### PR TITLE
chore: Contributor License Agreement + CLA Assistant + reconciled contribution terms

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,38 @@
+# CLA Assistant — asks first-time contributors to sign the Prism CLA (CLA.md)
+# with a one-click PR comment, and records signatures in signatures/cla.json.
+#
+# One-time setup by the maintainer:
+#   - Create a fine-grained/classic Personal Access Token with `repo` scope and
+#     add it as a repository secret named CLA_PAT (needed so the bot can commit
+#     the signature file). GITHUB_TOKEN alone can't push the signature commit.
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA and I agree') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/sandydargoport/prism/blob/master/CLA.md'
+          branch: 'master'
+          allowlist: sandydargoport,dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: 'Thanks for the contribution! Before it can be merged, please read our [Contributor License Agreement](https://github.com/sandydargoport/prism/blob/master/CLA.md) and, if you agree, post a comment below with exactly this text:'
+          custom-pr-sign-comment: 'I have read the CLA and I agree'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you! ✅'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,77 @@
+# Prism Contributor License Agreement
+
+Thank you for contributing to Prism. This Contributor License Agreement (the
+"Agreement") records the rights you grant to the Prism project maintainer,
+Sandy Dargoport (the "Maintainer"), for the contributions you make to the
+project.
+
+Its purpose is to keep Prism's licensing flexible — so the project can, if the
+Maintainer ever chooses, be offered under additional or different terms (for
+example, a commercial or supported edition) — while letting you keep ownership
+of your work.
+
+By submitting a Contribution to a Prism repository (including any Contribution
+you have already submitted), you agree to the following, on behalf of yourself
+and, if applicable, the entity you represent:
+
+## 1. Definitions
+
+- **"You"** means the individual or legal entity making a Contribution.
+- **"Contribution"** means any original work of authorship — including code,
+  documentation, tests, or other materials, and any modifications or additions
+  to existing work — that You intentionally submit to the project (for example,
+  via a pull request, patch, or issue attachment).
+
+## 2. Copyright License
+
+You retain all ownership of the copyright in Your Contribution. You grant the
+Maintainer, and the recipients of software distributed by the Maintainer, a
+perpetual, worldwide, non-exclusive, royalty-free, transferable, and
+irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute Your
+Contribution and such derivative works **under any license terms the Maintainer
+chooses, including open-source, source-available, proprietary, or commercial
+terms.**
+
+## 3. Patent License
+
+You grant the Maintainer and such recipients a perpetual, worldwide,
+non-exclusive, royalty-free, transferable, and irrevocable (except as stated
+below) patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer Your Contribution, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the project. If
+any entity institutes patent litigation against You or any other entity
+alleging that Your Contribution, or the project to which You contributed,
+constitutes patent infringement, then any patent licenses granted to that
+entity under this Agreement terminate as of the date such litigation is filed.
+
+## 4. Your Representations
+
+You represent that:
+
+- You are legally entitled to grant the above licenses.
+- Each of Your Contributions is Your original creation, or You otherwise have
+  the right to submit it under this Agreement.
+- If Your employer has rights to intellectual property You create, You have
+  received permission to make the Contributions on behalf of that employer, or
+  Your employer has waived such rights.
+- Your Contribution does not, to Your knowledge, violate any third party's
+  copyrights, trademarks, patents, or other intellectual property rights.
+
+## 5. No Obligation
+
+You understand that the Maintainer is under no obligation to use or include Your
+Contribution. Contributions are provided "as is," without warranty of any kind.
+
+## 6. No Other Relationship
+
+This Agreement does not create any employment, agency, partnership, or joint
+venture relationship between You and the Maintainer.
+
+---
+
+**How to sign.** New contributors are asked to agree to this CLA on their first
+pull request (a bot posts a one-time link to click "I agree"). Existing
+contributors may agree by commenting **"I have read the CLA and I agree"** on a
+pull request or issue, or by adding their name to `CONTRIBUTORS-CLA.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,23 @@ project's license.
 
 ## Licensing of Contributions
 
-By submitting a contribution (pull request, patch, or commit) you agree that:
+By submitting a contribution (pull request, patch, or commit) to Prism, you
+agree that:
 
-- your contribution is licensed under the **PolyForm Noncommercial License
-  1.0.0**, the same license as Prism;
-- you have the right to license it under those terms; and
-- you consent to a **Hosting Exception** permitting third parties to host
-  Prism on behalf of end users for their personal, noncommercial use, provided
-  such an exception grants no right to sell, sublicense, rebrand, or otherwise
-  commercialize the software.
+- Your contribution is licensed under the **PolyForm Noncommercial License
+  1.0.0**, together with Prism's **Hosting Exception** — the same terms as
+  Prism itself — so it stays free for families to self-host, including
+  one-click deployment on managed hosting platforms for personal, noncommercial
+  use.
+- You have the right to license your contribution under those terms.
+- Consistent with Prism's [`LICENSE`](LICENSE), **all commercial rights in the
+  software, including in your contribution, are reserved to the project
+  maintainer.** No third party may sell, sublicense, rebrand, or otherwise
+  commercialize Prism or your contribution, and the maintainer retains the
+  right to offer Prism under additional or commercial terms in the future.
 
-This keeps Prism free for families to self-host — including one-click on
-managed platforms — while ensuring no one can commercialize the project or
-your contributions. See the Hosting Exception in [`LICENSE`](LICENSE).
+This keeps Prism free for families forever and permits managed hosting for
+personal, noncommercial use, while preserving the maintainer's ability to
+sustain the project — without ever removing the free noncommercial edition. For
+code and documentation contributions, we also ask you to sign the
+[Contributor License Agreement](CLA.md), which records this grant.


### PR DESCRIPTION
Sets up the contributor-IP hygiene needed to keep Prism's commercial optionality clean, **without changing the license or what users get.**

## Context
Prism stays **PolyForm Noncommercial 1.0.0 + the Hosting Exception** — free for families to self-host, one-click managed hosting (PikaPods etc.) permitted, and **all commercial rights reserved to the maintainer**. This PR just makes that airtight across *contributors'* code too, so a future commercial/supported edition (or an acquisition) is a clean asset rather than a copyright scramble.

## Changes
- **`CLA.md`** — a license-grant Contributor License Agreement. Contributors **keep their copyright** but grant the maintainer broad rights (including relicensing/commercial). Standard open-core pattern (same shape Wealthfolio uses).
- **`CONTRIBUTING.md`** — reconciled the 'Licensing of Contributions' wording: the old *'no one can commercialize your contributions'* read as 'not even the maintainer,' contradicting the LICENSE's *'all commercial rights are reserved to the licensor.'* Now consistent — commercial rights reserved to the maintainer, family-first framing kept.
- **`.github/workflows/cla.yml`** — CLA Assistant so future PRs require a one-click sign-off; from here on no uncovered contributor copyright accrues.

## Maintainer setup TODO
Add a repo secret **`CLA_PAT`** (a PAT with `repo` scope) so the bot can record signatures in `signatures/cla.json`.

## Follow-up (not in this PR)
Retroactive CLA sign-off from existing external contributors (@m4rtski, @CornHead764, @iann, @JD-Gonz, @ricky-davis) — friendly outreach drafts to come for your approval. #269 (landing @m4rtski's #253) is held until he signs.

_Not legal advice — worth a lawyer's glance at `CLA.md` before relying on it for a commercial move._