### PR TITLE
fix(config): validate ENCRYPTION_KEY at startup and name the failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,16 +47,27 @@ APP_URL=http://localhost:3000
 # set this so installs can be counted by channel. Defaults to "docker":
 # PRISM_DEPLOYMENT=pikapods
 
-# --- Security Secrets ---
-# Generate with: openssl rand -hex 32
-# Or: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# --- Security Secrets (REQUIRED — generate real values) ---
+#
+# Generate each one with:
+#   openssl rand -hex 32
+# or:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#
+# Run it once per key; do not reuse the same value for all three.
+#
+# These are left EMPTY on purpose. They used to ship with placeholder text like
+# "generate_a_64_hex_character_string_here", which looks configured: Prism
+# starts and appears healthy, then every integration that stores a credential
+# fails much later with an error that points at the integration rather than at
+# the key. An empty value is unmistakably unset. See #307.
+#
+# ENCRYPTION_KEY must be exactly 64 hexadecimal characters (32 bytes). Prism
+# checks it at startup and prints a clear error if it is missing or malformed.
 
-SESSION_SECRET=generate_a_random_32_character_string_here
-PIN_ENCRYPTION_KEY=generate_another_random_32_character_string
-
-# Used for encrypting OAuth tokens at rest (AES-256-GCM)
-# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-ENCRYPTION_KEY=generate_a_64_hex_character_string_here
+SESSION_SECRET=
+PIN_ENCRYPTION_KEY=
+ENCRYPTION_KEY=
 
 # --- Self-hosted integrations on your LAN (SSRF allowlist) ---
 # To prevent Prism from being used to probe your internal network, it blocks

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -20,6 +20,7 @@ import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { encrypt } from '@/lib/utils/crypto';
 import { logError } from '@/lib/utils/logError';
+import { EncryptionKeyError } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
 import { refreshAccessToken, TokenRevokedError } from '@/lib/integrations/google-calendar';
