### PR TITLE
feat(birthdays): detect from any calendar source, not two hardcoded ones

### DIFF
--- a/docs/features/BIRTHDAYS.md
+++ b/docs/features/BIRTHDAYS.md
@@ -1,0 +1,78 @@
+# Birthdays & Milestones
+
+The Birthdays widget shows upcoming birthdays, anniversaries and milestones, with
+how many days away each one is and how old the person is turning.
+
+**You don't type birthdays into Prism.** It reads them from the calendars and
+contacts you already keep, so they stay correct in one place rather than two.
+
+## Where they come from
+
+| Source | What Prism reads |
+|---|---|
+| Any connected calendar | All-day events with **birthday** or **anniversary** in the title |
+| iCloud / CardDAV contacts | The birthday field on your contact cards |
+| Google Contacts | Google's own generated birthday calendar |
+
+Calendars of every kind are scanned — Google, iCloud/CalDAV, iCal subscriptions,
+and calendars created inside Prism itself.
+
+!!! tip "iPhone birthdays"
+    iCloud contacts are CardDAV, so the birthdays saved against contacts on your
+    phone come straight through. Tick **contact birthdays** when connecting
+    iCloud under *Settings → Integrations*.
+
+## Adding one Prism can't find
+
+Give it a source: put the birthday on a calendar, and Prism picks it up on the
+next sync. Your own local Prism calendar is fine for this — you don't need an
+external account.
+
+1. Create an **all-day** event on the birthday. A timed event is read as
+   something happening *near* a birthday rather than the birthday itself.
+2. Title it with the person's name and the word **birthday**:
+   `Grandma's Birthday`
+3. Optionally add the year in brackets to show their age:
+   `Grandma's Birthday (1948)`
+
+Without a year you still get the date and the countdown, just no age.
+
+## Anniversaries and milestones
+
+**Anniversaries** work the same way — put **anniversary** in the title.
+
+**Milestones** have no obvious keyword, so Prism looks for the shape instead: an
+all-day event that **repeats every year** and carries a **year** in the title.
+
+```
+Ana and Ben (2005)     ✅ milestone
+Moved into the house     ❌ no year, so it's just an event
+```
+
+If you keep a calendar where *everything* on it is a life event, open
+**Manage calendars** and turn on **"Treat every all-day event here as a birthday
+or milestone"**. Titles on that calendar then need no keyword at all.
+
+## Other languages
+
+Titles are matched in English and German — `Geburtstag`, `Hochzeitstag` and
+`Jubiläum` all work. Adding another language is a one-line change in
+`src/lib/services/birthday-detect.ts`; contributions welcome.
+
+## Removing one
+
+Deleting a birthday in Prism keeps it deleted. It won't come back on the next
+sync even though the calendar event still exists, so you can prune the list
+without editing the underlying calendar. Delete the calendar event too if you
+want it gone everywhere.
+
+## What Prism deliberately ignores
+
+- **Read-only calendars you subscribe to** — school terms, public holidays and
+  the like. This is what stops "No School — Martin Luther King's Birthday"
+  becoming a family birthday.
+- **Events happening near a birthday** — "birthday party", "prep for Sam's
+  birthday", "birthday dinner". These describe the celebration, not the day.
+
+If a birthday you expect is missing, check the event is all-day and that its
+calendar isn't a read-only subscription.

