### PR TITLE
chore(release): 1.18.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.18.1] – 2026-08-28
+
+### Fixed
+- **A misconfigured encryption key is now reported clearly instead of surfacing later as a broken integration.** If the `ENCRYPTION_KEY` in your `.env` was missing, left as the example placeholder, or otherwise malformed, Prism started and looked completely healthy — nothing encrypts until an integration first stores a credential. The problem only appeared later, as an unexplained failure when connecting Google Calendar, iCloud, bus tracking or photo sources, which pointed at those integrations rather than at the key. Prism now checks the key when it starts and prints a clear message saying what is wrong and how to generate a valid one, and connecting an account will tell you the key is at fault rather than blaming your credentials. The example `.env` no longer ships placeholder values for secrets, since a placeholder looks configured when it isn't.
+
 ## [1.18.0] – 2026-08-28
 
 ### Added

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.18.0"
+version: "1.18.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release for [#307](https://github.com/sandydargoport/prism/issues/307).

## Fixed

- **A misconfigured `ENCRYPTION_KEY` is now reported clearly** instead of surfacing later as a broken integration. Prism validates the key at startup, says what is wrong and how to generate a valid one, and connecting an account now blames the key rather than your credentials. `.env.example` no longer ships placeholder values for secrets, since a placeholder looks configured when it isn't.

Version synced across `package.json`, `ha-app/config.yaml` and the changelog.