### PR TITLE
feat(integrations): connect Google Calendar via pasted refresh token (no public URL)

### DIFF
--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -20,6 +20,21 @@ OAuth grants Prism read+write access to your Google Calendars. You can create, e
 
 The connection covers Calendar specifically. If you also want Google Tasks sync, that's configured per-list inside the Google provider card on the same *Settings → Integrations* page.
 
+### Google Calendar without a public URL (OAuth Playground)
+
+*Settings → Integrations → Google → **Connect without a public URL (advanced)**.*
+
+The normal **Connect** button needs a public HTTPS address, because Google refuses to register a private/LAN redirect URI (e.g. `http://homeassistant.local:8123/…` or `http://192.168.x.x:3000/…`) — you'll see *"must end with a public top-level domain."* If Prism only runs on your LAN (Home Assistant add-on, bare Docker) and you'd rather not put it behind a public URL, you can still get full read+write by generating a refresh token yourself with Google's OAuth Playground and pasting it into Prism. The sign-in stays entirely on Google's own domain — nothing routes through a third party.
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials), create an **OAuth 2.0 Client ID** (type *Web application*) and enable the **Google Calendar API**.
+2. Add `https://developers.google.com/oauthplayground` to the client's **Authorized redirect URIs**.
+3. Open the [OAuth 2.0 Playground](https://developers.google.com/oauthplayground), click the gear icon, tick **"Use your own OAuth credentials"**, and paste the same Client ID and Secret.
+4. In *Step 1*, select **Google Calendar API v3 → `https://www.googleapis.com/auth/calendar`**, click **Authorize APIs**, and sign in with the account whose calendars you want.
+5. In *Step 2*, click **Exchange authorization code for tokens** and copy the **Refresh token**.
+6. In Prism, open the *Connect without a public URL (advanced)* section of the Google card and paste the Client ID, Client Secret, and Refresh token. Prism validates them with Google and imports your calendars with full read+write.
+
+**Heads-up — publish your consent screen to Production.** If your OAuth consent screen is left in *Testing* mode, Google expires refresh tokens after **7 days** and the connection stops working. Publish the app to *Production* (no verification is required for your own use of Calendar scopes) so it keeps working. If a connection ever goes stale, just re-paste a fresh refresh token in the same place. To revoke access entirely, go to *Google Account → Security → Third-party access*.
+
 ### iCal subscriptions (read-only)
 
 *Open the Calendar page → **Manage** → Subscribe to a calendar → paste URL.*

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -248,3 +248,6 @@ See [docs/voice-api.md](voice-api.md) for the full endpoint reference, request/r
 - Check the Prism container is running: `docker ps`
 - Test the endpoint manually: `curl -H "Authorization: Bearer YOUR_TOKEN" http://prism.local:3000/api/chores`
 - Check HA logs for connection errors
+
+**Google Calendar won't connect — "must end with a public top-level domain"**
+- The add-on runs on a private LAN address, which Google refuses to accept as an OAuth redirect URI. Either put Prism behind a public HTTPS URL, or use the no-public-URL method (paste a refresh token from Google's OAuth Playground). See [Calendar → Google Calendar without a public URL](features/CALENDAR.md#google-calendar-without-a-public-url-oauth-playground).

--- a/src/app/api/__tests__/googleManualToken.test.ts
+++ b/src/app/api/__tests__/googleManualToken.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment node
+ *
+ * Security suite for POST /api/integrations/google/manual-token.
+ * The load-bearing assertions: auth/role gating, error mapping, and that NO
+ * response body or log line ever contains the pasted refresh token or client
+ * secret on any exit path.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+const mockRequireAuth = jest.fn();
+const mockRequireRole = jest.fn();
+const mockGetCreds = jest.fn();
+const mockRefresh = jest.fn();
+const mockFetchEmail = jest.fn();
+const mockStore = jest.fn();
+const mockLogError = jest.fn();
+const mockLogActivity = jest.fn();
+const mockSelect = jest.fn();
+const mockInsert = jest.fn();
+const mockUpdate = jest.fn();
+const valuesSpy = jest.fn((_v?: unknown) => Promise.resolve());
+
+jest.mock('@/lib/auth', () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  requireRole: (...a: unknown[]) => mockRequireRole(...a),
+}));
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    select: (...a: unknown[]) => mockSelect(...a),
+    insert: (...a: unknown[]) => mockInsert(...a),
+    update: (...a: unknown[]) => mockUpdate(...a),
+  },
+}));
+jest.mock('@/lib/db/schema', () => ({ settings: { key: 'key', value: 'value' } }));
+jest.mock('drizzle-orm', () => ({ eq: jest.fn() }));
+jest.mock('@/lib/utils/crypto', () => ({ encrypt: (v: string) => `enc(${v})` }));
+jest.mock('@/lib/utils/logError', () => ({ logError: (...a: unknown[]) => mockLogError(...a) }));
+jest.mock('@/lib/services/auditLog', () => ({ logActivity: (...a: unknown[]) => mockLogActivity(...a) }));
+jest.mock('@/lib/integrations/credentialStore', () => ({
+  getGoogleCredentials: (...a: unknown[]) => mockGetCreds(...a),
+}));
+jest.mock('@/lib/integrations/oauth-userinfo', () => ({
+  fetchGoogleAccountEmail: (...a: unknown[]) => mockFetchEmail(...a),
+}));
+jest.mock('@/lib/integrations/googleCalendarStore', () => ({
+  storeGoogleCalendarConnection: (...a: unknown[]) => mockStore(...a),
+}));
+jest.mock('@/lib/integrations/google-calendar', () => {
+  class TokenRevokedError extends Error {}
+  return {
+    __esModule: true,
+    TokenRevokedError,
+    refreshAccessToken: (...a: unknown[]) => mockRefresh(...a),
+  };
+});
+
+import { POST } from '../integrations/google/manual-token/route';
+import { TokenRevokedError } from '@/lib/integrations/google-calendar';
+
+const CLIENT_ID = '123-abc.apps.googleusercontent.com';
+const SECRET = 'GOCSPX-supersecret_value';
+const TOKEN = '1//0gSuperSecretRefreshToken';
+const goodBody = { clientId: CLIENT_ID, clientSecret: SECRET, refreshToken: TOKEN };
+
+function req(body: object) {
+  return new NextRequest('http://localhost/api/integrations/google/manual-token', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** No response body and no log argument may ever contain the secret or token. */
+function expectNoLeak(bodyText: string) {
+  expect(bodyText).not.toContain(SECRET);
+  expect(bodyText).not.toContain(TOKEN);
+  const logged = mockLogError.mock.calls.flat().map(String).join(' ');
+  expect(logged).not.toContain(SECRET);
+  expect(logged).not.toContain(TOKEN);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAuth.mockResolvedValue({ userId: 'p1', role: 'parent' });
+  mockRequireRole.mockReturnValue(undefined);
+  mockGetCreds.mockResolvedValue(null);
+  mockRefresh.mockResolvedValue({
+    access_token: 'at_plain',
+    expires_in: 3600,
+    scope: 'https://www.googleapis.com/auth/calendar openid email',
+    token_type: 'Bearer',
+  });
+  mockFetchEmail.mockResolvedValue('user@example.com');
+  mockStore.mockResolvedValue({
+    calendarCount: 2,
+    inserted: 2,
+    updated: 0,
+    skippedDismissed: 0,
+    accountEmail: 'user@example.com',
+  });
+  mockSelect.mockReturnValue({ from: () => ({ where: () => [] }) });
+  mockInsert.mockReturnValue({ values: valuesSpy });
+  mockUpdate.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+});
+
+describe('POST /api/integrations/google/manual-token — auth', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockRequireAuth.mockResolvedValue(NextResponse.json({ error: 'unauth' }, { status: 401 }));
+    const res = await POST(req(goodBody));
+    expect(res.status).toBe(401);
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a role without canModifySettings', async () => {
+    mockRequireRole.mockReturnValue(NextResponse.json({ error: 'forbidden' }, { status: 403 }));
+    const res = await POST(req(goodBody));
+    expect(res.status).toBe(403);
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/integrations/google/manual-token — validation & mapping', () => {
+  it('400 invalid_input on a malformed client id (never echoes the value)', async () => {
+    const res = await POST(req({ ...goodBody, clientId: 'nope' }));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expectNoLeak(JSON.stringify(body));
+  });
+
+  it('409 when a different client is already configured and no overwrite', async () => {
+    mockGetCreds.mockResolvedValue({ clientId: 'other.apps.googleusercontent.com', clientSecret: 'x', redirectUri: '', gmailRedirectUri: '' });
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('client_mismatch_confirm_required');
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when overwriteCredentials confirms the replacement', async () => {
+    mockGetCreds.mockResolvedValue({ clientId: 'other.apps.googleusercontent.com', clientSecret: 'x', redirectUri: '', gmailRedirectUri: '' });
+    const res = await POST(req({ ...goodBody, overwriteCredentials: true }));
+    expect(res.status).toBe(200);
+  });
+
+  it('400 invalid_grant when the token is revoked/expired', async () => {
+    mockRefresh.mockRejectedValue(new TokenRevokedError('invalid_grant'));
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_grant');
+    expectNoLeak(JSON.stringify(body));
+  });
+
+  it('400 invalid_client when the id/secret pair is rejected', async () => {
+    mockRefresh.mockRejectedValue(new Error('400 invalid_client: bad'));
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_client');
+  });
+
+  it('400 missing_calendar_scope when the token lacks calendar access', async () => {
+    mockRefresh.mockResolvedValue({ access_token: 'at', expires_in: 3600, scope: 'openid email', token_type: 'Bearer' });
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('missing_calendar_scope');
+    expect(mockStore).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/integrations/google/manual-token — success', () => {
+  it('200, stores the pasted refresh token, encrypts creds, audits counts only', async () => {
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, calendarCount: 2, accountEmail: 'user@example.com' });
+    expectNoLeak(JSON.stringify(body));
+
+    // Exactly one refresh + one store.
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockStore).toHaveBeenCalledTimes(1);
+
+    // The PASTED refresh token is what gets stored.
+    expect(mockStore.mock.calls[0][0].tokens.refreshToken).toBe(TOKEN);
+
+    // Client creds persisted encrypted — never in plaintext.
+    const stored = valuesSpy.mock.calls[0]?.[0] as { value: { clientId: string; clientSecret: string } };
+    // encrypt() is applied to both (the real impl is AES-GCM; the mock echoes
+    // inside enc(…), so we assert the wrapper was called rather than absence of
+    // the plaintext — real ciphertext never contains it).
+    expect(stored.value.clientSecret).toBe(`enc(${SECRET})`);
+    expect(stored.value.clientId).toBe(`enc(${CLIENT_ID})`);
+
+    // Audit summary carries a count, not credentials.
+    const summary = mockLogActivity.mock.calls[0][0].summary as string;
+    expect(summary).toContain('2 calendars');
+    expect(summary).not.toContain(TOKEN);
+  });
+
+  it('persists client creds BEFORE storing calendar rows (bound-client ordering)', async () => {
+    const order: string[] = [];
+    valuesSpy.mockImplementation(() => {
+      order.push('creds');
+      return Promise.resolve();
+    });
+    mockStore.mockImplementation(() => {
+      order.push('store');
+      return Promise.resolve({ calendarCount: 1, inserted: 1, updated: 0, skippedDismissed: 0, accountEmail: null });
+    });
+    await POST(req(goodBody));
+    expect(order).toEqual(['creds', 'store']);
+  });
+});

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { db } from '@/lib/db/client';
-import { calendarSources, settings } from '@/lib/db/schema';
+import { calendarSources } from '@/lib/db/schema';
 import { logError } from '@/lib/utils/logError';
 import {
   exchangeCodeForTokens,
@@ -14,6 +14,7 @@ import { encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchGoogleAccountEmail } from '@/lib/integrations/oauth-userinfo';
+import { storeGoogleCalendarConnection } from '@/lib/integrations/googleCalendarStore';
 import { consumeOAuthState } from '@/lib/auth/oauthState';
 
 const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
@@ -164,66 +165,23 @@ export async function GET(request: Request) {
       return NextResponse.redirect(returnUrlFor(returnSection, 'success=google_reauth'));
     }
 
-    // Fetch calendars using the plaintext token (before we discard it)
-    const calendars = await fetchCalendarList(tokens.access_token);
-
-    // Fetch dismissed Google calendar IDs so we don't recreate user-deleted calendars
-    const dismissedSet = await tombstoneIdSet(DISMISSED_GOOGLE_CALENDARS_KEY);
-
-    for (const calendar of calendars) {
-      // Skip calendars the user has previously deleted from Prism
-      if (dismissedSet.has(calendar.id)) continue;
-      const existing = await db.query.calendarSources.findFirst({
-        where: (cs, { and, eq }) =>
-          and(
-            eq(cs.provider, 'google'),
-            eq(cs.sourceCalendarId, calendar.id)
-          ),
-      });
-
-      if (existing) {
-        const prev = (existing.syncErrors as Record<string, unknown>) || {};
-        await db
-          .update(calendarSources)
-          .set({
-            accessToken: encryptedAccessToken,
-            refreshToken: encryptedRefreshToken || existing.refreshToken,
-            tokenExpiresAt,
-            accountEmail: accountEmail ?? undefined,
-            syncErrors: prev.userOverride ? { userOverride: true } : null,
-            updatedAt: new Date(),
-          })
-          .where(eq(calendarSources.id, existing.id));
-      } else {
-        const calendarName = (calendar.summary || 'Untitled Calendar').slice(0, 255);
-        const isWritable = calendar.accessRole === 'writer' || calendar.accessRole === 'owner';
-
-        await db.insert(calendarSources).values({
-          // Owner is the authenticated caller, not a client-supplied state
-          // field (which was previously attacker-controllable).
-          userId: auth.userId,
-          provider: 'google',
-          sourceCalendarId: calendar.id,
-          dashboardCalendarName: calendarName,
-          displayName: calendarName,
-          color: calendar.backgroundColor || undefined,
-          // Calendars hidden in the user's Google list come in disabled, so
-          // they're available in Manage Calendars without cluttering the board.
-          enabled: !calendar.hidden,
-          showInEventModal: isWritable,
-          accessToken: encryptedAccessToken,
-          refreshToken: encryptedRefreshToken,
-          tokenExpiresAt,
-          accountEmail,
-        });
-      }
-    }
+    // Store tokens + calendars via the shared helper (identical logic is used by
+    // the manual refresh-token / OAuth Playground path so the two never drift).
+    const result = await storeGoogleCalendarConnection({
+      userId: auth.userId,
+      tokens: {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token ?? null,
+        expiresIn: tokens.expires_in,
+      },
+      accountEmail,
+    });
 
     logActivity({
       userId: auth.userId,
       action: 'create',
       entityType: 'integration',
-      summary: `Connected Google Calendar integration (${calendars.length} calendars)`,
+      summary: `Connected Google Calendar integration (${result.calendarCount} calendars)`,
     });
 
     // Redirect back to settings with success message

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -1,0 +1,190 @@
+/**
+ * POST /api/integrations/google/manual-token
+ *
+ * Connect Google Calendar (full read/write) by pasting {client id, client
+ * secret, refresh token} generated via Google's OAuth 2.0 Playground — for
+ * LAN-only installs that can't register a public HTTPS redirect URI. No browser
+ * redirect, no hosted relay.
+ *
+ * Security posture (see the manual-token threat model):
+ *  - Auth-gated (canModifySettings); userId comes from the session, never input.
+ *  - Write-only: there is no GET; the response never contains token/secret material.
+ *  - The pasted refresh token, client secret, and client id are encrypted at rest.
+ *  - The request body is NEVER logged; error logs carry only a fixed category.
+ *  - Validates the pasted token with exactly one refresh + one calendar-list call.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { requireAuth, requireRole } from '@/lib/auth';
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { encrypt } from '@/lib/utils/crypto';
+import { logError } from '@/lib/utils/logError';
+import { logActivity } from '@/lib/services/auditLog';
+import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
+import { refreshAccessToken, TokenRevokedError } from '@/lib/integrations/google-calendar';
+import { fetchGoogleAccountEmail } from '@/lib/integrations/oauth-userinfo';
+import { storeGoogleCalendarConnection } from '@/lib/integrations/googleCalendarStore';
+import { googleManualTokenSchema } from '@/lib/validations/googleManualToken';
+
+const CREDENTIALS_KEY = 'credentials.google';
+
+/** Persist the pasted client id/secret to the same key the setup wizard writes. */
+async function upsertGoogleClientCredentials(
+  clientId: string,
+  clientSecret: string,
+  existing: { redirectUri?: string; gmailRedirectUri?: string } | null,
+): Promise<void> {
+  const value = {
+    clientId: encrypt(clientId),
+    clientSecret: encrypt(clientSecret),
+    // Redirect URI is unused by the refresh grant; preserve any existing value.
+    redirectUri: existing?.redirectUri ?? '',
+    gmailRedirectUri: existing?.gmailRedirectUri ?? existing?.redirectUri ?? '',
+  };
+  const rows = await db.select().from(settings).where(eq(settings.key, CREDENTIALS_KEY));
+  if (rows.length > 0) {
+    await db.update(settings).set({ value }).where(eq(settings.key, CREDENTIALS_KEY));
+  } else {
+    await db.insert(settings).values({ key: CREDENTIALS_KEY, value });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
+  // Parse + validate. Field names may be surfaced; submitted values never are.
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_input', message: 'Request body must be JSON.' }, { status: 400 });
+  }
+  const parsed = googleManualTokenSchema.safeParse(body);
+  if (!parsed.success) {
+    const field = parsed.error.issues[0]?.path.join('.') || 'input';
+    return NextResponse.json(
+      { error: 'invalid_input', message: `The ${field} field is missing or malformed.` },
+      { status: 400 },
+    );
+  }
+  const { clientId, clientSecret, refreshToken, overwriteCredentials } = parsed.data;
+
+  try {
+    // Guard: replacing a *different* stored client would break browser-flow
+    // connections. Require explicit confirmation. A rotated secret for the same
+    // client id is a normal update and proceeds.
+    const existing = await getGoogleCredentials();
+    if (existing?.clientId && existing.clientId !== clientId && !overwriteCredentials) {
+      return NextResponse.json(
+        {
+          error: 'client_mismatch_confirm_required',
+          message:
+            'A different Google client is already configured. Replacing it will break any calendars connected through the browser flow until they are re-authenticated.',
+        },
+        { status: 409 },
+      );
+    }
+
+    // Validate the pasted token against the pasted creds — exactly one refresh.
+    let tokens;
+    try {
+      tokens = await refreshAccessToken(refreshToken, { clientId, clientSecret });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      if (err instanceof TokenRevokedError || /invalid_grant/i.test(msg)) {
+        return NextResponse.json(
+          {
+            error: 'invalid_grant',
+            message:
+              'Google rejected the refresh token. It may be revoked, expired (consent screens in "Testing" mode expire refresh tokens after 7 days), or minted with a different client ID/secret than the ones you pasted.',
+          },
+          { status: 400 },
+        );
+      }
+      if (/invalid_client|unauthorized_client/i.test(msg)) {
+        return NextResponse.json(
+          { error: 'invalid_client', message: 'Google rejected the client ID / secret pair.' },
+          { status: 400 },
+        );
+      }
+      // Network / unexpected — log a fixed category only, never the message body.
+      logError('google/manual-token: token validation failed', 'network_or_unexpected');
+      return NextResponse.json(
+        { error: 'google_unreachable', message: 'Could not reach Google to validate the token. Please try again.' },
+        { status: 502 },
+      );
+    }
+
+    // Scope check — the token must actually carry Calendar access.
+    const scope = tokens.scope || '';
+    const hasCalendar =
+      /auth\/calendar(\.events|\.readonly)?(\s|$)/.test(scope) ||
+      (/auth\/calendar\.events/.test(scope) && /auth\/calendar\.readonly/.test(scope));
+    if (!hasCalendar) {
+      return NextResponse.json(
+        {
+          error: 'missing_calendar_scope',
+          message:
+            'The token was not granted Calendar access. In the Playground, select the Google Calendar API v3 scope before authorizing.',
+        },
+        { status: 400 },
+      );
+    }
+
+    // Best-effort account email (Playground tokens often lack the email scope;
+    // storeGoogleCalendarConnection falls back to the primary calendar id).
+    const accountEmail = await fetchGoogleAccountEmail(tokens.access_token);
+
+    // Persist the pasted client creds BEFORE storing rows: the refresh token is
+    // bound to this client, so background sync must use exactly this pair.
+    await upsertGoogleClientCredentials(clientId, clientSecret, existing);
+
+    // Store calendars. Persist the *pasted* refresh token — the refresh grant
+    // does not return a new one.
+    let result;
+    try {
+      result = await storeGoogleCalendarConnection({
+        userId: auth.userId,
+        tokens: { accessToken: tokens.access_token, refreshToken, expiresIn: tokens.expires_in },
+        accountEmail,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      if (/accessNotConfigured|SERVICE_DISABLED|has not been used|PERMISSION_DENIED|Calendar API/i.test(msg)) {
+        return NextResponse.json(
+          {
+            error: 'calendar_api_disabled',
+            message: 'Enable the Google Calendar API for this project in the Google Cloud Console.',
+          },
+          { status: 400 },
+        );
+      }
+      logError('google/manual-token: reading calendar list failed', 'unexpected');
+      return NextResponse.json(
+        { error: 'google_unreachable', message: 'Could not read your calendar list from Google. Please try again.' },
+        { status: 502 },
+      );
+    }
+
+    logActivity({
+      userId: auth.userId,
+      action: 'create',
+      entityType: 'integration',
+      summary: `Connected Google Calendar via manual refresh token (${result.calendarCount} calendars)`,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      calendarCount: result.calendarCount,
+      accountEmail: result.accountEmail,
+    });
+  } catch (err) {
+    // Never surface or log the request body / credentials.
+    logError('google/manual-token failed:', err instanceof Error ? err.name : 'error');
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
+
+/**
+ * Connect Google Calendar without a public URL by pasting a refresh token
+ * generated via Google's OAuth 2.0 Playground. For LAN-only installs (Home
+ * Assistant add-on, bare Docker on a private IP) where Google refuses to
+ * register a private/non-HTTPS redirect URI.
+ *
+ * Write-only: the secret and refresh token are never read back to the UI.
+ */
+export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
+  const { confirm, dialogProps } = useConfirmDialog();
+  const [clientId, setClientId] = React.useState('');
+  const [clientSecret, setClientSecret] = React.useState('');
+  const [refreshToken, setRefreshToken] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+
+  const canSave = clientId.trim() && clientSecret.trim() && refreshToken.trim() && !saving;
+
+  const submit = async (overwriteCredentials: boolean) => {
+    const res = await fetch('/api/integrations/google/manual-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: clientId.trim(),
+        clientSecret: clientSecret.trim(),
+        refreshToken: refreshToken.trim(),
+        overwriteCredentials,
+      }),
+    });
+    return res;
+  };
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      let res = await submit(false);
+
+      if (res.status === 409) {
+        // A different Google client is already configured — confirm replacement.
+        const data = await res.json().catch(() => ({}));
+        const ok = await confirm(
+          'Replace existing Google client?',
+          data.message ||
+            'A different Google client is already configured. Calendars connected through the browser flow will need to be re-authenticated.',
+        );
+        if (!ok) return;
+        res = await submit(true);
+      }
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || 'Could not connect with the pasted token.');
+      }
+
+      const data = await res.json();
+      toast({
+        title: 'Google Calendar connected',
+        description: `${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported.`,
+        variant: 'success',
+      });
+      // Clear the sensitive fields; they're never hydrated from the server.
+      setClientSecret('');
+      setRefreshToken('');
+      onSaved?.();
+    } catch (err) {
+      toast({
+        title: 'Could not connect',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    'h-9 w-full rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
+  const linkClass = 'text-primary hover:underline';
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        On a LAN-only install (no public URL), Google won&apos;t accept your address as a redirect
+        URI. Instead, generate a refresh token with Google&apos;s{' '}
+        <a
+          href="https://developers.google.com/oauthplayground"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClass}
+        >
+          OAuth 2.0 Playground
+        </a>{' '}
+        and paste it here — the login stays on Google&apos;s own domain.
+      </p>
+
+      <ol className="list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
+        <li>
+          In the{' '}
+          <a
+            href="https://console.cloud.google.com/apis/credentials"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClass}
+          >
+            Google Cloud Console
+          </a>
+          , create an OAuth 2.0 Client ID (Web application) and enable the{' '}
+          <span className="font-medium">Google Calendar API</span>.
+        </li>
+        <li>
+          Add <code className="rounded bg-muted px-1">https://developers.google.com/oauthplayground</code>{' '}
+          to the client&apos;s <span className="font-medium">Authorized redirect URIs</span>.
+        </li>
+        <li>
+          Open the Playground → gear icon → check{' '}
+          <span className="font-medium">&ldquo;Use your own OAuth credentials&rdquo;</span> → paste the
+          same Client ID and Secret.
+        </li>
+        <li>
+          Step 1: select{' '}
+          <code className="rounded bg-muted px-1">https://www.googleapis.com/auth/calendar</code> →{' '}
+          <span className="font-medium">Authorize APIs</span> → sign in with the Google account you want.
+        </li>
+        <li>
+          Step 2: <span className="font-medium">Exchange authorization code for tokens</span> → copy the{' '}
+          <span className="font-medium">Refresh token</span>.
+        </li>
+        <li>Paste all three values below.</li>
+      </ol>
+
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100">
+        If your OAuth consent screen is in <span className="font-medium">Testing</span> mode, Google
+        expires refresh tokens after 7 days. Publish the app to{' '}
+        <span className="font-medium">Production</span> (no verification is needed for your own use of
+        Calendar scopes) so it keeps working — otherwise you&apos;ll have to re-paste weekly.
+      </div>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client ID</span>
+        <input
+          className={inputClass}
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="1234567890-abc123.apps.googleusercontent.com"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Client secret</span>
+        <input
+          className={inputClass}
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          placeholder="GOCSPX-…"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-muted-foreground">Refresh token</span>
+        <input
+          className={inputClass}
+          type="password"
+          value={refreshToken}
+          onChange={(e) => setRefreshToken(e.target.value)}
+          placeholder="1//0g…"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <Button size="sm" onClick={handleSave} disabled={!canSave}>
+        {saving ? 'Validating with Google…' : 'Connect with token'}
+      </Button>
+
+      <ConfirmDialog {...dialogProps} />
+    </div>
+  );
+}

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -10,6 +10,7 @@ import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import { ProviderCardShell } from '../shared/ProviderCardShell';
 import { CollapsibleSubSection } from '../shared/CollapsibleSubSection';
 import { GoogleCredentialsForm } from './GoogleCredentialsForm';
