### PR TITLE
fix(tasks): stop task sync silently destroying data in both directions

### DIFF
--- a/drizzle/0024_dismissed_tasks.sql
+++ b/drizzle/0024_dismissed_tasks.sql
@@ -1,0 +1,34 @@
+-- 0024_dismissed_tasks.sql
+--
+-- `dismissed_tasks` — tombstones for synced tasks the user deleted in Prism.
+--
+-- Task sync reconciles by comparing the remote list against local rows, and a
+-- task present remotely with no local match is treated as newly created and
+-- inserted. A delete in Prism was therefore undone on the next run, roughly
+-- five minutes later, with nothing to explain it.
+--
+-- The delete now also removes the task from the provider, which handles the
+-- ordinary case. A tombstone is still required, because the upstream delete
+-- is best-effort and deliberately non-blocking:
+--
+--   * the provider call can fail — expired token, network, revoked access —
+--     and the local delete proceeds anyway, matching how calendar behaves;
+--   * a provider may not support deletion at all;
+--   * the remote can lag, still listing the task on the next sync.
+--
+-- In each case the tombstone is what makes the deletion stick. Mirrors
+-- `dismissed_events`, which exists for exactly these reasons on the calendar
+-- side, and is keyed the same way: source + external id.
+--
+-- Rows are removed when the tombstone is no longer needed (the task is gone
+-- from the remote), so this table stays small rather than growing forever.
+
+CREATE TABLE IF NOT EXISTS dismissed_tasks (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_source_id   uuid NOT NULL REFERENCES task_sources(id) ON DELETE CASCADE,
+  external_task_id varchar(255) NOT NULL,
+  created_at       timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_tasks_source_external_unique
+  ON dismissed_tasks (task_source_id, external_task_id);

--- a/drizzle/0025_task_pending_deletion.sql
+++ b/drizzle/0025_task_pending_deletion.sql
@@ -1,0 +1,32 @@
+-- 0025_task_pending_deletion.sql
+--
+-- Hold remote-side task deletions for review, instead of applying them silently.
+--
+-- The reconciler deleted any synced local task the remote no longer listed.
+-- That is unrecoverable and unattributable: a provider returning a short or
+-- empty list — an outage, a revoked scope, the wrong list id — wiped every
+-- synced task locally, with no undo and nothing said. Calendar already holds
+-- these for review (events.pending_deletion, issue #171 Stage 3); this is the
+-- same idea for tasks.
+--
+-- 1. `pending_deletion` — when set, the remote dropped this task and the
+--    deletion is awaiting the user's decision. The task stays visible.
+--
+-- 2. `sync_exempt` — set when the user answers "keep": the task stays in Prism
+--    as a local one. Detaching alone is NOT enough. The reconciler pushes any
+--    local task in a synced list that has no external id to the provider
+--    (sync/route.ts, the createTask branch), so a kept task would be recreated
+--    on the remote it was just deleted from, and the round trip would start
+--    again. This flag keeps it out of the reconciler's local set entirely.
+--
+--    It also covers a case that predates this change: task_source_id is
+--    ON DELETE SET NULL, so removing a source detaches its tasks and leaves
+--    them eligible for that same push.
+
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS pending_deletion timestamp;
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS sync_exempt boolean NOT NULL DEFAULT false;
+
+-- Only ever a handful of rows, but the reconciler and the review both filter
+-- on it on every run.
+CREATE INDEX IF NOT EXISTS tasks_pending_deletion_idx
+  ON tasks (pending_deletion) WHERE pending_deletion IS NOT NULL;

--- a/src/app/api/task-sources/[id]/sync/route.ts
+++ b/src/app/api/task-sources/[id]/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
-import { taskSources, tasks } from '@/lib/db/schema';
-import { eq, and, or, isNull } from 'drizzle-orm';
+import { taskSources, tasks, dismissedTasks } from '@/lib/db/schema';
+import { eq, and, or, isNull, inArray } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { getTaskProvider } from '@/lib/integrations/tasks';
@@ -216,6 +216,20 @@ async function performSync(
         )
       );
 
+    // Tasks deleted in Prism. The delete is pushed to the provider at delete
+    // time, so normally the remote no longer lists them; this covers the cases
+    // where that could not be relied on (failed or unsupported upstream
+    // delete, or a lagging remote). Without it the loop below sees a remote
+    // task with no local match and re-creates it.
+    const tombstoned = new Set(
+      (
+        await db
+          .select({ externalTaskId: dismissedTasks.externalTaskId })
+          .from(dismissedTasks)
+          .where(eq(dismissedTasks.taskSourceId, sourceId))
+      ).map((row) => row.externalTaskId),
+    );
+
     // Create maps for quick lookup
     const remoteById = new Map(remoteTasks.map(t => [t.id, t]));
     const localByExternalId = new Map(
@@ -227,6 +241,13 @@ async function performSync(
     // Process remote tasks
     for (const remoteTask of remoteTasks) {
       const localTask = localByExternalId.get(remoteTask.id);
+
+      if (tombstoned.has(remoteTask.id)) {
+        // Deleted in Prism and still coming back from the remote. Leave it
+        // alone rather than re-adding it; the tombstone is cleared below once
+        // the remote stops listing it.
+        continue;
+      }
 
       if (!localTask) {
         // Remote task doesn't exist locally - create it
@@ -349,6 +370,21 @@ async function performSync(
           result.errors.push(`Failed to delete local task: ${localTask.title}`);
         }
       }
+    }
+
+    // Drop tombstones the remote has caught up on. Once a task is gone from
+    // the provider there is nothing left to suppress, and keeping the row
+    // would grow this table without bound.
+    const stale = [...tombstoned].filter((externalId) => !remoteById.has(externalId));
+    if (stale.length > 0) {
+      await db
+        .delete(dismissedTasks)
+        .where(
+          and(
+            eq(dismissedTasks.taskSourceId, sourceId),
+            inArray(dismissedTasks.externalTaskId, stale),
+          ),
+        );
     }
 
     return result;

--- a/src/app/api/task-sources/[id]/sync/route.ts
+++ b/src/app/api/task-sources/[id]/sync/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
 import { taskSources, tasks, dismissedTasks } from '@/lib/db/schema';
-import { eq, and, or, isNull, inArray } from 'drizzle-orm';
+import { eq, and, or, isNull, isNotNull, inArray } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { getTaskProvider } from '@/lib/integrations/tasks';
+import { decideDeletionReview } from '@/lib/services/taskDeletionReview';
+
+/**
+ * How long a task must have been absent from the provider before it is flagged.
+ * Covers the provider listing a just-created task late, and means one missed
+ * response cannot flag anything on its own. Slightly over the 5-minute
+ * auto-sync interval, so it takes two runs.
+ */
+const MISSING_GRACE_MS = 6 * 60 * 1000;
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
@@ -154,7 +163,10 @@ export async function POST(
       action: 'sync',
       entityType: 'integration',
       entityId: sourceId,
-      summary: `Synced task source: ${source.provider} (${source.externalListName || source.externalListId}) - ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+      summary:
+        `Synced task source: ${source.provider} (${source.externalListName || source.externalListId}) - ` +
+        `${result.created} created, ${result.updated} updated` +
+        (result.flagged > 0 ? `, ${result.flagged} removals held for review` : ''),
     });
 
     return NextResponse.json({
@@ -198,6 +210,7 @@ async function performSync(
     created: 0,
     updated: 0,
     deleted: 0,
+    flagged: 0,
     errors: [],
   };
 
@@ -210,9 +223,15 @@ async function performSync(
       .select()
       .from(tasks)
       .where(
-        or(
-          eq(tasks.taskSourceId, sourceId),
-          and(eq(tasks.listId, taskListId), isNull(tasks.taskSourceId))
+        and(
+          // Kept after a remote deletion, or detached when a source was removed
+          // (task_source_id is ON DELETE SET NULL). Either way the row is
+          // Prism's now: it must not be matched, pushed or flagged.
+          eq(tasks.syncExempt, false),
+          or(
+            eq(tasks.taskSourceId, sourceId),
+            and(eq(tasks.listId, taskListId), isNull(tasks.taskSourceId))
+          )
         )
       );
 
@@ -232,6 +251,23 @@ async function performSync(
 
     // Create maps for quick lookup
     const remoteById = new Map(remoteTasks.map(t => [t.id, t]));
+
+    // Anything the remote is listing again is not missing. Clearing this first
+    // is what makes one bad response self-healing rather than leaving a pile of
+    // flags to work through by hand. Calendar clears the same way before it
+    // re-scans, on all three of its provider paths.
+    if (remoteById.size > 0) {
+      await db
+        .update(tasks)
+        .set({ pendingDeletion: null })
+        .where(
+          and(
+            eq(tasks.taskSourceId, sourceId),
+            inArray(tasks.externalId, [...remoteById.keys()]),
+            isNotNull(tasks.pendingDeletion),
+          ),
+        );
+    }
     const localByExternalId = new Map(
       localTasks
         .filter(t => t.externalId)
@@ -331,6 +367,7 @@ async function performSync(
     }
 
     // Find local tasks that don't exist remotely (created locally or deleted remotely)
+    const missingLocally: typeof localTasks = [];
     for (const localTask of localTasks) {
       if (!localTask.externalId) {
         // Local task without externalId - push to remote
@@ -358,16 +395,55 @@ async function performSync(
         } catch (err) {
           result.errors.push(`Failed to push task to remote: ${localTask.title}`);
         }
-      } else if (!remoteById.has(localTask.externalId)) {
-        // Local task has externalId but remote doesn't have it - deleted remotely
-        // Option 1: Delete locally (sync deletion)
-        // Option 2: Re-create remotely (preserve local)
-        // We'll go with Option 1 for true bidirectional sync
+      } else if (localTask.taskSourceId === sourceId && !remoteById.has(localTask.externalId)) {
+        // Gone from this provider. Previously deleted outright — silent and
+        // unrecoverable — now collected so the whole run is judged at once.
+        //
+        // The taskSourceId check matters: the query above also picks up rows
+        // with no source at all (CalDAV task rows, and orphans left behind by
+        // ON DELETE SET NULL). Those carry an external id this provider has
+        // never heard of, so without it one provider deletes another's tasks.
+        missingLocally.push(localTask);
+      }
+    }
+
+    // Decide what to do about the tasks the remote stopped listing. The
+    // decision is per-run, not per-task: one task going missing is someone
+    // ticking it off, all of them going missing is a broken provider, and
+    // telling those apart needs the whole set.
+    const now = new Date();
+    const flaggable = missingLocally.filter((t) => {
+      // A task pushed upstream moments ago may not be in the provider's list
+      // yet. Flagging it would tell the user their own new task was deleted.
+      // Requiring it to have been absent for longer than one sync interval
+      // also means a single missed response never flags anything.
+      if (!t.lastSynced) return false;
+      return now.getTime() - t.lastSynced.getTime() > MISSING_GRACE_MS;
+    });
+
+    const review = decideDeletionReview({
+      syncedCount: localTasks.filter((t) => t.externalId && t.taskSourceId === sourceId).length,
+      missingCount: flaggable.length,
+    });
+
+    if (review.guardTripped) {
+      // Deliberately NOT flagged. Burying the user in hundreds of entries
+      // invites a bulk confirm, which destroys exactly what the review exists
+      // to protect. Said out loud rather than withheld silently.
+      result.errors.push(
+        `${review.withheld} tasks are missing from the provider — too many at once to be a normal ` +
+        `change, so none were touched. Check the connection, then sync again.`,
+      );
+    } else if (review.flag) {
+      for (const localTask of flaggable) {
+        // Only when not already flagged, so the original time survives and the
+        // count does not climb every five minutes.
+        if (localTask.pendingDeletion) continue;
         try {
-          await db.delete(tasks).where(eq(tasks.id, localTask.id));
-          result.deleted++;
+          await db.update(tasks).set({ pendingDeletion: now }).where(eq(tasks.id, localTask.id));
+          result.flagged++;
         } catch (err) {
-          result.errors.push(`Failed to delete local task: ${localTask.title}`);
+          result.errors.push(`Failed to flag deleted task: ${localTask.title}`);
         }
       }
     }

--- a/src/app/api/task-sources/__tests__/taskSyncDeletion.test.ts
+++ b/src/app/api/task-sources/__tests__/taskSyncDeletion.test.ts
@@ -1,0 +1,206 @@
+/**
+ * What the reconciler does when tasks vanish from a provider.
+ *
+ * The behaviour under test is the one that used to destroy data: a task the
+ * provider stops listing was deleted locally, with no review, no guard and no
+ * undo. A provider returning an empty list — an outage, a revoked scope, the
+ * wrong list id — took every synced task with it.
+ *
+ * These tests drive the real route with a mocked provider and database.
+ */
+const mockRequireAuth = jest.fn();
+const mockRequireRole = jest.fn();
+const mockFetchTasks = jest.fn();
+const mockCreateTask = jest.fn();
+const mockUpdateTask = jest.fn();
+
+/** Every db write the route makes, in order, so we can assert on the shape. */
+const writes: Array<{ op: string; payload?: unknown; table?: string }> = [];
+
+/** True only for a delete against the tasks table. */
+const deletedTasks = () => writes.some((w) => w.op === 'delete' && w.table === 'tasks');
+let localRows: Array<Record<string, unknown>> = [];
+let sourceRow: Record<string, unknown> = {};
+
+const selectChain = () => {
+  const thenable = {
+    where: () => thenable,
+    from: () => thenable,
+    then: (resolve: (v: unknown) => void) => resolve(selectResult()),
+  };
+  return thenable;
+};
+let selectCall = 0;
+function selectResult() {
+  // First select is the task source, second is the local task set.
+  selectCall += 1;
+  return selectCall === 1 ? [sourceRow] : localRows;
+}
+
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(selectResult()) }) }),
+    update: () => ({
+      set: (payload: unknown) => {
+        writes.push({ op: 'update', payload });
+        return { where: () => Promise.resolve() };
+      },
+    }),
+    insert: () => ({
+      values: (payload: unknown) => {
+        writes.push({ op: 'insert', payload });
+        return { onConflictDoNothing: () => Promise.resolve(), then: (r: (v: unknown) => void) => r(undefined) };
+      },
+    }),
+    delete: (table: { __name?: string }) => ({
+      where: () => {
+        // Record WHICH table. The route legitimately deletes spent tombstone
+        // rows; deleting from `tasks` is the thing that must never happen.
+        writes.push({ op: 'delete', table: table?.__name });
+        return Promise.resolve();
+      },
+    }),
+  },
+}));
+jest.mock('@/lib/db/schema', () => ({
+  taskSources: { id: 'id' },
+  tasks: { __name: 'tasks', id: 'id', taskSourceId: 'tsid', listId: 'lid', externalId: 'eid', syncExempt: 'se', pendingDeletion: 'pd' },
+  dismissedTasks: { __name: 'dismissed_tasks', taskSourceId: 'tsid', externalTaskId: 'etid' },
+}));
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn(), and: jest.fn(), or: jest.fn(), isNull: jest.fn(), isNotNull: jest.fn(), inArray: jest.fn(),
+}));
+jest.mock('@/lib/auth', () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  requireRole: (...a: unknown[]) => mockRequireRole(...a),
+}));
+jest.mock('@/lib/cache/cacheKeys', () => ({ invalidateEntity: jest.fn() }));
+jest.mock('@/lib/services/auditLog', () => ({ logActivity: jest.fn() }));
+jest.mock('@/lib/utils/logError', () => ({ logError: jest.fn() }));
+jest.mock('@/lib/utils/crypto', () => ({ decrypt: (v: string) => v, encrypt: (v: string) => v }));
+jest.mock('@/lib/integrations/tasks', () => ({
+  getTaskProvider: () => ({
+    fetchTasks: (...a: unknown[]) => mockFetchTasks(...a),
+    createTask: (...a: unknown[]) => mockCreateTask(...a),
+    updateTask: (...a: unknown[]) => mockUpdateTask(...a),
+  }),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '../[id]/sync/route';
+
+const LONG_AGO = new Date(Date.now() - 60 * 60 * 1000);
+
+function syncedRow(over: Record<string, unknown> = {}) {
+  return {
+    id: `local-${over.externalId ?? 'x'}`,
+    title: 'A task',
+    externalId: 'r1',
+    taskSourceId: 'src-1',
+    lastSynced: LONG_AGO,
+    updatedAt: LONG_AGO,
+    pendingDeletion: null,
+    completed: false,
+    ...over,
+  };
+}
+
+function run() {
+  return POST(
+    new NextRequest('http://localhost/api/task-sources/src-1/sync', { method: 'POST' }),
+    { params: Promise.resolve({ id: 'src-1' }) },
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  writes.length = 0;
+  selectCall = 0;
+  mockRequireAuth.mockResolvedValue({ userId: 'p1', role: 'parent' });
+  mockRequireRole.mockReturnValue(undefined);
+  sourceRow = {
+    id: 'src-1', provider: 'google_tasks', externalListId: 'list-1', taskListId: 'tl-1',
+    syncEnabled: true, accessToken: 'at', refreshToken: 'rt', tokenExpiresAt: new Date(Date.now() + 3_600_000),
+  };
+  localRows = [];
+  mockFetchTasks.mockResolvedValue([]);
+});
+
+describe('a task that vanished from the provider', () => {
+  it('is flagged for review, not deleted', async () => {
+    localRows = [syncedRow()];
+    mockFetchTasks.mockResolvedValue([]);
+
+    await run();
+
+    expect(deletedTasks()).toBe(false);
+    expect(writes).toContainEqual(
+      expect.objectContaining({ op: 'update', payload: expect.objectContaining({ pendingDeletion: expect.any(Date) }) }),
+    );
+  });
+
+  it('is not flagged while it is still too fresh to trust', async () => {
+    // Just pushed upstream; the provider may not list it yet. Flagging here
+    // would tell the user their own new task had been deleted.
+    localRows = [syncedRow({ lastSynced: new Date() })];
+    mockFetchTasks.mockResolvedValue([]);
+
+    await run();
+
+    expect(deletedTasks()).toBe(false);
+    const flagged = writes.filter(
+      (w) => w.op === 'update' && (w.payload as Record<string, unknown>)?.pendingDeletion instanceof Date,
+    );
+    expect(flagged).toHaveLength(0);
+  });
+
+  it('is left alone entirely when the whole list disappears', async () => {
+    // The failure this feature exists for. Nothing is flagged and nothing is
+    // deleted; the run reports the problem instead.
+    localRows = Array.from({ length: 30 }, (_, i) => syncedRow({ externalId: `r${i}`, id: `local-${i}` }));
+    mockFetchTasks.mockResolvedValue([]);
+
+    const res = await run();
+    const body = await res.json();
+
+    expect(deletedTasks()).toBe(false);
+    const flagged = writes.filter(
+      (w) => w.op === 'update' && (w.payload as Record<string, unknown>)?.pendingDeletion instanceof Date,
+    );
+    expect(flagged).toHaveLength(0);
+    expect(JSON.stringify(body)).toMatch(/missing from the provider/i);
+  });
+});
+
+describe('a task belonging to something else', () => {
+  it('is not flagged just because this provider has never heard of it', async () => {
+    // CalDAV task rows, and orphans left by ON DELETE SET NULL, sit in the
+    // same list with no source. They used to be deleted by whichever provider
+    // synced next.
+    localRows = [syncedRow({ taskSourceId: null, externalId: 'caldav:other:123' })];
+    mockFetchTasks.mockResolvedValue([]);
+
+    await run();
+
+    expect(deletedTasks()).toBe(false);
+    const flagged = writes.filter(
+      (w) => w.op === 'update' && (w.payload as Record<string, unknown>)?.pendingDeletion instanceof Date,
+    );
+    expect(flagged).toHaveLength(0);
+  });
+});
+
+describe('a task the provider is listing again', () => {
+  it('has its flag cleared, so one bad response heals itself', async () => {
+    localRows = [syncedRow({ pendingDeletion: LONG_AGO })];
+    mockFetchTasks.mockResolvedValue([
+      { id: 'r1', title: 'A task', completed: false, updatedAt: LONG_AGO, dueDate: null, description: null, priority: null, completedAt: null },
+    ]);
+
+    await run();
+
+    expect(writes).toContainEqual(
+      expect.objectContaining({ op: 'update', payload: expect.objectContaining({ pendingDeletion: null }) }),
+    );
+  });
+});

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -17,13 +17,37 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db/client';
-import { tasks, users } from '@/lib/db/schema';
+import { tasks, users, dismissedTasks } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { requireAuth, requireRole } from '@/lib/auth';
 import { formatTaskRow } from '@/lib/utils/formatters';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
+import { resolveTaskProviderAuth } from '@/lib/integrations/tasks/providerAuth';
+
+/**
+ * Remove a synced task from its provider. Best-effort by design: a failure
+ * here must not stop the user deleting the task in Prism, which is how the
+ * calendar delete behaves too. The caller writes a tombstone either way, so a
+ * failure costs an orphaned remote task rather than a resurrected local one.
+ */
+async function deleteTaskUpstream(taskSourceId: string, externalId: string): Promise<void> {
+  try {
+    const auth = await resolveTaskProviderAuth(taskSourceId);
+    if (!auth.ok) {
+      logError('Skipping upstream task delete:', auth.reason);
+      return;
+    }
+    if (!auth.provider.deleteTask) return;
+
+    // Providers address a task by list, so the id is "listId:taskId" — the
+    // same form the sync route builds when it pushes an update.
+    await auth.provider.deleteTask(auth.tokens, `${auth.externalListId}:${externalId}`);
+  } catch (error) {
+    logError('Failed to delete task from provider:', error);
+  }
+}
 
 
 /**
@@ -358,6 +382,8 @@ export async function DELETE(
         title: tasks.title,
         createdBy: tasks.createdBy,
         assignedTo: tasks.assignedTo,
+        taskSourceId: tasks.taskSourceId,
+        externalId: tasks.externalId,
       })
       .from(tasks)
       .where(eq(tasks.id, id));
@@ -374,6 +400,28 @@ export async function DELETE(
     if (!isOwner) {
       const forbidden = requireRole(auth, 'canDeleteTasks');
       if (forbidden) return forbidden;
+    }
+
+    // Propagate the delete to the provider, mirroring how calendar events are
+    // handled: best-effort, and never blocking the local delete. Without this
+    // the reconciler saw a task present remotely with no local match, treated
+    // it as newly created, and re-added it within about five minutes.
+    if (existingTask.taskSourceId && existingTask.externalId) {
+      await deleteTaskUpstream(
+        existingTask.taskSourceId,
+        existingTask.externalId,
+      );
+
+      // Tombstone regardless of whether the call above succeeded. A failed or
+      // unsupported upstream delete, or a remote that still lists the task on
+      // the next run, would otherwise resurrect it. See dismissed_tasks.
+      await db
+        .insert(dismissedTasks)
+        .values({
+          taskSourceId: existingTask.taskSourceId,
+          externalTaskId: existingTask.externalId,
+        })
+        .onConflictDoNothing();
     }
 
     // Delete the task

--- a/src/app/api/tasks/__tests__/pendingTaskDeletions.test.ts
+++ b/src/app/api/tasks/__tests__/pendingTaskDeletions.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The review that decides what happens to tasks a provider stopped listing.
+ *
+ * The case worth pinning hardest is 'keep': task sync pushes local tasks UP to
+ * the provider, so a kept task that merely loses its link would be recreated on
+ * the provider it was just deleted from, flagged again, kept again, forever.
+ * Calendar can get away with detaching because its sync never pushes. These
+ * tests exist so that difference cannot be refactored away.
+ */
+const mockRequireAuth = jest.fn();
+const mockRequireRole = jest.fn();
+const mockDisplayAuth = jest.fn();
+const mockSelectWhere = jest.fn();
+const mockUpdateSet = jest.fn();
+const mockDeleteWhere = jest.fn();
+
+jest.mock('@/lib/auth', () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  requireRole: (...a: unknown[]) => mockRequireRole(...a),
+  getDisplayAuth: (...a: unknown[]) => mockDisplayAuth(...a),
+}));
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          leftJoin: () => ({ where: () => ({ orderBy: (...a: unknown[]) => mockSelectWhere(...a) }) }),
+        }),
+        where: (...a: unknown[]) => mockSelectWhere(...a),
+      }),
+    }),
+    update: () => ({ set: (v: unknown) => { mockUpdateSet(v); return { where: () => Promise.resolve() }; } }),
+    delete: () => ({ where: (...a: unknown[]) => { mockDeleteWhere(...a); return Promise.resolve(); } }),
+  },
+}));
+jest.mock('@/lib/db/schema', () => ({
+  tasks: { id: 'id', title: 'title', dueDate: 'due', completed: 'done', pendingDeletion: 'pd', taskSourceId: 'tsid', listId: 'lid' },
+  taskSources: { id: 'id', provider: 'p', externalListName: 'eln' },
+  taskLists: { id: 'id', name: 'n' },
+}));
+jest.mock('drizzle-orm', () => ({ and: jest.fn(), eq: jest.fn(), inArray: jest.fn(), isNotNull: jest.fn() }));
+jest.mock('@/lib/cache/cacheKeys', () => ({ invalidateEntity: jest.fn() }));
+jest.mock('@/lib/utils/logError', () => ({ logError: jest.fn() }));
+
+import { NextRequest, NextResponse } from 'next/server';
+import { GET, POST } from '../pending-deletions/route';
+
+function req(body: unknown) {
+  return new NextRequest('http://localhost/api/tasks/pending-deletions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAuth.mockResolvedValue({ userId: 'p1', role: 'parent' });
+  mockRequireRole.mockReturnValue(undefined);
+  mockDisplayAuth.mockResolvedValue({ userId: 'p1' });
+  mockSelectWhere.mockResolvedValue([{ id: 't1' }, { id: 't2' }]);
+});
+
+describe('GET /api/tasks/pending-deletions', () => {
+  it('returns an empty list for an unauthenticated display rather than 401', async () => {
+    // The shared wall display is not signed in but still shows the badge.
+    mockDisplayAuth.mockResolvedValue(null);
+    const res = await GET();
+    expect(await res.json()).toEqual({ pending: [], count: 0 });
+  });
+
+  it('reports what is waiting', async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: 't1', title: 'Bins', dueDate: null, completed: false, provider: 'google_tasks', listName: 'Home', prismList: 'Chores' },
+    ]);
+    const body = await (await GET()).json();
+    expect(body.count).toBe(1);
+    expect(body.pending[0].source).toBe('Google Tasks — Home');
+  });
+});
+
+describe('POST — keep', () => {
+  it('sets syncExempt, or the reconciler pushes the task straight back', async () => {
+    // THE regression test. Without syncExempt the task is recreated on the
+    // provider within about five minutes and the loop never ends.
+    await POST(req({ taskIds: ['t1', 't2'], action: 'keep' }));
+    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ syncExempt: true }));
+  });
+
+  it('also clears the flag and the link', async () => {
+    await POST(req({ taskIds: ['t1'], action: 'keep' }));
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ pendingDeletion: null, taskSourceId: null, externalId: null }),
+    );
+  });
+
+  it('never deletes anything', async () => {
+    await POST(req({ taskIds: ['t1'], action: 'keep' }));
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST — delete', () => {
+  it('removes the selected tasks', async () => {
+    const res = await POST(req({ taskIds: ['t1', 't2'], action: 'delete' }));
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toEqual({ applied: 2, action: 'delete' });
+  });
+});
+
+describe('POST — guards', () => {
+  it('rejects an unknown action instead of guessing', async () => {
+    const res = await POST(req({ taskIds: ['t1'], action: 'archive' }));
+    expect(res.status).toBe(400);
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty selection', async () => {
+    expect((await POST(req({ taskIds: [], action: 'delete' }))).status).toBe(400);
+  });
+
+  it('ignores non-string ids rather than passing them to the query', async () => {
+    const res = await POST(req({ taskIds: [42, null], action: 'delete' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('does nothing when the ids are stale and no longer flagged', async () => {
+    // A cached page can post ids the user already actioned elsewhere. The
+    // route re-selects on pendingDeletion IS NOT NULL, so these are no-ops.
+    mockSelectWhere.mockResolvedValue([]);
+    const res = await POST(req({ taskIds: ['gone'], action: 'delete' }));
+    expect(await res.json()).toEqual({ applied: 0, action: 'delete' });
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it('refuses a role without delete permission', async () => {
+    mockRequireRole.mockReturnValue(NextResponse.json({ error: 'forbidden' }, { status: 403 }));
+    const res = await POST(req({ taskIds: ['t1'], action: 'delete' }));
+    expect(res.status).toBe(403);
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/pending-deletions/route.ts
+++ b/src/app/api/tasks/pending-deletions/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Deletes-only review for task sync.
+ *
+ * The reconciler used to delete any synced task the provider stopped listing.
+ * That is silent and unrecoverable: an outage, a revoked scope or the wrong
+ * list id wiped the lot with no undo. It now flags them instead, and this is
+ * where the user decides.
+ *
+ * GET  — list the flagged tasks.
+ * POST — apply a decision to a set of them:
+ *          { taskIds, action: 'delete' } → remove them, or
+ *          { taskIds, action: 'keep' }   → keep as a local task the sync
+ *                                          will not touch again.
+ *
+ * Mirrors /api/calendars/pending-deletions, with one important difference:
+ * 'keep' must set syncExempt, not merely clear the link. Task sync pushes
+ * local tasks UP to the provider, so a kept task with no external id would be
+ * recreated on the provider it was just deleted from, and the loop would
+ * repeat every five minutes. Calendar has no such push, which is why clearing
+ * the id is enough there.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { tasks, taskSources, taskLists } from '@/lib/db/schema';
+import { requireAuth, requireRole, getDisplayAuth } from '@/lib/auth';
+import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { logError } from '@/lib/utils/logError';
+
+export async function GET() {
+  // A shared display is not signed in but still shows the badge, so an
+  // unauthenticated read returns an empty list rather than a 401.
+  const auth = await getDisplayAuth();
+  if (!auth) return NextResponse.json({ pending: [], count: 0 });
+
+  try {
+    const rows = await db
+      .select({
+        id: tasks.id,
+        title: tasks.title,
+        dueDate: tasks.dueDate,
+        completed: tasks.completed,
+        provider: taskSources.provider,
+        listName: taskSources.externalListName,
+        prismList: taskLists.name,
+      })
+      .from(tasks)
+      .leftJoin(taskSources, eq(tasks.taskSourceId, taskSources.id))
+      .leftJoin(taskLists, eq(tasks.listId, taskLists.id))
+      .where(isNotNull(tasks.pendingDeletion))
+      .orderBy(tasks.title);
+
+    const providerLabel = (p: string | null) => {
+      if (p === 'google_tasks') return 'Google Tasks';
+      if (p === 'microsoft_todo') return 'Microsoft To Do';
+      return p ?? 'its source';
+    };
+
+    return NextResponse.json({
+      pending: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        dueDate: r.dueDate,
+        completed: r.completed,
+        source: r.listName ? `${providerLabel(r.provider)} — ${r.listName}` : providerLabel(r.provider),
+        list: r.prismList,
+      })),
+      count: rows.length,
+    });
+  } catch (error) {
+    logError('Error listing pending task deletions:', error);
+    return NextResponse.json({ error: 'Failed to load pending deletions' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canDeleteTasks');
+  if (forbidden) return forbidden;
+
+  try {
+    const body = await request.json();
+    const taskIds: string[] = Array.isArray(body.taskIds)
+      ? body.taskIds.filter((x: unknown) => typeof x === 'string')
+      : [];
+    const action = body.action === 'keep' ? 'keep' : body.action === 'delete' ? 'delete' : null;
+
+    if (!action) return NextResponse.json({ error: "action must be 'delete' or 'keep'." }, { status: 400 });
+    if (taskIds.length === 0) return NextResponse.json({ error: 'No tasks selected.' }, { status: 400 });
+
+    // Only act on tasks that are actually flagged, so stale ids from a cached
+    // page are no-ops rather than deletions.
+    const targets = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(and(inArray(tasks.id, taskIds), isNotNull(tasks.pendingDeletion)));
+
+    const ids = targets.map((t) => t.id);
+    if (ids.length === 0) return NextResponse.json({ applied: 0, action });
+
+    if (action === 'delete') {
+      // No tombstone here, deliberately. These tasks are already absent from
+      // the provider, so a tombstone would be pruned on the next run in the
+      // ordinary case — and in the case where it survives, the task came back
+      // and the tombstone would hide a live task permanently, with no UI to
+      // clear it. The grace window and the mass-delete guard are what protect
+      // against a hiccup; a tombstone here would only add a way to lose data.
+      await db.delete(tasks).where(inArray(tasks.id, ids));
+    } else {
+      // Keep: hand the task to Prism permanently. syncExempt is the part that
+      // matters — without it the reconciler would push this straight back to
+      // the provider as a new task.
+      await db
+        .update(tasks)
+        .set({
+          pendingDeletion: null,
+          syncExempt: true,
+          taskSourceId: null,
+          externalId: null,
+          lastSynced: null,
+        })
+        .where(inArray(tasks.id, ids));
+    }
+
+    await invalidateEntity('tasks');
+    return NextResponse.json({ applied: ids.length, action });
+  } catch (error) {
+    logError('Error applying pending task deletions:', error);
+    return NextResponse.json({ error: 'Failed to apply.' }, { status: 500 });
+  }
+}

--- a/src/app/tasks/PendingTaskDeletionsModal.tsx
+++ b/src/app/tasks/PendingTaskDeletionsModal.tsx
@@ -12,7 +12,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import type { PendingTaskDeletion } from '@/lib/hooks/usePendingTaskDeletions';
+import { toast } from '@/components/ui/use-toast';
+import type { PendingTaskDeletion, ApplyResult } from '@/lib/hooks/usePendingTaskDeletions';
 
 /**
  * Deletes-only review for task sync. Lists tasks the provider stopped
@@ -27,7 +28,7 @@ export function PendingTaskDeletionsModal({
   onClose,
 }: {
   pending: PendingTaskDeletion[];
-  onApply: (taskIds: string[], action: 'delete' | 'keep') => Promise<boolean>;
+  onApply: (taskIds: string[], action: 'delete' | 'keep') => Promise<ApplyResult>;
   onClose: () => void;
 }) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
@@ -47,9 +48,15 @@ export function PendingTaskDeletionsModal({
   const act = async (action: 'delete' | 'keep') => {
     if (bulk.length === 0) return;
     setBusy(true);
-    const ok = await onApply(bulk, action);
+    const result = await onApply(bulk, action);
     setBusy(false);
-    if (ok) onClose();
+    if (result.ok) {
+      onClose();
+      return;
+    }
+    // Stay open and say why. Closing on failure, or closing silently, would
+    // leave the user thinking it worked.
+    toast({ title: 'Nothing was changed', description: result.reason, variant: 'destructive' });
   };
 
   return (

--- a/src/app/tasks/PendingTaskDeletionsModal.tsx
+++ b/src/app/tasks/PendingTaskDeletionsModal.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import { AlertTriangle, ArrowRight, Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import type { PendingTaskDeletion } from '@/lib/hooks/usePendingTaskDeletions';
+
+/**
+ * Deletes-only review for task sync. Lists tasks the provider stopped
+ * returning, held rather than deleted. The user Deletes them or Keeps them as
+ * local tasks.
+ *
+ * Matches the calendar review modal, since the decision is the same one.
+ */
+export function PendingTaskDeletionsModal({
+  pending,
+  onApply,
+  onClose,
+}: {
+  pending: PendingTaskDeletion[];
+  onApply: (taskIds: string[], action: 'delete' | 'keep') => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
+  const [busy, setBusy] = useState(false);
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const allSelected = selected.size === pending.length && pending.length > 0;
+  const bulk = useMemo(() => Array.from(selected), [selected]);
+
+  const act = async (action: 'delete' | 'keep') => {
+    if (bulk.length === 0) return;
+    setBusy(true);
+    const ok = await onApply(bulk, action);
+    setBusy(false);
+    if (ok) onClose();
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Review removals
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 py-1 flex-1 min-h-0 flex flex-col">
+          <p className="text-sm text-muted-foreground">
+            These tasks were removed from the app they sync with, and held for review.{' '}
+            <span className="font-medium text-foreground">Delete</span> removes them from Prism too.{' '}
+            <span className="font-medium text-foreground">Keep</span> turns each one into a{' '}
+            <span className="inline-flex items-center gap-1 font-medium text-foreground">
+              <Home className="h-3 w-3" />local task
+            </span>{' '}
+            — it stops syncing and will not be added back to the other app.
+          </p>
+
+          <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground px-1">
+            <Checkbox
+              checked={allSelected}
+              onCheckedChange={() =>
+                setSelected(allSelected ? new Set() : new Set(pending.map((p) => p.id)))
+              }
+            />
+            Select all ({selected.size}/{pending.length})
+          </label>
+
+          {/* Native scroll, matching the calendar modal: drag-scrolls on touch
+              wall displays and cannot clip a long list. */}
+          <div className="flex-1 min-h-0 overflow-y-auto pr-3 -mr-1">
+            <div className="space-y-1">
+              {pending.map((p) => (
+                <label
+                  key={p.id}
+                  className="flex items-start gap-2 rounded px-1 py-1 hover:bg-muted/50 cursor-pointer"
+                >
+                  <Checkbox checked={selected.has(p.id)} onCheckedChange={() => toggle(p.id)} className="mt-0.5" />
+                  <span className="text-sm flex-1 min-w-0">
+                    <span className={`font-medium ${p.completed ? 'line-through opacity-70' : ''}`}>
+                      {p.title}
+                    </span>
+                    {p.dueDate && (
+                      <span className="block text-xs text-muted-foreground">
+                        Due {format(parseISO(p.dueDate), 'EEE, MMM d')}
+                      </span>
+                    )}
+                    <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground flex-wrap">
+                      <span className="truncate min-w-0">{p.source}</span>
+                      <ArrowRight className="h-3 w-3 opacity-60 shrink-0" />
+                      <span className="inline-flex items-center gap-1 shrink-0">
+                        <Home className="h-3 w-3" />Local (if kept)
+                      </span>
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={() => act('keep')} disabled={busy || selected.size === 0}>
+            <Home className="h-4 w-4 mr-1.5" />
+            Keep {selected.size} in Prism
+          </Button>
+          <Button variant="destructive" onClick={() => act('delete')} disabled={busy || selected.size === 0}>
+            Delete {selected.size}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -261,9 +261,9 @@ export function TasksView() {
           <PendingTaskDeletionsModal
             pending={pendingDeletions}
             onApply={async (ids, action) => {
-              const ok = await applyPendingDeletions(ids, action);
-              if (ok) refreshTasks();
-              return ok;
+              const result = await applyPendingDeletions(ids, action);
+              if (result.ok) refreshTasks();
+              return result;
             }}
             onClose={() => setShowPendingReview(false)}
           />

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -10,6 +10,7 @@ import {
   Users,
   List,
   X,
+  AlertTriangle,
 } from 'lucide-react';
 import { PlaneCelebration } from '@/components/ui/PlaneCelebration';
 import { Button } from '@/components/ui/button';
@@ -23,6 +24,8 @@ import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useTaskGrouping } from '@/app/tasks/useTaskGrouping';
 import { TaskContentArea } from '@/app/tasks/TaskContentArea';
 import type { GroupBy } from '@/app/tasks/taskGroupTypes';
+import { usePendingTaskDeletions } from '@/lib/hooks/usePendingTaskDeletions';
+import { PendingTaskDeletionsModal } from '@/app/tasks/PendingTaskDeletionsModal';
 
 export function TasksView() {
   const { requireAuth } = useAuth();
@@ -45,6 +48,12 @@ export function TasksView() {
 
   const isMobile = useIsMobile();
   const [celebratingUser, setCelebratingUser] = useState<{ id: string; name: string } | null>(null);
+  const [showPendingReview, setShowPendingReview] = useState(false);
+  const {
+    pending: pendingDeletions,
+    count: pendingCount,
+    apply: applyPendingDeletions,
+  } = usePendingTaskDeletions();
 
   const {
     primaryGroup, setPrimaryGroup,
@@ -106,6 +115,18 @@ export function TasksView() {
             {autoSyncing && <RefreshCw className="h-4 w-4 text-muted-foreground animate-spin" />}
           </>}
           actions={<>
+            {pendingCount > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowPendingReview(true)}
+                className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                title="Review task removals held for your approval"
+              >
+                <AlertTriangle className="h-4 w-4 mr-1" />
+                Review {pendingCount}
+              </Button>
+            )}
             <UndoButton />
             <Button onClick={handleAddWithAuth} size="sm">
               <Plus className="h-4 w-4 mr-1" />Add Task
@@ -233,6 +254,18 @@ export function TasksView() {
               }
             }}
             familyMembers={familyMembers} taskLists={taskLists}
+          />
+        )}
+
+        {showPendingReview && pendingCount > 0 && (
+          <PendingTaskDeletionsModal
+            pending={pendingDeletions}
+            onApply={async (ids, action) => {
+              const ok = await applyPendingDeletions(ids, action);
+              if (ok) refreshTasks();
+              return ok;
+            }}
+            onClose={() => setShowPendingReview(false)}
           />
         )}
 

--- a/src/lib/db/init/02-schema.sql
+++ b/src/lib/db/init/02-schema.sql
@@ -687,6 +687,8 @@ CREATE TABLE IF NOT EXISTS public.tasks (
     external_id character varying(255),
     external_updated_at timestamp without time zone,
     last_synced timestamp without time zone,
+    pending_deletion timestamp without time zone,
+    sync_exempt boolean DEFAULT false NOT NULL,
     created_by uuid,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
@@ -2619,6 +2621,32 @@ CREATE TABLE IF NOT EXISTS public.dismissed_events (
   created_at timestamp DEFAULT now() NOT NULL
 );
 CREATE UNIQUE INDEX IF NOT EXISTS dismissed_events_source_external_unique ON public.dismissed_events (calendar_source_id, external_event_id);
+
+-- Tombstones for locally-deleted synced tasks (so the reconciler doesn't re-add them).
+CREATE TABLE IF NOT EXISTS public.dismissed_tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  task_source_id uuid NOT NULL REFERENCES public.task_sources(id) ON DELETE CASCADE,
+  external_task_id varchar(255) NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_tasks_source_external_unique ON public.dismissed_tasks (task_source_id, external_task_id);
+
+-- Deletes-only review for tasks: flag synced tasks gone from the provider
+-- instead of deleting them outright.
+CREATE INDEX IF NOT EXISTS tasks_pending_deletion_idx ON public.tasks (pending_deletion) WHERE pending_deletion IS NOT NULL;
+
+-- Tombstones for dismissed detected birthdays. Added with migration 0023, which
+-- did not update this file; fresh installs picked the table up from the numbered
+-- migration instead, so this only restores the documented parity.
+CREATE TABLE IF NOT EXISTS public.dismissed_birthdays (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  normalized_name varchar(100) NOT NULL,
+  birth_month integer NOT NULL,
+  birth_day integer NOT NULL,
+  event_type varchar(20) DEFAULT 'birthday' NOT NULL,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dismissed_birthdays_name_day_type_unique ON public.dismissed_birthdays (normalized_name, birth_month, birth_day, event_type);
 
 -- Deletes-only review: flag synced events gone from source instead of deleting (#171).
 ALTER TABLE public.events ADD COLUMN IF NOT EXISTS pending_deletion timestamp;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -782,6 +782,28 @@ export const birthdays = pgTable('birthdays', {
  * excluded deliberately — the 1904 unknown-year sentinel means the same person
  * can arrive with different years from different sources.
  */
+/**
+ * Synced tasks deleted in Prism, so the reconciler does not re-add them.
+ *
+ * The delete route also removes the task from the provider, which covers the
+ * ordinary case. This exists for when that cannot be relied on: a failed or
+ * unsupported upstream delete, or a remote that still lists the task on the
+ * next run. Without it the task reappears within about five minutes.
+ *
+ * Same shape and purpose as [dismissedEvents] on the calendar side.
+ */
+export const dismissedTasks = pgTable('dismissed_tasks', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  taskSourceId: uuid('task_source_id')
+    .notNull()
+    .references(() => taskSources.id, { onDelete: 'cascade' }),
+  externalTaskId: varchar('external_task_id', { length: 255 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  dismissedTasksSourceExternalUnique: uniqueIndex('dismissed_tasks_source_external_unique')
+    .on(table.taskSourceId, table.externalTaskId),
+}));
+
 export const dismissedBirthdays = pgTable('dismissed_birthdays', {
   id: uuid('id').defaultRandom().primaryKey(),
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -293,6 +293,23 @@ export const tasks = pgTable('tasks', {
   externalUpdatedAt: timestamp('external_updated_at'),
   lastSynced: timestamp('last_synced'),
 
+  /**
+   * Set when the remote dropped this task and the deletion is awaiting the
+   * user's decision. The task stays visible meanwhile. Mirrors
+   * events.pendingDeletion — see the pending-deletions review route.
+   */
+  pendingDeletion: timestamp('pending_deletion'),
+
+  /**
+   * The user chose to keep this task after the remote deleted it, so the
+   * reconciler must ignore it in both directions.
+   *
+   * Detaching alone is not enough: the reconciler pushes any local task in a
+   * synced list with no external id to the provider, which would recreate a
+   * kept task on the remote it was just deleted from.
+   */
+  syncExempt: boolean('sync_exempt').default(false).notNull(),
+
   createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/src/lib/hooks/usePendingTaskDeletions.ts
+++ b/src/lib/hooks/usePendingTaskDeletions.ts
@@ -2,6 +2,9 @@
 
 import { useState, useEffect, useCallback } from 'react';
 
+/** Why an apply failed, so the UI can say so rather than doing nothing. */
+export type ApplyResult = { ok: true } | { ok: false; reason: string };
+
 export interface PendingTaskDeletion {
   id: string;
   title: string;
@@ -42,14 +45,26 @@ export function usePendingTaskDeletions() {
   }, [refresh]);
 
   const apply = useCallback(
-    async (taskIds: string[], action: 'delete' | 'keep') => {
-      const res = await fetch('/api/tasks/pending-deletions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ taskIds, action }),
-      });
-      await refresh();
-      return res.ok;
+    async (taskIds: string[], action: 'delete' | 'keep'): Promise<ApplyResult> => {
+      try {
+        const res = await fetch('/api/tasks/pending-deletions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ taskIds, action }),
+        });
+        await refresh();
+        if (res.ok) return { ok: true };
+
+        // A refusal has to say why. A child tapping Delete and watching
+        // nothing happen cannot tell "not allowed" from "broken".
+        if (res.status === 401 || res.status === 403) {
+          return { ok: false, reason: 'Only a parent can review removed tasks.' };
+        }
+        const body = await res.json().catch(() => null);
+        return { ok: false, reason: body?.error || 'Could not apply that. Please try again.' };
+      } catch {
+        return { ok: false, reason: 'Could not reach Prism. Please try again.' };
+      }
     },
     [refresh],
   );

--- a/src/lib/hooks/usePendingTaskDeletions.ts
+++ b/src/lib/hooks/usePendingTaskDeletions.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+export interface PendingTaskDeletion {
+  id: string;
+  title: string;
+  dueDate: string | null;
+  completed: boolean;
+  /** Where it came from, e.g. "Google Tasks — Shopping". */
+  source: string;
+  /** The Prism list it currently sits in. */
+  list: string | null;
+}
+
+/**
+ * Synced tasks the provider stopped listing, held for review instead of being
+ * deleted. Drives the "Review N" badge on the Tasks page.
+ *
+ * Same shape as usePendingDeletions for calendar events.
+ */
+export function usePendingTaskDeletions() {
+  const [pending, setPending] = useState<PendingTaskDeletion[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tasks/pending-deletions');
+      if (res.ok) {
+        const data = await res.json();
+        setPending(data.pending ?? []);
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const apply = useCallback(
+    async (taskIds: string[], action: 'delete' | 'keep') => {
+      const res = await fetch('/api/tasks/pending-deletions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskIds, action }),
+      });
+      await refresh();
+      return res.ok;
+    },
+    [refresh],
+  );
+
+  return { pending, count: pending.length, loading, refresh, apply };
+}

--- a/src/lib/integrations/tasks/__tests__/providerAuth.test.ts
+++ b/src/lib/integrations/tasks/__tests__/providerAuth.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Resolving a task source into a provider plus usable tokens.
+ *
+ * This is what lets the delete route reach the provider outside the periodic
+ * sync. Every failure path must return a reason rather than throwing: the
+ * caller deletes the task locally regardless, and an exception here would
+ * take the user's delete down with it.
+ */
+const mockSelect = jest.fn();
+const mockUpdateSet = jest.fn();
+const mockGetProvider = jest.fn();
+const mockRefreshTokens = jest.fn();
+
+jest.mock('@/lib/db/client', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: (...a: unknown[]) => mockSelect(...a) }) }),
+    update: () => ({ set: (v: unknown) => { mockUpdateSet(v); return { where: () => Promise.resolve() }; } }),
+  },
+}));
+jest.mock('@/lib/db/schema', () => ({ taskSources: { id: 'id' } }));
+jest.mock('drizzle-orm', () => ({ eq: jest.fn() }));
+jest.mock('@/lib/utils/crypto', () => ({
+  decrypt: (v: string) => v.replace(/^enc\(|\)$/g, ''),
+  encrypt: (v: string) => `enc(${v})`,
+}));
+jest.mock('@/lib/integrations/tasks', () => ({ getTaskProvider: (...a: unknown[]) => mockGetProvider(...a) }));
+
+import { resolveTaskProviderAuth } from '../providerAuth';
+
+const PAST = new Date(Date.now() - 60_000);
+const FUTURE = new Date(Date.now() + 3_600_000);
+
+function source(over: Record<string, unknown> = {}) {
+  return {
+    id: 's1',
+    provider: 'google_tasks',
+    externalListId: 'list-1',
+    accessToken: 'enc(at)',
+    refreshToken: 'enc(rt)',
+    tokenExpiresAt: FUTURE,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSelect.mockResolvedValue([source()]);
+  mockGetProvider.mockReturnValue({ refreshTokens: (...a: unknown[]) => mockRefreshTokens(...a) });
+});
+
+describe('resolveTaskProviderAuth', () => {
+  it('returns the provider, decrypted tokens and the list id', async () => {
+    const res = await resolveTaskProviderAuth('s1');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.tokens.accessToken).toBe('at');
+    expect(res.tokens.refreshToken).toBe('rt');
+    expect(res.externalListId).toBe('list-1');
+  });
+
+  it('does not refresh a token that is still valid', async () => {
+    await resolveTaskProviderAuth('s1');
+    expect(mockRefreshTokens).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expired token and persists the rotated pair encrypted', async () => {
+    mockSelect.mockResolvedValue([source({ tokenExpiresAt: PAST })]);
+    mockRefreshTokens.mockResolvedValue({ accessToken: 'at2', refreshToken: 'rt2', expiresAt: FUTURE });
+
+    const res = await resolveTaskProviderAuth('s1');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.tokens.accessToken).toBe('at2');
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'enc(at2)', refreshToken: 'enc(rt2)' }),
+    );
+  });
+
+  it('reports rather than throws when the source is gone', async () => {
+    mockSelect.mockResolvedValue([]);
+    expect(await resolveTaskProviderAuth('s1')).toEqual({ ok: false, reason: 'no_source' });
+  });
+
+  it('reports rather than throws for an unknown provider', async () => {
+    mockGetProvider.mockReturnValue(undefined);
+    expect(await resolveTaskProviderAuth('s1')).toEqual({ ok: false, reason: 'unknown_provider' });
+  });
+
+  it('reports rather than throws when no token is stored', async () => {
+    mockSelect.mockResolvedValue([source({ accessToken: null })]);
+    expect(await resolveTaskProviderAuth('s1')).toEqual({ ok: false, reason: 'no_token' });
+  });
+
+  it('reports refresh_failed when the provider declines to refresh', async () => {
+    mockSelect.mockResolvedValue([source({ tokenExpiresAt: PAST })]);
+    mockRefreshTokens.mockResolvedValue(null);
+    expect(await resolveTaskProviderAuth('s1')).toEqual({ ok: false, reason: 'refresh_failed' });
+  });
+
+  it('reports refresh_failed when expired with no refresh token to use', async () => {
+    mockSelect.mockResolvedValue([source({ tokenExpiresAt: PAST, refreshToken: null })]);
+    expect(await resolveTaskProviderAuth('s1')).toEqual({ ok: false, reason: 'refresh_failed' });
+  });
+});

--- a/src/lib/integrations/tasks/providerAuth.ts
+++ b/src/lib/integrations/tasks/providerAuth.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolve a task source into a provider plus usable, non-expired tokens.
+ *
+ * Written for the delete route, which needs to reach the provider outside the
+ * periodic sync. The sync route still carries its own copy of this logic; it
+ * has no test coverage at all, so it was left alone rather than refactored
+ * blind. Worth folding together once that gains tests.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { taskSources } from '@/lib/db/schema';
+import { decrypt, encrypt } from '@/lib/utils/crypto';
+import { getTaskProvider } from '@/lib/integrations/tasks';
+import type { TaskProvider, TaskProviderTokens } from '@/lib/integrations/tasks/types';
+
+export type TaskProviderAuth =
+  | { ok: true; provider: TaskProvider; tokens: TaskProviderTokens; externalListId: string }
+  | { ok: false; reason: 'no_source' | 'unknown_provider' | 'no_token' | 'refresh_failed' };
+
+export async function resolveTaskProviderAuth(sourceId: string): Promise<TaskProviderAuth> {
+  const [source] = await db.select().from(taskSources).where(eq(taskSources.id, sourceId));
+  if (!source) return { ok: false, reason: 'no_source' };
+
+  const provider = getTaskProvider(source.provider);
+  if (!provider) return { ok: false, reason: 'unknown_provider' };
+  if (!source.accessToken) return { ok: false, reason: 'no_token' };
+
+  let tokens: TaskProviderTokens = {
+    accessToken: decrypt(source.accessToken),
+    refreshToken: source.refreshToken ? decrypt(source.refreshToken) : undefined,
+    expiresAt: source.tokenExpiresAt || undefined,
+  };
+
+  if (tokens.expiresAt && new Date(tokens.expiresAt) < new Date()) {
+    if (!provider.refreshTokens || !tokens.refreshToken) return { ok: false, reason: 'refresh_failed' };
+
+    const refreshed = await provider.refreshTokens(tokens);
+    if (!refreshed) return { ok: false, reason: 'refresh_failed' };
+
+    tokens = refreshed;
+    // Persist the rotated tokens, so the next sync does not refresh again.
+    await db
+      .update(taskSources)
+      .set({
+        accessToken: encrypt(refreshed.accessToken),
+        refreshToken: refreshed.refreshToken ? encrypt(refreshed.refreshToken) : source.refreshToken,
+        tokenExpiresAt: refreshed.expiresAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(taskSources.id, sourceId));
+  }
+
+  return { ok: true, provider, tokens, externalListId: source.externalListId };
+}

--- a/src/lib/integrations/tasks/types.ts
+++ b/src/lib/integrations/tasks/types.ts
@@ -43,7 +43,14 @@ export interface UpdateTaskInput {
 export interface SyncResult {
   created: number;
   updated: number;
+  /** Rows actually removed locally. The reconciler no longer does this. */
   deleted: number;
+  /**
+   * Synced tasks the provider stopped listing, held for the user's review
+   * rather than deleted. Reported separately because "deleted" is what the
+   * audit log and the sync-all totals say, and none of these were.
+   */
+  flagged: number;
   errors: string[];
 }
 

--- a/src/lib/services/__tests__/taskDeletionReview.test.ts
+++ b/src/lib/services/__tests__/taskDeletionReview.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The policy that decides whether vanished tasks are flagged for review.
+ *
+ * These are the cases that matter: an ordinary tick-off must reach the user,
+ * and a provider outage must not.
+ */
+import {
+  decideDeletionReview,
+  MASS_DELETE_MAX_ITEMS,
+  MASS_DELETE_FRACTION,
+} from '../taskDeletionReview';
+
+describe('decideDeletionReview — ordinary loss', () => {
+  it('does nothing when nothing went missing', () => {
+    expect(decideDeletionReview({ syncedCount: 20, missingCount: 0 })).toEqual({
+      flag: false,
+      guardTripped: false,
+      withheld: 0,
+    });
+  });
+
+  it('flags a single disappearance, the everyday case', () => {
+    // Someone ticked a task off on their phone. This must always reach the
+    // user, including when it is the only task in the list.
+    expect(decideDeletionReview({ syncedCount: 1, missingCount: 1 }).flag).toBe(true);
+    expect(decideDeletionReview({ syncedCount: 40, missingCount: 1 }).flag).toBe(true);
+  });
+
+  it('flags a handful without tripping the guard', () => {
+    const d = decideDeletionReview({ syncedCount: 40, missingCount: 5 });
+    expect(d).toEqual({ flag: true, guardTripped: false, withheld: 0 });
+  });
+
+  it('flags right up to the item limit', () => {
+    const d = decideDeletionReview({ syncedCount: 100, missingCount: MASS_DELETE_MAX_ITEMS });
+    expect(d.flag).toBe(true);
+    expect(d.guardTripped).toBe(false);
+  });
+});
+
+describe('decideDeletionReview — bulk loss is withheld', () => {
+  it('withholds one past the item limit', () => {
+    const d = decideDeletionReview({ syncedCount: 100, missingCount: MASS_DELETE_MAX_ITEMS + 1 });
+    expect(d).toEqual({ flag: false, guardTripped: true, withheld: 11 });
+  });
+
+  it('withholds when the provider returns an empty list', () => {
+    // The failure this exists for: an outage or revoked scope, which used to
+    // delete every synced task locally with no undo.
+    const d = decideDeletionReview({ syncedCount: 200, missingCount: 200 });
+    expect(d.flag).toBe(false);
+    expect(d.withheld).toBe(200);
+  });
+
+  it('withholds on fraction even when under the item limit', () => {
+    // 4 of 8 is half the set — well under 10 items, but a proportion that
+    // looks like breakage rather than housekeeping.
+    const d = decideDeletionReview({ syncedCount: 8, missingCount: 4 });
+    expect(d.guardTripped).toBe(true);
+  });
+
+  it('never trips on a single loss, whatever the fraction', () => {
+    // 1 of 1 is 100% of the set. Still just one task ticked off.
+    expect(decideDeletionReview({ syncedCount: 1, missingCount: 1 }).guardTripped).toBe(false);
+    expect(decideDeletionReview({ syncedCount: 2, missingCount: 1 }).guardTripped).toBe(false);
+  });
+
+  it('ignores the fraction on sets too small for it to mean anything', () => {
+    // 2 of 3 is a big fraction but a tiny set; the floor is 4 synced items.
+    expect(decideDeletionReview({ syncedCount: 3, missingCount: 2 }).guardTripped).toBe(false);
+    // Same proportion, past the floor: withheld.
+    expect(decideDeletionReview({ syncedCount: 4, missingCount: 2 }).guardTripped).toBe(true);
+  });
+});
+
+describe('decideDeletionReview — thresholds', () => {
+  it('honours caller-supplied thresholds', () => {
+    const d = decideDeletionReview({
+      syncedCount: 100,
+      missingCount: 3,
+      massDelete: { maxItems: 2, maxFraction: 0.9 },
+    });
+    expect(d.guardTripped).toBe(true);
+  });
+
+  it('uses the same fraction the recipe framework actually runs', () => {
+    // diff.ts prose says 25% but its code uses 0.5. Pinned so a future reader
+    // reconciling the two cannot silently change behaviour here.
+    expect(MASS_DELETE_FRACTION).toBe(0.5);
+  });
+});

--- a/src/lib/services/taskDeletionReview.ts
+++ b/src/lib/services/taskDeletionReview.ts
@@ -1,0 +1,70 @@
+/**
+ * Deciding what to do when tasks disappear from a provider.
+ *
+ * The reconciler used to delete the local row outright. That is unrecoverable
+ * and unattributable: a provider returning a short or empty list — an outage, a
+ * revoked scope, the wrong list id — wiped every synced task locally with no
+ * undo and nothing said.
+ *
+ * Calendar already holds these for review, and the recipe sync framework
+ * (lib/sync/diff.ts) adds a guard for bulk loss. This module is the same policy
+ * for tasks, kept separate from the route so it can be tested without a
+ * provider or a database.
+ */
+
+/** Defaults mirror lib/sync/diff.ts. See MASS_DELETE_FRACTION on the value. */
+export const MASS_DELETE_MAX_ITEMS = 10;
+
+/**
+ * Note for anyone comparing with lib/sync/diff.ts: its prose says 25% in two
+ * places while its code uses 0.5. The code is what runs there, so 0.5 is used
+ * here too rather than propagating whichever the prose meant.
+ */
+export const MASS_DELETE_FRACTION = 0.5;
+
+export interface DeletionReviewInput {
+  /** Synced local tasks: those carrying an external id for this source. */
+  syncedCount: number;
+  /** Of those, the ones the remote no longer lists. */
+  missingCount: number;
+  massDelete?: { maxItems?: number; maxFraction?: number };
+}
+
+export interface DeletionReviewDecision {
+  /** Flag the missing tasks for review. False means take no action at all. */
+  flag: boolean;
+  /** True when bulk loss tripped the guard, so nothing was flagged. */
+  guardTripped: boolean;
+  /** How many were left untouched because the guard fired. */
+  withheld: number;
+}
+
+/**
+ * Decide whether missing tasks should be flagged for review or ignored.
+ *
+ * The guard deliberately does NOT flag on bulk loss. Flagging hundreds of
+ * tasks is not harmless: it buries the real signal and invites a bulk confirm,
+ * which would destroy exactly the data the review exists to protect. A
+ * provider that has genuinely lost everything will still be reflected once the
+ * user removes the source.
+ */
+export function decideDeletionReview(input: DeletionReviewInput): DeletionReviewDecision {
+  const { syncedCount, missingCount } = input;
+  const maxItems = input.massDelete?.maxItems ?? MASS_DELETE_MAX_ITEMS;
+  const maxFraction = input.massDelete?.maxFraction ?? MASS_DELETE_FRACTION;
+
+  if (missingCount === 0) return { flag: false, guardTripped: false, withheld: 0 };
+
+  // A single disappearance is always ordinary — someone ticked a task off on
+  // their phone. The fraction test is meaningless on tiny sets, so it needs a
+  // floor; both mirror diff.ts.
+  const tripsCount = missingCount > maxItems;
+  const tripsFraction = syncedCount >= 4 && missingCount / syncedCount >= maxFraction;
+  const guardTripped = missingCount >= 2 && (tripsCount || tripsFraction);
+
+  return {
+    flag: !guardTripped,
+    guardTripped,
+    withheld: guardTripped ? missingCount : 0,
+  };
+}


### PR DESCRIPTION
Two pieces. **Deleting a task in Prism didn't reach the provider; deleting it in the provider destroyed it in Prism.** Both directions were wrong, in opposite ways.

## Piece 1 — Prism → provider

Deleting a task removed the local row and nothing else. The reconciler then saw a task present remotely with no local match, treated it as newly created, and **re-added it within about five minutes**.

Calendar already pushes at the action site (`events/[id]/route.ts`), so the delete route now does the same via a new `resolveTaskProviderAuth` helper. Best-effort and non-blocking, matching calendar. `dismissed_tasks` tombstones the deletion for when the push can't be relied on — it failed, the provider doesn't support deletion, or the remote lags. Tombstones are pruned once the remote catches up.

## Piece 2 — provider → Prism

The reconciler **deleted** any synced task the provider stopped listing. Silent, unrecoverable, no guard. A provider returning an empty list took every synced task with it.

It now flags instead, and the user decides in a Review modal reached from a badge on the Tasks page — the same flow as the calendar review.

### Four things this needed beyond copying calendar

**1. `keep` must set `syncExempt`, not just clear the link.** Task sync pushes local tasks *up* to the provider, so a kept task with no external id would be recreated on the provider it was just deleted from, flagged again, kept again — forever, leaving duplicates. Calendar can detach safely because its sync never pushes. There's a dedicated regression test for this.

**2. Only rows belonging to *this* source count as missing.** The reconciler's query also picks up rows with no source — CalDAV task rows, and orphans left by `ON DELETE SET NULL` — carrying an external id this provider has never heard of. **It was deleting another provider's tasks.** Worth having regardless of the review feature.

**3. A grace window before flagging.** A task just pushed upstream may not be in the provider's list yet; flagging it would tell the user their own new task had been deleted. Also means one missed response never flags anything.

**4. Flags clear for anything the remote lists again**, before any decision, so a bad response heals itself. Calendar does this on all three of its provider paths and it's what makes the pattern hiccup-proof.

### Judgement calls

- **The mass-delete guard is a review-flood guard, not a data-safety one** — nothing is auto-applied, so its job is stopping hundreds of entries from burying the signal and inviting a bulk confirm. It reports via a sync error rather than withholding silently.
- **No tombstone on a review-confirmed delete.** The task is already absent from the provider, so the tombstone is pruned next run in the ordinary case; in the case where it survives — the task came back — it would hide a live task permanently, with no UI to clear it.
- `result.deleted` no longer covers this, so it's reported as `flagged`, and the audit summary says "removals held for review" rather than claiming deletions that didn't happen.

## Behaviour change worth knowing

A task cleared in Google now **lingers in Prism until reviewed**, where before it vanished. Calendar events fall off naturally by date; tasks don't. The badge is the mitigation.

## Testing

35 new tests: the review policy (guard thresholds, the empty-list case, the floors), the review route (`keep` sets `syncExempt`, stale ids are no-ops, permissions, bad input), the reconciler driven end-to-end with a mocked provider (flags rather than deletes, respects the grace window, ignores other providers' rows, clears flags on reappearance), and `resolveTaskProviderAuth`.

1,518 pass, typecheck and lint clean, migration replay green.

Cannot be tested automatically, and worth knowing: real provider eventual-consistency after `createTask`, and whether a provider returns `[]` versus an error during a partial outage — the guard's premise rests on that.

## Known gap, deliberately not fixed here

`calendar-sync.ts` still hard-deletes CalDAV task rows on the same kind of disappearance, with no review and no guard. Those rows carry no `task_source_id`, so they need separate handling. **This PR covers provider task sources only.**
