### PR TITLE
docs(integrations): complete the Google-without-a-public-URL setup guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Integrations
+- **Connect Google Calendar on a Home Assistant / LAN-only install — no public URL required.** If Prism only runs on your local network (the Home Assistant add-on, or bare Docker on a private IP), Google refuses to accept your address as an OAuth redirect, so the normal **Connect** button can't finish. There's now a **"Connect without a public URL (advanced)"** option under *Settings → Integrations → Google*: you generate a refresh token with Google's OAuth Playground and paste it in for full two-way calendar sync — the sign-in stays entirely on Google's own domain, with no reverse proxy or tunnel needed. The in-app instructions walk through the whole setup end-to-end — creating the project, publishing the consent screen to Production (so the connection doesn't expire after 7 days), and generating the token — all under a single Google account.
+
 ## [1.16.2] – 2026-08-23
 
 ### Integrations

--- a/docs/features/CALENDAR.md
+++ b/docs/features/CALENDAR.md
@@ -26,14 +26,25 @@ The connection covers Calendar specifically. If you also want Google Tasks sync,
 
 The normal **Connect** button needs a public HTTPS address, because Google refuses to register a private/LAN redirect URI (e.g. `http://homeassistant.local:8123/…` or `http://192.168.x.x:3000/…`) — you'll see *"must end with a public top-level domain."* If Prism only runs on your LAN (Home Assistant add-on, bare Docker) and you'd rather not put it behind a public URL, you can still get full read+write by generating a refresh token yourself with Google's OAuth Playground and pasting it into Prism. The sign-in stays entirely on Google's own domain — nothing routes through a third party.
 
-1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials), create an **OAuth 2.0 Client ID** (type *Web application*) and enable the **Google Calendar API**.
-2. Add `https://developers.google.com/oauthplayground` to the client's **Authorized redirect URIs**.
-3. Open the [OAuth 2.0 Playground](https://developers.google.com/oauthplayground), click the gear icon, tick **"Use your own OAuth credentials"**, and paste the same Client ID and Secret.
-4. In *Step 1*, select **Google Calendar API v3 → `https://www.googleapis.com/auth/calendar`**, click **Authorize APIs**, and sign in with the account whose calendars you want.
-5. In *Step 2*, click **Exchange authorization code for tokens** and copy the **Refresh token**.
-6. In Prism, open the *Connect without a public URL (advanced)* section of the Google card and paste the Client ID, Client Secret, and Refresh token. Prism validates them with Google and imports your calendars with full read+write.
+**Do everything signed into a single Google account** — the one whose calendars you want — ideally in a private/incognito window, so you never mix up accounts. Account confusion (the project under one account, the calendars under another) is the #1 cause of setup trouble here.
 
-**Heads-up — publish your consent screen to Production.** If your OAuth consent screen is left in *Testing* mode, Google expires refresh tokens after **7 days** and the connection stops working. Publish the app to *Production* (no verification is required for your own use of Calendar scopes) so it keeps working. If a connection ever goes stale, just re-paste a fresh refresh token in the same place. To revoke access entirely, go to *Google Account → Security → Third-party access*.
+1. In the [Google Cloud Console](https://console.cloud.google.com/), **create a project**, then enable the **Google Calendar API**.
+2. Configure the **OAuth consent screen** (User type **External**; fill in the app name and your support/developer email).
+3. **Publish the app to Production.** This is the important one — in *Testing* mode Google expires refresh tokens after **7 days**; publishing removes that limit. Because you own the project, you can click through the one-time "Google hasn't verified this app" notice (**Advanced → proceed**) — no formal verification is needed for your own use of the Calendar scope.
+4. Create an **OAuth Client ID** of type **Web application**. Under **Authorized redirect URIs**, add exactly `https://developers.google.com/oauthplayground`. Copy the **Client ID** and **Client Secret** — the secret is shown only once.
+5. Open the [OAuth 2.0 Playground](https://developers.google.com/oauthplayground) → gear icon → tick **"Use your own OAuth credentials"** → paste that Client ID and Secret.
+6. In *Step 1*, enter the scope `https://www.googleapis.com/auth/calendar` → **Authorize APIs** → sign in → **Advanced → proceed → Allow**.
+7. In *Step 2*, click **Exchange authorization code for tokens** and copy the **Refresh token** (starts with `1//`).
+8. In Prism, open **Settings → Integrations → Google → "Connect without a public URL (advanced)"** and paste the **Client ID, Client Secret, and Refresh token**. Prism validates them with Google and imports your calendars with full read+write.
+
+**Troubleshooting:**
+
+- *"Google rejected the client ID / secret pair"* — the Client ID and Secret don't match, or the secret was rotated. Open your client in the Console, generate a fresh secret (shown only once), and use it in **both** the Playground and Prism.
+- *"Google rejected the refresh token"* — it's expired, revoked, or was minted with a *different* client than the one you pasted. Generate a fresh token in the Playground using the exact same Client ID + Secret, in one pass, and paste it right away. Make sure you copied the **Refresh token** (`1//…`), not the Access token (`ya29.…`).
+- **The Playground's *Exchange* returns no refresh token** — you've already granted the app once. Revoke it at [myaccount.google.com/permissions](https://myaccount.google.com/permissions), then Authorize again for a fresh consent.
+- **The project doesn't appear in the Console** — you're signed into the wrong Google account. The project, client, consent screen, and Playground authorization must **all** be the same account.
+
+To revoke Prism's access entirely, go to *Google Account → Security → Third-party access*.
 
 ### iCal subscriptions (read-only)
 

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -101,46 +101,71 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
         and paste it here — the login stays on Google&apos;s own domain.
       </p>
 
+      <p className="text-xs font-medium text-foreground">
+        Do all of this signed into a <span className="underline">single</span> Google account — the one
+        whose calendars you want — ideally in a private/incognito window, so you never mix up accounts.
+      </p>
+
       <ol className="list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
         <li>
           In the{' '}
           <a
-            href="https://console.cloud.google.com/apis/credentials"
+            href="https://console.cloud.google.com/"
             target="_blank"
             rel="noopener noreferrer"
             className={linkClass}
           >
             Google Cloud Console
           </a>
-          , create an OAuth 2.0 Client ID (Web application) and enable the{' '}
-          <span className="font-medium">Google Calendar API</span>.
+          , create a project, then enable the <span className="font-medium">Google Calendar API</span>.
         </li>
         <li>
-          Add <code className="rounded bg-muted px-1">https://developers.google.com/oauthplayground</code>{' '}
-          to the client&apos;s <span className="font-medium">Authorized redirect URIs</span>.
+          Configure the <span className="font-medium">OAuth consent screen</span> (User type:{' '}
+          <span className="font-medium">External</span>), then <span className="font-medium">Publish</span>{' '}
+          it to <span className="font-medium">Production</span> — this is what keeps the connection from
+          expiring after 7 days.
         </li>
         <li>
-          Open the Playground → gear icon → check{' '}
-          <span className="font-medium">&ldquo;Use your own OAuth credentials&rdquo;</span> → paste the
-          same Client ID and Secret.
+          Create an <span className="font-medium">OAuth Client ID</span> of type{' '}
+          <span className="font-medium">Web application</span>, and add{' '}
+          <code className="rounded bg-muted px-1">https://developers.google.com/oauthplayground</code> to
+          its <span className="font-medium">Authorized redirect URIs</span>. Copy the Client ID and Secret
+          (the secret is shown only once).
         </li>
         <li>
-          Step 1: select{' '}
+          Open the{' '}
+          <a
+            href="https://developers.google.com/oauthplayground"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClass}
+          >
+            OAuth Playground
+          </a>{' '}
+          → gear icon → check{' '}
+          <span className="font-medium">&ldquo;Use your own OAuth credentials&rdquo;</span> → paste that
+          Client ID and Secret.
+        </li>
+        <li>
+          Step 1: enter the scope{' '}
           <code className="rounded bg-muted px-1">https://www.googleapis.com/auth/calendar</code> →{' '}
-          <span className="font-medium">Authorize APIs</span> → sign in with the Google account you want.
+          <span className="font-medium">Authorize APIs</span> → sign in → if warned the app isn&apos;t
+          verified, choose <span className="font-medium">Advanced → proceed</span> (expected for your own
+          app) → <span className="font-medium">Allow</span>.
         </li>
         <li>
           Step 2: <span className="font-medium">Exchange authorization code for tokens</span> → copy the{' '}
           <span className="font-medium">Refresh token</span>.
         </li>
-        <li>Paste all three values below.</li>
+        <li>Paste the Client ID, Client Secret, and Refresh token below.</li>
       </ol>
 
       <div className="rounded-md border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100">
-        If your OAuth consent screen is in <span className="font-medium">Testing</span> mode, Google
-        expires refresh tokens after 7 days. Publish the app to{' '}
-        <span className="font-medium">Production</span> (no verification is needed for your own use of
-        Calendar scopes) so it keeps working — otherwise you&apos;ll have to re-paste weekly.
+        <span className="font-medium">Keep it from expiring:</span> publish the consent screen to{' '}
+        <span className="font-medium">Production</span> (step 2). In <span className="font-medium">Testing</span>{' '}
+        mode Google expires refresh tokens after 7 days. Publishing shows a one-time &ldquo;Google
+        hasn&apos;t verified this app&rdquo; notice — click <span className="font-medium">Advanced → proceed</span>;
+        that&apos;s normal for an app you run yourself.
       </div>
 
       <label className="block space-y-1">


### PR DESCRIPTION
Expands the in-app help + CALENDAR.md to the full tested setup (single account, project + Calendar API, publish consent screen to Production to avoid the 7-day expiry, create client, mint token) plus a troubleshooting section. Adds the announce CHANGELOG entry for the HA-focused feature. All generic — no personal values.