### PR TITLE
chore(security): block PII and AI attribution from reaching GitHub text

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/guard-outbound.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/guard-outbound.sh
+++ b/scripts/guard-outbound.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# ============================================================================
+# PreToolUse guard — blocks publishing PII or AI attribution to GitHub.
+#
+# WHY
+# ---
+# scripts/scan-pii.sh runs pre-commit over tracked files, so nothing reaches a
+# *file* uncleaned. But `gh pr create`, `gh issue comment`, `gh pr edit`,
+# `gh release create` and friends publish text that never touches the working
+# tree, so they bypassed every check that existed.
+#
+# That gap published a real town and postal code, copied out of a live running
+# instance, into a public PR body. The town was already in the denylist. The
+# rule existed; nothing enforced it on this path.
+#
+# This hook reads the proposed Bash command, extracts whatever body text it
+# would publish (--body, --body-file, --notes, --notes-file, --title), and
+# refuses the call if scan-text.sh objects.
+#
+# It also blocks AI attribution ("Generated with Claude Code", Co-Authored-By
+# trailers), which CLAUDE.md forbids and which kept reappearing because the
+# harness default adds it.
+#
+# INPUT : hook JSON on stdin ({"tool_input":{"command":"..."}})
+# OUTPUT: exit 0 allows; exit 2 blocks and returns the reason to the model.
+# ============================================================================
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCANNER="$REPO_DIR/scripts/scan-text.sh"
+
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# Only guard commands that actually publish to GitHub.
+grep -qE '\bgh\s+(pr|issue|release|api|gist)\b' <<<"$cmd" || exit 0
+grep -qE '\-\-(body|body-file|notes|notes-file|title)\b|addDiscussionComment|createIssue|updateIssue' <<<"$cmd" || exit 0
+
+tmp=$(mktemp); trap 'rm -f "$tmp"' EXIT
+
+# Inline --body / --title / --notes values.
+python3 - "$cmd" >>"$tmp" <<'PY' 2>/dev/null || true
+import re, sys
+c = sys.argv[1]
+for m in re.finditer(r'--(?:body|title|notes)[= ]\s*(["\'])(.*?)\1', c, re.S):
+    print(m.group(2))
+# GraphQL discussion/issue mutations carry the text inline too.
+for m in re.finditer(r'body\s*:\s*(["\'])(.*?)\1', c, re.S):
+    print(m.group(2))
+PY
+
+# Referenced --body-file / --notes-file contents.
+while read -r f; do
+  [ -r "$f" ] && cat "$f" >>"$tmp"
+done < <(grep -oE '\-\-(body-file|notes-file)[= ]\s*[^ ]+' <<<"$cmd" | sed -E 's/.*(body-file|notes-file)[= ]\s*//' | tr -d '"'"'"'')
+
+# Process substitution: --notes-file <(awk ... FILE)
+while read -r f; do
+  [ -r "$f" ] && cat "$f" >>"$tmp"
+done < <(grep -oE '<\(.*?([A-Za-z0-9_./-]+\.md)' <<<"$cmd" | grep -oE '[A-Za-z0-9_./-]+\.md' || true)
+
+[ -s "$tmp" ] || exit 0
+
+# --- AI attribution (CLAUDE.md forbids it anywhere) -------------------------
+if grep -qiE 'generated with \[?claude code|co-authored-by:.*claude|🤖 generated' "$tmp"; then
+  echo "BLOCKED: this text contains AI attribution. CLAUDE.md forbids it in commits, PR bodies, issue and discussion comments, and release notes. Remove the line and retry." >&2
+  exit 2
+fi
+
+# --- PII ---------------------------------------------------------------------
+if ! out=$(bash "$SCANNER" "$tmp" 2>&1); then
+  echo "BLOCKED: this text would publish maintainer PII to GitHub." >&2
+  echo "$out" >&2
+  echo "Replace the offending values with fictional stand-ins. Never paste values read from the live database, .env, or a running container into anything published." >&2
+  exit 2
+fi
+exit 0

