### PR TITLE
feat(stats): by-version chart + arch and new-installs

### DIFF
--- a/collector/worker.js
+++ b/collector/worker.js
@@ -119,20 +119,29 @@ async function handleStats(url, env) {
 
   const q = (sql) => env.DB.prepare(sql).all().then((r) => r.results);
 
-  const [total, active7, active30, byVersion, byDeployment] = await Promise.all([
-    env.DB.prepare('SELECT COUNT(*) AS n FROM checkins').first('n'),
-    env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-7 days')`).first('n'),
-    env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days')`).first('n'),
-    q(`SELECT version, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY version ORDER BY n DESC`),
-    q(`SELECT deployment, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY deployment ORDER BY n DESC`),
-  ]);
+  const [total, active7, active30, new7, new30, byVersion, byDeployment, byArch, newInstallsByWeek] =
+    await Promise.all([
+      env.DB.prepare('SELECT COUNT(*) AS n FROM checkins').first('n'),
+      env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-7 days')`).first('n'),
+      env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days')`).first('n'),
+      env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE first_seen >= datetime('now','-7 days')`).first('n'),
+      env.DB.prepare(`SELECT COUNT(*) AS n FROM checkins WHERE first_seen >= datetime('now','-30 days')`).first('n'),
+      q(`SELECT version, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY version ORDER BY n DESC`),
+      q(`SELECT deployment, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY deployment ORDER BY n DESC`),
+      q(`SELECT COALESCE(arch,'unknown') AS arch, COUNT(*) AS n FROM checkins WHERE last_seen >= datetime('now','-30 days') GROUP BY COALESCE(arch,'unknown') ORDER BY n DESC`),
+      q(`SELECT strftime('%Y-%W', first_seen) AS week, COUNT(*) AS n FROM checkins GROUP BY week ORDER BY week`),
+    ]);
 
   return json({
     totalInstalls: total,
     activeInstalls7d: active7,
     activeInstalls30d: active30,
+    newInstalls7d: new7,
+    newInstalls30d: new30,
     byVersion,
     byDeployment,
+    byArch,
+    newInstallsByWeek,
     generatedAt: new Date().toISOString(),
   });
 }

--- a/scripts/build-stats-issue.mjs
+++ b/scripts/build-stats-issue.mjs
@@ -5,11 +5,14 @@
 //   prev.md     - the existing issue body (may be empty on first run); its
 //                 embedded history block is the rolling time-series datastore
 // Writes:
-//   body.md     - the new issue body (current tables + stacked-bar chart +
-//                 refreshed hidden history)
+//   body.md     - the new issue body (tables + stacked-bar charts + refreshed
+//                 hidden history)
 //
 // The issue is both the display and the datastore, so no branch, file, or
 // database is needed to keep adoption history. One data point per day, deduped.
+// The arch table and new-installs sections render only when the collector
+// provides those fields, so this script is forward-compatible with a Worker
+// that has not been redeployed yet.
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
@@ -18,7 +21,7 @@ const HISTORY_OPEN = '<!-- PRISM_STATS_HISTORY';
 const HISTORY_CLOSE = '-->';
 const CHART_WINDOW = 90; // most-recent days to plot
 
-// Stable colors for known sources; anything new draws from the fallback palette.
+// Stable colors for known sources; versions/others draw from the palette.
 const SOURCE_COLORS = {
   docker: '#2496ed',
   ha: '#41bdf5',
@@ -26,70 +29,96 @@ const SOURCE_COLORS = {
   local: '#8395a7',
   unknown: '#b2bec3',
 };
-const FALLBACK = ['#e17055', '#00b894', '#fdcb6e', '#0984e3', '#d63031', '#a29bfe'];
+const PALETTE = ['#0984e3', '#00b894', '#fdcb6e', '#e17055', '#6c5ce7', '#d63031', '#00cec9', '#e84393'];
 
 function readHistory(prev) {
   const start = prev.indexOf(HISTORY_OPEN);
   if (start === -1) return [];
   const rest = prev.slice(start + HISTORY_OPEN.length);
   const end = rest.indexOf(HISTORY_CLOSE);
-  const json = (end === -1 ? rest : rest.slice(0, end)).trim();
+  const raw = (end === -1 ? rest : rest.slice(0, end)).trim();
   try {
-    const parsed = JSON.parse(json);
+    const parsed = JSON.parse(raw);
     return Array.isArray(parsed.points) ? parsed.points : [];
   } catch {
     return [];
   }
 }
 
+const QC = 'https://quickchart.io/chart?bkg=white&v=4';
+
+function stackedBarUrl(points, dimension, title, fixedColors) {
+  const keys = [...new Set(points.flatMap((p) => Object.keys(p[dimension] || {})))].sort();
+  let pi = 0;
+  const colorFor = (k) => fixedColors[k] || PALETTE[pi++ % PALETTE.length];
+  const datasets = keys.map((k) => ({
+    label: k,
+    data: points.map((p) => (p[dimension] || {})[k] ?? 0),
+    backgroundColor: colorFor(k),
+  }));
+  const cfg = {
+    type: 'bar',
+    data: { labels: points.map((p) => p.date), datasets },
+    options: {
+      plugins: { title: { display: true, text: title }, legend: { position: 'bottom' } },
+      scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true, ticks: { precision: 0 } } },
+    },
+  };
+  return `${QC}&w=760&h=360&c=${encodeURIComponent(JSON.stringify(cfg))}`;
+}
+
+function barUrl(rows, labelKey, title) {
+  const cfg = {
+    type: 'bar',
+    data: {
+      labels: rows.map((r) => r[labelKey]),
+      datasets: [{ label: 'new installs', data: rows.map((r) => r.n), backgroundColor: '#00b894' }],
+    },
+    options: {
+      plugins: { title: { display: true, text: title }, legend: { display: false } },
+      scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
+    },
+  };
+  return `${QC}&w=760&h=300&c=${encodeURIComponent(JSON.stringify(cfg))}`;
+}
+
 const stats = JSON.parse(readFileSync('stats.json', 'utf8'));
 const prev = existsSync('prev.md') ? readFileSync('prev.md', 'utf8') : '';
 const history = readHistory(prev);
-
 const today = (process.env.STATS_DATE || new Date().toISOString().slice(0, 10)).trim();
 
-const sources = {};
-for (const row of stats.byDeployment ?? []) {
-  sources[(row.deployment || 'unknown').trim()] = row.n;
-}
+const toMap = (arr, key) =>
+  Object.fromEntries((arr || []).map((r) => [String(r[key] ?? 'unknown').trim(), r.n]));
 
-// Upsert today's point so re-runs on the same day overwrite rather than dupe.
-const point = { date: today, sources };
+// Upsert today's point (deduped) with both source and version breakdowns.
+const point = { date: today, sources: toMap(stats.byDeployment, 'deployment'), versions: toMap(stats.byVersion, 'version') };
 const idx = history.findIndex((p) => p.date === today);
 if (idx >= 0) history[idx] = point;
 else history.push(point);
 history.sort((a, b) => a.date.localeCompare(b.date));
 
-// ---- stacked bar chart (QuickChart) ----
 const plotted = history.slice(-CHART_WINDOW);
-const allSources = [...new Set(plotted.flatMap((p) => Object.keys(p.sources)))].sort();
-let fi = 0;
-const datasets = allSources.map((s) => ({
-  label: s,
-  data: plotted.map((p) => p.sources[s] ?? 0),
-  backgroundColor: SOURCE_COLORS[s] ?? FALLBACK[fi++ % FALLBACK.length],
-}));
-const chartConfig = {
-  type: 'bar',
-  data: { labels: plotted.map((p) => p.date), datasets },
-  options: {
-    plugins: {
-      title: { display: true, text: 'Prism installs by source over time' },
-      legend: { position: 'bottom' },
-    },
-    scales: {
-      x: { stacked: true },
-      y: { stacked: true, beginAtZero: true, ticks: { precision: 0 } },
-    },
-  },
-};
-const chartUrl =
-  'https://quickchart.io/chart?bkg=white&w=760&h=360&v=4&c=' +
-  encodeURIComponent(JSON.stringify(chartConfig));
+const sourceChart = stackedBarUrl(plotted, 'sources', 'Installs by source over time', SOURCE_COLORS);
+const versionChart = stackedBarUrl(plotted, 'versions', 'Installs by version over time', {});
 
-// ---- current snapshot tables ----
 const rows = (arr, key) =>
   arr && arr.length ? arr.map((r) => `| ${r[key]} | ${r.n} |`).join('\n') : '| _(none yet)_ | |';
+
+// Sections that only appear once the collector exposes the fields.
+const newInstallsRows =
+  stats.newInstalls7d != null || stats.newInstalls30d != null
+    ? `| New installs (7 days) | ${stats.newInstalls7d ?? 0} |\n| New installs (30 days) | ${stats.newInstalls30d ?? 0} |\n`
+    : '';
+
+const growthSection =
+  Array.isArray(stats.newInstallsByWeek) && stats.newInstallsByWeek.length
+    ? `\n## New installs per week\n\n![New installs per week](${barUrl(stats.newInstallsByWeek, 'week', 'New installs per week')})\n`
+    : '';
+
+const archSection =
+  Array.isArray(stats.byArch) && stats.byArch.length
+    ? `\n## By architecture (last 30 days)\n\n| Arch | Installs |\n|---|---|\n${rows(stats.byArch, 'arch')}\n`
+    : '';
 
 const stamp = new Date().toISOString().replace('T', ' ').slice(0, 16);
 
@@ -103,11 +132,15 @@ _Auto-updated ${stamp} UTC. Aggregate opt-out telemetry, so treat it as a floor,
 | Total installs | ${stats.totalInstalls ?? 0} |
 | Active (7 days) | ${stats.activeInstalls7d ?? 0} |
 | Active (30 days) | ${stats.activeInstalls30d ?? 0} |
+${newInstallsRows}
+## Installs by source over time
 
-## Adoption by source over time
+![Installs by source over time](${sourceChart})
 
-![Prism installs by source over time](${chartUrl})
+## Installs by version over time
 
+![Installs by version over time](${versionChart})
+${growthSection}
 ## By source (last 30 days)
 
 | Source | Installs |
@@ -119,7 +152,7 @@ ${rows(stats.byDeployment, 'deployment')}
 | Version | Installs |
 |---|---|
 ${rows(stats.byVersion, 'version')}
-
+${archSection}
 ${HISTORY_OPEN}
 ${JSON.stringify({ points: history })}
 ${HISTORY_CLOSE}
@@ -127,5 +160,6 @@ ${HISTORY_CLOSE}
 
 writeFileSync('body.md', body);
 console.log(
-  `Wrote body.md: ${history.length} day(s) of history, sources = ${allSources.join(', ') || 'none'}, chart url ${chartUrl.length} chars`,
+  `Wrote body.md: ${history.length} day(s) of history; sources+versions charted` +
+    `${archSection ? ', arch table' : ''}${growthSection ? ', new-installs chart' : ''}.`,
 );


### PR DESCRIPTION
Extends the install-stats dashboard.

**Ships now (no redeploy needed):**
- Second stacked bar: **installs by version over time** (watch releases roll out), alongside by-source. Both breakdowns are stored per day in the issue's hidden history.

**Lights up after the collector Worker is redeployed:**
- `/stats` now also returns `byArch` (x86 vs ARM/Pi), `newInstalls7d` / `newInstalls30d`, and `newInstallsByWeek` (from `first_seen` — so the growth series is backfilled, not start-from-now).
- The generator renders an **arch table**, **new-installs metrics**, and a **new installs / week** chart *only when those fields are present*, so it's forward-compatible: nothing breaks before the redeploy; the sections appear after.

**Maintainer step to activate arch + new-installs:** `cd collector && wrangler deploy` (needs your Cloudflare creds). By-version works immediately.