### PR TITLE
feat(stats): pinned-issue install dashboard with adoption-by-source chart

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,79 @@
+name: Install stats
+
+# Publishes an aggregate install-stats snapshot into a single pinned issue,
+# and appends one data point per day so the issue's stacked-bar chart shows
+# adoption by source over time. The token is a repo Actions secret and never
+# leaves the runner; nothing is committed to any branch.
+
+on:
+  schedule:
+    - cron: '17 12 * * *' # daily, ~12:17 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: install-stats
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Fetch current stats
+        env:
+          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
+        run: |
+          if [ -z "${STATS_TOKEN}" ]; then
+            echo "::error::STATS_TOKEN secret is not set. Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          bash scripts/stats.sh > stats.json
+          test -s stats.json
+
+      - name: Find existing dashboard issue
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          num=$(gh issue list --state all --limit 200 --json number,title \
+                  --jq 'map(select(.title == "📊 Install stats")) | .[0].number // empty')
+          echo "number=${num}" >> "$GITHUB_OUTPUT"
+
+      - name: Read previous issue body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ steps.find.outputs.number }}" ]; then
+            gh issue view "${{ steps.find.outputs.number }}" --json body --jq .body > prev.md
+          else
+            : > prev.md
+          fi
+
+      - name: Build issue body
+        run: node scripts/build-stats-issue.mjs
+
+      - name: Create or update the pinned issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          num="${{ steps.find.outputs.number }}"
+          if [ -n "${num}" ]; then
+            gh issue edit "${num}" --body-file body.md
+            echo "Updated issue #${num}"
+          else
+            url=$(gh issue create --title "📊 Install stats" --body-file body.md)
+            num="${url##*/}"
+            echo "Created issue #${num}"
+            id=$(gh issue view "${num}" --json id --jq .id)
+            gh api graphql -f query='mutation($id:ID!){ pinIssue(input:{issueId:$id}){ issue { number } } }' -f id="${id}" \
+              || echo "::warning::Could not pin the issue automatically. Pin it once by hand and future runs will keep updating it."
+          fi

