### PR TITLE
feat(stats): track registry downloads daily and clarify install metrics

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -39,6 +39,14 @@ jobs:
           bash scripts/stats.sh > stats.json
           test -s stats.json
 
+      # Registry download counts, scraped from the public package pages because
+      # GHCR publishes no download API. Fail-soft on purpose: a GitHub markup
+      # change must not take the telemetry dashboard down with it — the
+      # downloads section just disappears until the parser is fixed.
+      - name: Fetch registry download counts
+        continue-on-error: true
+        run: node scripts/fetch-ghcr-downloads.mjs
+
       - name: Find existing dashboard issue
         id: find
         env:

--- a/scripts/build-stats-issue.mjs
+++ b/scripts/build-stats-issue.mjs
@@ -1,9 +1,10 @@
 // Builds the body for the pinned "Install stats" dashboard issue.
 //
 // Reads:
-//   stats.json  - the current /stats snapshot from the collector Worker
-//   prev.md     - the existing issue body (may be empty on first run); its
-//                 embedded history block is the rolling time-series datastore
+//   stats.json     - the current /stats snapshot from the collector Worker
+//   downloads.json - optional registry download counts (fetch-ghcr-downloads.mjs)
+//   prev.md        - the existing issue body (may be empty on first run); its
+//                    embedded history block is the rolling time-series datastore
 // Writes:
 //   body.md     - the new issue body (tables + stacked-bar charts + refreshed
 //                 hidden history)
@@ -31,17 +32,31 @@ const SOURCE_COLORS = {
 };
 const PALETTE = ['#0984e3', '#00b894', '#fdcb6e', '#e17055', '#6c5ce7', '#d63031', '#00cec9', '#e84393'];
 
-function readHistory(prev) {
+// Published images, coloured to match the source palette above.
+const PACKAGE_COLORS = {
+  prism: '#2496ed',
+  'prism-ha-amd64': '#41bdf5',
+  'prism-ha-aarch64': '#7b61ff',
+};
+
+// The embedded block holds two independent series: `points` (install snapshots,
+// one per run) and `downloads` (registry pulls, one per calendar day). A body
+// written before downloads existed simply yields an empty second series.
+function readStore(prev) {
+  const empty = { points: [], downloads: [] };
   const start = prev.indexOf(HISTORY_OPEN);
-  if (start === -1) return [];
+  if (start === -1) return empty;
   const rest = prev.slice(start + HISTORY_OPEN.length);
   const end = rest.indexOf(HISTORY_CLOSE);
   const raw = (end === -1 ? rest : rest.slice(0, end)).trim();
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed.points) ? parsed.points : [];
+    return {
+      points: Array.isArray(parsed.points) ? parsed.points : [],
+      downloads: Array.isArray(parsed.downloads) ? parsed.downloads : [],
+    };
   } catch {
-    return [];
+    return empty;
   }
 }
 
