### PR TITLE
chore(release): 1.18.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.18.2] – 2026-08-28
+
+### Added
+- **Google Tasks and bus-tracking Gmail can now be connected without a public web address.** Prism has supported Google Tasks as a task source for a while, but connecting it required Google's browser sign-in, which needs a public HTTPS address that a home-network-only install does not have. The same paste-a-token method already used for Google Calendar now covers Tasks and Gmail too, and one token can carry all three. You choose which: in Google's OAuth Playground you paste only the lines for the parts you want, so a token can cover your calendar and tasks while leaving your email alone. Prism tells you afterwards exactly what the token enabled. The exact lines to paste are shown in *Settings → Integrations → Google*. Note that a token cannot gain access later, so to add something you generate a fresh one with the extra line included.
+
 ## [1.18.1] – 2026-08-28
 
 ### Fixed

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.18.1"
+version: "1.18.2"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Addresses #310.

## Added

- **Google Tasks and bus-tracking Gmail can be connected without a public web address.** Tasks has been supported for a while, but connecting it required Google's browser sign-in, which needs a public HTTPS address a LAN-only install doesn't have. The paste-a-token method already used for Calendar now covers Tasks and Gmail too, and one token can carry all three.

Which parts you enable is your choice: paste only the scope lines you want, so a token can cover calendar and tasks while leaving email alone. Prism reports afterwards exactly what the token enabled.

Version synced across `package.json`, `ha-app/config.yaml` and the changelog.