--- a/scripts/scan-text.sh
+++ b/scripts/scan-text.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Prism — PII scanner for OUTBOUND TEXT (PR bodies, issue/discussion comments,
+# release notes: anything published to GitHub that is not a tracked file).
+#
+# WHY THIS EXISTS
+# ---------------
+# scripts/scan-pii.sh runs pre-commit over `git ls-files`, so it only ever sees
+# tracked files. A pull-request body, an issue comment and a discussion reply
+# are GitHub metadata, never touch the working tree, and were therefore
+# completely unscanned.
+#
+# That gap leaked a real town and postal code into a public PR body as
+# before/after "evidence" pulled from the maintainer's live instance. The town
+# was already in the denylist; nothing simply ever checked. Live data copied
+# out of a running instance is the highest-risk text there is, because it is
+# real by construction.
+#
+# USAGE
+#   bash scripts/scan-text.sh <file>          # scan a drafted body
+#   cat body.md | bash scripts/scan-text.sh   # or via stdin
+#
+# Exits 0 if clean, 1 on any match. Matched denylist entries are reported by
+# position, never printed, so running this in a shared terminal cannot itself
+# leak the list.
+#
+# DENYLIST: same file as scan-pii.sh —
+#   $PRISM_PII_DENYLIST  OR  ~/.config/prism-pii-denylist.txt
+# ============================================================================
+set -uo pipefail
+
+INPUT="${1:-/dev/stdin}"
+[ -r "$INPUT" ] || { echo "[scan-text] cannot read: $INPUT" >&2; exit 2; }
+TEXT=$(cat "$INPUT")
+fail=0
+
+# ── Layer 1: maintainer denylist (real names, town, address, IPs, domains) ──
+DENYLIST="${PRISM_PII_DENYLIST:-$HOME/.config/prism-pii-denylist.txt}"
+if [ -f "$DENYLIST" ]; then
+  n=0
+  while IFS= read -r entry; do
+    case "$entry" in ''|\#*) continue ;; esac
+    n=$((n + 1))
+    # Word-boundary match, not substring. A short denylist entry (a first name,
+    # a street) otherwise fires inside ordinary words — "install", "Locale" and
+    # "milestone" all matched on an early version, and a scanner that cries wolf
+    # is one people learn to ignore. Entries containing punctuation or spaces
+    # (IPs, domains, addresses) fall back to a plain substring match, since word
+    # boundaries behave badly around dots and dashes.
+    if [[ "$entry" =~ ^[A-Za-z0-9]+$ ]]; then
+      match_expr="\\b${entry}\\b"
+      hit=$(grep -niE -- "$match_expr" <<<"$TEXT" | head -3)
+    else
+      hit=$(grep -niF -- "$entry" <<<"$TEXT" | head -3)
+    fi
+    if [ -n "$hit" ]; then
+      echo "[scan-text] DENYLIST MATCH: entry #$n (value withheld)"
+      sed 's/^/    line /' <<<"$hit"
+      fail=1
+    fi
+  done < "$DENYLIST"
+else
+  echo "[scan-text] WARNING: no denylist at $DENYLIST — layer 1 skipped" >&2
+fi
+
+# ── Layer 2: built-in patterns ──────────────────────────────────────────────
+check() {
+  local label="$1" pattern="$2"
+  if grep -qEi -- "$pattern" <<<"$TEXT"; then
+    echo "[scan-text] $label:"
+    grep -nEi -- "$pattern" <<<"$TEXT" | head -3 | sed 's/^/    /'
+    fail=1
+  fi
+}
+
+# Private / LAN / Tailscale addresses.
+check "private IP" '\b(10\.[0-9]{1,3}|192\.168|172\.(1[6-9]|2[0-9]|3[01])|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7]))\.[0-9]{1,3}(\.[0-9]{1,3})?\b'
+# Real-looking emails. grep -E has no lookahead, so match broadly then drop
+# the addresses that are safe by definition (RFC2606 examples, GH noreply).
+if grep -oEi -- '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b' <<<"$TEXT" \
+     | grep -viE '@(example\.(com|org|net)|.*users\.noreply\.github\.com)$' | grep -q .; then
+  echo "[scan-text] email address:"
+  grep -nEi -- '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b' <<<"$TEXT" | head -3 | sed 's/^/    /'
+  fail=1
+fi
+# US ZIP+state pairs, the shape that leaked.
+check "US postal code" '\b[A-Z]{2},?\s+[0-9]{5}(-[0-9]{4})?\b'
+# Lat/long pairs precise enough to locate a home.
+check "GPS coordinates" '\b-?[0-9]{1,3}\.[0-9]{4,},\s*-?[0-9]{1,3}\.[0-9]{4,}\b'
+
+if [ "$fail" -eq 0 ]; then
+  echo "[scan-text] Clean: safe to publish."
+else
+  echo "[scan-text] Do NOT publish. Replace the offending values with fictional stand-ins." >&2
+fi
+exit "$fail"

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -185,6 +185,18 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     // Never surface or log the request body / credentials.
     logError('google/manual-token failed:', err instanceof Error ? err.name : 'error');
-    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+    // This branch must carry a message. Every *expected* failure above returns
+    // a specific diagnosis, so when this one returned a bare error code the
+    // client fell back to "Could not connect with the pasted token" — which
+    // reads as "your token is wrong" and sends people to re-mint a token that
+    // was never the problem. Say plainly that this one is on us.
+    return NextResponse.json(
+      {
+        error: 'internal_error',
+        message:
+          'Something went wrong on the Prism side while connecting, so this is not a problem with your token. Check the Prism logs for a line mentioning "google/manual-token" and include it if you report this.',
+      },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
Two commits: a user-facing error-message fix, and the guard that should have prevented a leak this week.

## fix(google): say when a manual-token failure is ours

Reported on the Google Playground thread: *"Could not connect with pasted token"*, with a verified `1//` refresh token.

Every **expected** failure in the manual-token route already returns a precise diagnosis: wrong client id/secret, revoked or expired token, missing Calendar scope, Calendar API not enabled. But the outer catch-all returned a bare `{ error: 'internal_error' }` with **no message**, so the client's `data.message || 'Could not connect with the pasted token.'` fell through to the generic string.

The result is that an unexpected server-side exception gets reported to the user as a bad token. They then re-mint a token that was never the problem, which is exactly what the reporter did several times.

The catch-all now says the failure is on Prism's side and points at the log line to quote. Credential-safe logging is unchanged: still only the error name, never the request body.

## chore(security): guard outbound text

`scan-pii.sh` runs pre-commit over tracked files, so nothing reaches a *file* uncleaned. But `gh pr create`, `gh issue comment`, `gh pr edit` and `gh release create` publish text that never touches the working tree, and that path had no check at all.

That gap published a real town and postal code, read out of a live running instance, into a public PR body. The value was **already in the denylist**. The rule existed; nothing enforced it on that path.

Adds two pieces:

| | |
|---|---|
| `scan-text.sh` | Scans arbitrary outbound text against the same denylist, plus patterns for private IPs, emails, US postal codes and GPS pairs. Alphanumeric denylist entries match on **word boundaries** — substring matching fired inside "install", "Locale" and "milestone", and a scanner that cries wolf is one people learn to ignore. |
| `guard-outbound.sh` | `PreToolUse` hook. Reads the proposed command, extracts whatever it would publish (`--body`, `--body-file`, `--notes`, `--notes-file`, `--title`, inline GraphQL `body:`), and **exits 2 to refuse the call** if the text hits the denylist. |

It also blocks AI attribution, which `CLAUDE.md` forbids and which kept reappearing because a tooling default adds a footer to pull requests.

Verified against the exact string that leaked: refused. Verified against all seven existing PR bodies: clean, no false positives.

## Note on CLAUDE.md

The attribution rule previously gave commit trailers as its example, which made it easy to apply narrowly. It now names every surface and records the live-data rule that was only ever implicit. `CLAUDE.md` is gitignored, so that change is local and isn't in this diff.