### PR TITLE
fix(calendar): manage-modal sideways scroll + hidden-hours persistence

### DIFF
--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -26,7 +26,7 @@ export function ManageCalendarsModal({
 }) {
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-3xl max-h-[85vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>Manage calendars</DialogTitle>
         </DialogHeader>

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -890,7 +890,7 @@ function AddIcalSubscriptionCard({ onAdded }: { onAdded: () => void }) {
         </details>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="grid gap-3 sm:grid-cols-[1fr_220px_auto]">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto]">
           <Input
             type="url"
             placeholder="webcal://p99-caldav.icloud.com/published/..."

--- a/src/lib/hooks/__tests__/useHiddenHours.test.ts
+++ b/src/lib/hooks/__tests__/useHiddenHours.test.ts
@@ -7,6 +7,18 @@ import { useHiddenHours } from '../useHiddenHours';
 
 const STORAGE_KEY = 'prism:calendar-hidden-hours';
 
+// useHiddenHours now reconciles against /api/settings; jsdom has no global
+// fetch, so stub it to an empty-settings response (the DB reconcile becomes a
+// no-op and the localStorage-cache behavior these tests assert is preserved).
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ settings: {} }) }),
+  ) as unknown as typeof fetch;
+});
+afterAll(() => {
+  delete (global as { fetch?: unknown }).fetch;
+});
+
 beforeEach(() => {
   localStorage.clear();
 });

--- a/src/lib/hooks/useHiddenHours.ts
+++ b/src/lib/hooks/useHiddenHours.ts
@@ -3,7 +3,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { CalendarEvent } from '@/types/calendar';
 
-const HIDDEN_HOURS_KEY = 'prism:calendar-hidden-hours';
+// localStorage key doubles as a fast-paint cache AND the migration source for
+// installs that stored hidden-hours locally before it moved to the database.
+const CACHE_KEY = 'prism:calendar-hidden-hours';
+// Database settings key (persists across updates + shared across devices).
+const SETTING_KEY = 'calendarHiddenHours';
 
 interface HiddenHoursSettings {
   /** Mode for hour filtering */
@@ -26,39 +30,84 @@ const DEFAULT_SETTINGS: HiddenHoursSettings = {
   enabled: false,
 };
 
+function normalize(parsed: unknown): HiddenHoursSettings {
+  const p = (parsed ?? {}) as Partial<HiddenHoursSettings>;
+  return {
+    mode: p.mode === 'manual' || p.mode === 'auto-fit' ? p.mode : DEFAULT_SETTINGS.mode,
+    startHour: typeof p.startHour === 'number' ? p.startHour : DEFAULT_SETTINGS.startHour,
+    endHour: typeof p.endHour === 'number' ? p.endHour : DEFAULT_SETTINGS.endHour,
+    bufferHours: typeof p.bufferHours === 'number' ? p.bufferHours : DEFAULT_SETTINGS.bufferHours,
+    enabled: typeof p.enabled === 'boolean' ? p.enabled : DEFAULT_SETTINGS.enabled,
+  };
+}
+
 export function useHiddenHours() {
   const [settings, setSettingsState] = useState<HiddenHoursSettings>(DEFAULT_SETTINGS);
   const [loaded, setLoaded] = useState(false);
 
-  // Load from localStorage on mount
   useEffect(() => {
+    // 1. Instant paint from the localStorage cache (so the calendar doesn't
+    //    flash default hours before the DB responds).
+    let cached: HiddenHoursSettings | null = null;
     try {
-      const saved = localStorage.getItem(HIDDEN_HOURS_KEY);
+      const saved = localStorage.getItem(CACHE_KEY);
       if (saved) {
-        const parsed = JSON.parse(saved);
-        setSettingsState({
-          mode: typeof parsed.mode === 'string' && (parsed.mode === 'manual' || parsed.mode === 'auto-fit') ? parsed.mode : DEFAULT_SETTINGS.mode,
-          startHour: typeof parsed.startHour === 'number' ? parsed.startHour : DEFAULT_SETTINGS.startHour,
-          endHour: typeof parsed.endHour === 'number' ? parsed.endHour : DEFAULT_SETTINGS.endHour,
-          bufferHours: typeof parsed.bufferHours === 'number' ? parsed.bufferHours : DEFAULT_SETTINGS.bufferHours,
-          enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULT_SETTINGS.enabled,
-        });
+        cached = normalize(JSON.parse(saved));
+        setSettingsState(cached);
       }
     } catch {
-      // Use defaults
+      // ignore
     }
     setLoaded(true);
+
+    // 2. Authoritative value from the database; reconcile + refresh the cache.
+    let active = true;
+    fetch('/api/settings')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!active) return;
+        const dbValue = data?.settings?.[SETTING_KEY];
+        if (dbValue && typeof dbValue === 'object') {
+          const norm = normalize(dbValue);
+          setSettingsState(norm);
+          try {
+            localStorage.setItem(CACHE_KEY, JSON.stringify(norm));
+          } catch {
+            // ignore
+          }
+        } else if (cached) {
+          // One-time migration: DB has no value yet but this device had a local
+          // one — push it up so it persists and reaches other devices.
+          fetch('/api/settings', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ key: SETTING_KEY, value: cached }),
+          }).catch(() => {});
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      active = false;
+    };
   }, []);
 
-  // Save to localStorage
   const setSettings = useCallback((newSettings: Partial<HiddenHoursSettings>) => {
     setSettingsState((prev) => {
       const updated = { ...prev, ...newSettings };
+      // Cache locally for instant paint next load.
       try {
-        localStorage.setItem(HIDDEN_HOURS_KEY, JSON.stringify(updated));
+        localStorage.setItem(CACHE_KEY, JSON.stringify(updated));
       } catch {
-        // Ignore storage errors
+        // ignore
       }
+      // Persist to the DB (requires settings permission; a display-only session
+      // silently keeps the local value if the PATCH is refused).
+      fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: SETTING_KEY, value: updated }),
+      }).catch(() => {});
       return updated;
     });
   }, []);


### PR DESCRIPTION
Two calendar UX fixes.

**Manage-calendars modal no longer scrolls sideways** — the iCal-subscription row's grid `1fr` track couldn't shrink below its content; switched to `minmax(0,1fr)`, plus a horizontal-overflow clip on the dialog as a backstop.

**Hidden-hours now persists in the database** (was localStorage-only, so per-device and lost on updates). Stored as `calendarHiddenHours` via `/api/settings`; localStorage kept as a fast-paint cache; one-time migration pushes any existing local value to the DB so no one loses their setting.

Green locally: tsc 0, jest 1400, lint 0. Both deployed to the maintainer's install for verification.