### PR TITLE
perf(calendar): scope per-view event filtering + view-change transitions

### DIFF
--- a/src/app/calendar/useCalendarViewData.ts
+++ b/src/app/calendar/useCalendarViewData.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useTransition } from 'react';
 import {
   format,
   startOfWeek,
@@ -28,12 +28,16 @@ export type { CalendarGroup } from '@/lib/hooks';
 export function useCalendarViewData() {
   const { weekStartsOn } = useWeekStartsOn();
   const { displayTimezone } = useTimeFormat();
+  // View/date changes trigger a heavy re-bucket + grid re-render. Running those
+  // as a transition keeps the switcher/nav responsive (and lets us show a subtle
+  // pending state) instead of freezing while the new view computes.
+  const [isNavPending, startTransition] = useTransition();
   const [currentDate, setCurrentDate] = useState(new Date());
 
   useEffect(() => {
     setCurrentDate(toDisplayDate(new Date(), displayTimezone));
   }, [displayTimezone]);
-  const [viewType, setViewType] = useState<CalendarViewType>(() => {
+  const [viewType, setViewTypeState] = useState<CalendarViewType>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('prism-calendar-view-type') as CalendarViewType | null;
       const valid: CalendarViewType[] = ['agenda', 'day', 'week', 'weekVertical', 'multiWeek', 'month', 'threeMonth'];
@@ -41,6 +45,10 @@ export function useCalendarViewData() {
     }
     return 'month';
   });
+  const setViewType = useCallback(
+    (next: CalendarViewType) => startTransition(() => setViewTypeState(next)),
+    [],
+  );
 
   useEffect(() => {
     localStorage.setItem('prism-calendar-view-type', viewType);
@@ -146,12 +154,12 @@ export function useCalendarViewData() {
   }, [apiEvents, filterEvents]);
 
   const goToToday = useCallback(
-    () => setCurrentDate(toDisplayDate(new Date(), displayTimezone)),
+    () => startTransition(() => setCurrentDate(toDisplayDate(new Date(), displayTimezone))),
     [displayTimezone],
   );
 
   const goToPrevious = useCallback(() => {
-    setCurrentDate(prev => {
+    startTransition(() => setCurrentDate(prev => {
       switch (viewType) {
         case 'agenda': return prev; // no navigation
         case 'day': return subDays(prev, 1);
@@ -161,11 +169,11 @@ export function useCalendarViewData() {
         case 'month': return subMonths(prev, 1);
         case 'threeMonth': return subMonths(prev, 1);
       }
-    });
+    }));
   }, [viewType, weekCount]);
 
   const goToNext = useCallback(() => {
-    setCurrentDate(prev => {
+    startTransition(() => setCurrentDate(prev => {
       switch (viewType) {
         case 'agenda': return prev; // no navigation
         case 'day': return addDays(prev, 1);
@@ -175,7 +183,7 @@ export function useCalendarViewData() {
         case 'month': return addMonths(prev, 1);
         case 'threeMonth': return addMonths(prev, 1);
       }
-    });
+    }));
   }, [viewType, weekCount]);
 
   const getDateRangeTitle = useCallback((): string => {
@@ -218,5 +226,6 @@ export function useCalendarViewData() {
     overlays, setOverlays,
     events, loading, error, refreshEvents,
     goToToday, goToPrevious, goToNext, getDateRangeTitle,
+    isNavPending,
   };
 }

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -26,6 +26,7 @@ import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, isCalendarEventPast, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -88,7 +89,10 @@ export function MonthView({
 
   const numWeeks = Math.ceil(days.length / 7);
   const dayNames = [...DAYS_SHORT_ARRAY.slice(weekStartsOn), ...DAYS_SHORT_ARRAY.slice(0, weekStartsOn)];
-  const spanningEvents = events
+  // Scope the wide event list to this month grid's visible range once, so the
+  // spanning + per-day filters iterate ~40 events instead of thousands.
+  const scopedEvents = eventsOverlappingRange(events, calendarStart, calendarEnd);
+  const spanningEvents = scopedEvents
     .filter((event) => eventSpansMultipleDisplayDays(
       event.startTime,
       event.endTime,
@@ -139,7 +143,7 @@ export function MonthView({
               rowDate,
               displayTimezone,
             )));
-          const dayEvents = events
+          const dayEvents = scopedEvents
             .filter((event) => !spanningEventSet.has(event))
             .filter((event) => eventOccursOnDisplayDay(
               event.startTime,

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -26,6 +26,7 @@ import { useCardCapacity } from '@/lib/hooks/useCardCapacity';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, isCalendarEventPast, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -86,7 +87,10 @@ export function MultiWeekView({
     weeks.push(hideWeekends ? row.filter((d) => d.getDay() !== 0 && d.getDay() !== 6) : row);
   }
   const colCount = hideWeekends ? 5 : 7;
-  const spanningEvents = events
+  // Scope the wide event list to the visible weeks once, so the spanning +
+  // per-day filters iterate the local slice instead of thousands of events.
+  const scopedEvents = eventsOverlappingRange(events, weekStart, addDays(weekStart, weekCount * 7));
+  const spanningEvents = scopedEvents
     .filter((event) => eventSpansMultipleDisplayDays(
       event.startTime,
       event.endTime,
@@ -136,7 +140,7 @@ export function MultiWeekView({
                   date={date}
                   rowDates={week}
                   spanningEvents={rowSpanningEvents}
-                  events={events}
+                  events={scopedEvents}
                   onEventClick={onEventClick}
                   compact={compact}
                   bordered={bordered}

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -23,6 +23,7 @@ import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { useTimeFormat } from '@/components/providers';
 import { InlineCalendarEvent, SpanningEventRows } from './cells';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, toDisplayDate } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -79,7 +80,10 @@ function MiniMonth({
   for (let i = 0; i < days.length; i += 7) {
     weeks.push(days.slice(i, i + 7));
   }
-  const spanningEvents = events
+  // Scope the wide event list to this mini-month's visible grid once, so the
+  // spanning filter and the per-day filter below iterate ~40 events, not thousands.
+  const scopedEvents = eventsOverlappingRange(events, calendarStart, calendarEnd);
+  const spanningEvents = scopedEvents
     .filter((event) => eventSpansMultipleDisplayDays(
       event.startTime,
       event.endTime,
@@ -131,7 +135,7 @@ function MiniMonth({
               {week.map((date, dayIndex) => {
               const inMonth = isSameMonth(date, month);
               const today = isSameDay(date, displayNow);
-              const dayEvents = events
+              const dayEvents = scopedEvents
                 .filter((event) => !spanningEventSet.has(event))
                 .filter((event) => eventOccursOnDisplayDay(
                   event.startTime,

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -30,6 +30,7 @@ import {
   formatDisplayTimeRange,
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -77,7 +78,10 @@ export function WeekView({
   const { settings: hiddenSettings, toggleHidden, getVisibleHours } = useHiddenHours();
 
   const weekEnd = addDays(weekStart, 7);
-  const timedWeekEvents = events
+  // Scope the wide event list to this week once; the per-day/per-hour filters
+  // below all read the local slice instead of thousands of events.
+  const scopedEvents = eventsOverlappingRange(events, weekStart, weekEnd);
+  const timedWeekEvents = scopedEvents
     .filter((event) => {
       const displayStart = toDisplayDate(event.startTime, displayTimezone);
       return !event.allDay
@@ -96,7 +100,7 @@ export function WeekView({
 
   // Multi-day timed events share the persistent header with all-day events so
   // they do not become oversized blocks in the hourly grid.
-  const getAllDayEvents = (date: Date) => events.filter((event) =>
+  const getAllDayEvents = (date: Date) => scopedEvents.filter((event) =>
     (event.allDay || eventSpansMultipleDisplayDays(
       event.startTime,
       event.endTime,
@@ -124,14 +128,14 @@ export function WeekView({
   // across the entire day, so events that overlap but start in different
   // hours still split the column horizontally).
   const getDayTimedEvents = (date: Date) =>
-    events.filter((event) =>
+    scopedEvents.filter((event) =>
       !event.allDay
       && !eventSpansMultipleDisplayDays(event.startTime, event.endTime, false, displayTimezone)
       && isSameDay(toDisplayDate(event.startTime, displayTimezone), date));
 
   // Get timed events for a specific day and hour
   const getHourEvents = (date: Date, hour: number) =>
-    events.filter(
+    scopedEvents.filter(
       (e) =>
         isSameDay(toDisplayDate(e.startTime, displayTimezone), date) &&
         !e.allDay &&

--- a/src/lib/hooks/useDayBucketsForRange.ts
+++ b/src/lib/hooks/useDayBucketsForRange.ts
@@ -142,6 +142,20 @@ export function useDayBucketsForRange({
     const start = startOfDay(from);
     const end = startOfDay(to);
 
+    // Pre-filter to events that overlap [from, to] (padded ±1 day so a
+    // timezone boundary can never drop a real match) so the per-day membership
+    // check below iterates a small slice instead of the full, up-to-several-
+    // thousand-event dataset on every view switch / month advance. The precise
+    // per-day check (eventOnDay) is unchanged, so results are identical.
+    const DAY_MS = 86_400_000;
+    const filterStartMs = start.getTime() - DAY_MS;
+    const filterEndMs = end.getTime() + 2 * DAY_MS;
+    const rangeEvents = overlays.events
+      ? events.filter(
+          (e) => e.startTime.getTime() <= filterEndMs && e.endTime.getTime() >= filterStartMs,
+        )
+      : EMPTY_EVENTS;
+
     const safeMeals = overlays.meals ? meals ?? EMPTY_MEALS : EMPTY_MEALS;
     const safeChores = overlays.chores ? chores ?? EMPTY_CHORES : EMPTY_CHORES;
     const safeTasks = overlays.tasks ? tasks ?? EMPTY_TASKS : EMPTY_TASKS;
@@ -154,7 +168,7 @@ export function useDayBucketsForRange({
       const key = dateKey(date);
 
       const dayEvents = overlays.events
-        ? events.filter((e) => eventOnDay(e, date, displayTimezone))
+        ? rangeEvents.filter((e) => eventOnDay(e, date, displayTimezone))
         : EMPTY_EVENTS;
       const allDayEvents = dayEvents
         .filter((e) => e.allDay)

--- a/src/lib/utils/calendarRange.ts
+++ b/src/lib/utils/calendarRange.ts
@@ -28,3 +28,23 @@ export function getFullCalendarRange(today: Date): { start: Date; end: Date } {
     end: endOfYear(addYears(today, 2)),
   };
 }
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Narrow a full (wide-window) event list to just those overlapping [from, to],
+ * padded ±1 day so a timezone boundary can never drop a real match. Views fetch
+ * one wide dataset (~thousands of events) but render a small window; scoping to
+ * the visible range first turns their per-day O(days × all_events) filtering
+ * into O(days × visible_events). The precise per-day membership check each view
+ * already runs is unchanged, so results are identical.
+ */
+export function eventsOverlappingRange<T extends { startTime: Date; endTime: Date }>(
+  events: T[],
+  from: Date,
+  to: Date,
+): T[] {
+  const start = from.getTime() - DAY_MS;
+  const end = to.getTime() + 2 * DAY_MS;
+  return events.filter((e) => e.startTime.getTime() <= end && e.endTime.getTime() >= start);
+}


### PR DESCRIPTION
Calendar was sluggish switching views / advancing 3-month on the thin client. Not a fetch problem (wide window is fetched once + cached); the cost was each view re-filtering the full ~5000-event list per visible day (3-month ≈ 460k checks/recompute).

- `eventsOverlappingRange()` scopes events to each view's visible range once (padded ±1 day for tz safety) before the per-day filters — Month/MultiWeek/Week/ThreeMonth + the shared `useDayBucketsForRange`. Membership logic unchanged → identical results.
- View/date changes run as React transitions so the UI stays responsive.

Green: tsc 0, jest 1400, lint 0. Deployed to the maintainer's install for verification.