### PR TITLE
chore(release): 1.16.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.16.2] – 2026-08-23
+
+### Integrations
+- **Connect Google Calendar without a public URL.** For installs that only run on your local network (Home Assistant add-on, LAN-only Docker) — where Google refuses to register a private address as an OAuth redirect URI — you can now connect Google Calendar by pasting a refresh token you generate with Google's OAuth Playground, under Settings → Integrations → Google → "Connect without a public URL (advanced)." It's full two-way read/write, needs no public URL or reverse proxy, and the sign-in stays on Google's own domain.
+
 ## [1.16.1] – 2026-08-22
 
 ### Calendar

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.16.1"
+version: "1.16.2"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release: ships the Google-Calendar-without-a-public-URL (OAuth Playground refresh-token) feature quietly (patch bump = no in-app update notice) for HA validation before a wider minor announce.