### PR TITLE
feat(google): accept a read-only calendar token instead of rejecting it

### DIFF
--- a/src/app/api/__tests__/googleManualToken.test.ts
+++ b/src/app/api/__tests__/googleManualToken.test.ts
@@ -225,3 +225,55 @@ describe('POST /api/integrations/google/manual-token — success', () => {
     expect(order).toEqual(['creds', 'store']);
   });
 });
+
+describe('POST /api/integrations/google/manual-token — read-only calendar', () => {
+  const READONLY = 'https://www.googleapis.com/auth/calendar.readonly openid email';
+
+  beforeEach(() => {
+    mockRefresh.mockResolvedValue({
+      access_token: 'at_plain',
+      expires_in: 3600,
+      scope: READONLY,
+      token_type: 'Bearer',
+    });
+  });
+
+  it('connects rather than rejecting, and reports read-only', async () => {
+    const res = await POST(req(goodBody));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.capabilities).toEqual(['calendarReadonly']);
+    expect(body.enabled).toBe('Calendar (read-only)');
+    expect(body.calendarCount).toBe(2);
+  });
+
+  it('tells the store the token cannot write, so no calendar offers an event form', async () => {
+    // The whole point of the flag: per-calendar accessRole describes the
+    // ACCOUNT's rights, so without this an owned calendar would still show in
+    // the event modal and fail on submit.
+    await POST(req(goodBody));
+    expect(mockStore).toHaveBeenCalledTimes(1);
+    expect(mockStore.mock.calls[0][0].readOnly).toBe(true);
+  });
+
+  it('does not set the read-only flag for a full-access token', async () => {
+    mockRefresh.mockResolvedValue({
+      access_token: 'at_plain',
+      expires_in: 3600,
+      scope: 'https://www.googleapis.com/auth/calendar openid email',
+      token_type: 'Bearer',
+    });
+    await POST(req(goodBody));
+    expect(mockStore.mock.calls[0][0].readOnly).toBe(false);
+  });
+
+  it('still records the calendar count in the audit log', async () => {
+    // Regression: the summary keyed off 'calendar' alone, so read-only
+    // connections logged no count while full ones did.
+    await POST(req(goodBody));
+    const summary = mockLogActivity.mock.calls[0][0].summary as string;
+    expect(summary).toContain('2 calendars');
+    expect(summary).toContain('read-only');
+  });
+});

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -365,7 +365,14 @@ export async function POST(request: NextRequest) {
           externalEventId = googleEvent.id;
         } catch (error) {
           logError('Failed to create event on Google Calendar:', error);
-          googleWarning = 'Event was saved locally but could not be synced to Google Calendar.';
+          // A scope failure is permanent — the token cannot write, and retrying
+          // will fail identically. Saying "could not be synced" invites a retry
+          // that cannot work, so name the cause and the fix instead.
+          const msg = error instanceof Error ? error.message : '';
+          googleWarning = /insufficient|forbidden|\b403\b/i.test(msg)
+            ? 'Event saved locally. This Google connection is read-only, so it was not added to Google Calendar. ' +
+              'Reconnect with the calendar.events scope to create events there.'
+            : 'Event was saved locally but could not be synced to Google Calendar.';
         }
       }
     }

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -150,7 +150,7 @@ export async function POST(request: NextRequest) {
     // Store calendars. Persist the *pasted* refresh token — the refresh grant
     // does not return a new one.
     let result: { calendarCount: number; accountEmail?: string | null } = { calendarCount: 0 };
-    if (capabilities.includes('calendar')) {
+    if (capabilities.includes('calendar') || capabilities.includes('calendarReadonly')) {
     try {
       result = await storeGoogleCalendarConnection({
         userId: auth.userId,

--- a/src/app/api/integrations/google/manual-token/route.ts
+++ b/src/app/api/integrations/google/manual-token/route.ts
@@ -156,6 +156,7 @@ export async function POST(request: NextRequest) {
         userId: auth.userId,
         tokens: { accessToken: tokens.access_token, refreshToken, expiresIn: tokens.expires_in },
         accountEmail,
+        readOnly: capabilities.includes('calendarReadonly'),
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : '';
@@ -222,7 +223,9 @@ export async function POST(request: NextRequest) {
       action: 'create',
       entityType: 'integration',
       summary: `Connected Google via manual refresh token: ${describeCapabilities(capabilities)}${
-        capabilities.includes('calendar') ? ` (${result.calendarCount} calendars)` : ''
+        capabilities.includes('calendar') || capabilities.includes('calendarReadonly')
+          ? ` (${result.calendarCount} calendars)`
+          : ''
       }`,
     });
 

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -71,8 +71,8 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
       }
       if (data.capabilities?.includes('calendarReadonly')) {
         parts.push(
-          `${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported, read-only` +
-          ' · add calendar.events to create events from Prism',
+          `${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported, ` +
+          'read-only (Prism cannot add events to them)',
         );
       }
       if (data.capabilities?.includes('gmail')) parts.push('Gmail connected for bus tracking');
@@ -134,8 +134,9 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
               https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly
             </code>
             <span className="mt-0.5 block">
-              The <code>calendar.readonly</code> line on its own also works and gives you a read-only
-              calendar: events show in Prism, but you cannot create or edit them there.
+              The <code>calendar.readonly</code> line on its own also works and gives you read-only
+              calendars: their events show in Prism, but they are not offered when you add an
+              event. Include the <code>calendar.events</code> line as well to create events from Prism.
             </span>
           </li>
           <li>

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -69,6 +69,12 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
       if (data.capabilities?.includes('calendar')) {
         parts.push(`${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported`);
       }
+      if (data.capabilities?.includes('calendarReadonly')) {
+        parts.push(
+          `${data.calendarCount ?? 0} calendar${data.calendarCount === 1 ? '' : 's'} imported, read-only` +
+          ' · add calendar.events to create events from Prism',
+        );
+      }
       if (data.capabilities?.includes('gmail')) parts.push('Gmail connected for bus tracking');
       if (data.needsTaskListSelection) parts.push('choose which task lists to show under Tasks sync');
       toast({
@@ -127,6 +133,10 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
             <code className="mt-0.5 block break-all text-[11px]">
               https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly
             </code>
+            <span className="mt-0.5 block">
+              The <code>calendar.readonly</code> line on its own also works and gives you a read-only
+              calendar: events show in Prism, but you cannot create or edit them there.
+            </span>
           </li>
           <li>
             <strong>Tasks</strong> &mdash; Google Tasks as a task source:

--- a/src/lib/integrations/__tests__/googleCalendarStore.test.ts
+++ b/src/lib/integrations/__tests__/googleCalendarStore.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Storage rules for a Google calendar connection, focused on the one thing the
+ * row must get right: whether Prism offers an event form for it.
+ *
+ * `showInEventModal` is what AddEventModal filters on. Getting it wrong does
+ * not fail at connect time; it fails weeks later when someone types an event
+ * and submits it, which is the failure mode this area keeps producing.
+ */
+const mockFindFirst = jest.fn();
+const insertValuesSpy = jest.fn();
+const updateSetSpy = jest.fn();
+
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    query: { calendarSources: { findFirst: (...a: unknown[]) => mockFindFirst(...a) } },
+    insert: () => ({ values: (v: unknown) => { insertValuesSpy(v); return Promise.resolve(); } }),
+    update: () => ({ set: (v: unknown) => { updateSetSpy(v); return { where: () => Promise.resolve() }; } }),
+  },
+}));
+jest.mock('@/lib/db/schema', () => ({ calendarSources: { id: 'id', provider: 'provider', sourceCalendarId: 'src' } }));
+jest.mock('drizzle-orm', () => ({ eq: jest.fn() }));
+jest.mock('@/lib/utils/crypto', () => ({ encrypt: (v: string) => `enc(${v})` }));
+jest.mock('@/lib/services/settingsTombstone', () => ({ tombstoneIdSet: () => Promise.resolve(new Set()) }));
+
+const mockFetchList = jest.fn();
+jest.mock('@/lib/integrations/google-calendar', () => ({
+  __esModule: true,
+  DISMISSED_GOOGLE_CALENDARS_KEY: 'dismissed',
+  fetchCalendarList: (...a: unknown[]) => mockFetchList(...a),
+}));
+
+import { storeGoogleCalendarConnection } from '../googleCalendarStore';
+
+const tokens = { accessToken: 'at', refreshToken: 'rt', expiresIn: 3600 };
+const base = { userId: 'u1', tokens, accountEmail: 'user@example.com' };
+
+/** A calendar the account fully owns — the strongest case for writability. */
+const OWNED = { id: 'c1', summary: 'Family', accessRole: 'owner', primary: true, hidden: false };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFindFirst.mockResolvedValue(undefined);
+  mockFetchList.mockResolvedValue([OWNED]);
+});
+
+describe('storeGoogleCalendarConnection — new rows', () => {
+  it('offers the event form for an owned calendar on a writable token', async () => {
+    await storeGoogleCalendarConnection(base);
+    expect(insertValuesSpy.mock.calls[0][0].showInEventModal).toBe(true);
+  });
+
+  it('does NOT offer it on a read-only token, even for an owned calendar', async () => {
+    // accessRole is the ACCOUNT's right, not the TOKEN's. Trusting it here is
+    // exactly how a read-only connection ends up with an event form that 403s.
+    await storeGoogleCalendarConnection({ ...base, readOnly: true });
+    expect(insertValuesSpy.mock.calls[0][0].showInEventModal).toBe(false);
+  });
+
+  it('still stores the calendar itself — read-only means read, not skip', async () => {
+    const result = await storeGoogleCalendarConnection({ ...base, readOnly: true });
+    expect(insertValuesSpy).toHaveBeenCalledTimes(1);
+    expect(result.calendarCount).toBe(1);
+    expect(insertValuesSpy.mock.calls[0][0].enabled).toBe(true);
+  });
+
+  it('defaults to writable when the flag is omitted (existing callers unchanged)', async () => {
+    await storeGoogleCalendarConnection(base);
+    expect(insertValuesSpy.mock.calls[0][0].showInEventModal).toBe(true);
+  });
+});
+
+describe('storeGoogleCalendarConnection — existing rows', () => {
+  beforeEach(() => mockFindFirst.mockResolvedValue({ id: 'row1', syncErrors: null }));
+
+  it('revokes the event form when reconnecting read-only', async () => {
+    await storeGoogleCalendarConnection({ ...base, readOnly: true });
+    expect(updateSetSpy.mock.calls[0][0].showInEventModal).toBe(false);
+  });
+
+  it('leaves the setting alone when reconnecting writable', async () => {
+    // Asymmetric on purpose: losing write access is a fact worth forcing, but
+    // re-ticking a box the user deliberately cleared would be overreach.
+    await storeGoogleCalendarConnection(base);
+    expect(updateSetSpy.mock.calls[0][0]).not.toHaveProperty('showInEventModal');
+  });
+});

--- a/src/lib/integrations/__tests__/googleManualScopes.test.ts
+++ b/src/lib/integrations/__tests__/googleManualScopes.test.ts
@@ -51,10 +51,28 @@ describe('detectCapabilities', () => {
     expect(detectCapabilities(undefined)).toEqual([]);
   });
 
-  it('does not mistake calendar.readonly alone for calendar access', () => {
-    // The browser flow always grants the pair; readonly alone cannot write, so
-    // treating it as full calendar access would fail later on the first write.
-    expect(detectCapabilities('https://www.googleapis.com/auth/calendar.readonly')).toEqual([]);
+  it('treats calendar.readonly alone as read-only, not full calendar access', () => {
+    // Readonly can list and read calendars but cannot write events. Calling it
+    // full access would fail later on the first write, which is the silent
+    // failure this area keeps producing; rejecting it outright would drop a
+    // legitimate use, the same shape as an iCal subscription. So it connects,
+    // and is reported as read-only.
+    const caps = detectCapabilities('https://www.googleapis.com/auth/calendar.readonly');
+    expect(caps).toEqual(['calendarReadonly']);
+    expect(caps).not.toContain('calendar');
+  });
+
+  it('does not also report read-only when the full pair is granted', () => {
+    expect(detectCapabilities(CAL_PAIR)).toEqual(['calendar']);
+  });
+
+  it('does not report read-only for the broad calendar scope', () => {
+    expect(detectCapabilities(CAL_BROAD)).toEqual(['calendar']);
+  });
+
+  it('ignores calendar.events on its own, which cannot list calendars', () => {
+    // users/me/calendarList needs readonly or broad, so setup would fail.
+    expect(detectCapabilities('https://www.googleapis.com/auth/calendar.events')).toEqual([]);
   });
 });
 

--- a/src/lib/integrations/googleCalendarStore.ts
+++ b/src/lib/integrations/googleCalendarStore.ts
@@ -46,8 +46,16 @@ export async function storeGoogleCalendarConnection(params: {
   userId: string;
   tokens: GoogleTokenBundle;
   accountEmail: string | null;
+  /**
+   * The token carries calendar.readonly but not calendar.events, so it cannot
+   * write to ANY calendar — including ones Google reports as owned. Per-calendar
+   * accessRole describes the account's rights, not the token's, so it is the
+   * wrong thing to gate on here and would leave these sources offering an event
+   * form that fails on submit.
+   */
+  readOnly?: boolean;
 }): Promise<StoreResult> {
-  const { userId, tokens } = params;
+  const { userId, tokens, readOnly = false } = params;
 
   const tokenExpiresAt = new Date(Date.now() + tokens.expiresIn * 1000);
   const encryptedAccessToken = encrypt(tokens.accessToken);
@@ -88,6 +96,10 @@ export async function storeGoogleCalendarConnection(params: {
           // Only overwrite the email when we resolved one, so a transient
           // userinfo failure doesn't blank an existing label.
           accountEmail: accountEmail ?? undefined,
+          // Only forced in the read-only direction. Reconnecting with a
+          // writable token must not silently re-tick a box the user turned
+          // off; losing write access is a fact, hiding a calendar is a choice.
+          ...(readOnly ? { showInEventModal: false } : {}),
           syncErrors: prev.userOverride ? { userOverride: true } : null,
           updatedAt: new Date(),
         })
@@ -95,7 +107,8 @@ export async function storeGoogleCalendarConnection(params: {
       updated++;
     } else {
       const calendarName = (calendar.summary || 'Untitled Calendar').slice(0, 255);
-      const isWritable = calendar.accessRole === 'writer' || calendar.accessRole === 'owner';
+      const isWritable =
+        !readOnly && (calendar.accessRole === 'writer' || calendar.accessRole === 'owner');
       await db.insert(calendarSources).values({
         userId,
         provider: 'google',

--- a/src/lib/integrations/googleManualScopes.ts
+++ b/src/lib/integrations/googleManualScopes.ts
@@ -14,7 +14,7 @@
  * Prism their Gmail simply does not tick that scope, and nothing else changes.
  */
 
-export type GoogleCapability = 'calendar' | 'tasks' | 'gmail';
+export type GoogleCapability = 'calendar' | 'calendarReadonly' | 'tasks' | 'gmail';
 
 interface CapabilitySpec {
   /** Does the granted scope string cover this capability? */
@@ -27,12 +27,27 @@ interface CapabilitySpec {
 
 export const GOOGLE_CAPABILITIES: Record<GoogleCapability, CapabilitySpec> = {
   calendar: {
-    // The browser flow asks for calendar.events + calendar.readonly; a
-    // Playground user may instead tick the single broader auth/calendar.
+    // Full two-way sync. Setup lists calendars via users/me/calendarList, which
+    // needs calendar.readonly or the broad calendar scope; creating events needs
+    // calendar.events or broad. So neither narrow scope alone delivers two-way
+    // sync, and the browser flow accordingly grants both.
     matches: (s) =>
       /auth\/calendar(\s|$)/.test(s) ||
       (/auth\/calendar\.events/.test(s) && /auth\/calendar\.readonly/.test(s)),
     label: 'Calendar',
+    playgroundApi: 'Google Calendar API v3',
+  },
+  calendarReadonly: {
+    // calendar.readonly on its own can list and read calendars but cannot write
+    // events. That is a legitimate thing to want — the same shape as an iCal
+    // subscription — so it connects rather than being rejected. It is reported
+    // as read-only, because a calendar that silently refuses new events is the
+    // failure mode this whole area keeps producing.
+    matches: (s) =>
+      !/auth\/calendar(\s|$)/.test(s) &&
+      !/auth\/calendar\.events/.test(s) &&
+      /auth\/calendar\.readonly/.test(s),
+    label: 'Calendar (read-only)',
     playgroundApi: 'Google Calendar API v3',
   },
   tasks: {


### PR DESCRIPTION
Follow-up to #312, which tightened the calendar scope check without flagging it.

## What changed unintentionally

| | Accepted |
|---|---|
| Before #312 | `auth/calendar` **or** `calendar.events` **or** `calendar.readonly` — any one |
| After #312 | `auth/calendar` **or** both narrow scopes |

So a token carrying only `calendar.readonly` stopped connecting.

## The tightening had a reason

Setup lists calendars via `users/me/calendarList`, which needs `calendar.readonly` or the broad scope — **`calendar.events` alone cannot do it**. Creating events needs `calendar.events` or broad.

So neither narrow scope alone delivers the two-way sync the integration advertises, and accepting one silently produces a calendar that refuses to write.

## But rejecting read-only removed something legitimate

A read-only Google calendar is the same shape as an iCal subscription, which Prism already supports and actively recommends. So `calendar.readonly` alone now connects, as a read-only source.

`calendar.events` alone is still rejected, since it cannot complete setup at all.

## Read-only has to mean something downstream

Reporting read-only in a toast and then forgetting it would just move the write failure from connect time to first-write time. The fact is persisted.

There is already a per-row gate for this: `showInEventModal`, which `AddEventModal` filters on, and which the CalDAV path sets to `false` for exactly this reason. It was being set from Google's per-calendar `accessRole` — which describes the **account's** rights, not the **token's**. An owned calendar therefore came back writable even when the token could not write to anything.

`storeGoogleCalendarConnection` now takes `readOnly` and gates on it, so these sources are imported and displayed but never offered as a target for a new event.

Reconnect behaviour is deliberately asymmetric:

- reconnecting **read-only** forces the flag off — losing write access is a fact
- reconnecting **writable** leaves it alone — re-ticking a box the user cleared would be overreach

## Also fixed

- The audit summary keyed off `calendar` alone, so read-only connections logged no calendar count while full ones did.
- A write that fails on scope said "could not be synced to Google Calendar", inviting a retry that cannot succeed. It now names the cause and the fix.

## Testing

Ten new cases across three files: scope detection for each combination, the flag reaching the store, and the store's insert/update gating in both directions.

1,475 tests pass, typecheck clean.
