### PR TITLE
docs(decisions): log the outbound-PII gap and the birthday detection rewrite

### DIFF
--- a/docs/decisions-log.md
+++ b/docs/decisions-log.md
@@ -6,6 +6,38 @@ Format per entry: what it was, why it's gone, and the specific lessons worth not
 
 ---
 
+## Publishing PII to GitHub metadata — the gap `scan-pii.sh` never covered (2026-08-28)
+
+**What happened:** A real town and postal code, read out of the maintainer's live running instance, were published in the body of a public PR as before/after evidence. The value was **already in the PII denylist**. Nothing caught it, because `scan-pii.sh` is a pre-commit hook that walks `git ls-files` — and a pull-request body is GitHub metadata that never touches the working tree.
+
+**Why it matters more than it looks:** PR and issue bodies are *not* git objects, so nothing propagated to any clone or fork. But GitHub retains **edit-history revisions**, and the pre-edit text stays readable through the `userContentEdits` GraphQL field long after the body is fixed. There is **no API to delete a revision** — it is UI-only, via the "edited" link on the body. Notification emails already delivered cannot be recalled at all.
+
+**Lessons worth not re-learning:**
+
+- The denylist was never the weak point. **Coverage was.** Any new publishing path (a `gh` subcommand, a bot, a webhook) needs to be added to the guard, or it is unprotected by default.
+- Values read from the live DB, `.env`, container env or a running API response are **real by construction**. They are the highest-risk text there is, and "it's just a town" is exactly the reasoning that leaks a town.
+- Denylist entries must match on **word boundaries**, not substrings. A first-pass substring matcher fired inside "install", "Locale" and "milestone". A scanner that cries wolf is one people learn to ignore, which is worse than no scanner.
+- Verification has to sweep every surface, not just the one that leaked: PR/issue **bodies, comments, and edit histories**, discussions, releases, commit messages, file history across all refs, and private repos.
+
+**What now enforces it:** `scripts/scan-text.sh` (scans arbitrary outbound text against the same denylist) and `scripts/guard-outbound.sh` (a `PreToolUse` hook that reads a proposed `gh` command, extracts what it would publish, and refuses the call). Rules alone had already failed once; the hook is the part that actually prevents.
+
+---
+
+## Birthday detection — why the "Friends & Family" magic name had to go (2026-08-28)
+
+**What it was:** Birthdays could only enter Prism through two hardcoded Google calendars: Google's generated contacts calendar, and any source whose *name contained "friends"*. Shipped in #296 as content-based detection across every provider.
+
+**Why the old design failed:** It worked for exactly one person — whoever happened to keep a calendar with that name. It was documented nowhere, so [discussion #292](https://github.com/sandydargoport/prism/discussions/292) had no answer to give. It also **under-collected by 25%** on the maintainer's own account, missing birthdays sitting on a shared calendar, a personal calendar and a "Family" calendar.
+
+**Lessons worth not re-learning:**
+
+- **Measure precision on real titles, not counts.** Counting regex hits said 99.4% precision. Reading the actual titles found a birthday party's prep task, a public holiday named after a person, and a teacher from a school feed — all of which a count-based check called clean.
+- **Two filters did more than the keyword.** Requiring `allDay`, and skipping read-only subscription calendars, removed nearly all false positives. The second is what keeps holiday and school feeds out, and it generalises to users who subscribe to far more of them.
+- **Do not require `recurring`.** It excludes local calendars entirely, since Prism cannot yet set recurrence on a locally-created event ([#59](https://github.com/sandydargoport/prism/issues/59)) — and local calendars are the whole point, because "put it on your own calendar" is how you add a birthday without a data-entry form.
+- **Milestones have no keyword**, which is what forced the magic name originally. They are detected by shape instead: all-day, annually recurring, carrying a year. The heart character one user writes is deliberately *not* a signal.
+- **English-only keyword matching is an invisible failure.** Prism ships a German UI; a German household writing "Omas Geburtstag" would have got nothing, with no error to explain it. Keywords cover English and German.
+- Contributor-facing behaviour that depends on a magic string is a bug even when it works. If it can't be explained in a docs page, it can't be supported.
+
 ## `feat/photo-sources-icloud-shared` — iCloud Shared Album source (deleted 2026-06-16)
 
 **What it was:** Phase B of [#57](https://github.com/sandydargoport/prism/issues/57) — pull photos from a public iCloud Shared Album by pasting its share link, no Apple Developer account. PR #92.


### PR DESCRIPTION
Two post-mortems for the decisions log, so the reasoning survives the branches.

**Publishing PII to GitHub metadata.** The denylist was never the weak point — coverage was. `scan-pii.sh` walks `git ls-files`, so a PR body was unprotected by construction, and any future publishing path is unprotected by default unless added to the guard. Also records that PR bodies are metadata rather than git objects, so nothing reaches a clone or fork, but GitHub retains edit-history revisions that only the UI can delete.

**Birthday detection.** Why the magic calendar name had to go, why measuring precision by counting regex hits was misleading (reading actual titles found false positives a count called clean), why `recurring` must not be required, and why English-only keyword matching is an invisible failure for a project shipping a German UI.