@@ -72,7 +87,7 @@ function barUrl(rows, labelKey, title) {
     type: 'bar',
     data: {
       labels: rows.map((r) => r[labelKey]),
-      datasets: [{ label: 'new installs', data: rows.map((r) => r.n), backgroundColor: '#00b894' }],
+      datasets: [{ label: 'newly visible', data: rows.map((r) => r.n), backgroundColor: '#00b894' }],
     },
     options: {
       plugins: { title: { display: true, text: title }, legend: { display: false } },
@@ -84,7 +99,7 @@ function barUrl(rows, labelKey, title) {
 
 const stats = JSON.parse(readFileSync('stats.json', 'utf8'));
 const prev = existsSync('prev.md') ? readFileSync('prev.md', 'utf8') : '';
-const history = readHistory(prev);
+const { points: history, downloads: dlHistoryPrev } = readStore(prev);
 const today = (process.env.STATS_DATE || new Date().toISOString().slice(0, 10)).trim();
 
 const toMap = (arr, key) =>
@@ -105,14 +120,24 @@ const rows = (arr, key) =>
   arr && arr.length ? arr.map((r) => `| ${r[key]} | ${r.n} |`).join('\n') : '| _(none yet)_ | |';
 
 // Sections that only appear once the collector exposes the fields.
+// "Newly visible", not "new": the collector's first_seen is the first time an
+// install ever checked in, which for anything installed before the update check
+// shipped (1.15.0, 2026-08-19) is its upgrade date, not its install date. Older
+// installs therefore arrive as they upgrade, and labelling that "new installs"
+// would read as growth that never happened.
 const newInstallsRows =
   stats.newInstalls7d != null || stats.newInstalls30d != null
-    ? `| New installs (7 days) | ${stats.newInstalls7d ?? 0} |\n| New installs (30 days) | ${stats.newInstalls30d ?? 0} |\n`
+    ? `| Newly visible (7 days) | ${stats.newInstalls7d ?? 0} |\n| Newly visible (30 days) | ${stats.newInstalls30d ?? 0} |\n`
     : '';
 
 const growthSection =
   Array.isArray(stats.newInstallsByWeek) && stats.newInstallsByWeek.length
-    ? `\n## New installs per week\n\n![New installs per week](${barUrl(stats.newInstallsByWeek, 'week', 'New installs per week')})\n`
+    ? `\n## Newly visible installs per week
+
+_First check-in, not install date. Installs predating 1.15.0 appear here when
+they upgrade, so expect a ramp that reflects upgrade adoption, not new users._
+
+![Newly visible installs per week](${barUrl(stats.newInstallsByWeek, 'week', 'Newly visible installs per week')})\n`
     : '';
 
 const archSection =
@@ -120,19 +145,72 @@ const archSection =
     ? `\n## By architecture (last 30 days)\n\n| Arch | Installs |\n|---|---|\n${rows(stats.byArch, 'arch')}\n`
     : '';
 
+// --- Registry downloads -----------------------------------------------------
+// GitHub serves a rolling 30-day window per package, so every run backfills
+// anything we missed and corrects the most recent day (which arrives partial).
+// We keep our own copy so the series survives past GitHub's 30-day horizon.
+const dlPackages = existsSync('downloads.json')
+  ? JSON.parse(readFileSync('downloads.json', 'utf8')).packages ?? {}
+  : {};
+
+const byDate = new Map(dlHistoryPrev.map((p) => [p.date, p]));
+for (const [name, info] of Object.entries(dlPackages)) {
+  for (const { date, count } of info.daily || []) {
+    const point = byDate.get(date) ?? { date, byPkg: {} };
+    point.byPkg = { ...point.byPkg, [name]: count };
+    byDate.set(date, point);
+  }
+}
+// Bounded so the embedded datastore can't grow the issue body past GitHub's
+// 65k limit — a couple of years of daily points is far more than we plot.
+const DL_RETENTION_DAYS = 400;
+const dlHistory = [...byDate.values()]
+  .sort((a, b) => a.date.localeCompare(b.date))
+  .slice(-DL_RETENTION_DAYS);
+
+// Drop the newest day from the chart only: it is still accumulating and would
+// draw a false cliff. It stays in history and is corrected on the next run.
+const dlPlotted = dlHistory.slice(-CHART_WINDOW).slice(0, -1);
+
+const downloadRows = Object.entries(dlPackages)
+  .map(([name, info]) => {
+    const last30 = (info.daily || []).reduce((sum, d) => sum + d.count, 0);
+    return `| \`${name}\` | ${info.total ?? '—'} | ${last30} |`;
+  })
+  .join('\n');
+
+const downloadsSection = Object.keys(dlPackages).length
+  ? `\n## Registry downloads (GHCR)
+
+_Pulls, not installs. Mirrors, scanners and auto-updaters poll continuously, so
+the flat daily baseline is mostly automated traffic. Read the **shape** — bumps
+above baseline after a release are real people updating — not the total._
+
+| Image | Total (all time) | Last 30 days |
+|---|---|---|
+${downloadRows}
+${dlPlotted.length ? `\n![Registry downloads per day](${stackedBarUrl(dlPlotted, 'byPkg', 'Registry downloads per day', PACKAGE_COLORS)})\n` : ''}`
+  : '';
+
 const stamp = new Date().toISOString().replace('T', ' ').slice(0, 16);
 
 const body = `${MARKER}
 # Prism install stats
 
-_Auto-updated ${stamp} UTC. Aggregate opt-out telemetry, so treat it as a floor, not a census._
+_Auto-updated ${stamp} UTC. Anonymous opt-out check-ins — a floor, not a census._
 
 | Metric | Count |
 |---|---|
-| Total installs | ${stats.totalInstalls ?? 0} |
+| Total installs (ever seen) | ${stats.totalInstalls ?? 0} |
 | Active (7 days) | ${stats.activeInstalls7d ?? 0} |
-| Active (30 days) | ${stats.activeInstalls30d ?? 0} |
+| **Active (30 days)** | ${stats.activeInstalls30d ?? 0} |
 ${newInstallsRows}
+_**Active (30 days)** is the figure to quote: an exact, de-duplicated count of
+installs still checking in — one install counts once however often it updates.
+**Total** never decays, since check-in rows are never deleted, so it drifts above
+reality as installs are retired. Both undercount: anything below 1.15.0 has no
+check-in code at all, and opted-out or offline installs never report._
+
 ## Installs by source over time
 
 ![Installs by source over time](${sourceChart})
@@ -152,14 +230,15 @@ ${rows(stats.byDeployment, 'deployment')}
 | Version | Installs |
 |---|---|
 ${rows(stats.byVersion, 'version')}
-${archSection}
+${archSection}${downloadsSection}
 ${HISTORY_OPEN}
-${JSON.stringify({ points: history })}
+${JSON.stringify({ points: history, downloads: dlHistory })}
 ${HISTORY_CLOSE}
 `;
 
 writeFileSync('body.md', body);
 console.log(
   `Wrote body.md: ${history.length} day(s) of history; sources+versions charted` +
-    `${archSection ? ', arch table' : ''}${growthSection ? ', new-installs chart' : ''}.`,
+    `${archSection ? ', arch table' : ''}${growthSection ? ', new-installs chart' : ''}` +
+    `${downloadsSection ? `, downloads (${dlHistory.length} day(s), ${Object.keys(dlPackages).length} image(s))` : ''}.`,
 );

--- a/scripts/fetch-ghcr-downloads.mjs
+++ b/scripts/fetch-ghcr-downloads.mjs
@@ -1,0 +1,77 @@
+// Pulls registry download counts for Prism's published container images and
+// writes downloads.json for build-stats-issue.mjs to render.
+//
+// Why scrape: GitHub's Packages REST API exposes no download_count for
+// container packages (it exists for npm/maven/etc. but not GHCR), and the
+// GraphQL package fields are deprecated. The public package page is the only
+// place the number is published, so we read it there. That makes this step
+// inherently fragile — it parses HTML GitHub can change at any time — so the
+// workflow runs it fail-soft and the dashboard simply omits the section when
+// the parse comes back empty.
+//
+// What the page gives us, per package:
+//   - an exact all-time total (the abbreviated "2.22K" text carries the real
+//     number in the h3's title attribute)
+//   - a 30-day daily series encoded in the sparkline's rects
+// The daily series is retroactive, so the first run already backfills a month.
+//
+// Output: downloads.json
+//   { fetchedAt, packages: { <name>: { total, daily: [{date, count}] } } }
+
+import { writeFileSync } from 'node:fs';
+
+const OWNER = process.env.GHCR_OWNER || process.env.GITHUB_REPOSITORY_OWNER || 'sandydargoport';
+const PACKAGES = (process.env.GHCR_PACKAGES || 'prism,prism-ha-amd64,prism-ha-aarch64')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+/** Exact all-time total: <span>Total downloads</span> <h3 title="2222">2.22K</h3> */
+function parseTotal(html) {
+  const m = html.match(/Total downloads<\/span>\s*<h3[^>]*\btitle="(\d+)"/);
+  return m ? Number(m[1]) : null;
+}
+
+/** 30-day daily series from the sparkline rects. */
+function parseDaily(html) {
+  return [...html.matchAll(/data-merge-count="(\d+)"\s+data-date="(\d{4}-\d{2}-\d{2})"/g)]
+    .map((m) => ({ date: m[2], count: Number(m[1]) }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** User and org accounts live on different paths; try both before giving up. */
+async function fetchPackagePage(name) {
+  const paths = [
+    `https://github.com/users/${OWNER}/packages/container/package/${name}`,
+    `https://github.com/orgs/${OWNER}/packages/container/package/${name}`,
+  ];
+  for (const url of paths) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': 'prism-install-stats' } });
+      if (res.ok) return await res.text();
+    } catch {
+      // Network hiccup on one path; fall through and try the other.
+    }
+  }
+  return null;
+}
+
+const packages = {};
+for (const name of PACKAGES) {
+  const html = await fetchPackagePage(name);
+  if (!html) {
+    console.log(`::warning::${name}: package page unreachable; skipping`);
+    continue;
+  }
+  const total = parseTotal(html);
+  const daily = parseDaily(html);
+  if (total == null && !daily.length) {
+    console.log(`::warning::${name}: no download figures found (page markup may have changed)`);
+    continue;
+  }
+  packages[name] = { total, daily };
+  console.log(`${name}: total=${total ?? 'n/a'} dailyPoints=${daily.length}`);
+}
+
+writeFileSync('downloads.json', JSON.stringify({ fetchedAt: new Date().toISOString(), packages }));
+console.log(`Wrote downloads.json for ${Object.keys(packages).length}/${PACKAGES.length} package(s).`);


### PR DESCRIPTION
## Why

The install counter shipped on 2026-08-19 in 1.15.0. Anything older has no check-in code, so today's `total = 7` is an exact count of *installs that have already upgraded to 1.15.0+* — not of the install base. Two problems follow:

1. There is no opt-out-proof signal to sanity-check it against.
2. The dashboard's labels invite misreading, because `first_seen` is the first *check-in*, not the install date.

This adds the second signal and fixes the labels.

## Registry downloads

GHCR publishes no download API for container packages — the REST `download_count` field exists for npm/maven/etc. but not containers, and the GraphQL package fields are deprecated ([community #146215](https://github.com/orgs/community/discussions/146215)). The public package page is the only place the number appears, so `scripts/fetch-ghcr-downloads.mjs` reads it there:

- an exact all-time total (the page shows `2.22K`, but the real `2222` is in the `title` attribute)
- a 30-day daily series encoded in the sparkline's rects

The daily series is **retroactive**, so the first run backfills a month rather than starting from zero — the 1.15.x and 1.16.x releases are already covered.

Parsing HTML is inherently fragile, so the workflow step is `continue-on-error`: if GitHub changes the markup, the downloads section disappears until the parser is fixed and the telemetry dashboard is unaffected.

### Downloads are pulls, not installs

The data makes this vivid, and the rendered section says so:

- **`prism` (standalone):** a flat 26–41 downloads *every single day*, completely indifferent to release days. That's mirrors, scanners and auto-updaters — not people.
- **`prism-ha-*`:** long runs of exactly zero, then bursts on release day (4 → 11 → 28 around 1.15.5/1.16.0). That's people clicking Update.

So the useful signal is the bump above baseline, not the cumulative total. One open question the recorded series will settle: whether a single update registers as one download or several (the amd64 image keeps producing bursts of exactly 5), which is why no headcount is claimed here.

## Label clarity

- `New installs (7/30 days)` → `Newly visible (7/30 days)`
- `New installs per week` → `Newly visible installs per week`, with a note that installs predating 1.15.0 appear when they upgrade

Without this, the next two months of upgrade adoption would draw a steep curve that looks like user growth and isn't.

The metrics table now also states that **Active (30 days)** is the figure to quote — an exact, de-duplicated count of installs still checking in — while **Total** never decays, since check-in rows are never deleted, and drifts above reality as installs are retired.

## Storage

Download history is kept as a second series in the issue's existing embedded datastore, bounded to 400 days so the body cannot outgrow GitHub's 65k limit. Bodies written before this change parse fine (the second series just reads empty).

## Testing

Ran the full pipeline locally against the live #278 dashboard:

- backfilled 30 days across all 3 images, existing install history preserved
- chart URL renders (HTTP 200, `image/png`)
- re-running with its own output as input is idempotent — no duplicated days
- workflow YAML parses with the new step in the right position
- body is 8KB against the 65536 limit

Once merged, the workflow can be run manually rather than waiting for the 12:17 UTC schedule.

Refs #278