+import { GoogleManualTokenForm } from './GoogleManualTokenForm';
 import type { IntegrationStatus } from '../shared/useIntegrationStatus';
 import type { ConnectionStatus } from '../shared/ConnectionStatusBadge';
 import { connectedAsLabel } from '../shared/connectedAs';
@@ -208,6 +209,14 @@ export function GoogleProviderCard({
             </Button>
           </CollapsibleSubSection>
         )}
+        <CollapsibleSubSection
+          id="google-manual-token"
+          label="Connect without a public URL (advanced)"
+          summary="Paste a refresh token from Google's OAuth Playground — for LAN-only installs, or to re-paste an expired one"
+          forceOpen={forceSubSectionOpen === 'google-manual-token'}
+        >
+          <GoogleManualTokenForm onSaved={() => window.location.reload()} />
+        </CollapsibleSubSection>
         <CollapsibleSubSection
           id="google-calendars"
           label="Calendars"

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -159,8 +159,13 @@ export class TokenRevokedError extends Error {
 /**
  * Refresh access token using refresh token
  */
-export async function refreshAccessToken(refreshToken: string): Promise<GoogleTokens> {
-  const { clientId, clientSecret } = await getConfig();
+export async function refreshAccessToken(
+  refreshToken: string,
+  credentialsOverride?: { clientId: string; clientSecret: string },
+): Promise<GoogleTokens> {
+  // The manual-token flow validates a pasted refresh token against pasted, not-
+  // yet-stored credentials; every other caller uses the stored config.
+  const { clientId, clientSecret } = credentialsOverride ?? (await getConfig());
 
   const response = await fetch(GOOGLE_TOKEN_URL, {
     method: 'POST',

--- a/src/lib/integrations/googleCalendarStore.ts
+++ b/src/lib/integrations/googleCalendarStore.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared storage for a successful Google Calendar connection.
+ *
+ * Extracted from the fresh-connect branch of the OAuth callback so the manual
+ * refresh-token path (OAuth Playground) stores calendars identically — same
+ * encryption, same dismissed-calendar tombstones, same per-calendar upsert —
+ * and the two paths can never drift.
+ *
+ * Never logs or returns token material.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { calendarSources } from '@/lib/db/schema';
+import { encrypt } from '@/lib/utils/crypto';
+import { fetchCalendarList, DISMISSED_GOOGLE_CALENDARS_KEY } from '@/lib/integrations/google-calendar';
+import { tombstoneIdSet } from '@/lib/services/settingsTombstone';
+
+export type GoogleTokenBundle = {
+  /** Plaintext access token — encrypted inside this module before storage. */
+  accessToken: string;
+  /** Plaintext refresh token (or null) — encrypted inside this module. */
+  refreshToken: string | null;
+  /** Seconds until the access token expires, from the token response. */
+  expiresIn: number;
+};
+
+export type StoreResult = {
+  calendarCount: number;
+  inserted: number;
+  updated: number;
+  skippedDismissed: number;
+  /** The account email actually stored (resolved value, incl. the fallback). */
+  accountEmail: string | null;
+};
+
+/**
+ * Fetch the calendar list with `tokens.accessToken`, honor dismissed-calendar
+ * tombstones, and upsert one `calendarSources` row per calendar with encrypted
+ * tokens. Callers own their own audit logging (summaries differ).
+ *
+ * `accountEmail` is the best-effort value from userinfo; when null (a
+ * Playground token often lacks the email scope) we fall back to the primary
+ * calendar's id, which for Google *is* the account email.
+ */
+export async function storeGoogleCalendarConnection(params: {
+  userId: string;
+  tokens: GoogleTokenBundle;
+  accountEmail: string | null;
+}): Promise<StoreResult> {
+  const { userId, tokens } = params;
+
+  const tokenExpiresAt = new Date(Date.now() + tokens.expiresIn * 1000);
+  const encryptedAccessToken = encrypt(tokens.accessToken);
+  const encryptedRefreshToken = tokens.refreshToken ? encrypt(tokens.refreshToken) : null;
+
+  const calendars = await fetchCalendarList(tokens.accessToken);
+
+  // Fallback: Google's primary-calendar id is the account email.
+  const primaryId = calendars.find((c) => c.primary)?.id;
+  const accountEmail =
+    params.accountEmail ?? (primaryId && primaryId.includes('@') ? primaryId : null);
+
+  const dismissedSet = await tombstoneIdSet(DISMISSED_GOOGLE_CALENDARS_KEY);
+
+  let inserted = 0;
+  let updated = 0;
+  let skippedDismissed = 0;
+
+  for (const calendar of calendars) {
+    if (dismissedSet.has(calendar.id)) {
+      skippedDismissed++;
+      continue;
+    }
+
+    const existing = await db.query.calendarSources.findFirst({
+      where: (cs, { and, eq: eqInner }) =>
+        and(eqInner(cs.provider, 'google'), eqInner(cs.sourceCalendarId, calendar.id)),
+    });
+
+    if (existing) {
+      const prev = (existing.syncErrors as Record<string, unknown>) || {};
+      await db
+        .update(calendarSources)
+        .set({
+          accessToken: encryptedAccessToken,
+          refreshToken: encryptedRefreshToken || existing.refreshToken,
+          tokenExpiresAt,
+          // Only overwrite the email when we resolved one, so a transient
+          // userinfo failure doesn't blank an existing label.
+          accountEmail: accountEmail ?? undefined,
+          syncErrors: prev.userOverride ? { userOverride: true } : null,
+          updatedAt: new Date(),
+        })
+        .where(eq(calendarSources.id, existing.id));
+      updated++;
+    } else {
+      const calendarName = (calendar.summary || 'Untitled Calendar').slice(0, 255);
+      const isWritable = calendar.accessRole === 'writer' || calendar.accessRole === 'owner';
+      await db.insert(calendarSources).values({
+        userId,
+        provider: 'google',
+        sourceCalendarId: calendar.id,
+        dashboardCalendarName: calendarName,
+        displayName: calendarName,
+        color: calendar.backgroundColor || undefined,
+        // Calendars hidden in the user's Google list come in disabled.
+        enabled: !calendar.hidden,
+        showInEventModal: isWritable,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        tokenExpiresAt,
+        accountEmail,
+      });
+      inserted++;
+    }
+  }
+
+  return { calendarCount: calendars.length, inserted, updated, skippedDismissed, accountEmail };
+}

--- a/src/lib/validations/__tests__/googleManualToken.test.ts
+++ b/src/lib/validations/__tests__/googleManualToken.test.ts
@@ -1,0 +1,43 @@
+import { googleManualTokenSchema } from '../googleManualToken';
+
+const valid = {
+  clientId: '1234567890-abcDEF123.apps.googleusercontent.com',
+  clientSecret: 'GOCSPX-abcDEF123_secret',
+  refreshToken: '1//0gABCdef-_123/456',
+};
+
+describe('googleManualTokenSchema', () => {
+  it('accepts realistic Playground values and defaults overwriteCredentials', () => {
+    const parsed = googleManualTokenSchema.parse(valid);
+    expect(parsed.clientId).toBe(valid.clientId);
+    expect(parsed.overwriteCredentials).toBe(false);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    const parsed = googleManualTokenSchema.parse({
+      ...valid,
+      refreshToken: `  ${valid.refreshToken}  `,
+    });
+    expect(parsed.refreshToken).toBe(valid.refreshToken);
+  });
+
+  it('rejects a client ID without the googleusercontent suffix', () => {
+    expect(googleManualTokenSchema.safeParse({ ...valid, clientId: 'not-a-google-client' }).success).toBe(false);
+  });
+
+  it('rejects a client secret with spaces or control characters', () => {
+    expect(googleManualTokenSchema.safeParse({ ...valid, clientSecret: 'has spaces' }).success).toBe(false);
+    expect(googleManualTokenSchema.safeParse({ ...valid, clientSecret: 'tab\tsecret' }).success).toBe(false);
+  });
+
+  it('rejects a refresh token with HTML / quote characters (injection guard)', () => {
+    expect(googleManualTokenSchema.safeParse({ ...valid, refreshToken: '"><img src=x>' }).success).toBe(false);
+    expect(googleManualTokenSchema.safeParse({ ...valid, refreshToken: "1//0g';DROP" }).success).toBe(false);
+  });
+
+  it('rejects empty and overlong values', () => {
+    expect(googleManualTokenSchema.safeParse({ ...valid, refreshToken: '' }).success).toBe(false);
+    expect(googleManualTokenSchema.safeParse({ ...valid, refreshToken: '1'.repeat(2000) }).success).toBe(false);
+    expect(googleManualTokenSchema.safeParse({ ...valid, clientSecret: '' }).success).toBe(false);
+  });
+});

--- a/src/lib/validations/googleManualToken.ts
+++ b/src/lib/validations/googleManualToken.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+/**
+ * Validation for the manual Google refresh-token connect flow (OAuth Playground).
+ *
+ * These three values are pasted by an admin and are high-value credentials, so
+ * the schema is deliberately strict on charset + length: the values are only
+ * ever sent to Google as URL-encoded form bodies and then stored encrypted, and
+ * a tight regex keeps anything unexpected out before it reaches either.
+ */
+export const googleManualTokenSchema = z.object({
+  clientId: z
+    .string()
+    .trim()
+    .min(20)
+    .max(200)
+    .regex(
+      /^[A-Za-z0-9\-_.]+\.apps\.googleusercontent\.com$/,
+      'Must be a Google OAuth client ID ending in .apps.googleusercontent.com',
+    ),
+  clientSecret: z
+    .string()
+    .trim()
+    .min(10)
+    .max(200)
+    // Printable ASCII, no spaces (Google secrets look like "GOCSPX-…").
+    .regex(/^[\x21-\x7e]+$/, 'Invalid characters in client secret'),
+  refreshToken: z
+    .string()
+    .trim()
+    .min(20)
+    .max(1024)
+    // Playground refresh tokens look like "1//0g…".
+    .regex(/^[A-Za-z0-9\-_./]+$/, 'Invalid characters in refresh token'),
+  // Explicit consent to replace an existing, *different* stored client id/secret.
+  overwriteCredentials: z.boolean().optional().default(false),
+});
+
+export type GoogleManualTokenInput = z.infer<typeof googleManualTokenSchema>;


### PR DESCRIPTION
## What & why

Adds an **advanced "Connect without a public URL"** path for Google Calendar, for LAN-only installs (Home Assistant add-on, bare Docker on a private IP) where Google refuses to register a private/`.local` redirect URI (`"must end with a public top-level domain"` — reported by @olet1234).

The user generates a refresh token themselves via Google's **OAuth 2.0 Playground** (using their own client id/secret) and pastes `{client id, secret, refresh token}` into Prism. Prism validates it, persists the client credentials, and imports calendars with full read+write. The sign-in stays entirely on Google's own domain — **no hosted relay, no third-party redirect, no new public infrastructure.**

This is the pragmatic alternative to a hosted OAuth relay, which was considered and deliberately shelved (an internet-facing OAuth service is a large attack surface, and routing users' Google auth through a third-party domain erodes trust). The browser **Connect** button remains the simple path for anyone who has a public URL (PikaPods, or an HA user behind a tunnel).

## How it works

- New write-only `POST /api/integrations/google/manual-token`:
  - Auth-gated (`requireAuth` + `requireRole('canModifySettings')`); `userId` from the session, never the body.
  - Validates with exactly **one** `refreshAccessToken` + **one** `fetchCalendarList` call.
  - Persists the pasted client id/secret to `credentials.google` **before** storing calendar rows (refresh tokens are bound to the client that minted them, so background sync must use exactly this pair).
  - `409` confirm-required when replacing a *different* existing client, so a paste can't silently break browser-flow connections.
  - Returns only `{ ok, calendarCount, accountEmail }` — never token/secret material.
- `googleCalendarStore.ts`: the calendar-upsert logic **extracted from the OAuth callback** so the browser and paste paths store identically (and can't drift). The callback now calls it (net −58 lines there).
- `refreshAccessToken(refreshToken, credentialsOverride?)`: optional override so validation can use pasted-but-unstored creds; all existing callers unchanged.
- UI: a "Connect without a public URL (advanced)" sub-section on the Google card with the Playground steps and a **7-day Testing-mode expiry** caution. Doubles as the re-paste/rotate path when connected.

## Security

- Client secret + refresh token **encrypted at rest** (existing AES-256-GCM), **never logged** (error logs carry only a fixed category), **never echoed** in any response.
- Strict zod schema bounds charset/length on all three inputs.
- Ran through the security-review process — **no high-confidence vulnerabilities** (auth gating, no secret in responses/logs, no injection, no SSRF all verified).

## Tests

- `googleManualToken` schema test (accepts realistic values; rejects injection/whitespace/overlong/empty).
- Endpoint **security suite**: 401/403, each Google-error mapping, 409 mismatch + overwrite, and — for every exit path — asserts no refresh token / client secret appears in the response body or logs; asserts creds encrypted and persisted before rows.
- `tsc` 0, lint 0, and the 51 existing Google/calendar/oauthState tests still pass.

## Docs

- `docs/features/CALENDAR.md`: "Google Calendar without a public URL (OAuth Playground)" step-by-step + Production-consent-screen warning + revocation.
- `docs/home-assistant.md`: troubleshooting cross-link.