--- a/drizzle/0023_dismissed_birthdays.sql
+++ b/drizzle/0023_dismissed_birthdays.sql
@@ -1,0 +1,45 @@
+-- 0023_dismissed_birthdays.sql
+--
+-- Two changes supporting source-agnostic birthday detection.
+--
+-- 1. `dismissed_birthdays` — tombstones for detected birthdays the user
+--    deleted. Detection now re-reads every calendar on each sync, so without
+--    a tombstone a dismissed entry is simply re-added on the next run and the
+--    delete button appears not to work. Mirrors the existing
+--    `dismissed_events` pattern.
+--
+--    Keyed on normalised name + month/day rather than a source event id: the
+--    same person legitimately arrives from several calendars and from CardDAV
+--    contacts, and dismissing them once should hold everywhere. The year is
+--    deliberately excluded — 1904 is the unknown-year sentinel, so the same
+--    person can arrive carrying different years from different sources.
+--
+-- 2. Seeds `provider_config.lifeEventsCalendar` for calendars that the old
+--    hardcoded logic treated as birthday sources: any source whose name
+--    contained "friends" (the FRIENDS_FAMILY_CALENDAR_NAME magic string), and
+--    Google's generated contacts birthday calendar. Existing installs keep
+--    the behaviour they had, with no user action, while the magic string
+--    disappears from the code.
+
+CREATE TABLE IF NOT EXISTS dismissed_birthdays (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  normalized_name varchar(100) NOT NULL,
+  birth_month     integer NOT NULL,
+  birth_day       integer NOT NULL,
+  event_type      varchar(20) NOT NULL DEFAULT 'birthday',
+  created_at      timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_birthdays_name_day_type_unique
+  ON dismissed_birthdays (normalized_name, birth_month, birth_day, event_type);
+
+-- Idempotent: only touches rows that don't already carry the flag.
+UPDATE calendar_sources
+SET provider_config = COALESCE(provider_config, '{}'::jsonb)
+                      || '{"lifeEventsCalendar": true}'::jsonb
+WHERE (provider_config->>'lifeEventsCalendar') IS NULL
+  AND (
+    COALESCE(display_name, '') ILIKE '%friends%'
+    OR COALESCE(dashboard_calendar_name, '') ILIKE '%friends%'
+    OR source_calendar_id LIKE '%addressbook#contacts%'
+  );

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Travel Map: features/TRAVEL.md
       - Weekend Ideas: features/WEEKEND.md
       - Bus Tracking: features/BUS.md
+      - Birthdays & Milestones: features/BIRTHDAYS.md
       - Languages (i18n): features/LANGUAGES.md
       - Display Modes: features/DISPLAY-MODES.md
       - Mobile (PWA): features/MOBILE.md

--- a/src/app/api/birthdays/[id]/route.ts
+++ b/src/app/api/birthdays/[id]/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/api/withAuth';
 import { db } from '@/lib/db/client';
 import { birthdays, users } from '@/lib/db/schema';
+import { dismissBirthday } from '@/lib/services/birthday-detect';
 import { eq } from 'drizzle-orm';
 import { createBirthdaySchema, validateRequest } from '@/lib/validations';
 import { logError } from '@/lib/utils/logError';
@@ -229,7 +230,12 @@ export async function DELETE(
 
       // Check if birthday exists
       const [existingBirthday] = await db
-        .select({ id: birthdays.id, name: birthdays.name })
+        .select({
+          id: birthdays.id,
+          name: birthdays.name,
+          birthDate: birthdays.birthDate,
+          eventType: birthdays.eventType,
+        })
         .from(birthdays)
         .where(eq(birthdays.id, id));
 
@@ -240,7 +246,15 @@ export async function DELETE(
         );
       }
 
-      // Delete the birthday
+      // Tombstone first, then delete. Detection re-reads every calendar on
+      // each sync, so without this the row is simply re-added on the next run
+      // and the delete appears not to have worked.
+      await dismissBirthday({
+        name: existingBirthday.name,
+        birthDate: existingBirthday.birthDate,
+        eventType: existingBirthday.eventType,
+      });
+
       await db
         .delete(birthdays)
         .where(eq(birthdays.id, id));

--- a/src/app/api/birthdays/sync/route.ts
+++ b/src/app/api/birthdays/sync/route.ts
@@ -1,295 +1,46 @@
 /**
- *
  * ENDPOINT: POST /api/birthdays/sync
  *
- * Fetches events from Google Calendar sources:
- * 1. Birthdays calendar (addressbook#contacts@group.v.calendar.google.com)
- * 2. "Friends & Family" calendar (matched by name from calendarSources)
+ * Detects birthdays, anniversaries and milestones across EVERY calendar
+ * source — google, ical, caldav and local — by scanning the normalised
+ * `events` table.
  *
- * Parses event titles to extract name, type, and year, then upserts
- * into the birthdays table.
+ * Previously this read two hardcoded Google calendars (the Google Contacts
+ * birthday calendar, and any source whose name contained "friends"). That only
+ * worked for users who happened to keep a calendar with that name, missed
+ * birthdays sitting on every other calendar, and was documented nowhere
+ * (discussion #292). The detection logic now lives in
+ * `src/lib/services/birthday-detect.ts`.
  *
+ * Response shape is unchanged so existing callers keep working:
+ * CalendarsSection.tsx and useBirthdays.ts.
  */
 
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { db } from '@/lib/db/client';
-import { calendarSources } from '@/lib/db/schema';
-import { eq, and } from 'drizzle-orm';
 import { logError } from '@/lib/utils/logError';
-import { upsertBirthday } from '@/lib/services/birthday-merge';
-import { invalidateEntity } from '@/lib/cache/cacheKeys';
-import {
-  fetchCalendarEvents,
-  refreshAccessToken,
-  type GoogleCalendarEvent,
-} from '@/lib/integrations/google-calendar';
-import { decrypt, encrypt } from '@/lib/utils/crypto';
+import { detectBirthdaysFromEvents } from '@/lib/services/birthday-detect';
 
-/** The special Google Contacts birthday calendar ID */
-const BIRTHDAYS_CALENDAR_ID = 'addressbook#contacts@group.v.calendar.google.com';
-
-/** Friends & Family calendar name to match against */
-const FRIENDS_FAMILY_CALENDAR_NAME = 'Friends & Family';
-
-type EventType = 'birthday' | 'anniversary' | 'milestone';
-
-interface ParsedEvent {
-  name: string;
-  eventType: EventType;
-  birthDate: string; // YYYY-MM-DD
-  year: number | null; // Birth year or start year
-}
-
-/**
- * Parse a Google Calendar event into a birthday/milestone record
- */
-function parseCalendarEvent(event: GoogleCalendarEvent): ParsedEvent | null {
-  const title = event.summary || '';
-  if (!title.trim()) return null;
-
-  // Determine the event date
-  const dateStr = event.start.date || event.start.dateTime?.split('T')[0];
-  if (!dateStr) return null;
-
-  // Detect event type from title
-  let eventType: EventType = 'milestone';
-  let name = title;
-
-  if (/birthday/i.test(title)) {
-    eventType = 'birthday';
-    // Strip "'s Birthday", "Birthday - ", etc.
-    name = title
-      .replace(/['']s\s+birthday/i, '')
-      .replace(/\s*-\s*birthday/i, '')
-      .replace(/birthday\s*-?\s*/i, '')
-      .trim();
-  } else if (/anniversary/i.test(title)) {
-    eventType = 'anniversary';
-    name = title
-      .replace(/['']s\s+anniversary/i, '')
-      .replace(/\s*-\s*anniversary/i, '')
-      .replace(/anniversary\s*-?\s*/i, '')
-      .trim();
-  }
-
-  // Look for a 4-digit year in title or description
-  let year: number | null = null;
-  const combinedText = `${title} ${event.description || ''}`;
-  const yearMatch = combinedText.match(/\b(19\d{2}|20\d{2})\b/);
-  if (yearMatch) {
-    year = parseInt(yearMatch[1]!, 10);
-  }
-
-  // Clean up name:
-  // Remove parenthesized year like "(1993)" or "(2008)"
-  name = name.replace(/\s*\(\d{4}\)\s*/g, ' ');
-  // Remove trailing possessive 's or ' left from title parsing
-  name = name.replace(/['']s?\s*$/, '');
-  // Collapse whitespace
-  name = name.replace(/\s+/g, ' ').trim();
-  if (!name) name = title;
-
-  return {
-    name,
-    eventType,
-    birthDate: dateStr,
-    year,
-  };
-}
-
-/**
- * Get a valid access token for a calendar source, refreshing if needed
- * Tokens are stored encrypted, so we decrypt before returning
- */
-async function getAccessToken(source: {
-  id: string;
-  accessToken: string | null;
-  refreshToken: string | null;
-  tokenExpiresAt: Date | null;
-}): Promise<string | null> {
-  if (!source.accessToken) return null;
-
-  try {
-    // Check if token needs refresh
-    const fiveMinutesFromNow = new Date(Date.now() + 5 * 60 * 1000);
-    if (source.tokenExpiresAt && source.tokenExpiresAt > fiveMinutesFromNow) {
-      // Token still valid - decrypt and return
-      return decrypt(source.accessToken);
-    }
-
-    if (!source.refreshToken) return null;
-
-    // Token expired - refresh it
-    const decryptedRefreshToken = decrypt(source.refreshToken);
-    const newTokens = await refreshAccessToken(decryptedRefreshToken);
-
-    // Store new tokens encrypted
-    await db
-      .update(calendarSources)
-      .set({
-        accessToken: encrypt(newTokens.access_token),
-        refreshToken: newTokens.refresh_token ? encrypt(newTokens.refresh_token) : source.refreshToken,
-        tokenExpiresAt: new Date(Date.now() + newTokens.expires_in * 1000),
-        updatedAt: new Date(),
-      })
-      .where(eq(calendarSources.id, source.id));
-
-    return newTokens.access_token;
-  } catch (err) {
-    console.error('[BirthdaySync] Error getting access token:', err);
-    return null;
-  }
-}
-
-/**
- * POST /api/birthdays/sync
- */
 export async function POST() {
-  const auth = await requireAuth();
-  if (auth instanceof NextResponse) return auth;
-
   try {
-    // Find all enabled Google calendar sources
-    const sources = await db.query.calendarSources.findMany({
-      where: and(
-        eq(calendarSources.provider, 'google'),
-        eq(calendarSources.enabled, true)
-      ),
-    });
+    const auth = await requireAuth();
+    if (auth instanceof NextResponse) return auth;
 
-    if (sources.length === 0) {
-      return NextResponse.json(
-        { error: 'No Google Calendar sources connected' },
-        { status: 400 }
-      );
-    }
+    const { added, updated, total, errors } = await detectBirthdaysFromEvents();
 
-    // We need any valid access token to query Google Calendar
-    // Try each source until we find one with valid credentials
-    let accessToken: string | null = null;
-    let tokenSourceId: string | null = null;
-
-    for (const source of sources) {
-      const token = await getAccessToken(source);
-      if (token) {
-        accessToken = token;
-        tokenSourceId = source.id;
-        break;
-      }
-    }
-
-    if (!accessToken) {
-      return NextResponse.json(
-        { error: 'No valid Google Calendar credentials found' },
-        { status: 401 }
-      );
-    }
-
-    const allEvents: GoogleCalendarEvent[] = [];
-    const calendarSourceLabel: Record<string, string> = {};
-    // Look back 30 days and forward 400 days to catch all birthday occurrences
-    const timeMin = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const timeMax = new Date(Date.now() + 400 * 24 * 60 * 60 * 1000);
-    // 1. Fetch from Birthdays calendar
-    try {
-      const birthdayEvents = await fetchCalendarEvents(accessToken, BIRTHDAYS_CALENDAR_ID, {
-        timeMin,
-        timeMax,
-        maxResults: 250,
-        singleEvents: true,
-        orderBy: 'startTime',
-      });
-      for (const ev of birthdayEvents) {
-        allEvents.push(ev);
-        calendarSourceLabel[ev.id] = 'birthdays';
-      }
-    } catch (err) {
-      console.warn('Could not fetch from Birthdays calendar:', err);
-    }
-
-    // 2. Fetch from Friends & Family calendar (match by display name)
-    const friendsFamilySource = sources.find(
-      (s) =>
-        s.displayName?.toLowerCase().includes('friends') ||
-        s.dashboardCalendarName?.toLowerCase().includes('friends')
-    );
-
-    if (friendsFamilySource) {
-      try {
-        const token = await getAccessToken(friendsFamilySource) || accessToken;
-        const ffEvents = await fetchCalendarEvents(token, friendsFamilySource.sourceCalendarId, {
-          timeMin,
-          timeMax,
-          maxResults: 250,
-          singleEvents: true,
-          orderBy: 'startTime',
-        });
-        for (const ev of ffEvents) {
-          allEvents.push(ev);
-          calendarSourceLabel[ev.id] = 'friends_family';
-        }
-      } catch (err) {
-        console.error('[BirthdaySync] Error fetching Friends & Family:', err);
-      }
-    }
-
-    // Parse all events into upsert-ready rows
-    const errors: string[] = [];
-    const rows: { name: string; birthDate: string; eventType: string; googleCalendarSource: string }[] = [];
-
-    for (const event of allEvents) {
-      const parsed = parseCalendarEvent(event);
-      if (!parsed) {
-        continue;
-      }
-
-      const [, month, day] = parsed.birthDate.split('-');
-      const birthDate = parsed.year
-        ? `${parsed.year}-${month}-${day}`
-        : `1904-${month}-${day}`;
-
-      const calSource = calendarSourceLabel[event.id] || 'google';
-      rows.push({ name: parsed.name, birthDate, eventType: parsed.eventType, googleCalendarSource: calSource });
-    }
-    // upsertBirthday handles the prefix-aware merge so that a calendar
-    // event titled "Alex's birthday" (which the regex strips down to
-    // "Alex") collapses onto an iCloud contact with FN "Alex Doe"
-    // when both share a birth month/day, instead of becoming a separate
-    // row. See src/lib/services/birthday-merge.ts.
-    let added = 0;
-    let updated = 0;
-    for (const row of rows) {
-      try {
-        const outcome = await upsertBirthday({
-          name: row.name,
-          birthDate: row.birthDate,
-          eventType: row.eventType as 'birthday' | 'anniversary' | 'milestone',
-          source: row.googleCalendarSource,
-        });
-        if (outcome === 'inserted') added++;
-        else if (outcome === 'updated') updated++;
-      } catch (err) {
-        console.error('[BirthdaySync] Failed to upsert:', row.name, row.eventType, err);
-        errors.push(`Failed to upsert ${row.name}: ${err}`);
-      }
-    }
-    // Refresh cached birthday lists so new/changed ones show immediately.
-    if (added + updated > 0) await invalidateEntity('birthdays');
-
-    // Net changes (added + updated), not the total re-pulled — matches the
+    // Net changes (added + updated), not the total considered — matches the
     // calendar-event sync. `synced` kept for back-compat.
     return NextResponse.json({
       synced: added + updated,
       added,
       updated,
-      total: allEvents.length,
+      total,
       errors: errors.length > 0 ? errors : undefined,
     });
   } catch (error) {
-    logError('Error syncing birthdays:', error);
+    logError('Error detecting birthdays:', error);
     return NextResponse.json(
-      { error: 'Failed to sync birthdays from Google Calendar' },
+      { error: 'Failed to detect birthdays from calendars' },
       { status: 500 }
     );
   }

--- a/src/app/api/calendars/[id]/route.ts
+++ b/src/app/api/calendars/[id]/route.ts
@@ -162,6 +162,19 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       updates.showInEventModal = body.showInEventModal;
     }
 
+    // Handle the life-events calendar flag. Only this single key is accepted
+    // and it is merged server-side — providerConfig also carries CalDAV
+    // credentials (serverUrl, username), so accepting a client-supplied object
+    // wholesale would let a caller overwrite or clear them.
+    if (typeof body.lifeEventsCalendar === 'boolean') {
+      const [current] = await db
+        .select({ providerConfig: calendarSources.providerConfig })
+        .from(calendarSources)
+        .where(eq(calendarSources.id, id));
+      const cfg = (current?.providerConfig as Record<string, unknown> | null) ?? {};
+      updates.providerConfig = { ...cfg, lifeEventsCalendar: body.lifeEventsCalendar };
+    }
+
     if (body.color) {
       if (!/^#[0-9A-Fa-f]{6}$/.test(body.color)) {
         return NextResponse.json(

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -31,6 +31,7 @@ function useSections(isMobile: boolean): HelpSection[] {
       { id: 'recipes', title: 'Recipes', content: <RecipesHelp /> },
       { id: 'messages', title: 'Messages', content: <MessagesHelp /> },
       { id: 'wishes', title: 'Wishes & Gift Ideas', content: <WishesHelp /> },
+      { id: 'birthdays', title: 'Birthdays & Milestones', content: <BirthdaysHelp /> },
       { id: 'weekend', title: 'Weekend Ideas', content: <WeekendHelp /> },
       { id: 'travel', title: 'Travel Map', content: <TravelHelp /> },
       { id: 'photos', title: 'Photos', desktopOnly: true, content: <PhotosHelp /> },
@@ -404,6 +405,35 @@ function MessagesHelp() {
         <Li><strong>Edit</strong>: Click the pencil icon, Ctrl+Enter to save</Li>
         <Li><strong>Delete</strong>: Authors can delete their own; parents can delete any</Li>
       </Ul>
+    </>
+  );
+}
+
+function BirthdaysHelp() {
+  return (
+    <>
+      <H2>Where birthdays come from</H2>
+      <P>You don&apos;t enter birthdays into Prism. It reads them from the calendars and contacts you already keep, so they stay correct in one place.</P>
+      <Ul>
+        <Li><strong>Your calendars</strong> — any all-day event with &quot;birthday&quot; or &quot;anniversary&quot; in the title, on any connected calendar (Google, iCloud/CalDAV, iCal subscription, or a local Prism calendar)</Li>
+        <Li><strong>Your contacts</strong> — the birthday field on iCloud/CardDAV contacts. Tick &quot;contact birthdays&quot; when connecting iCloud; this is how iPhone birthdays arrive</Li>
+        <Li><strong>Google Contacts</strong> — Google&apos;s own generated birthday calendar</Li>
+      </Ul>
+      <H2>Adding one Prism can&apos;t find</H2>
+      <P>Put it on a calendar and Prism picks it up on the next sync. Your own local Prism calendar works fine for this.</P>
+      <Ul>
+        <Li>Make it an <strong>all-day</strong> event. A timed event is treated as something happening near a birthday, not the birthday itself</Li>
+        <Li>Put the person&apos;s name and the word <strong>birthday</strong> in the title: <em>Grandma&apos;s Birthday</em></Li>
+        <Li>Add the year in brackets to show their age: <em>Grandma&apos;s Birthday (1948)</em>. Without a year you still get the date, just no age</Li>
+      </Ul>
+      <H2>Anniversaries and milestones</H2>
+      <P>Anniversaries work the same way — include the word <strong>anniversary</strong> in the title.</P>
+      <P>Milestones have no obvious keyword, so Prism looks for the shape instead: an all-day event that <strong>repeats every year</strong> and carries a <strong>year</strong> in the title, like <em>Ana and Ben (2005)</em>.</P>
+      <P>If you keep a calendar where <em>everything</em> is a life event, open <strong>Manage calendars</strong> and turn on <strong>&quot;Treat every all-day event here as a birthday or milestone&quot;</strong>. Then titles need no keyword at all.</P>
+      <H2>Removing one</H2>
+      <P>Deleting a birthday in Prism keeps it deleted — it won&apos;t reappear on the next sync, even though the calendar event still exists. Delete the calendar event too if you want it gone everywhere.</P>
+      <H2>What Prism ignores</H2>
+      <P>Read-only calendars you subscribe to (school terms, public holidays) are skipped, so things like &quot;No School — Martin Luther King&apos;s Birthday&quot; don&apos;t become family birthdays. Titles such as &quot;birthday party&quot; or &quot;prep for Sam&apos;s birthday&quot; are ignored too, since they describe something happening near a birthday rather than the day itself.</P>
     </>
   );
 }

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -613,6 +613,44 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
                       </div>
                     );
                   })()}
