### PR TITLE
refactor(google): define every Google OAuth scope in one place

### DIFF
--- a/src/app/api/auth/google-tasks/route.ts
+++ b/src/app/api/auth/google-tasks/route.ts
@@ -7,7 +7,9 @@ import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 // `openid email` lets us identify which Google account authorized, for the
 // "Connected as <email>" label on the Integrations card (#100).
-const SCOPES = 'https://www.googleapis.com/auth/tasks openid email';
+import { TASKS_BROWSER_SCOPES } from '@/lib/integrations/googleScopes';
+
+const SCOPES = TASKS_BROWSER_SCOPES;
 
 export async function GET(request: Request) {
   const auth = await requireAuth();

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -5,6 +5,46 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
+import { GOOGLE_CAPABILITIES, type GoogleCapability } from '@/lib/integrations/googleManualScopes';
+
+/**
+ * The capabilities a user can ask for by pasting scopes, in the order shown.
+ *
+ * Only the prose lives here — the scope lines themselves come from
+ * GOOGLE_CAPABILITIES, which is also what validates the resulting token. That
+ * is deliberate: these instructions and that check used to be separate copies,
+ * and #312 changed one without the other.
+ *
+ * 'calendarReadonly' is described inside the Calendar entry rather than listed
+ * as its own bullet, because it is a weaker version of the same thing, not a
+ * fourth feature to choose.
+ */
+const PASTEABLE: Array<{ key: GoogleCapability; blurb: string; note?: React.ReactNode }> = [
+  {
+    key: 'calendar',
+    blurb: 'two-way sync. Both lines:',
+    note: (
+      <>
+        The{' '}
+        <code>{GOOGLE_CAPABILITIES.calendarReadonly.playgroundScopes.join(' ')}</code> line on its
+        own also works and gives you read-only calendars: their events show in Prism, but they are
+        not offered when you add an event.
+      </>
+    ),
+  },
+  { key: 'tasks', blurb: 'Google Tasks as a task source:' },
+  {
+    key: 'gmail',
+    blurb: 'bus tracking only:',
+    note: (
+      <>
+        Bus tracking marks the transport emails it has read, which needs <code>modify</code>.{' '}
+        <code>gmail.readonly</code> also works if you would rather it never wrote anything, but then
+        those emails stay unread in your inbox.
+      </>
+    ),
+  },
+];
 
 /**
  * Connect Google Calendar without a public URL by pasting a refresh token
@@ -128,30 +168,15 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
           space-separated. Paste only what you want Prism to use:
         </p>
         <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground">
-          <li>
-            <strong>Calendar</strong> &mdash; two-way sync. Both lines:
-            <code className="mt-0.5 block break-all text-[11px]">
-              https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly
-            </code>
-            <span className="mt-0.5 block">
-              The <code>calendar.readonly</code> line on its own also works and gives you read-only
-              calendars: their events show in Prism, but they are not offered when you add an
-              event. Include the <code>calendar.events</code> line as well to create events from Prism.
-            </span>
-          </li>
-          <li>
-            <strong>Tasks</strong> &mdash; Google Tasks as a task source:
-            <code className="mt-0.5 block break-all text-[11px]">https://www.googleapis.com/auth/tasks</code>
-          </li>
-          <li>
-            <strong>Gmail</strong> &mdash; bus tracking only:
-            <code className="mt-0.5 block break-all text-[11px]">https://www.googleapis.com/auth/gmail.modify</code>
-            <span className="mt-0.5 block">
-              Bus tracking marks the transport emails it has read, which needs <code>modify</code>.
-              <code> gmail.readonly</code> also works if you would rather it never wrote anything, but then
-              those emails stay unread in your inbox.
-            </span>
-          </li>
+          {PASTEABLE.map(({ key, blurb, note }) => (
+            <li key={key}>
+              <strong>{GOOGLE_CAPABILITIES[key].label}</strong> &mdash; {blurb}
+              <code className="mt-0.5 block break-all text-[11px]">
+                {GOOGLE_CAPABILITIES[key].playgroundScopes.join(' ')}
+              </code>
+              {note ? <span className="mt-0.5 block">{note}</span> : null}
+            </li>
+          ))}
         </ul>
         <p className="text-xs text-muted-foreground">
           Leave one out and Prism simply will not enable it. A token cannot gain a scope later, so to add
@@ -208,8 +233,7 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
           Client ID and Secret.
         </li>
         <li>
-          Step 1: enter the scope{' '}
-          <code className="rounded bg-muted px-1">https://www.googleapis.com/auth/calendar</code> →{' '}
+          Step 1: enter the scopes you chose above &rarr;{' '}
           <span className="font-medium">Authorize APIs</span> → sign in → if warned the app isn&apos;t
           verified, choose <span className="font-medium">Advanced → proceed</span> (expected for your own
           app) → <span className="font-medium">Allow</span>.

--- a/src/lib/integrations/__tests__/googleManualScopes.test.ts
+++ b/src/lib/integrations/__tests__/googleManualScopes.test.ts
@@ -7,7 +7,7 @@
  * a capability they asked for, or wires up one they deliberately withheld.
  */
 
-import { detectCapabilities, describeCapabilities } from '../googleManualScopes';
+import { detectCapabilities, describeCapabilities, GOOGLE_CAPABILITIES } from '../googleManualScopes';
 
 const CAL_PAIR = 'https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly';
 const CAL_BROAD = 'https://www.googleapis.com/auth/calendar';
@@ -86,5 +86,29 @@ describe('describeCapabilities', () => {
 
   it('says nothing rather than producing an empty string', () => {
     expect(describeCapabilities([])).toBe('nothing');
+  });
+});
+
+describe('advertised scopes round-trip through the validator', () => {
+  // The setup screen renders playgroundScopes verbatim. If a scope set the UI
+  // tells a user to paste no longer satisfies matches(), that user follows the
+  // instructions and gets rejected — the #312 failure, in the other direction.
+  const CAPS = Object.keys(GOOGLE_CAPABILITIES) as Array<keyof typeof GOOGLE_CAPABILITIES>;
+
+  it.each(CAPS)('pasting exactly what %s advertises enables it', (cap) => {
+    const pasted = GOOGLE_CAPABILITIES[cap].playgroundScopes.join(' ');
+    expect(detectCapabilities(pasted)).toContain(cap);
+  });
+
+  it('every capability advertises at least one scope', () => {
+    for (const cap of CAPS) {
+      expect(GOOGLE_CAPABILITIES[cap].playgroundScopes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('matches whole scope entries, not prefixes of longer ones', () => {
+    // 'auth/tasks' must not be found inside a hypothetical 'auth/tasks.extra',
+    // which is a different, narrower grant.
+    expect(detectCapabilities('https://www.googleapis.com/auth/tasks.readonly')).toEqual([]);
   });
 });

--- a/src/lib/integrations/__tests__/googleScopeGuard.test.ts
+++ b/src/lib/integrations/__tests__/googleScopeGuard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Structural guard: Google scope URLs live in exactly one file.
+ *
+ * Prism requests scopes from several places that must agree — two browser
+ * sign-in flows, the Gmail flow, the setup screen telling a manual/Playground
+ * user what to paste, and the validator reading the resulting token back. When
+ * each held its own copy, #312 changed the validator alone and left the setup
+ * screen advertising something it would now reject. No file was wrong on its
+ * own, so nothing caught it.
+ *
+ * A behavioural test cannot catch that class of bug, because the copies are
+ * only inconsistent with each other. This one reads the source instead.
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+const SRC = join(process.cwd(), 'src');
+const HOME = join('src', 'lib', 'integrations', 'googleScopes.ts');
+
+/** Any Google OAuth scope URL, e.g. https://www.googleapis.com/auth/tasks */
+const SCOPE_URL = /googleapis\.com\/auth\/[\w.]+/g;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      // Tests may name scopes literally: pinning the exact URL a token must
+      // carry is the point of those assertions, not a duplicate definition.
+      if (entry !== '__tests__') walk(full, out);
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('Google scope definitions', () => {
+  const offenders = walk(SRC)
+    .map((f) => ({ file: relative(process.cwd(), f), text: readFileSync(f, 'utf8') }))
+    .filter(({ file }) => file !== HOME)
+    .map(({ file, text }) => ({ file, hits: [...new Set(text.match(SCOPE_URL) ?? [])] }))
+    .filter(({ hits }) => hits.length > 0);
+
+  it('appear only in googleScopes.ts', () => {
+    // If this fails: import the scope from googleScopes.ts instead of writing
+    // the URL again. Add it there first if it is genuinely new.
+    expect(offenders.map((o) => `${o.file}: ${o.hits.join(', ')}`)).toEqual([]);
+  });
+
+  it('are actually defined there, so the guard cannot pass by being empty', () => {
+    const home = readFileSync(join(process.cwd(), HOME), 'utf8');
+    expect([...new Set(home.match(SCOPE_URL) ?? [])].length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/src/lib/integrations/gmail.ts
+++ b/src/lib/integrations/gmail.ts
@@ -5,13 +5,12 @@
  */
 
 const GOOGLE_OAUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+import { GMAIL_BROWSER_SCOPES } from '@/lib/integrations/googleScopes';
+
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GMAIL_API = 'https://www.googleapis.com/gmail/v1';
 
-const SCOPES = [
-  'https://www.googleapis.com/auth/gmail.readonly',
-  'https://www.googleapis.com/auth/gmail.modify',
-].join(' ');
+const SCOPES = GMAIL_BROWSER_SCOPES;
 
 export interface GmailTokens {
   access_token: string;

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -15,19 +15,12 @@
  */
 const GOOGLE_OAUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+import { CALENDAR_BROWSER_SCOPES } from '@/lib/integrations/googleScopes';
+
 const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
 
-/**
- * Required scopes for Google Calendar access
- */
-const SCOPES = [
-  'https://www.googleapis.com/auth/calendar.readonly',
-  'https://www.googleapis.com/auth/calendar.events',
-  // Identify which Google account authorized, for the "Connected as <email>"
-  // label on the Integrations card (#100). Read-only identity scopes.
-  'openid',
-  'email',
-].join(' ');
+/** Required scopes for Google Calendar access. Defined in googleScopes.ts. */
+const SCOPES = CALENDAR_BROWSER_SCOPES;
 
 /**
  * Google Calendar Event from API

--- a/src/lib/integrations/googleManualScopes.ts
+++ b/src/lib/integrations/googleManualScopes.ts
@@ -12,7 +12,16 @@
  * read back what Google says the token covers and enable each capability it
  * actually has. Someone who wants Calendar and Tasks but would rather not hand
  * Prism their Gmail simply does not tick that scope, and nothing else changes.
+ *
+ * Scope URLs are NOT written here. They come from googleScopes.ts, so the
+ * lines the setup screen tells a user to paste and the check that reads the
+ * resulting token cannot disagree — see the note there.
  */
+import { GOOGLE_SCOPE } from '@/lib/integrations/googleScopes';
+
+/** Matches a scope URL as a whole entry, not as a prefix of a longer one. */
+const has = (scope: string) => (granted: string) =>
+  granted.split(/\s+/).includes(scope);
 
 export type GoogleCapability = 'calendar' | 'calendarReadonly' | 'tasks' | 'gmail';
 
@@ -23,6 +32,12 @@ interface CapabilitySpec {
   label: string;
   /** What to tick in the OAuth Playground to grant it. */
   playgroundApi: string;
+  /**
+   * The exact lines a manual/Playground user pastes to get this capability.
+   * The setup screen renders these rather than repeating the URLs, and a test
+   * feeds them back through `matches`, so advertised-but-rejected cannot ship.
+   */
+  playgroundScopes: string[];
 }
 
 export const GOOGLE_CAPABILITIES: Record<GoogleCapability, CapabilitySpec> = {
@@ -32,10 +47,11 @@ export const GOOGLE_CAPABILITIES: Record<GoogleCapability, CapabilitySpec> = {
     // calendar.events or broad. So neither narrow scope alone delivers two-way
     // sync, and the browser flow accordingly grants both.
     matches: (s) =>
-      /auth\/calendar(\s|$)/.test(s) ||
-      (/auth\/calendar\.events/.test(s) && /auth\/calendar\.readonly/.test(s)),
+      has(GOOGLE_SCOPE.calendarBroad)(s) ||
+      (has(GOOGLE_SCOPE.calendarEvents)(s) && has(GOOGLE_SCOPE.calendarReadonly)(s)),
     label: 'Calendar',
     playgroundApi: 'Google Calendar API v3',
+    playgroundScopes: [GOOGLE_SCOPE.calendarEvents, GOOGLE_SCOPE.calendarReadonly],
   },
   calendarReadonly: {
     // calendar.readonly on its own can list and read calendars but cannot write
@@ -44,22 +60,25 @@ export const GOOGLE_CAPABILITIES: Record<GoogleCapability, CapabilitySpec> = {
     // as read-only, because a calendar that silently refuses new events is the
     // failure mode this whole area keeps producing.
     matches: (s) =>
-      !/auth\/calendar(\s|$)/.test(s) &&
-      !/auth\/calendar\.events/.test(s) &&
-      /auth\/calendar\.readonly/.test(s),
+      !has(GOOGLE_SCOPE.calendarBroad)(s) &&
+      !has(GOOGLE_SCOPE.calendarEvents)(s) &&
+      has(GOOGLE_SCOPE.calendarReadonly)(s),
     label: 'Calendar (read-only)',
     playgroundApi: 'Google Calendar API v3',
+    playgroundScopes: [GOOGLE_SCOPE.calendarReadonly],
   },
   tasks: {
-    matches: (s) => /auth\/tasks(\s|$)/.test(s),
+    matches: has(GOOGLE_SCOPE.tasks),
     label: 'Tasks',
     playgroundApi: 'Tasks API v1',
+    playgroundScopes: [GOOGLE_SCOPE.tasks],
   },
   gmail: {
     // Bus tracking parses transport emails; readonly is enough to do that.
-    matches: (s) => /auth\/gmail\.(readonly|modify)/.test(s),
+    matches: (s) => has(GOOGLE_SCOPE.gmailModify)(s) || has(GOOGLE_SCOPE.gmailReadonly)(s),
     label: 'Gmail (bus tracking)',
     playgroundApi: 'Gmail API v1',
+    playgroundScopes: [GOOGLE_SCOPE.gmailModify],
   },
 };
 

--- a/src/lib/integrations/googleScopes.ts
+++ b/src/lib/integrations/googleScopes.ts
@@ -1,0 +1,67 @@
+/**
+ * Every Google OAuth scope Prism asks for, written down exactly once.
+ *
+ * Prism requests scopes from four places that must agree: the browser sign-in
+ * flows for Calendar and Tasks, the Gmail flow behind bus tracking, the
+ * instructions telling a manual/Playground user which lines to paste, and the
+ * validator that reads back what a pasted token actually carries.
+ *
+ * They used to hold their own copies of the URLs. In #312 the validator was
+ * changed on its own, and nothing noticed that the instructions still told
+ * users to paste something it would now reject — the drift is invisible until
+ * a user hits it, because no single file is wrong on its own.
+ *
+ * So the literals live here and nowhere else. `scopeGuard.test.ts` fails the
+ * build if a `googleapis.com/auth/…` string reappears in another file, and
+ * `googleManualScopes.test.ts` round-trips each advertised scope set through
+ * the validator, so instructions that would be rejected cannot ship.
+ */
+
+export const GOOGLE_SCOPE = {
+  /** Read calendars and events. Required to list calendars at all. */
+  calendarReadonly: 'https://www.googleapis.com/auth/calendar.readonly',
+  /** Create and edit events. Cannot list calendars on its own. */
+  calendarEvents: 'https://www.googleapis.com/auth/calendar.events',
+  /** Full calendar access. Playground users often pick this single line. */
+  calendarBroad: 'https://www.googleapis.com/auth/calendar',
+  tasks: 'https://www.googleapis.com/auth/tasks',
+  /**
+   * Read mail, and change labels. Bus tracking clears UNREAD on the transport
+   * emails it consumes, so read-only is not enough for the default behaviour.
+   */
+  gmailModify: 'https://www.googleapis.com/auth/gmail.modify',
+  /** Strict subset of gmailModify: reading works, clearing UNREAD does not. */
+  gmailReadonly: 'https://www.googleapis.com/auth/gmail.readonly',
+  /**
+   * Identify which account authorized, for the "Connected as <email>" label.
+   * Browser flows only — a Playground token usually lacks these, and the
+   * connection falls back to the primary calendar id.
+   */
+  openid: 'openid',
+  email: 'email',
+} as const;
+
+/** Space-separated scope string for the Calendar browser sign-in. */
+export const CALENDAR_BROWSER_SCOPES = [
+  GOOGLE_SCOPE.calendarReadonly,
+  GOOGLE_SCOPE.calendarEvents,
+  GOOGLE_SCOPE.openid,
+  GOOGLE_SCOPE.email,
+].join(' ');
+
+/** Space-separated scope string for the Google Tasks browser sign-in. */
+export const TASKS_BROWSER_SCOPES = [
+  GOOGLE_SCOPE.tasks,
+  GOOGLE_SCOPE.openid,
+  GOOGLE_SCOPE.email,
+].join(' ');
+
+/**
+ * Space-separated scope string for the Gmail (bus tracking) flow.
+ *
+ * `modify` alone, not `modify` + `readonly`. Requesting both was redundant —
+ * readonly is a strict subset — and it made the browser flow ask for something
+ * the paste-a-token instructions never mentioned, which is the drift this
+ * module exists to remove.
+ */
+export const GMAIL_BROWSER_SCOPES = GOOGLE_SCOPE.gmailModify;

--- a/src/lib/integrations/tasks/google-tasks.ts
+++ b/src/lib/integrations/tasks/google-tasks.ts
@@ -2,7 +2,7 @@
  * Google Tasks Integration
  *
  * Uses Google Tasks API v1 to sync tasks bidirectionally.
- * Requires OAuth tokens with https://www.googleapis.com/auth/tasks scope.
+ * Requires OAuth tokens carrying GOOGLE_SCOPE.tasks (see googleScopes.ts).
  *
  * API Reference: https://developers.google.com/tasks/reference/rest
  */


### PR DESCRIPTION
Google OAuth scope URLs were written out in **five** files:

| File | Role |
|---|---|
| `google-calendar.ts` | Calendar browser sign-in |
| `auth/google-tasks/route.ts` | Tasks browser sign-in |
| `gmail.ts` | Gmail flow (bus tracking) |
| `GoogleManualTokenForm.tsx` | The lines a Playground user is told to paste |
| `googleManualScopes.ts` | The validator reading a pasted token back |

Nothing kept them in agreement. #312 changed the validator alone and left the setup screen advertising a scope set it would then reject. **No file was wrong on its own**, which is why review didn't catch it.

## The fix

The literals live in `googleScopes.ts` and nowhere else. The setup screen renders `GOOGLE_CAPABILITIES[cap].playgroundScopes` instead of repeating URLs, so the lines a user pastes are by construction the lines the validator checks for.

## Two guards

Agreement between copies isn't something a behavioural test can observe, so both guards are structural:

- **`googleScopeGuard.test.ts`** walks `src/` and fails if a `googleapis.com/auth/` URL appears outside `googleScopes.ts`. Tests are exempt, where naming the exact URL *is* the assertion. A second case asserts the home file is non-empty, so the guard can't pass by finding nothing anywhere.
- **`googleManualScopes.test.ts`** round-trips each capability's advertised scopes back through `detectCapabilities`, so instructions that would be rejected can't ship.

## Drift found on the way

- The Gmail flow requested `gmail.readonly` **and** `gmail.modify` while the setup screen showed only `modify`. `readonly` is a strict subset, so asking for both was redundant; `modify` is what bus tracking needs, since it clears `UNREAD`. Now `modify` alone, matching what users are told.
- Step 1 of the numbered setup told users to enter `auth/calendar` — a *third* variant, different from the list directly above it. It now refers back to that list.

## Also

Scope matching is whole-entry rather than substring, so a narrower future scope like `tasks.readonly` can't satisfy a check for `tasks`.

No user-visible behaviour change beyond the corrected instructions. 1,483 tests pass, typecheck clean.
