### PR TITLE
fix(calendar): widen Manage-calendars modal (max-w-5xl)

### DIFF
--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -26,7 +26,7 @@ export function ManageCalendarsModal({
 }) {
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="w-[calc(100vw-2rem)] max-w-3xl max-h-[85vh] overflow-y-auto overflow-x-hidden">
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-5xl max-h-[85vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>Manage calendars</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
Follow-up to the overflow fix: max-w-3xl was too narrow on large wall displays, cramping the content. Bump to max-w-5xl; still responsive on small screens.