### PR TITLE
fix(cla): guard the bot on the fork flag, not the repository name

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,12 +20,18 @@ permissions:
 
 jobs:
   cla:
-    # Only ever run in this repository. Workflow files travel with a fork, so
-    # without this guard the bot fires inside contributors' own forks: it walks
-    # the commit authors of their private PRs (including upstream authors picked
-    # up by a routine master sync) and nags each one to sign a CLA they aren't
-    # party to. Signing there can't work either, since CLA_PAT only exists here.
-    if: github.repository == 'sandydargoport/prism'
+    # Never run in a fork. Workflow files travel with a fork, so without this
+    # guard the bot fires inside contributors' own repos: it walks the commit
+    # authors of their private PRs (including upstream authors picked up by a
+    # routine master sync) and nags each one to sign a CLA they aren't party
+    # to. Signing there can't work either, since CLA_PAT only exists here.
+    #
+    # Tested against the repository's own fork flag rather than its name, so a
+    # rename or a transfer to an org can't silently disable the bot here. Note
+    # this reads the event payload: it holds for the issue_comment and
+    # pull_request_target triggers above, but a schedule or workflow_dispatch
+    # trigger carries no `repository` object and would skip the job.
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
Follow-up to #290.

## Problem with the current guard

#290 used `if: github.repository == 'sandydargoport/prism'`. It stops the nag in forks, but it hardcodes an identity and fails in the dangerous direction — rename the repo, or transfer it to an org (plausible given #178), and the guard evaluates false in the **canonical** repo. The CLA bot silently stops running everywhere, contributions land unsigned, and nothing surfaces it.

## Fix

```yaml
if: github.event.repository.fork == false
```

Verified it discriminates correctly:

| Repo | `.fork` |
|---|---|
| `sandydargoport/prism` | `false` |
| `iann/prism` | `true` |
| `m4rtski/prism` | `true` |

Survives renames and org transfers, and states the actual intent rather than an identity that happens to correlate with it.

## Caveat, noted in the file

The expression reads the event payload, so it depends on the trigger carrying a `repository` object. Both triggers this workflow uses (`issue_comment`, `pull_request_target`) do. A `schedule` or `workflow_dispatch` trigger added later would carry none and the job would skip — a safer failure than the hardcode's, but still silent, hence the comment.
