### PR TITLE
perf(calendar): scope the remaining views (day/2-week/vertical-week/agenda)

### DIFF
--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -22,6 +22,7 @@ import {
   toDisplayDate,
   type TimeFormat,
 } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -80,7 +81,10 @@ export function AgendaView({
   const cards = displayMode === 'cards';
   const startDate = startOfDay(toDisplayDate(new Date(), displayTimezone));
 
-  const filteredEvents = events
+  // Scope the wide event list to the agenda horizon once, so the per-day
+  // membership check below iterates a small slice instead of thousands.
+  const scopedEvents = eventsOverlappingRange(events, startDate, addDays(startDate, days));
+  const filteredEvents = scopedEvents
     .filter(e => Array.from({ length: days }, (_, i) => addDays(startDate, i))
       .some(date => eventOccursOnDisplayDay(
         e.startTime,

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -29,6 +29,7 @@ import {
   formatDisplayTimeRange,
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 export interface DayViewSideBySideProps {
   currentDate: Date;
@@ -89,7 +90,8 @@ export function DayViewSideBySide({
 
   // Get visible hours (filtered if hidden mode is enabled)
   const dayStart = startOfDay(currentDate);
-  const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+  const scopedEvents = eventsOverlappingRange(events, currentDate, currentDate);
+  const dayEvents = scopedEvents.filter((event) => eventOccursOnDisplayDay(
     event.startTime,
     event.endTime,
     event.allDay,

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -21,6 +21,7 @@ import {
   formatDisplayTime,
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 export interface TwoWeekViewProps {
   currentDate: Date;
@@ -52,8 +53,10 @@ export function TwoWeekView({
   const week1Num = getWeek(week1[0]!);
   const week2Num = getWeek(week2[0]!);
 
+  // Scope the wide event list to the two visible weeks once.
+  const scopedEvents = eventsOverlappingRange(events, weekStart, addDays(weekStart, 14));
   const renderDayCell = (date: Date, compact: boolean = false) => {
-    const dayEvents = events.filter((event) => eventOccursOnDisplayDay(
+    const dayEvents = scopedEvents.filter((event) => eventOccursOnDisplayDay(
       event.startTime,
       event.endTime,
       event.allDay,

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -25,6 +25,7 @@ import {
   isCalendarEventPast,
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
+import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -73,6 +74,8 @@ export function WeekVerticalView({
   const cellBgStyle = cellBg ? { backgroundColor: hexToRgba(cellBg, cellBgOpacity) } : undefined;
   const weekStart = startOfWeek(currentDate, { weekStartsOn });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  // Scope the wide event list to this week once; passed into each day row.
+  const scopedEvents = eventsOverlappingRange(events, weekStart, addDays(weekStart, 7));
   const now = toDisplayDate(new Date(), displayTimezone);
   const today = startOfDay(now);
 
@@ -124,7 +127,7 @@ export function WeekVerticalView({
           key={day.toISOString()}
           day={day}
           today={today}
-          events={events}
+          events={scopedEvents}
           displayGroups={displayGroups}
           getEventsForGroup={getEventsForGroup}
           bordered={bordered}


### PR DESCRIPTION
Follow-up to #281: applies the same `eventsOverlappingRange` scoping to the lighter views so none re-filter the full ~5000-event list per day. Agenda's filter checked each event against every horizon day, so it's included. Membership logic unchanged. tsc 0, jest 1400, lint 0.