### PR TITLE
chore(release): 1.17.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.17.0] – 2026-08-23
+
 ### Integrations
 - **Connect Google Calendar on a Home Assistant / LAN-only install — no public URL required.** If Prism only runs on your local network (the Home Assistant add-on, or bare Docker on a private IP), Google refuses to accept your address as an OAuth redirect, so the normal **Connect** button can't finish. There's now a **"Connect without a public URL (advanced)"** option under *Settings → Integrations → Google*: you generate a refresh token with Google's OAuth Playground and paste it in for full two-way calendar sync — the sign-in stays entirely on Google's own domain, with no reverse proxy or tunnel needed. The in-app instructions walk through the whole setup end-to-end — creating the project, publishing the consent screen to Production (so the connection doesn't expire after 7 days), and generating the token — all under a single Google account.
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.16.2"
+version: "1.17.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Minor release announcing the HA-focused feature: connect Google Calendar without a public URL (OAuth Playground refresh-token paste), plus the complete in-app + docs setup guide. Minor bump surfaces the in-app update notice to users.