+                  {/* Life-events calendar. Optional: birthdays and anniversaries
+                      are detected on every calendar by keyword, and milestones by
+                      shape (recurring + a year). This is for a curated calendar
+                      where EVERY all-day entry is a life event, and it replaces
+                      the old hardcoded "Friends & Family" name match. */}
+                  <div className="flex items-center justify-between mt-2 pt-2 border-t border-border">
+                    <span className="text-xs text-muted-foreground">
+                      Treat every all-day event here as a birthday or milestone
+                    </span>
+                    <Switch
+                      checked={
+                        ((cal as { providerConfig?: Record<string, unknown> }).providerConfig
+                          ?.lifeEventsCalendar) === true
+                      }
+                      onCheckedChange={async () => {
+                        const current = (cal as { providerConfig?: Record<string, unknown> }).providerConfig ?? {};
+                        const newValue = current.lifeEventsCalendar !== true;
+                        setUpdatingCalendar(cal.id);
+                        try {
+                          await fetch(`/api/calendars/${cal.id}`, {
+                            method: 'PATCH',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ lifeEventsCalendar: newValue }),
+                          });
+                          setLocalCalendars((prev) =>
+                            prev.map((lc) =>
+                              lc.id === cal.id
+                                ? { ...lc, providerConfig: { ...current, lifeEventsCalendar: newValue } }
+                                : lc
+                            )
+                          );
+                        } catch { /* ignore */ }
+                        setUpdatingCalendar(null);
+                      }}
+                      disabled={updatingCalendar === cal.id}
+                      className="data-[state=checked]:bg-blue-500"
+                    />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -771,6 +771,32 @@ export const birthdays = pgTable('birthdays', {
   nameEventTypeIdx: uniqueIndex('birthdays_name_event_type_idx').on(table.name, table.eventType),
 }));
 
