### PR TITLE
fix(setup): require an authenticated parent for weather and Kroger credentials

### DIFF
--- a/docs/api-auth-levels.md
+++ b/docs/api-auth-levels.md
@@ -105,6 +105,23 @@ Documents the authentication requirement for each API route. There are three acc
 | `/api/audit-logs` | Auth + Parent | — |
 | `/api/health` | Public | — |
 
+### Setup
+`/api/setup/credentials/*` are reached from **Settings**, not the setup wizard,
+so they all require an authenticated parent. `/api/setup/complete` and
+`/api/setup/status` run before any account exists and are necessarily public.
+
+| Route | GET | POST |
+|---|---|---|
+| `/api/setup/status` | Public | — |
+| `/api/setup/complete` | — | Public ¹ |
+| `/api/setup/credentials/google` | — | Auth + Parent |
+| `/api/setup/credentials/microsoft` | — | Auth + Parent |
+| `/api/setup/credentials/kroger` | — | Auth + Parent |
+| `/api/setup/credentials/weather` | — | Auth + Parent |
+
+> ¹ Writes the `setupComplete` marker during first-time setup, before any user
+> exists to authenticate as.
+
 ### Voice / Alexa
 | Route | GET | POST |
 |---|---|---|

--- a/src/app/api/setup/credentials/kroger/route.ts
+++ b/src/app/api/setup/credentials/kroger/route.ts
@@ -7,8 +7,14 @@ import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { encrypt } from '@/lib/utils/crypto';
+import { requireAuth, requireRole } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
   try {
     const body = await request.json() as {
       clientId?: string;

--- a/src/app/api/setup/credentials/weather/route.ts
+++ b/src/app/api/setup/credentials/weather/route.ts
@@ -7,8 +7,14 @@ import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { encrypt } from '@/lib/utils/crypto';
+import { requireAuth, requireRole } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+  const forbidden = requireRole(auth, 'canModifySettings');
+  if (forbidden) return forbidden;
+
   try {
     const body = await request.json() as { apiKey?: string };
     const { apiKey } = body;


### PR DESCRIPTION
`POST /api/setup/credentials/weather` and `/kroger` had **no auth check at all**, while their `google` and `microsoft` siblings both call `requireAuth` followed by `requireRole('canModifySettings')`.

Anyone able to reach the host could overwrite those stored API keys.

## The fix

Both now do what the siblings do — the same two guards, in the same order, before anything else runs. Nothing else changes: values are still encrypted the same way and written to the same `settings` rows.

## Why this is safe to apply

Neither endpoint is reached by the setup wizard, despite the path:

- **Kroger** is called from Settings (`KrogerConnectionCard.tsx:53`), where the user is already an authenticated parent — so the new check is satisfied by every real caller.
- **Weather** has no caller at all. `credentialStore.getWeatherApiKey()` still reads the value it writes, so it was secured rather than removed.

## Docs

`docs/api-auth-levels.md` had no entry for any `/api/setup` route. Adds a Setup section covering all six, and records why `/api/setup/complete` and `/api/setup/status` are necessarily public — they run before an account exists to authenticate as.

## Testing

1,483 tests pass, typecheck clean. No behavioural change for authenticated parents, which is every caller that exists.