--- a/scripts/build-stats-issue.mjs
+++ b/scripts/build-stats-issue.mjs
@@ -1,0 +1,131 @@
+// Builds the body for the pinned "Install stats" dashboard issue.
+//
+// Reads:
+//   stats.json  - the current /stats snapshot from the collector Worker
+//   prev.md     - the existing issue body (may be empty on first run); its
+//                 embedded history block is the rolling time-series datastore
+// Writes:
+//   body.md     - the new issue body (current tables + stacked-bar chart +
+//                 refreshed hidden history)
+//
+// The issue is both the display and the datastore, so no branch, file, or
+// database is needed to keep adoption history. One data point per day, deduped.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+const MARKER = '<!-- PRISM_STATS_DASHBOARD -->';
+const HISTORY_OPEN = '<!-- PRISM_STATS_HISTORY';
+const HISTORY_CLOSE = '-->';
+const CHART_WINDOW = 90; // most-recent days to plot
+
+// Stable colors for known sources; anything new draws from the fallback palette.
+const SOURCE_COLORS = {
+  docker: '#2496ed',
+  ha: '#41bdf5',
+  pikapods: '#7b61ff',
+  local: '#8395a7',
+  unknown: '#b2bec3',
+};
+const FALLBACK = ['#e17055', '#00b894', '#fdcb6e', '#0984e3', '#d63031', '#a29bfe'];
+
+function readHistory(prev) {
+  const start = prev.indexOf(HISTORY_OPEN);
+  if (start === -1) return [];
+  const rest = prev.slice(start + HISTORY_OPEN.length);
+  const end = rest.indexOf(HISTORY_CLOSE);
+  const json = (end === -1 ? rest : rest.slice(0, end)).trim();
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed.points) ? parsed.points : [];
+  } catch {
+    return [];
+  }
+}
+
+const stats = JSON.parse(readFileSync('stats.json', 'utf8'));
+const prev = existsSync('prev.md') ? readFileSync('prev.md', 'utf8') : '';
+const history = readHistory(prev);
+
+const today = (process.env.STATS_DATE || new Date().toISOString().slice(0, 10)).trim();
+
+const sources = {};
+for (const row of stats.byDeployment ?? []) {
+  sources[(row.deployment || 'unknown').trim()] = row.n;
+}
+
+// Upsert today's point so re-runs on the same day overwrite rather than dupe.
+const point = { date: today, sources };
+const idx = history.findIndex((p) => p.date === today);
+if (idx >= 0) history[idx] = point;
+else history.push(point);
+history.sort((a, b) => a.date.localeCompare(b.date));
+
+// ---- stacked bar chart (QuickChart) ----
+const plotted = history.slice(-CHART_WINDOW);
+const allSources = [...new Set(plotted.flatMap((p) => Object.keys(p.sources)))].sort();
+let fi = 0;
+const datasets = allSources.map((s) => ({
+  label: s,
+  data: plotted.map((p) => p.sources[s] ?? 0),
+  backgroundColor: SOURCE_COLORS[s] ?? FALLBACK[fi++ % FALLBACK.length],
+}));
+const chartConfig = {
+  type: 'bar',
+  data: { labels: plotted.map((p) => p.date), datasets },
+  options: {
+    plugins: {
+      title: { display: true, text: 'Prism installs by source over time' },
+      legend: { position: 'bottom' },
+    },
+    scales: {
+      x: { stacked: true },
+      y: { stacked: true, beginAtZero: true, ticks: { precision: 0 } },
+    },
+  },
+};
+const chartUrl =
+  'https://quickchart.io/chart?bkg=white&w=760&h=360&v=4&c=' +
+  encodeURIComponent(JSON.stringify(chartConfig));
+
+// ---- current snapshot tables ----
+const rows = (arr, key) =>
+  arr && arr.length ? arr.map((r) => `| ${r[key]} | ${r.n} |`).join('\n') : '| _(none yet)_ | |';
+
+const stamp = new Date().toISOString().replace('T', ' ').slice(0, 16);
+
+const body = `${MARKER}
+# Prism install stats
+
+_Auto-updated ${stamp} UTC. Aggregate opt-out telemetry, so treat it as a floor, not a census._
+
+| Metric | Count |
+|---|---|
+| Total installs | ${stats.totalInstalls ?? 0} |
+| Active (7 days) | ${stats.activeInstalls7d ?? 0} |
+| Active (30 days) | ${stats.activeInstalls30d ?? 0} |
+
+## Adoption by source over time
+
+![Prism installs by source over time](${chartUrl})
+
+## By source (last 30 days)
+
+| Source | Installs |
+|---|---|
+${rows(stats.byDeployment, 'deployment')}
+
+## By version (last 30 days)
+
+| Version | Installs |
+|---|---|
+${rows(stats.byVersion, 'version')}
+
+${HISTORY_OPEN}
+${JSON.stringify({ points: history })}
+${HISTORY_CLOSE}
+`;
+
+writeFileSync('body.md', body);
+console.log(
+  `Wrote body.md: ${history.length} day(s) of history, sources = ${allSources.join(', ') || 'none'}, chart url ${chartUrl.length} chars`,
+);


### PR DESCRIPTION
Adds a scheduled workflow that maintains a single **pinned "📊 Install stats" issue** — current totals + by-source and by-version tables, plus a **QuickChart stacked bar of installs by source over time** (docker / ha / pikapods / …).

### How it works
- Runs daily (+ a **Run workflow** button for on-demand refresh).
- Fetches the aggregate `/stats` snapshot via `scripts/stats.sh`. `STATS_TOKEN` is a **repo Actions secret** and never leaves the runner.
- `scripts/build-stats-issue.mjs` reads the current pinned issue, appends today's point to a rolling history embedded in a hidden HTML comment in the issue body (one point per day, deduped), and rewrites the body with the tables + chart.
- **No branch, file, or database** — the issue is both the display and the datastore. First run creates and pins the issue.

### One-time setup (maintainer)
- Add `STATS_TOKEN` under **Settings → Secrets and variables → Actions** (same token the collector's `/stats` uses).

### Notes
- The chart has **no history to backfill** — it starts empty and fills one bar per day going forward.
- Data is aggregate only (counts by version/deployment, no PII).
- Verified locally: generator accumulates/dedupes history and adds new sources automatically; the QuickChart config returns a valid PNG.