### PR TITLE
chore(stats): stats.sh wrapper for the telemetry /stats endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .env.production
 .env.production.local
 !.env.example
+
+# Wrangler local secrets (telemetry collector). Keep tokens out of git.
+.dev.vars
 .claude/settings.local.json
 
 # Dependencies

--- a/collector/.dev.vars.example
+++ b/collector/.dev.vars.example
@@ -1,0 +1,4 @@
+# Local secrets for the Prism telemetry collector.
+# Copy this file to collector/.dev.vars (which is gitignored) and fill in the
+# value. Used by `wrangler dev` for local runs and by `npm run stats`.
+STATS_TOKEN=

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "type-check": "tsc --noEmit",
+    "stats": "bash scripts/stats.sh",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "test": "jest",

--- a/scripts/stats.sh
+++ b/scripts/stats.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Print Prism telemetry install stats from the collector Worker's token-gated
+# /stats endpoint, so you never have to paste the token on the command line.
+#
+# Token resolution order:
+#   1. $STATS_TOKEN in the environment
+#   2. STATS_TOKEN=... in collector/.dev.vars (gitignored; the same file
+#      wrangler already uses for local secrets)
+#
+# Override the endpoint with $PRISM_STATS_URL if the Worker ever moves.
+#
+# Usage:  bash scripts/stats.sh    (or: npm run stats)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+URL="${PRISM_STATS_URL:-https://prism-telemetry.sandydargoport.workers.dev/stats}"
+
+TOKEN="${STATS_TOKEN:-}"
+if [[ -z "$TOKEN" && -f collector/.dev.vars ]]; then
+  line="$(grep -E '^[[:space:]]*STATS_TOKEN[[:space:]]*=' collector/.dev.vars | head -1 || true)"
+  TOKEN="${line#*=}"
+  TOKEN="$(printf '%s' "$TOKEN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+    -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e 's/\r$//')"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  cat >&2 <<'ERR'
+No STATS_TOKEN found.
+  - Put it in collector/.dev.vars (gitignored):  STATS_TOKEN=your-token
+    (cp collector/.dev.vars.example collector/.dev.vars, then fill it in)
+  - or export STATS_TOKEN before running.
+ERR
+  exit 1
+fi
+
+resp="$(curl -fsS "${URL}?token=${TOKEN}")" \
+  || { echo "Request failed (check the token, network, or endpoint)." >&2; exit 1; }
+
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "$resp" | jq .
+elif command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$resp" | python3 -m json.tool
+else
+  printf '%s\n' "$resp"
+fi


### PR DESCRIPTION
Adds `scripts/stats.sh` (and `npm run stats`) to fetch install counts from the collector Worker's token-gated `/stats` endpoint without pasting the token each time.

- Reads `STATS_TOKEN` from `collector/.dev.vars` (gitignored) or `$STATS_TOKEN`.
- `collector/.dev.vars.example` documents the format; copy it to `.dev.vars` and fill in the token.
- Gitignores `.dev.vars` so the token can never be committed.
- Pretty-prints via jq, falls back to python3, then raw.

Endpoint overridable with `$PRISM_STATS_URL`.