@@ -183,6 +184,16 @@ export async function POST(request: NextRequest) {
       accountEmail: result.accountEmail,
     });
   } catch (err) {
+    // A misconfigured encryption key is a configuration problem, not a token
+    // problem, and saying so saves the user from troubleshooting Google. The
+    // message names no secret — only the shape of the key that was expected.
+    if (err instanceof EncryptionKeyError) {
+      logError('google/manual-token failed: encryption key invalid', err.message);
+      return NextResponse.json(
+        { error: 'encryption_key_invalid', message: `Prism's encryption key is not configured correctly, so it cannot store the credentials. This is not a problem with your token. ${err.message}` },
+        { status: 500 },
+      );
+    }
     // Never surface or log the request body / credentials.
     logError('google/manual-token failed:', err instanceof Error ? err.name : 'error');
     // This branch must carry a message. Every *expected* failure above returns

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -11,6 +11,32 @@ export async function register() {
     };
     setGlobalDispatcher(new Agent({ connect: { family: 4 } }));
 
+    // Check the encryption key before anything tries to use it. A bad key
+    // does not stop Prism running — nothing encrypts until an integration
+    // stores a credential — so the failure used to surface much later, in
+    // whichever integration happened to encrypt first, looking like a problem
+    // with that integration. One reporter spent a long time on Google OAuth
+    // troubleshooting for what was a placeholder left in .env (#307).
+    //
+    // Warn rather than refuse to start: an install that never stores a
+    // credential works fine without a key, and there is a documented
+    // PIN_ENCRYPTION_KEY fallback. Refusing would break working setups to
+    // report a problem they do not have.
+    const { checkEncryptionKey } = await import('./lib/utils/crypto');
+    const keyProblem = checkEncryptionKey();
+    if (keyProblem) {
+      console.error(
+        '\n' +
+        '='.repeat(72) + '\n' +
+        '  PRISM CONFIGURATION PROBLEM\n\n' +
+        `  ${keyProblem}\n\n` +
+        '  Prism will start, but anything that stores a credential will fail:\n' +
+        '  Google Calendar, iCloud/CalDAV, bus tracking and photo sources.\n' +
+        '  Set the key, then recreate the container.\n' +
+        '='.repeat(72) + '\n',
+      );
+    }
+
     // Lazy import of node-only code. Kept in a separate file so the edge
     // runtime bundle never resolves these heavy transitive deps (node-ical,
     // redis client, node:crypto).

--- a/src/lib/utils/__tests__/crypto.test.ts
+++ b/src/lib/utils/__tests__/crypto.test.ts
@@ -152,15 +152,80 @@ describe('getKey validation', () => {
     const savedPin = process.env.PIN_ENCRYPTION_KEY;
     delete process.env.ENCRYPTION_KEY;
     delete process.env.PIN_ENCRYPTION_KEY;
-    expect(() => encrypt('test')).toThrow('environment variable is required');
+    expect(() => encrypt('test')).toThrow(/ENCRYPTION_KEY is not set/);
     process.env.ENCRYPTION_KEY = savedKey;
     if (savedPin !== undefined) process.env.PIN_ENCRYPTION_KEY = savedPin;
   });
 
-  it('throws when ENCRYPTION_KEY is wrong length', () => {
+  it('throws when ENCRYPTION_KEY is malformed', () => {
     const saved = process.env.ENCRYPTION_KEY;
+    // 'tooshort' is both too short AND not hexadecimal. The validator reports
+    // the hex problem first, which is the more useful of the two: a value that
+    // isn't hex at all is usually a placeholder rather than a truncated key.
     process.env.ENCRYPTION_KEY = 'tooshort';
-    expect(() => encrypt('test')).toThrow('ENCRYPTION_KEY must be 64 hex characters');
+    expect(() => encrypt('test')).toThrow(/must be hexadecimal/);
     process.env.ENCRYPTION_KEY = saved;
+  });
+});
+
+/**
+ * Regression tests for #307. A placeholder ENCRYPTION_KEY left in .env made
+ * Prism start and appear healthy, then fail much later inside whichever
+ * integration encrypted first, reporting an error that pointed at the
+ * integration rather than at the key.
+ */
+describe('checkEncryptionKey', () => {
+  const original = process.env;
+  beforeEach(() => { process.env = { ...original }; });
+  afterAll(() => { process.env = original; });
+
+  const valid = 'a'.repeat(64);
+
+  it('accepts a valid 64-character hex key', async () => {
+    process.env.ENCRYPTION_KEY = valid;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toBeNull();
+  });
+
+  it('rejects the placeholder that shipped in .env.example', async () => {
+    process.env.ENCRYPTION_KEY = 'generate_a_64_hex_character_string_here';
+    delete process.env.PIN_ENCRYPTION_KEY;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toMatch(/placeholder/i);
+  });
+
+  it('rejects a non-hexadecimal value', async () => {
+    process.env.ENCRYPTION_KEY = 'z'.repeat(64);
+    delete process.env.PIN_ENCRYPTION_KEY;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toMatch(/hexadecimal/i);
+  });
+
+  it('rejects a key of the wrong length and says what it got', async () => {
+    process.env.ENCRYPTION_KEY = 'ab'.repeat(10);
+    delete process.env.PIN_ENCRYPTION_KEY;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toMatch(/64 hex characters.*is 20/i);
+  });
+
+  it('reports a missing key', async () => {
+    delete process.env.ENCRYPTION_KEY;
+    delete process.env.PIN_ENCRYPTION_KEY;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toMatch(/not set/i);
+  });
+
+  it('still accepts the PIN_ENCRYPTION_KEY fallback', async () => {
+    delete process.env.ENCRYPTION_KEY;
+    process.env.PIN_ENCRYPTION_KEY = valid;
+    const { checkEncryptionKey } = await import('../crypto');
+    expect(checkEncryptionKey()).toBeNull();
+  });
+
+  it('throws a named error so callers can tell config from data failures', async () => {
+    process.env.ENCRYPTION_KEY = 'generate_a_64_hex_character_string_here';
+    delete process.env.PIN_ENCRYPTION_KEY;
+    const { encrypt, EncryptionKeyError } = await import('../crypto');
+    expect(() => encrypt('x')).toThrow(EncryptionKeyError);
   });
 });

--- a/src/lib/utils/crypto.ts
+++ b/src/lib/utils/crypto.ts
@@ -4,20 +4,62 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
+/**
+ * Raised when the encryption key itself is unusable, as opposed to anything
+ * going wrong with the data being encrypted.
+ *
+ * It exists so callers can tell the two apart. Handlers deliberately log only
+ * `err.name` to keep credentials out of the logs, which meant a misconfigured
+ * key surfaced as a bare "Error" and read as a problem with whatever the user
+ * was doing at the time. A distinct name is safe to log and safe to show:
+ * nothing here contains a secret. See #307.
+ */
+export class EncryptionKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EncryptionKeyError';
+  }
+}
+
+/** Guidance appended to every key error, since the fix is always the same. */
+const HOW_TO_GENERATE =
+  'Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"';
+
+/**
+ * Validate the configured key without encrypting anything.
+ *
+ * Returns null when usable, or a human-readable reason when not. Used at
+ * startup so a bad key is reported once, loudly, instead of surfacing later as
+ * an unrelated-looking failure in whichever integration happens to encrypt
+ * first.
+ */
+export function checkEncryptionKey(): string | null {
+  const key = process.env.ENCRYPTION_KEY || process.env.PIN_ENCRYPTION_KEY;
+  if (!key) {
+    return `ENCRYPTION_KEY is not set (PIN_ENCRYPTION_KEY is accepted as a fallback). ${HOW_TO_GENERATE}`;
+  }
+  // A placeholder copied from .env.example is the common case: it looks
+  // configured, so nothing about the running app suggests otherwise.
+  if (/^generate_/i.test(key)) {
+    return `ENCRYPTION_KEY is still the example placeholder from .env.example. ${HOW_TO_GENERATE}`;
+  }
+  if (!/^[0-9a-fA-F]+$/.test(key)) {
+    return `ENCRYPTION_KEY must be hexadecimal, and this value contains other characters. ${HOW_TO_GENERATE}`;
+  }
+  if (key.length !== 64) {
+    return `ENCRYPTION_KEY must be 64 hex characters (32 bytes); this one is ${key.length}. ${HOW_TO_GENERATE}`;
+  }
+  return null;
+}
+
 function getKey(): Buffer {
   // Backward compatibility:
   // Older installs generated PIN_ENCRYPTION_KEY but not ENCRYPTION_KEY.
   // Prefer ENCRYPTION_KEY for integrations, fall back to PIN_ENCRYPTION_KEY.
-  const key = process.env.ENCRYPTION_KEY || process.env.PIN_ENCRYPTION_KEY;
-  if (!key) {
-    throw new Error('ENCRYPTION_KEY (or PIN_ENCRYPTION_KEY fallback) environment variable is required');
-  }
-  // Accept hex-encoded 32-byte key
-  const buf = Buffer.from(key, 'hex');
-  if (buf.length !== 32) {
-    throw new Error('ENCRYPTION_KEY/PIN_ENCRYPTION_KEY must be 64 hex characters (32 bytes)');
-  }
-  return buf;
+  const problem = checkEncryptionKey();
+  if (problem) throw new EncryptionKeyError(problem);
+  const key = (process.env.ENCRYPTION_KEY || process.env.PIN_ENCRYPTION_KEY)!;
+  return Buffer.from(key, 'hex');
 }
 
 /**


### PR DESCRIPTION
Fixes #307.

A `.env` still holding the example placeholder let Prism start and appear completely healthy, because nothing encrypts until an integration stores a credential. The failure surfaced much later inside Google OAuth, so the reporter spent a long time troubleshooting Google for what was a one-line config problem.

**This very likely also explains the unresolved "Could not connect with pasted token" report** on the Discussions thread: same symptom, same `google/manual-token failed: Error` log line.

## Three changes, each closing part of the path

**1. Validate at startup.** `checkEncryptionKey()` checks the key without encrypting anything, and `instrumentation.ts` calls it at boot.

It **warns rather than refusing to start**. An install that never stores a credential works fine without a key, and there is a documented `PIN_ENCRYPTION_KEY` fallback — refusing would break working setups to report a problem they don't have. The warning names the four integrations that will fail (Google Calendar, iCloud/CalDAV, bus tracking, photo sources).

**2. Name the failure.** `EncryptionKeyError` distinguishes a bad *key* from a bad *payload*.

The manual-token route logs `err.name` to keep credentials out of logs, which is exactly why the reporter's log said only `google/manual-token failed: Error` — a plain `Error` has the name `"Error"`. That route now recognises this case and says the key is misconfigured and the token is fine. The message names no secret, only the expected shape.

**3. Stop shipping placeholder values.** `.env.example` no longer sets the three secrets to text like `generate_a_64_hex_character_string_here`, which *looks* configured. Empty values cannot be mistaken for real ones. Same reasoning as commenting out the weather defaults in 1.17.2: a wrong default is worse than no default.

The placeholder case is detected **specifically**, rather than falling through to "not hexadecimal", because it points at where the value came from instead of at its format.

## Tests

Seven new cases covering the placeholder, non-hex, wrong-length, missing, and `PIN_ENCRYPTION_KEY` fallback paths, plus that `encrypt()` throws the named type.

Two existing tests asserted the older, vaguer wording. Behaviour is unchanged and the assertions now match. Worth noting `'tooshort'` is both too short *and* not hex, and the hex problem is reported first — a value that isn't hex at all is usually a placeholder rather than a truncated key.

1,451 tests pass.