### PR TITLE
fix(calendar): Manage-calendars modal no longer scrolls sideways on long names

### DIFF
--- a/src/components/settings/RemovedItemsManager.tsx
+++ b/src/components/settings/RemovedItemsManager.tsx
@@ -44,10 +44,11 @@ export function RemovedItemsManager({
               key={item.id}
               className="flex items-center justify-between gap-3 rounded-md border border-border/50 px-3 py-2"
             >
-              <span className="text-sm truncate">{item.name}</span>
+              <span className="text-sm truncate min-w-0 flex-1">{item.name}</span>
               <Button
                 variant="outline"
                 size="sm"
+                className="shrink-0"
                 disabled={restoringId === item.id}
                 onClick={() => onRestore(item.id)}
               >


### PR DESCRIPTION
The **Removed calendars** list (added in #262) rendered each name as a flex child with `truncate` but no `min-w-0`, so `truncate` never engaged — a long removed-calendar name forced the row, and the whole Manage-calendars modal, wider than its max width and produced horizontal scrolling.

Fix: `min-w-0 flex-1` on the name span so it ellipsizes, and `shrink-0` on the Restore button so it keeps its size. The connected-calendars rows already do this correctly; this brings the removed-items list in line.