### PR TITLE
feat(google): one pasted token can enable Calendar, Tasks and Gmail

### DIFF
--- a/src/app/api/__tests__/googleManualToken.test.ts
+++ b/src/app/api/__tests__/googleManualToken.test.ts
@@ -161,12 +161,15 @@ describe('POST /api/integrations/google/manual-token — validation & mapping', 
     expect(body.error).toBe('invalid_client');
   });
 
-  it('400 missing_calendar_scope when the token lacks calendar access', async () => {
+  // The route no longer requires Calendar specifically: a token is accepted if
+  // it covers ANY supported capability (Calendar, Tasks or Gmail), so the
+  // failure case is now "covers none of them". See #310.
+  it('400 no_supported_scope when the token covers none of the supported APIs', async () => {
     mockRefresh.mockResolvedValue({ access_token: 'at', expires_in: 3600, scope: 'openid email', token_type: 'Bearer' });
     const res = await POST(req(goodBody));
     const body = await res.json();
     expect(res.status).toBe(400);
-    expect(body.error).toBe('missing_calendar_scope');
+    expect(body.error).toBe('no_supported_scope');
     expect(mockStore).not.toHaveBeenCalled();
   });
 });
@@ -177,7 +180,14 @@ describe('POST /api/integrations/google/manual-token — success', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ ok: true, calendarCount: 2, accountEmail: 'user@example.com' });
+    expect(body).toEqual({
+      ok: true,
+      capabilities: ['calendar'],
+      enabled: 'Calendar',
+      needsTaskListSelection: false,
+      calendarCount: 2,
+      accountEmail: 'user@example.com',
+    });
     expectNoLeak(JSON.stringify(body));
 
     // Exactly one refresh + one store.

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -21,6 +21,8 @@ import { settings } from '@/lib/db/schema';
 import { encrypt } from '@/lib/utils/crypto';
 import { logError } from '@/lib/utils/logError';
 import { EncryptionKeyError } from '@/lib/utils/crypto';
+import { detectCapabilities, describeCapabilities } from '@/lib/integrations/googleManualScopes';
+import { stashGoogleTasksTokens, storeGmailBusCredentials } from '@/lib/integrations/googleManualConnect';
 import { logActivity } from '@/lib/services/auditLog';
 import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
 import { refreshAccessToken, TokenRevokedError } from '@/lib/integrations/google-calendar';