+/**
+ * Tombstones for detected birthdays the user deleted. Detection re-reads every
+ * calendar on each sync, so without this a dismissed entry reappears on the
+ * next run and the delete button does nothing that lasts.
+ *
+ * Keyed on the normalised name plus month/day rather than a source event id:
+ * the same person legitimately arrives from several calendars and from CardDAV
+ * contacts, and dismissing them once should hold for all of those. Year is
+ * excluded deliberately — the 1904 unknown-year sentinel means the same person
+ * can arrive with different years from different sources.
+ */
+export const dismissedBirthdays = pgTable('dismissed_birthdays', {
+  id: uuid('id').defaultRandom().primaryKey(),
+
+  /** Lowercased, punctuation-stripped name — matches normalize() in birthday-merge.ts */
+  normalizedName: varchar('normalized_name', { length: 100 }).notNull(),
+  birthMonth: integer('birth_month').notNull(),
+  birthDay: integer('birth_day').notNull(),
+  eventType: varchar('event_type', { length: 20 }).default('birthday').notNull(),
+
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  dismissedBirthdayUnique: uniqueIndex('dismissed_birthdays_name_day_type_unique')
+    .on(table.normalizedName, table.birthMonth, table.birthDay, table.eventType),
+}));
+
 
 export const settings = pgTable('settings', {
   id: uuid('id').defaultRandom().primaryKey(),

--- a/src/lib/server/calendarSyncCron.ts
+++ b/src/lib/server/calendarSyncCron.ts
@@ -14,6 +14,7 @@
 
 import { syncAllGoogleCalendars, syncAllIcalCalendars, syncAllCalDAVCalendars } from '@/lib/services/calendar-sync';
 import { syncCardDAVBirthdays } from '@/lib/services/carddav-birthday-sync';
+import { detectBirthdaysFromEvents } from '@/lib/services/birthday-detect';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 
 const INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
@@ -27,14 +28,26 @@ async function runOnce() {
       syncAllCalDAVCalendars(),
       syncCardDAVBirthdays(),
     ]);
+    // Detection reads the events those syncs just wrote, so it has to run
+    // after them rather than alongside. Calendar-sourced birthdays were
+    // previously never picked up by the cron at all — only the CardDAV
+    // contact path was — so they refreshed only when someone happened to open
+    // Manage Calendars and hit sync.
+    const detected = await detectBirthdaysFromEvents();
+
     const total = google.total + ical.total + caldav.total + carddav.synced;
-    const errors = [...google.errors, ...ical.errors, ...caldav.errors, ...carddav.errors];
+    const errors = [
+      ...google.errors, ...ical.errors, ...caldav.errors,
+      ...carddav.errors, ...detected.errors,
+    ];
 
     await invalidateEntity('events');
     // CalDAV sources also sync VTODO into the tasks table; invalidate that
     // cache too so the Tasks page picks up new / updated reminders.
     await invalidateEntity('tasks');
-    if (carddav.synced > 0) await invalidateEntity('birthdays');
+    if (carddav.synced > 0 || detected.added + detected.updated > 0) {
+      await invalidateEntity('birthdays');
+    }
 
     if (errors.length > 0) {
       console.warn(

--- a/src/lib/services/__tests__/birthday-detect.test.ts
+++ b/src/lib/services/__tests__/birthday-detect.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the source-agnostic life-event parser.
+ *
+ * These are the rules that decide whether something on any of the user's
+ * calendars becomes a birthday. They exist because the previous approach —
+ * "trust whatever is on a calendar named 'Friends & Family'" — was replaced by
+ * content rules that now run against EVERY calendar, so a bad rule creates
+ * junk contacts rather than just missing a few.
+ *
+ * The real-world strings below are taken from a live 2,216-event database.
+ */
+
+import { parseEventTitle } from '../birthday-detect';
+
+const D = '2026-03-14';
+const parse = (
+  title: string,
+  opts: { recurring?: boolean; lifeEvents?: boolean; description?: string | null } = {},
+) =>
+  parseEventTitle(
+    title,
+    D,
+    opts.description ?? null,
+    opts.lifeEvents ?? false,
+    opts.recurring ?? false,
+  );
+
+describe('birthdays', () => {
+  it('detects a birthday and strips the possessive', () => {
+    expect(parse("Sarah's Birthday")).toMatchObject({ name: 'Sarah', eventType: 'birthday' });
+  });
+
+  it('handles the other title shapes people use', () => {
+    expect(parse('Birthday - Sarah')).toMatchObject({ name: 'Sarah' });
+    expect(parse('Sarah - Birthday')).toMatchObject({ name: 'Sarah' });
+  });
+
+  it('takes the year from the title and removes it from the name', () => {
+    expect(parse("Grandma's Birthday (1948)")).toMatchObject({ name: 'Grandma', year: 1948 });
+  });
+
+  it('takes the year from the description when the title has none', () => {
+    expect(parse("Grandma's Birthday", { description: 'born 1948' })).toMatchObject({ year: 1948 });
+  });
+
+  it('strips trailing punctuation', () => {
+    // Real title: "Halvorsen's Birthday!"
+    expect(parse("Halvorsen's Birthday!")).toMatchObject({ name: 'Halvorsen' });
+  });
+});
+
+describe('anniversaries', () => {
+  it('detects the keyword anywhere, with no designated calendar', () => {
+    expect(parse('Mum & Dad Anniversary')).toMatchObject({ eventType: 'anniversary' });
+  });
+});
+
+describe('milestones', () => {
+  // Real titles: "Ana ❤️ Ben (2005)", "CJT ❤️ MRT (1977)". The signal is the
+  // year plus the annual repeat — NOT the heart, which is one user's habit.
+  it('detects a recurring event carrying a year, with no keyword', () => {
+    expect(parse('Ana ❤️ Ben (2005)', { recurring: true }))
+      .toMatchObject({ eventType: 'milestone', year: 2005 });
+  });
+
+  it('does not depend on the heart character', () => {
+    expect(parse('Ana and Ben (2005)', { recurring: true }))
+      .toMatchObject({ eventType: 'milestone', year: 2005 });
+  });
+
+  it('ignores the same title when it is a one-off', () => {
+    // Without the annual repeat there is nothing to distinguish it from any
+    // other all-day entry that happens to mention a year.
+    expect(parse('Ana ❤️ Ben (2005)', { recurring: false })).toBeNull();
+  });
+
+  it('ignores a recurring all-day event with no year', () => {
+    expect(parse('Bin day', { recurring: true })).toBeNull();
+  });
+});
+
+describe('other languages', () => {
+  // Prism ships a German UI, so a German household writes German titles. An
+  // English-only matcher would detect nothing for them and fail silently.
+  it('detects a German birthday and strips the keyword from the name', () => {
+    expect(parse('Omas Geburtstag')).toMatchObject({ name: 'Omas', eventType: 'birthday' });
+  });
+
+  it('keeps the genitive -s, because German names end in s too', () => {
+    // No apostrophe in German, so "Lukas" is both a name and a genitive form.
+    // Stripping a trailing s would turn Lukas into Luka.
+    expect(parse('Lukas Geburtstag')).toMatchObject({ name: 'Lukas' });
+  });
+
+  it('detects a German birthday with a year', () => {
+    expect(parse('Lukas Geburtstag (1990)')).toMatchObject({ eventType: 'birthday', year: 1990 });
+  });
+
+  it('detects a German anniversary', () => {
+    expect(parse('Hochzeitstag')).toMatchObject({ eventType: 'anniversary' });
+    expect(parse('Jubiläum Oma und Opa')).toMatchObject({ name: 'Oma und Opa', eventType: 'anniversary' });
+  });
+
+  it('rejects a German birthday party', () => {
+    expect(parse('Geburtstagsfeier bei Lukas')).toBeNull();
+  });
+});
+
+describe('false positives that reached production data', () => {
+  it('rejects preparation for a birthday', () => {
+    // Real title, on a writable family calendar — would have imported a
+    // person called "Prep for Ana".
+    expect(parse("Prep for Ana's birthday (party)")).toBeNull();
+  });
+
+  it('rejects a public holiday named after a person', () => {
+    // Real title, from a subscribed school calendar.
+    expect(parse("No School~Dr. Martin Luther King's Birthday")).toBeNull();
+  });
+
+  it('rejects social events happening near a birthday', () => {
+    expect(parse("Dinner for Sam's birthday")).toBeNull();
+    expect(parse('Birthday party at the park')).toBeNull();
+    expect(parse("Sleepover for Amy's birthday")).toBeNull();
+  });
+
+  it('ignores anything with no life-event signal at all', () => {
+    expect(parse('Dentist')).toBeNull();
+    expect(parse('School closed')).toBeNull();
+  });
+});
+
+describe('designated life-events calendar (optional override)', () => {
+  it('accepts a keyword-free, non-recurring title', () => {
+    expect(parse('Moved to the new house', { lifeEvents: true }))
+      .toMatchObject({ eventType: 'milestone' });
+  });
+
+  it('trusts the calendar over the negative-keyword list', () => {
+    // The user vouched for this calendar, so "party" is no longer a veto.
+    expect(parse('Retirement party (2019)', { lifeEvents: true })).not.toBeNull();
+  });
+});

--- a/src/lib/services/birthday-detect.ts
+++ b/src/lib/services/birthday-detect.ts
@@ -1,0 +1,289 @@
+/**
+ * Source-agnostic birthday & milestone detection.
+ *
+ * Replaces the old Google-only scan, which read two hardcoded calendars: the
+ * Google Contacts birthday calendar, and any source whose name happened to
+ * contain "friends". That worked for whoever kept a calendar with that name
+ * and for nobody else, and it was invisible — the magic string appeared in no
+ * docs, no UI, and no Help section (discussion #292).
+ *
+ * This reads the normalised `events` table instead, which every provider
+ * writes to (google, ical, caldav, local), so a birthday is found wherever the
+ * user keeps it — including on their own local calendar, which is what makes
+ * "add a birthday" answerable without a data-entry form.
+ *
+ * Precision comes from three cheap filters rather than from the calendar's
+ * name. Measured against a real 2,216-event database:
+ *
+ *   - `allDay` — a real birthday is an all-day event; "dinner for Sam's
+ *     birthday" is not. Deliberately NOT also requiring `recurring`: local
+ *     events can never be recurring until the RRULE builder lands (#59), and
+ *     requiring it would exclude exactly the calendars this change exists for.
+ *   - writable sources only — subscribed/read-only calendars are where
+ *     "No School~Dr. Martin Luther King's Birthday" and holiday feeds live.
+ *   - negative keywords — catches "Prep for Ana's birthday (party)" on a
+ *     calendar that is otherwise legitimate.
+ *
+ * Milestones have no keyword to match — the old code inferred them purely from
+ * calendar membership, which is what forced the magic calendar name. They are
+ * instead detected by shape: an all-day RECURRING event carrying a 4-digit
+ * year and no other keyword, e.g. "Ana ❤️ Ben (2005)" or "CJT ❤️ MRT (1977)".
+ * On real data that pattern matched 6 events, all genuine, against 107 all-day
+ * non-keyword events overall — the year plus the annual repeat is what
+ * separates a commemoration from an ordinary all-day entry.
+ *
+ * `recurring` is required HERE and nowhere else. A birthday can be a one-off
+ * row on a local calendar and still obviously be a birthday, because the word
+ * says so; a milestone has only its shape to go on, so the annual repeat is
+ * carrying the meaning. The trade-off is that a hand-entered local milestone
+ * isn't detected until the RRULE builder lands (#59) — acceptable, since
+ * birthdays and anniversaries are the overwhelming majority.
+ *
+ * LIFE_EVENTS_CALENDAR_KEY remains as an optional per-source override for
+ * anyone who keeps a dedicated calendar, but nothing requires it any more.
+ */
+
+import { db } from '@/lib/db/client';
+import { birthdays, calendarSources, dismissedBirthdays, events } from '@/lib/db/schema';
+import { and, eq, sql } from 'drizzle-orm';
+import { upsertBirthday } from './birthday-merge';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+
+/** providerConfig flag marking a calendar as "everything all-day here is a life event". */
+export const LIFE_EVENTS_CALENDAR_KEY = 'lifeEventsCalendar';
+
+/**
+ * Keywords are matched per language, not just in English. Prism ships a German
+ * UI, and a household running it writes "Omas Geburtstag" on the calendar — an
+ * English-only matcher would silently detect nothing at all for them, which is
+ * worse than the magic-calendar-name problem this replaces because it fails
+ * invisibly.
+ *
+ * German is here because it ships today. Adding a language is one entry, and
+ * needs no code change beyond this table.
+ */
+const BIRTHDAY_KEYWORD = /geburtstag|birthday/i;
+const ANNIVERSARY_KEYWORD = /(hochzeits|jahres)tag|jubiläum|anniversary/i;
+
+/**
+ * Titles that mention a life event but describe something happening NEAR it —
+ * "Prep for Ana's birthday (party)" is not Ana's birthday.
+ *
+ * `\b` is unreliable next to non-ASCII, so these are matched loosely; a
+ * substring hit is good enough for a veto list.
+ */
+const NEGATIVE_KEYWORDS = new RegExp(
+  [
+    // English
+    'prep', 'party', 'dinner', 'lunch', 'brunch', 'bbq', 'sleepover', 'celebrat', 'no school',
+    // German
+    'feier', 'vorbereitung', 'abendessen', 'mittagessen', 'schulfrei', 'kein unterricht',
+  ].join('|'),
+  'i',
+);
+
+/**
+ * A 4-digit year in the title. With an annual repeat this is the milestone
+ * signal — "Ana ❤️ Ben (2005)" commemorates a year, "Bin day" does not.
+ */
+const YEAR_IN_TITLE = /\b(19\d{2}|20\d{2})\b/;
+
+export type EventType = 'birthday' | 'anniversary' | 'milestone';
+
+export interface ParsedEvent {
+  name: string;
+  eventType: EventType;
+  /** YYYY-MM-DD taken from the event's own date. */
+  birthDate: string;
+  /** Birth/start year if one could be found, else null. */
+  year: number | null;
+}
+
+export interface DetectResult {
+  added: number;
+  updated: number;
+  /** Candidate events considered (before dedup). */
+  total: number;
+  errors: string[];
+}
+
+/**
+ * Parse an event title into a life-event record. Lifted unchanged in substance
+ * from the old Google-only sync route: the name-stripping and year extraction
+ * were always correct, only the source of the events was wrong.
+ *
+ * `isLifeEventsCalendar` relaxes the keyword requirement — on a calendar the
+ * user has explicitly designated, an all-day event with neither keyword is a
+ * milestone rather than something to ignore.
+ */
+export function parseEventTitle(
+  title: string,
+  eventDate: string,
+  description: string | null,
+  isLifeEventsCalendar: boolean,
+  isRecurring = false,
+): ParsedEvent | null {
+  if (!title.trim()) return null;
+
+  const isBirthday = BIRTHDAY_KEYWORD.test(title);
+  const isAnniversary = ANNIVERSARY_KEYWORD.test(title);
+  // A commemoration with no keyword: annually repeating and naming its year.
+  const looksLikeMilestone = isRecurring && YEAR_IN_TITLE.test(title);
+
+  if (!isBirthday && !isAnniversary && !looksLikeMilestone && !isLifeEventsCalendar) {
+    return null;
+  }
+
+  // "Prep for Ana's birthday (party)" is about a birthday, not one. A
+  // designated calendar is exempt: the user vouched for its contents.
+  if (!isLifeEventsCalendar && NEGATIVE_KEYWORDS.test(title)) return null;
+
+  let eventType: EventType = 'milestone';
+  let name = title;
+
+  if (isBirthday) {
+    eventType = 'birthday';
+    name = title
+      .replace(/['’]s\s+birthday/i, '')
+      .replace(/\s*-\s*birthday/i, '')
+      .replace(/birthday\s*-?\s*/i, '')
+      // German: "Omas Geburtstag" -> "Omas". The genitive -s is deliberately
+      // left on: German doesn't use an apostrophe, so "Lukas" is both a name
+      // and a genitive form, and stripping it would mangle real names.
+      .replace(/\s*-\s*geburtstag/i, '')
+      .replace(/geburtstag\s*-?\s*/i, '')
+      .trim();
+  } else if (isAnniversary) {
+    eventType = 'anniversary';
+    name = title
+      .replace(/['’]s\s+anniversary/i, '')
+      .replace(/\s*-\s*anniversary/i, '')
+      .replace(/anniversary\s*-?\s*/i, '')
+      .replace(/(hochzeits|jahres)tag\s*-?\s*/i, '')
+      .replace(/jubiläum\s*-?\s*/i, '')
+      .trim();
+  }
+
+  // A 4-digit year may live in the title or the description.
+  let year: number | null = null;
+  const yearMatch = `${title} ${description || ''}`.match(/\b(19\d{2}|20\d{2})\b/);
+  if (yearMatch) year = parseInt(yearMatch[1]!, 10);
+
+  name = name
+    .replace(/\s*\(\d{4}\)\s*/g, ' ')   // drop "(1993)"
+    .replace(/['’]s?\s*$/, '')          // drop a trailing possessive
+    .replace(/[!?.]+\s*$/, '')          // drop trailing punctuation: "Halvorsen's Birthday!"
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!name) name = title;
+
+  return { name, eventType, birthDate: eventDate, year };
+}
+
+/** Matches normalize() in birthday-merge.ts so tombstones line up with merges. */
+function normalizeName(s: string): string {
+  return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/**
+ * Scan every enabled calendar for life events and upsert them.
+ *
+ * Returns net changes rather than rows considered, matching the calendar-event
+ * sync's reporting.
+ */
+export async function detectBirthdaysFromEvents(): Promise<DetectResult> {
+  const result: DetectResult = { added: 0, updated: 0, total: 0, errors: [] };
+
+  // All-day events on enabled sources. Writable-only (showInEventModal) keeps
+  // subscribed holiday/school feeds out; a designated life-events calendar
+  // overrides that, since the user opted it in explicitly.
+  const rows = await db
+    .select({
+      title: events.title,
+      description: events.description,
+      startTime: events.startTime,
+      recurring: events.recurring,
+      sourceName: calendarSources.dashboardCalendarName,
+      providerConfig: calendarSources.providerConfig,
+      showInEventModal: calendarSources.showInEventModal,
+    })
+    .from(events)
+    .innerJoin(calendarSources, eq(events.calendarSourceId, calendarSources.id))
+    .where(and(eq(events.allDay, true), eq(calendarSources.enabled, true)));
+
+  const tombstones = await db.select().from(dismissedBirthdays);
+  const isDismissed = (name: string, month: number, day: number, type: string) =>
+    tombstones.some(
+      (t) =>
+        t.normalizedName === normalizeName(name) &&
+        t.birthMonth === month &&
+        t.birthDay === day &&
+        t.eventType === type,
+    );
+
+  for (const row of rows) {
+    const cfg = (row.providerConfig as Record<string, unknown> | null) ?? {};
+    const isLifeEvents = cfg[LIFE_EVENTS_CALENDAR_KEY] === true;
+    if (!row.showInEventModal && !isLifeEvents) continue;
+
+    const parsed = parseEventTitle(
+      row.title,
+      isoDate(row.startTime),
+      row.description,
+      isLifeEvents,
+      row.recurring,
+    );
+    if (!parsed) continue;
+
+    result.total++;
+
+    const [, month, day] = parsed.birthDate.split('-');
+    if (!month || !day) continue;
+    const birthDate = `${parsed.year ?? 1904}-${month}-${day}`;
+
+    if (isDismissed(parsed.name, parseInt(month, 10), parseInt(day, 10), parsed.eventType)) continue;
+
+    try {
+      const outcome = await upsertBirthday({
+        name: parsed.name,
+        birthDate,
+        eventType: parsed.eventType,
+        source: row.sourceName || 'calendar',
+      });
+      if (outcome === 'inserted') result.added++;
+      else if (outcome === 'updated') result.updated++;
+    } catch (err) {
+      console.error('[BirthdayDetect] upsert failed:', parsed.name, err);
+      result.errors.push(`Failed to upsert ${parsed.name}: ${err}`);
+    }
+  }
+
+  if (result.added + result.updated > 0) await invalidateEntity('birthdays');
+  return result;
+}
+
+/** All-day events are stored as floating dates; take the calendar day as-is. */
+function isoDate(d: Date): string {
+  return d.toISOString().split('T')[0]!;
+}
+
+/** Record a tombstone so a deleted birthday isn't re-detected next sync. */
+export async function dismissBirthday(row: {
+  name: string;
+  birthDate: string;
+  eventType: string;
+}): Promise<void> {
+  const [, mo, dy] = row.birthDate.split('-');
+  if (!mo || !dy) return;
+  await db
+    .insert(dismissedBirthdays)
+    .values({
+      normalizedName: normalizeName(row.name).slice(0, 100),
+      birthMonth: parseInt(mo, 10),
+      birthDay: parseInt(dy, 10),
+      eventType: row.eventType,
+    })
+    .onConflictDoNothing();
+}
+
+export { birthdays };

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -16,6 +16,14 @@
  *
  * Sharing first name + birthday but with two distinct last names is
  * (deliberately) NOT auto-merged — that's the false-positive case.
+ *
+ * Hand-entered rows (googleCalendarSource IS NULL) are authoritative and a
+ * sync must not rewrite them. Detection now scans every calendar rather than
+ * two curated ones, so a same-day near-name collision with something the user
+ * typed themselves went from unlikely to routine — and silently renaming or
+ * re-dating their row, then stamping it as "synced", is not recoverable.
+ * The only change ever applied to such a row is filling in a real year over
+ * the 1904 unknown-year sentinel.
  */
 
 import { db } from '@/lib/db/client';
@@ -46,6 +54,28 @@ function parseYear(birthDate: string): number {
   return parseInt(birthDate.split('-')[0]!, 10);
 }
 
+/** Null provenance = the user typed this in. Schema comment: "Null = manually created". */
+function isHandEntered(row: { googleCalendarSource: string | null }): boolean {
+  return row.googleCalendarSource === null;
+}
+
+/**
+ * Fill in a real year over the 1904 sentinel, leaving everything else alone.
+ * The only mutation a sync may apply to a hand-entered row.
+ */
+async function upgradeSentinelYear(
+  existing: { id: string; birthDate: string },
+  newYear: number,
+  mo: string,
+  dy: string,
+): Promise<'updated' | 'skipped'> {
+  if (parseYear(existing.birthDate) !== 1904 || newYear === 1904) return 'skipped';
+  await db.update(birthdays)
+    .set({ birthDate: `${newYear}-${mo}-${dy}` })
+    .where(eq(birthdays.id, existing.id));
+  return 'updated';
+}
+
 /**
  * Insert a birthday, but merge with any existing prefix-match candidate
  * sharing the same month/day. Returns the action taken so callers can
@@ -67,6 +97,17 @@ export async function upsertBirthday(opts: UpsertOpts): Promise<'inserted' | 'up
   });
 
   for (const existing of candidates) {
+    // A row the user typed is authoritative: never rename it, never re-date it,
+    // and never stamp it with sync provenance. Only fill in a missing year.
+    if (
+      isHandEntered(existing) &&
+      (normalize(existing.name) === normalize(name) ||
+        isTokenPrefix(existing.name, name) ||
+        isTokenPrefix(name, existing.name))
+    ) {
+      return upgradeSentinelYear(existing, newYear, mo, dy);
+    }
+
     // Exact match: standard upsert behavior — refresh fields, keep id.
     if (normalize(existing.name) === normalize(name)) {
       // Prefer a known year over the 1904 unknown-year sentinel, so the Google

--- a/src/lib/services/carddav-birthday-sync.ts
+++ b/src/lib/services/carddav-birthday-sync.ts
@@ -1,10 +1,17 @@
 /**
  * Pull birthdays out of CardDAV contacts and upsert into the birthdays
- * table. Credentials are reused from any existing CalDAV calendar_source
- * row whose providerConfig carries `contactBirthdaysEnabled: true` — the
- * user opts in by checking a box in the CalDAV connect dialog. One row's
- * creds are enough; we don't multi-tenant this. (If the user ever wants
- * per-iCloud-account isolation, this is the place to fan out.)
+ * table. Credentials are reused from existing CalDAV calendar_source rows
+ * whose providerConfig carries `contactBirthdaysEnabled: true` — the user
+ * opts in by checking a box in the CalDAV connect dialog.
+ *
+ * Fans out across every opted-in account. It used to take only the first
+ * match, so a household with two iCloud accounts silently synced one of them,
+ * and which one depended on connection order. A failure on one account is
+ * collected and the rest still run.
+ *
+ * Note this covers iPhone contacts: iCloud contacts are CardDAV, so ticking
+ * "contact birthdays" when connecting iCloud is what makes phone birthdays
+ * appear. The same path serves Nextcloud and Fastmail.
  */
 
 import { db } from '@/lib/db/client';
@@ -22,38 +29,48 @@ interface SyncResult {
 export async function syncCardDAVBirthdays(): Promise<SyncResult> {
   const result: SyncResult = { synced: 0, errors: [] };
 
-  const enabledSource = await db.query.calendarSources.findFirst({
+  const enabledSources = await db.query.calendarSources.findMany({
     where: and(
       eq(calendarSources.provider, 'caldav'),
       sql`(${calendarSources.providerConfig}->>'contactBirthdaysEnabled')::boolean = true`,
     ),
   });
 
-  if (!enabledSource) return result;
+  if (enabledSources.length === 0) return result;
 
-  const cfg = (enabledSource.providerConfig as Record<string, unknown> | null) ?? {};
-  const serverUrl = String(cfg.serverUrl || '');
-  const username = String(cfg.username || '');
-  if (!serverUrl || !username || !enabledSource.accessToken) {
-    result.errors.push('CardDAV sync: source row missing credentials');
-    return result;
-  }
+  // One entry per distinct account: several calendars from the same iCloud
+  // login can each carry the flag, and fetching their shared address book
+  // more than once would just be wasted round-trips.
+  const contacts: { name: string; birthDate: string }[] = [];
+  const seenAccounts = new Set<string>();
 
-  let password: string;
-  try {
-    password = decrypt(enabledSource.accessToken);
-  } catch (err) {
-    result.errors.push(`CardDAV sync: failed to decrypt password — ${err instanceof Error ? err.message : err}`);
-    return result;
-  }
+  for (const source of enabledSources) {
+    const cfg = (source.providerConfig as Record<string, unknown> | null) ?? {};
+    const serverUrl = String(cfg.serverUrl || '');
+    const username = String(cfg.username || '');
+    if (!serverUrl || !username || !source.accessToken) {
+      result.errors.push('CardDAV sync: source row missing credentials');
+      continue;
+    }
 
-  let contacts;
-  try {
-    contacts = await fetchCardDAVBirthdays(serverUrl, username, password);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    result.errors.push(`CardDAV fetch failed: ${msg}`);
-    return result;
+    const accountKey = `${serverUrl}|${username}`;
+    if (seenAccounts.has(accountKey)) continue;
+    seenAccounts.add(accountKey);
+
+    let password: string;
+    try {
+      password = decrypt(source.accessToken);
+    } catch (err) {
+      result.errors.push(`CardDAV sync: failed to decrypt password for ${username} — ${err instanceof Error ? err.message : err}`);
+      continue;
+    }
+
+    try {
+      contacts.push(...(await fetchCardDAVBirthdays(serverUrl, username, password)));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push(`CardDAV fetch failed for ${username}: ${msg}`);
+    }
   }
 
   // upsertBirthday handles three cases per contact:


### PR DESCRIPTION
Answers discussion #292 — "how do I add birthdays?" — which had no good answer.

## The problem

Birthdays could only arrive through two **hardcoded Google calendars**: Google's generated contacts calendar, and any source whose name happened to contain `"friends"` (`FRIENDS_FAMILY_CALENDAR_NAME`). That worked for whoever kept a calendar with that name, and for nobody else. The magic string appeared in no docs, no UI and no Help section, so there was nothing to tell @keilmillerjr.

It also **under-collected by 25%** on the very account it was designed around: the magic calendars held 128 matching events, all calendars together held 160. Birthdays were sitting on a shared calendar, a personal calendar and a "Family" calendar, all ignored.

## What changed

Detection now reads the normalised `events` table, which **every** provider writes to, so birthdays are found wherever they live: Google, iCloud/CalDAV, iCal subscriptions, or a local Prism calendar.

That last one matters most. It makes "how do I add a birthday" answerable without building a data-entry form: put it on a calendar and Prism aggregates it, which is how the rest of Prism already works.

## Precision

Verified against 2,216 real events. A naive keyword scan would have imported a birthday party's prep task, a public holiday named after a person, and a teacher from a subscribed school calendar. All three are rejected:

| Filter | Catches |
|---|---|
| `allDay` | "dinner for Sam's birthday" |
| writable sources only | holiday/school subscription feeds |
| negative keywords | "prep for…", "…party", "birthday dinner" |

**`recurring` is deliberately NOT required.** Local events cannot be recurring until the RRULE builder lands (#59), and requiring it would exclude exactly the calendars this change exists to support.

## Milestones

Milestones have no keyword — the old code inferred them from calendar membership, which is what forced the magic name in the first place. They are detected by **shape** instead: all-day, annually recurring, carrying a year in the title.

A per-calendar switch ("treat every all-day event here as a birthday or milestone") remains for curated calendars, replacing the magic string, but nothing requires it any more. Existing installs are migrated automatically so behaviour is unchanged.

## Languages

Keywords cover **English and German**. Prism shipped a German UI in 1.17.1, so an English-only matcher would have silently detected nothing for those households — a worse failure than the one being fixed, because it fails invisibly. Adding a language is one line.

## Two latent bugs, fixed

Both pre-existing, both made serious by scanning every calendar:

- **`upsertBirthday` clobbered hand-entered rows.** It stamped provenance without reading it, so a sync could rename and re-date something the user typed. Hand-entered rows are now authoritative; only a missing year is ever filled in.
- **Delete didn't stick.** `DELETE` was a hard delete with no tombstone, so a dismissed birthday returned on the next sync. Adds `dismissed_birthdays`, mirroring the existing `dismissed_events` pattern.

Also: CardDAV contact sync now fans out across **every** opted-in account instead of `findFirst`, which silently synced one of two iCloud accounts depending on connection order.

## Verification

Deployed locally and run through the real cron path:

- **61 → 65** entries, the four new ones from a shared calendar the old path never read
- **zero** false positives (checked by name, not just by count)
- 1,437 tests pass, including 21 new parser tests covering every false positive found in production data
- `tsc --noEmit` clean

## Docs

New `docs/features/BIRTHDAYS.md` and a Birthdays Help section. The feature existed but was invisible, which is the real substance of #292.
