### PR TITLE
fix(cla): only run the CLA bot in this repository

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,6 +20,12 @@ permissions:
 
 jobs:
   cla:
+    # Only ever run in this repository. Workflow files travel with a fork, so
+    # without this guard the bot fires inside contributors' own forks: it walks
+    # the commit authors of their private PRs (including upstream authors picked
+    # up by a routine master sync) and nags each one to sign a CLA they aren't
+    # party to. Signing there can't work either, since CLA_PAT only exists here.
+    if: github.repository == 'sandydargoport/prism'
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
## Problem

Workflow files travel with a fork, so `cla.yml` runs inside contributors' own forks. On a routine `upstream/master` sync PR the CLA Assistant walks every commit author in the range — which includes whoever authored upstream commits since that fork last synced — and nags each of them to sign a CLA they aren't party to, on a PR that proposes nothing here.

Observed on [iann/prism#77](https://github.com/iann/prism/pull/77), a sync of `master` into his personal branch:

> **0** out of **3** committers have signed the CLA.
> ❌ @MartinGierach ❌ @m4rtski ❌ @iann

Two of those are the same person (m4rtski's #253 merged the day before that sync) and none were contributing to Prism.

Signing there can't work either — the bot writes to `signatures/cla.json` via `CLA_PAT`, which only exists in this repository. It's a nag that cannot be satisfied.

## Fix

Guard the job on `github.repository`. Behaviour here is unchanged; the job becomes a no-op in every fork.

## Rollout

- This repo: identical behaviour, CLA Assistant still fires on real contributions.
- New forks: never see the nag.
- Existing forks: pick it up the next time they sync `master`. Note that `pull_request_target` reads the workflow from the PR's **base** branch, so a fork gets one final nag on the sync PR that carries the fix, then runs clean.