@@ -120,17 +122,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Scope check — the token must actually carry Calendar access.
-    const scope = tokens.scope || '';
-    const hasCalendar =
-      /auth\/calendar(\.events|\.readonly)?(\s|$)/.test(scope) ||
-      (/auth\/calendar\.events/.test(scope) && /auth\/calendar\.readonly/.test(scope));
-    if (!hasCalendar) {
+    // Enable whatever the token actually covers, rather than requiring
+    // Calendar. Scopes are fixed when the token is authorised, so this is the
+    // user's choice made in the Playground: tick Tasks but not Gmail and you
+    // get Tasks but not Gmail. Only a token covering nothing is an error.
+    const capabilities = detectCapabilities(tokens.scope);
+    if (capabilities.length === 0) {
       return NextResponse.json(
         {
-          error: 'missing_calendar_scope',
+          error: 'no_supported_scope',
           message:
-            'The token was not granted Calendar access. In the Playground, select the Google Calendar API v3 scope before authorizing.',
+            'This token was not granted any scope Prism can use. In the OAuth Playground, select at least one of: ' +
+            'Google Calendar API v3, Tasks API v1, or Gmail API v1 (for bus tracking), then authorize again.',
         },
         { status: 400 },
       );
@@ -146,7 +149,8 @@ export async function POST(request: NextRequest) {
 
     // Store calendars. Persist the *pasted* refresh token — the refresh grant
     // does not return a new one.
-    let result;
+    let result: { calendarCount: number; accountEmail?: string | null } = { calendarCount: 0 };
+    if (capabilities.includes('calendar')) {
     try {
       result = await storeGoogleCalendarConnection({
         userId: auth.userId,
@@ -170,18 +174,68 @@ export async function POST(request: NextRequest) {
         { status: 502 },
       );
     }
+    }
+
+    // Tasks: hand off to the flow the browser callback already feeds. It parks
+    // the tokens in Redis under a per-user key, then the existing list picker
+    // and /api/task-sources/finalize take over unchanged — the only step the
+    // redirect flow owned was getting the tokens there in the first place.
+    if (capabilities.includes('tasks')) {
+      try {
+        await stashGoogleTasksTokens({
+          userId: auth.userId,
+          accessToken: tokens.access_token,
+          refreshToken,
+          expiresIn: tokens.expires_in,
+          accountEmail,
+        });
+      } catch (err) {
+        logError('google/manual-token: stashing tasks tokens failed', err instanceof Error ? err.name : 'error');
+        return NextResponse.json(
+          { error: 'tasks_stash_failed', message: 'Connected, but could not start the Tasks list picker. Please try again.' },
+          { status: 502 },
+        );
+      }
+    }
+
+    // Gmail: used only by bus tracking. Same credential row the browser flow
+    // writes, so nothing downstream can tell which route produced it.
+    if (capabilities.includes('gmail')) {
+      try {
+        await storeGmailBusCredentials({
+          accessToken: tokens.access_token,
+          refreshToken,
+          expiresIn: tokens.expires_in,
+          accountEmail,
+        });
+      } catch (err) {
+        logError('google/manual-token: storing gmail credentials failed', err instanceof Error ? err.name : 'error');
+        return NextResponse.json(
+          { error: 'gmail_store_failed', message: 'Could not save the Gmail connection. Please try again.' },
+          { status: 502 },
+        );
+      }
+    }
 
     logActivity({
       userId: auth.userId,
       action: 'create',
       entityType: 'integration',
-      summary: `Connected Google Calendar via manual refresh token (${result.calendarCount} calendars)`,
+      summary: `Connected Google via manual refresh token: ${describeCapabilities(capabilities)}${
+        capabilities.includes('calendar') ? ` (${result.calendarCount} calendars)` : ''
+      }`,
     });
 
     return NextResponse.json({
       ok: true,
+      capabilities,
+      // Named so the UI can tell the user what this token did and did not
+      // cover. Someone who meant to include Tasks but forgot to tick it in the
+      // Playground otherwise sees a success message and no Tasks.
+      enabled: describeCapabilities(capabilities),
+      needsTaskListSelection: capabilities.includes('tasks'),
       calendarCount: result.calendarCount,
-      accountEmail: result.accountEmail,
+      accountEmail: result.accountEmail ?? accountEmail,
     });
   } catch (err) {
     // A misconfigured encryption key is a configuration problem, not a token

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -61,9 +61,19 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
       }
 
       const data = await res.json();
+      // Report what the token actually covered, not just that it worked. The
+      // scopes are chosen in the Playground, so someone who meant to include
+      // Tasks and forgot to tick it would otherwise see a success message and
+      // then wonder why no tasks appeared.
+      const parts: string[] = [];
+      if (data.capabilities?.includes('calendar')) {
+        parts.push(`${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported`);
+      }
+      if (data.capabilities?.includes('gmail')) parts.push('Gmail connected for bus tracking');
+      if (data.needsTaskListSelection) parts.push('choose which task lists to show under Tasks sync');
       toast({
-        title: 'Google Calendar connected',
-        description: `${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported.`,
+        title: `Google connected: ${data.enabled ?? 'Calendar'}`,
+        description: parts.join(' · ') || undefined,
         variant: 'success',
       });
       // Clear the sensitive fields; they're never hydrated from the server.
@@ -105,6 +115,20 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
         Do all of this signed into a <span className="underline">single</span> Google account — the one
         whose calendars you want — ideally in a private/incognito window, so you never mix up accounts.
       </p>
+
+        <p className="text-xs text-muted-foreground">
+          One token can cover more than the calendar. In the Playground&apos;s scope list, tick whichever of
+          these you want Prism to use, and only those:
+        </p>
+        <ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+          <li><strong>Google Calendar API v3</strong> &mdash; two-way calendar sync</li>
+          <li><strong>Tasks API v1</strong> &mdash; Google Tasks as a task source</li>
+          <li><strong>Gmail API v1</strong> &mdash; bus tracking only, which reads transport emails</li>
+        </ul>
+        <p className="text-xs text-muted-foreground">
+          Leave one out and Prism simply will not enable it. A token cannot gain a scope later, so to add
+          one afterwards you generate a new token with the extra scope ticked and paste it here again.
+        </p>
 
       <ol className="list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
         <li>

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -117,8 +117,34 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
       </p>
 
         <p className="text-xs text-muted-foreground">
-          One token can cover more than the calendar. In the Playground&apos;s scope list, tick whichever of
-          these you want Prism to use, and only those:
+          One token can cover more than the calendar. The Playground&apos;s API list is long, so use the
+          <strong> Input your own scopes</strong> box at the top of Step 1 and paste the lines you want,
+          space-separated. Paste only what you want Prism to use:
+        </p>
+        <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground">
+          <li>
+            <strong>Calendar</strong> &mdash; two-way sync. Both lines:
+            <code className="mt-0.5 block break-all text-[11px]">
+              https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly
+            </code>
+          </li>
+          <li>
+            <strong>Tasks</strong> &mdash; Google Tasks as a task source:
+            <code className="mt-0.5 block break-all text-[11px]">https://www.googleapis.com/auth/tasks</code>
+          </li>
+          <li>
+            <strong>Gmail</strong> &mdash; bus tracking only:
+            <code className="mt-0.5 block break-all text-[11px]">https://www.googleapis.com/auth/gmail.modify</code>
+            <span className="mt-0.5 block">
+              Bus tracking marks the transport emails it has read, which needs <code>modify</code>.
+              <code> gmail.readonly</code> also works if you would rather it never wrote anything, but then
+              those emails stay unread in your inbox.
+            </span>
+          </li>
+        </ul>
+        <p className="text-xs text-muted-foreground">
+          Leave one out and Prism simply will not enable it. A token cannot gain a scope later, so to add
+          one afterwards you generate a new token with the extra scope included and paste it here again.
         </p>
         <ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">
           <li><strong>Google Calendar API v3</strong> &mdash; two-way calendar sync</li>

--- a/src/lib/integrations/__tests__/googleManualScopes.test.ts
+++ b/src/lib/integrations/__tests__/googleManualScopes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A pasted Google token unlocks exactly the capabilities its scopes cover.
+ *
+ * This is a user-facing choice, not an implementation detail: someone happy to
+ * give Prism their calendar and tasks but not their Gmail simply does not tick
+ * that scope in the OAuth Playground. Getting this wrong either silently drops
+ * a capability they asked for, or wires up one they deliberately withheld.
+ */
+
+import { detectCapabilities, describeCapabilities } from '../googleManualScopes';
+
+const CAL_PAIR = 'https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly';
+const CAL_BROAD = 'https://www.googleapis.com/auth/calendar';
+const TASKS = 'https://www.googleapis.com/auth/tasks';
+const GMAIL_RO = 'https://www.googleapis.com/auth/gmail.readonly';
+
+describe('detectCapabilities', () => {
+  it('detects calendar from the pair the browser flow requests', () => {
+    expect(detectCapabilities(CAL_PAIR)).toEqual(['calendar']);
+  });
+
+  it('detects calendar from the single broad scope a Playground user may pick', () => {
+    expect(detectCapabilities(CAL_BROAD)).toEqual(['calendar']);
+  });
+
+  it('detects tasks on its own', () => {
+    expect(detectCapabilities(TASKS)).toEqual(['tasks']);
+  });
+
+  it('detects gmail on its own', () => {
+    expect(detectCapabilities(GMAIL_RO)).toEqual(['gmail']);
+  });
+
+  it('detects all three together', () => {
+    expect(detectCapabilities(`${CAL_PAIR} ${TASKS} ${GMAIL_RO}`).sort())
+      .toEqual(['calendar', 'gmail', 'tasks']);
+  });
+
+  it('honours a deliberate subset — calendar and tasks without gmail', () => {
+    const caps = detectCapabilities(`${CAL_PAIR} ${TASKS}`);
+    expect(caps).toContain('calendar');
+    expect(caps).toContain('tasks');
+    expect(caps).not.toContain('gmail');
+  });
+
+  it('returns nothing for unrelated scopes', () => {
+    expect(detectCapabilities('openid email profile')).toEqual([]);
+  });
+
+  it('returns nothing for an absent scope string', () => {
+    expect(detectCapabilities(undefined)).toEqual([]);
+  });
+
+  it('does not mistake calendar.readonly alone for calendar access', () => {
+    // The browser flow always grants the pair; readonly alone cannot write, so
+    // treating it as full calendar access would fail later on the first write.
+    expect(detectCapabilities('https://www.googleapis.com/auth/calendar.readonly')).toEqual([]);
+  });
+});
+
+describe('describeCapabilities', () => {
+  it('reads naturally for one, two and three', () => {
+    expect(describeCapabilities(['calendar'])).toBe('Calendar');
+    expect(describeCapabilities(['calendar', 'tasks'])).toBe('Calendar and Tasks');
+    expect(describeCapabilities(['calendar', 'tasks', 'gmail']))
+      .toBe('Calendar, Tasks and Gmail (bus tracking)');
+  });
+
+  it('says nothing rather than producing an empty string', () => {
+    expect(describeCapabilities([])).toBe('nothing');
+  });
+});

--- a/src/lib/integrations/googleManualConnect.ts
+++ b/src/lib/integrations/googleManualConnect.ts
@@ -1,0 +1,88 @@
+/**
+ * Persist a manually-pasted Google token for the capabilities that do not
+ * already have a shared store.
+ *
+ * Both functions deliberately write exactly what the corresponding browser
+ * OAuth callback writes, so nothing downstream can tell which route produced
+ * the connection. The redirect flow's only unique job was obtaining the tokens;
+ * once they exist, the rest of each flow is identical.
+ */
+
+import { db } from '@/lib/db/client';
+import { apiCredentials } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { encrypt } from '@/lib/utils/crypto';
+import { getRedisClient } from '@/lib/cache/getRedisClient';
+
+/** Matches TEMP_TOKEN_TTL in the google-tasks callback (5 minutes). */
+const TEMP_TOKEN_TTL = 300;
+
+interface TokenBundle {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  accountEmail?: string | null;
+}
+
+/**
+ * Park Tasks tokens where the list picker expects to find them.
+ *
+ * The browser callback stores them in Redis under this key and redirects to a
+ * list picker; `/api/task-sources/google-lists` reads the key to list the
+ * user's task lists and `/api/task-sources/finalize` reads it again to create
+ * the source. Writing the same key means both of those work untouched.
+ */
+export async function stashGoogleTasksTokens(
+  opts: TokenBundle & { userId: string },
+): Promise<void> {
+  const redis = await getRedisClient();
+  if (!redis) throw new Error('redis_unavailable');
+
+  await redis.setEx(
+    `google-tasks-temp:${opts.userId}:task:new`,
+    TEMP_TOKEN_TTL,
+    JSON.stringify({
+      accessToken: encrypt(opts.accessToken),
+      refreshToken: encrypt(opts.refreshToken),
+      tokenExpiresAt: new Date(Date.now() + opts.expiresIn * 1000).toISOString(),
+      rawAccessToken: opts.accessToken,
+      accountEmail: opts.accountEmail ?? null,
+    }),
+  );
+}
+
+/**
+ * Upsert the Gmail credentials bus tracking reads.
+ *
+ * Same `service: 'gmail-bus'` row the google-bus callback writes.
+ */
+export async function storeGmailBusCredentials(opts: TokenBundle): Promise<void> {
+  const credentials = {
+    accessToken: encrypt(opts.accessToken),
+    refreshToken: encrypt(opts.refreshToken),
+  };
+  const expiresAt = new Date(Date.now() + opts.expiresIn * 1000);
+
+  const existing = await db.query.apiCredentials.findFirst({
+    where: (creds, { eq: e }) => e(creds.service, 'gmail-bus'),
+  });
+
+  if (existing) {
+    await db
+      .update(apiCredentials)
+      .set({
+        encryptedCredentials: JSON.stringify(credentials),
+        expiresAt,
+        accountEmail: opts.accountEmail ?? undefined,
+        updatedAt: new Date(),
+      })
+      .where(eq(apiCredentials.id, existing.id));
+  } else {
+    await db.insert(apiCredentials).values({
+      service: 'gmail-bus',
+      encryptedCredentials: JSON.stringify(credentials),
+      expiresAt,
+      accountEmail: opts.accountEmail ?? null,
+    });
+  }
+}

--- a/src/lib/integrations/googleManualScopes.ts
+++ b/src/lib/integrations/googleManualScopes.ts
@@ -1,0 +1,65 @@
+/**
+ * Which Prism capabilities a pasted Google refresh token unlocks.
+ *
+ * LAN-only installs cannot use the browser OAuth redirect at all: Google
+ * refuses a private address as a redirect URI, so every `/api/auth/google-*`
+ * flow is unreachable for them. 1.17.0 worked around that for Calendar with a
+ * pasted refresh token from the OAuth Playground. Tasks and Gmail were left
+ * behind, which is what #310 reports.
+ *
+ * A token carries exactly the scopes granted when it was authorised, and
+ * refreshing never widens them. So rather than one endpoint per capability, we
+ * read back what Google says the token covers and enable each capability it
+ * actually has. Someone who wants Calendar and Tasks but would rather not hand
+ * Prism their Gmail simply does not tick that scope, and nothing else changes.
+ */
+
+export type GoogleCapability = 'calendar' | 'tasks' | 'gmail';
+
+interface CapabilitySpec {
+  /** Does the granted scope string cover this capability? */
+  matches: (scope: string) => boolean;
+  /** Shown in the Playground instructions and in the result summary. */
+  label: string;
+  /** What to tick in the OAuth Playground to grant it. */
+  playgroundApi: string;
+}
+
+export const GOOGLE_CAPABILITIES: Record<GoogleCapability, CapabilitySpec> = {
+  calendar: {
+    // The browser flow asks for calendar.events + calendar.readonly; a
+    // Playground user may instead tick the single broader auth/calendar.
+    matches: (s) =>
+      /auth\/calendar(\s|$)/.test(s) ||
+      (/auth\/calendar\.events/.test(s) && /auth\/calendar\.readonly/.test(s)),
+    label: 'Calendar',
+    playgroundApi: 'Google Calendar API v3',
+  },
+  tasks: {
+    matches: (s) => /auth\/tasks(\s|$)/.test(s),
+    label: 'Tasks',
+    playgroundApi: 'Tasks API v1',
+  },
+  gmail: {
+    // Bus tracking parses transport emails; readonly is enough to do that.
+    matches: (s) => /auth\/gmail\.(readonly|modify)/.test(s),
+    label: 'Gmail (bus tracking)',
+    playgroundApi: 'Gmail API v1',
+  },
+};
+
+/** Capabilities the granted scope string actually covers. */
+export function detectCapabilities(scope: string | undefined): GoogleCapability[] {
+  const s = scope ?? '';
+  return (Object.keys(GOOGLE_CAPABILITIES) as GoogleCapability[]).filter((c) =>
+    GOOGLE_CAPABILITIES[c].matches(s),
+  );
+}
+
+/** Human-readable list for a result message, e.g. "Calendar and Tasks". */
+export function describeCapabilities(caps: GoogleCapability[]): string {
+  const names = caps.map((c) => GOOGLE_CAPABILITIES[c].label);
+  if (names.length === 0) return 'nothing';
+  if (names.length === 1) return names[0]!;
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}


### PR DESCRIPTION
Addresses #310.

## Google Tasks already exists

Provider (`src/lib/integrations/tasks/google-tasks.ts`), OAuth routes, list picker, and a **Tasks sync** sub-section under the Google integration card. What doesn't exist is a way for a **LAN-only install** to reach it.

Every `/api/auth/google-*` flow uses a browser redirect, and Google refuses a private address as a redirect URI. 1.17.0 worked around that for Calendar with a pasted refresh token from the OAuth Playground; Tasks and Gmail were left behind. The reporter hadn't missed a setting — from where he's standing the feature genuinely isn't available.

## Scope-driven, not one endpoint per capability

The manual-token route now reads back the scopes Google says the token carries, and enables each capability it covers:

| Playground scope | Enables |
|---|---|
| Google Calendar API v3 | two-way calendar sync (unchanged) |
| Tasks API v1 | Google Tasks as a task source |
| Gmail API v1 | bus tracking only |

Scopes are fixed when a token is authorised and refreshing never widens them, so **this is the user's choice, made in the Playground**. Someone happy to share their calendar and tasks but not their Gmail simply doesn't tick that scope. Only a token covering *none* of the three is an error.

## Tasks needed no new plumbing

The browser callback's only unique job was parking tokens in Redis under `google-tasks-temp:{userId}:task:new`. The list picker and `/api/task-sources/finalize` read that key and work untouched, so writing the same key from here reuses both flows entirely.

Gmail writes the same `service: 'gmail-bus'` credential row the redirect callback writes, so nothing downstream can tell which route produced a connection.

## Reporting

The response and toast now name what the token actually covered. A success message that hides a missing capability is how someone ends up wondering why their tasks never appeared — the most likely mistake here is ticking two scopes when you meant three.

## Microsoft deliberately untouched

OneDrive and Microsoft To Do sit behind the same redirect wall, but that's a different token endpoint, different scope syntax, and no first-party equivalent of the Playground. Separate work with its own design, and nobody has asked for it.

## Note for existing users

A token can't gain a scope retroactively, so anyone already connected via the Playground needs to generate a new one with the extra scopes ticked. Unavoidable, and the form now says so.

## Testing

11 new capability-detection tests, including the deliberate-subset case and that `calendar.readonly` alone isn't mistaken for calendar access. Two existing route tests updated: the failure case is now "covers none of the supported APIs", and the success payload carries the capability fields.

1,462 tests pass, typecheck clean, no new lint errors.