### PR TITLE
chore(release): 1.16.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.16.0] – 2026-08-21
+
 ### Display
 - **Choose 12-hour or 24-hour time, family-wide.** A new time-format preference under Settings → Display applies everywhere times appear — clocks, weather, every calendar view, and the Away/Babysitter overlays — instead of each surface deciding on its own. Thanks to @m4rtski for the contribution.
 - **Pin a display timezone for the household.** You can now set the timezone Prism renders times in (defaults to each device's own, so nothing changes unless you set it) — keeping calendar, reminder, weather, and clock times consistent across devices. Also from @m4rtski's contribution.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.15.5"
+version: "1.16.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.15.5",
+  "version": "1.16.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Cuts **1.16.0** (minor — two user-facing features since 1.15.5).

### Display
- Family-wide 12/24-hour time preference (#269, @m4rtski)
- Pin a display timezone for the household (#269, @m4rtski)

### Calendar
- Multi-day events render as one continuous bar across month/multi-week/week views (#272, @m4rtski)
- All-day events created in Prism sync to Google correctly, on the right day (#272, @m4rtski)
- Manage-calendars modal no longer scrolls sideways on long removed-calendar names (#273)

Also includes the security + perf hardening from the batch review (Google error-body no longer reflected to clients, eventId URL-encoded, per-timezone Intl formatter cache).

Version bump touches all three synced files (package.json, ha-app/config.yaml, docs/CHANGELOG.md). Tag + GitHub release come after this merges.