### PR TITLE
feat(i18n): localise clock and weather, plus German corrections from #289

### DIFF
--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -28,6 +28,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
+import { useLocale } from 'next-intl';
 import { Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTimeFormat } from '@/components/providers';
@@ -83,6 +84,7 @@ export const ClockWidget = React.memo(function ClockWidget({
   className,
 }: ClockWidgetProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const locale = useLocale();
   const effectiveTimeFormat = format24Hour === undefined
     ? timeFormat
     : format24Hour ? '24h' : '12h';
@@ -105,13 +107,16 @@ export const ClockWidget = React.memo(function ClockWidget({
     return () => clearInterval(intervalId);
   }, []);
 
-  // Format strings for date-fns
-  // See: https://date-fns.org/docs/format
-  const dateFormat = 'EEEE, MMMM d'; // e.g., "Tuesday, January 21"
-
   // Formatted strings
   const timeString = formatDisplayTime(currentTime, effectiveTimeFormat, { showSeconds }, displayTimezone);
-  const dateString = format(toDisplayDate(currentTime, displayTimezone), dateFormat);
+  // Locale-aware, via Intl rather than a fixed date-fns pattern: word order
+  // differs per language ("Tuesday, January 21" vs "Dienstag, 21. Januar"), so
+  // a hardcoded pattern would render German words in US order.
+  const dateString = toDisplayDate(currentTime, displayTimezone).toLocaleDateString(locale, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
 
   // Size-based styling
   const timeStyles = {

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -42,6 +42,7 @@ import {
 import { cn } from '@/lib/utils';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
 import { WidgetContainer } from './WidgetContainer';
+import { useTranslations, useLocale } from 'next-intl';
 import { useTimeFormat } from '@/components/providers';
 import { formatDisplayHour, formatDisplayTime } from '@/lib/utils/timeFormat';
 
@@ -63,7 +64,32 @@ export interface CurrentWeather {
   condition: WeatherCondition;
   humidity: number;
   windSpeed: number;
+  /** Provider-supplied English text. Fallback when no descriptionKey exists. */
   description: string;
+  /**
+   * Stable i18n key under `weather.conditions`, set by providers whose
+   * condition text we generate ourselves (Open-Meteo). Absent for providers
+   * that return their own prose (Pirate Weather, OpenWeatherMap), which fall
+   * back to `description`.
+   */
+  descriptionKey?: string;
+}
+
+/**
+ * Localised short weekday from the provider's fixed Sun-Sat token.
+ *
+ * All three providers emit the same DAYS_SHORT_ARRAY tokens, each computed in
+ * whichever timezone is correct for that provider, so mapping the token back to
+ * an index preserves their timezone handling while letting the client pick the
+ * language. 2024-01-07 was a Sunday; UTC-anchored so the offset maps exactly.
+ */
+function localizeDayName(dayName: string, locale: string): string {
+  const idx = DAYS_SHORT_ARRAY.indexOf(dayName as (typeof DAYS_SHORT_ARRAY)[number]);
+  if (idx < 0) return dayName;
+  return new Date(Date.UTC(2024, 0, 7 + idx)).toLocaleDateString(locale, {
+    weekday: 'short',
+    timeZone: 'UTC',
+  });
 }
 
 export interface ForecastDay {
@@ -479,6 +505,7 @@ function CurrentConditions({
   timezone?: string;
 }) {
   const { timeFormat } = useTimeFormat();
+  const t = useTranslations('weather');
   const temp  = formatTemp(weather.temperature, units);
   const feels = formatTemp(weather.feelsLike, units);
 
@@ -493,7 +520,9 @@ function CurrentConditions({
         <div>
           <div className="text-4xl font-bold leading-none">{temp}</div>
           <div className="text-sm text-muted-foreground capitalize mt-0.5">
-            {weather.description}
+            {weather.descriptionKey && typeof t.has === 'function' && t.has(`conditions.${weather.descriptionKey}`)
+              ? t(`conditions.${weather.descriptionKey}`)
+              : weather.description}
           </div>
           {location && (
             <div className="text-xs text-muted-foreground/70 mt-0.5 truncate max-w-[140px]">
@@ -555,6 +584,8 @@ function DayHeader({
   days: ForecastDay[];
   units: WeatherUnits;
 }) {
+  const t = useTranslations('weather');
+  const locale = useLocale();
   const now = new Date();
   const todayLocalStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
@@ -576,7 +607,7 @@ function DayHeader({
         const d = new Date(day.date);
         const dayLocalStr = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
         const isToday = dayLocalStr === todayLocalStr;
-        const label = isToday ? 'TODAY' : day.dayName.toUpperCase();
+        const label = isToday ? t('today') : localizeDayName(day.dayName, locale).toUpperCase();
 
         const leftPct  = ((day.low  - globalMin) / span) * 100;
         const widthPct = ((day.high - day.low)   / span) * 100;

--- a/src/i18n/__tests__/catalogs.test.ts
+++ b/src/i18n/__tests__/catalogs.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Catalogue contract tests.
+ *
+ * The Jest `next-intl` mock always resolves against the English catalogue and
+ * its provider is a pass-through (see src/test-utils/nextIntlMock.tsx), so no
+ * rendering test can observe a German regression. What CAN be checked cheaply
+ * is the contract between the code and the catalogues, which is where drift
+ * actually happens: an English key added without its translation, or a new
+ * provider bucket emitted with no matching entry.
+ */
+import en from '@/i18n/messages/en.json';
+import de from '@/i18n/messages/de.json';
+import { wmoDescriptionKey } from '@/lib/integrations/openmeteo';
+import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
+
+type Dict = Record<string, unknown>;
+
+function flatten(obj: Dict, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) =>
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? flatten(value as Dict, `${prefix}${key}.`)
+      : [`${prefix}${key}`],
+  );
+}
+
+describe('i18n catalogues', () => {
+  it('German covers every English key, with no orphans', () => {
+    const enKeys = flatten(en as Dict).sort();
+    const deKeys = flatten(de as Dict).sort();
+    expect(deKeys.filter((k) => !enKeys.includes(k))).toEqual([]); // orphaned
+    expect(enKeys.filter((k) => !deKeys.includes(k))).toEqual([]); // untranslated
+  });
+
+  it('has no empty translations', () => {
+    const empties: string[] = [];
+    const walk = (obj: Dict, prefix = '') => {
+      for (const [key, value] of Object.entries(obj)) {
+        if (value && typeof value === 'object') walk(value as Dict, `${prefix}${key}.`);
+        else if (typeof value !== 'string' || value.trim() === '') empties.push(`${prefix}${key}`);
+      }
+    };
+    walk(de as Dict);
+    expect(empties).toEqual([]);
+  });
+});
+
+describe('weather condition keys', () => {
+  // Every WMO code the provider can see, including the buckets' edges and the
+  // gaps between them that fall through to the default.
+  const codes = [0, 1, 2, 3, 45, 48, 51, 55, 61, 65, 71, 75, 80, 82, 85, 86, 95, 99, 56, 66, 77, 4];
+
+  it('every key the provider emits exists in both catalogues', () => {
+    const conditions = (locale: Dict) =>
+      ((locale.weather as Dict | undefined)?.conditions ?? {}) as Dict;
+    for (const code of codes) {
+      const key = wmoDescriptionKey(code);
+      expect(Object.keys(conditions(en as Dict))).toContain(key);
+      expect(Object.keys(conditions(de as Dict))).toContain(key);
+    }
+  });
+});
+
+describe('weekday tokens', () => {
+  // WeatherWidget.localizeDayName maps these provider tokens back to an index
+  // before localising. If the shape changes, day labels silently stay English.
+  it('are the seven short English names the providers emit', () => {
+    expect([...DAYS_SHORT_ARRAY]).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+  });
+});

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -6,15 +6,15 @@
       "tasks": "Aufgaben",
       "chores": "Hausarbeiten",
       "goals": "Ziele",
-      "shopping": "Einkaufen",
-      "meals": "Mahlzeiten",
+      "shopping": "Einkaufsliste",
+      "meals": "Essensplan",
       "recipes": "Rezepte",
       "messages": "Nachrichten",
       "photos": "Fotos",
       "wishes": "Wünsche",
       "babysitter": "Babysitter",
       "travel": "Reisen",
-      "weekend": "Wochenende",
+      "weekend": "Wochenendideen",
       "settings": "Einstellungen"
     },
     "actions": {
@@ -34,12 +34,29 @@
   },
   "birthdays": {
     "title": "Anstehende Geburtstage & Meilensteine",
-    "empty": "Keine anstehenden Geburtstage oder Termine",
+    "empty": "Keine anstehenden Geburtstage oder Meilensteine",
     "colEvent": "Anlass",
     "colYears": "Jahre",
     "colDays": "Tage",
     "colDate": "Datum",
     "todayBadge": "HEUTE",
     "daysUntil": "{days, plural, =0 {Heute!} one {# Tag} other {# Tage}}"
+  },
+  "weather": {
+    "today": "HEUTE",
+    "conditions": {
+      "clearSky": "Klarer Himmel",
+      "mainlyClear": "Überwiegend klar",
+      "partlyCloudy": "Teilweise bewölkt",
+      "overcast": "Bedeckt",
+      "fog": "Nebel",
+      "drizzle": "Nieselregen",
+      "rain": "Regen",
+      "snow": "Schnee",
+      "rainShowers": "Regenschauer",
+      "snowShowers": "Schneeschauer",
+      "thunderstorm": "Gewitter",
+      "cloudy": "Bewölkt"
+    }
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -41,5 +41,22 @@
     "colDate": "Date",
     "todayBadge": "TODAY",
     "daysUntil": "{days, plural, =0 {Today!} one {# day} other {# days}}"
+  },
+  "weather": {
+    "today": "TODAY",
+    "conditions": {
+      "clearSky": "Clear sky",
+      "mainlyClear": "Mainly clear",
+      "partlyCloudy": "Partly cloudy",
+      "overcast": "Overcast",
+      "fog": "Fog",
+      "drizzle": "Drizzle",
+      "rain": "Rain",
+      "snow": "Snow",
+      "rainShowers": "Rain showers",
+      "snowShowers": "Snow showers",
+      "thunderstorm": "Thunderstorm",
+      "cloudy": "Cloudy"
+    }
   }
 }

--- a/src/lib/integrations/openmeteo.ts
+++ b/src/lib/integrations/openmeteo.ts
@@ -124,6 +124,28 @@ function mapWmoCode(code: number): WeatherCondition {
   return 'cloudy';
 }
 
+/**
+ * Stable translation key for a WMO code, mirroring describeWmo()'s buckets.
+ *
+ * Emitted alongside the English `description` so the client can localise the
+ * condition without the server needing to know the viewer's language. Keys
+ * live under the `weather.conditions` namespace in src/i18n/messages/*.json.
+ */
+export function wmoDescriptionKey(code: number): string {
+  if (code === 0) return 'clearSky';
+  if (code === 1) return 'mainlyClear';
+  if (code === 2) return 'partlyCloudy';
+  if (code === 3) return 'overcast';
+  if (code === 45 || code === 48) return 'fog';
+  if (code >= 51 && code <= 55) return 'drizzle';
+  if (code >= 61 && code <= 65) return 'rain';
+  if (code >= 71 && code <= 75) return 'snow';
+  if (code >= 80 && code <= 82) return 'rainShowers';
+  if (code >= 85 && code <= 86) return 'snowShowers';
+  if (code >= 95 && code <= 99) return 'thunderstorm';
+  return 'cloudy';
+}
+
 function describeWmo(code: number): string {
   // Human-readable description — kept intentionally short. The widget shows
   // this beneath the temperature.
@@ -248,6 +270,7 @@ export async function fetchWeatherData(
     humidity: Math.round(current.relative_humidity_2m),
     windSpeed: Math.round(current.wind_speed_10m),
     description: describeWmo(current.weather_code),
+    descriptionKey: wmoDescriptionKey(current.weather_code),
   };
 
   // ── Sunrise / sunset from today's daily entry ─────────────────────────────


### PR DESCRIPTION
Follows up @Buanz's native-speaker review in #289.

## German corrections

`Einkaufsliste`, `Essensplan`, `Wochenendideen`, and `…oder Meilensteine` for the empty-birthdays line. `chores` stays `Hausarbeiten` — he wants to use the feature before choosing between that, `Dienste` and `Pflichten`.

## Clock (his priority #2)

The date came from a hardcoded date-fns pattern, `'EEEE, MMMM d'`. Passing a locale alone would have produced German words in US order (`Mittwoch, Januar 21`), so it now formats through `Intl`, which lets each language pick its own ordering.

| Locale | Before | After |
|---|---|---|
| en | Wednesday, January 21 | Wednesday, January 21 (unchanged) |
| de | Wednesday, January 21 | **Mittwoch, 21. Januar** |

## Weather (his priority #3)

Two separate problems hid behind one `en-US`:

**Condition text.** Only Open-Meteo's description is ours — Pirate Weather and OpenWeatherMap return their own English prose. Open-Meteo now emits a stable `descriptionKey` alongside the existing English `description`, and the widget prefers the catalogue entry, falling back to provider text when no key exists. Localising the other two needs a `lang` parameter on the provider call: separate work.

**Day labels.** All three providers already emit the same `Sun`–`Sat` tokens, each computed in whichever timezone is correct for that provider. The widget maps the token back to an index and formats it client-side, so no locale has to reach the server and no cache key changes. `WED` → `MI`, `SUN` → `SO`; unrecognised tokens pass through untouched.

That approach was chosen specifically to preserve the UTC-anchoring in `openmeteo.ts`, which exists to stop the calendar day slipping between a UTC container and a viewer in another timezone. A naive client-side reformat would have reintroduced that bug.

Left alone deliberately: the other `'en-US'` in `openmeteo.ts`, which parses a `longOffset` timezone string rather than formatting anything for display.

## Tests

`next-intl` is globally mocked to resolve against English and its provider is a pass-through, so **no rendering test can observe a German regression**. Rather than fight the ESM transpile problem that mock exists to avoid, this adds catalogue *contract* tests, which cover the drift that actually happens:

- key parity in both directions (untranslated keys and orphans)
- no empty translations
- every WMO bucket the provider can emit has an entry in both catalogues
- the weekday tokens the widget maps against are the seven the providers emit

Verified they have teeth: deleting one German key fails two of the four.

## Not in scope

Calendar, which he ranked #1. And the report that German does not apply on 1.17.2 — the chain checks out end to end and it renders correctly locally, so that looks environmental rather than a code defect; being followed up in the issue.
