### PR TITLE
chore(release): 1.16.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.16.1] – 2026-08-22
+
+### Calendar
+- **Faster view switching and month navigation.** Flipping between calendar views and advancing the month (especially 3-month) is much snappier, and switching no longer briefly freezes the display while the new view renders. Each view now scopes its work to just the dates on screen instead of scanning the whole event history every time.
+- **The "hide hours" setting now sticks.** It is stored in the database instead of per-browser, so it survives updates and stays consistent across your devices.
+- **The Manage calendars window no longer scrolls sideways** and now uses more of the screen width on large displays.
+
 ## [1.16.0] – 2026-08-21
 
 ### Display

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.16.0"
+version: "1.16.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release 1.16.1 — calendar bug fixes + performance.

### Calendar
- Much faster view switching and month navigation (esp. 3-month); switching no longer blocks the display.
- "Hide hours" setting now persists in the DB (was per-browser, lost on updates).
- Manage-calendars window no longer scrolls sideways; wider on large displays.

Version bump touches all three synced files. Tag + GitHub release after merge.