### PR TITLE
fix(tasks): read Google credentials from the credential store, not the env

### DIFF
--- a/src/app/api/auth/google-tasks/callback/route.ts
+++ b/src/app/api/auth/google-tasks/callback/route.ts
@@ -5,6 +5,7 @@ import { getRedisClient } from '@/lib/cache/getRedisClient';
 import { logError } from '@/lib/utils/logError';
 import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
 import { fetchGoogleAccountEmail } from '@/lib/integrations/oauth-userinfo';
+import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
 
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const BASE_URL = process.env.APP_URL || process.env.BASE_URL || 'http://localhost:3000';
@@ -17,8 +18,11 @@ interface GoogleTokens {
 }
 
 async function exchangeCodeForTokens(code: string, redirectUriOverride?: string): Promise<GoogleTokens> {
-  const clientId = process.env.GOOGLE_CLIENT_ID;
-  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  // Same store the connect route reads, so the pair that started the flow is
+  // the pair that completes it.
+  const credentials = await getGoogleCredentials();
+  const clientId = credentials?.clientId;
+  const clientSecret = credentials?.clientSecret;
   const redirectUri = redirectUriOverride || process.env.GOOGLE_TASKS_REDIRECT_URI ||
     `${BASE_URL}/api/auth/google-tasks/callback`;
 

--- a/src/app/api/auth/google-tasks/route.ts
+++ b/src/app/api/auth/google-tasks/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireRole } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
 import { oauthSetupRedirect } from '@/lib/integrations/oauthSetupRedirect';
 import { resolveRedirectUri } from '@/lib/integrations/resolveRedirectUri';
+import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 // `openid email` lets us identify which Google account authorized, for the
@@ -18,7 +19,13 @@ export async function GET(request: Request) {
   const forbidden = requireRole(auth, 'canManageIntegrations');
   if (forbidden) return forbidden;
 
-  const clientId = process.env.GOOGLE_CLIENT_ID;
+  // Credentials may be stored in the database (Settings, or the paste-a-token
+  // flow) rather than the environment. Reading the env var directly made this
+  // route dead-end for every in-app configured install: no env var, so it
+  // redirected to a setup wizard that no longer offers Google once setup is
+  // complete. Calendar and Gmail have always gone through the credential store.
+  const credentials = await getGoogleCredentials();
+  const clientId = credentials?.clientId;
   const redirectUri = resolveRedirectUri(request, '/api/auth/google-tasks/callback'); // dynamic redirect URI per request (#124)
 
   if (!clientId) {

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -54,6 +54,13 @@ const PASTEABLE: Array<{ key: GoogleCapability; blurb: string; note?: React.Reac
  *
  * Write-only: the secret and refresh token are never read back to the UI.
  */
+/**
+ * Where the Google Tasks list picker lives. Matches the redirect the browser
+ * OAuth callback issues, so both paths land in the same place.
+ */
+const TASK_LIST_PICKER_URL =
+  '/settings?section=integrations&selectGoogleTasksList=true&newConnection=true#google-tasks';
+
 export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
   const { confirm, dialogProps } = useConfirmDialog();
   const [clientId, setClientId] = React.useState('');
@@ -116,7 +123,7 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
         );
       }
       if (data.capabilities?.includes('gmail')) parts.push('Gmail connected for bus tracking');
-      if (data.needsTaskListSelection) parts.push('choose which task lists to show under Tasks sync');
+      if (data.needsTaskListSelection) parts.push('choose which task lists to show');
       toast({
         title: `Google connected: ${data.enabled ?? 'Calendar'}`,
         description: parts.join(' · ') || undefined,
@@ -126,6 +133,16 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
       setClientSecret('');
       setRefreshToken('');
       onSaved?.();
+
+      // Tasks tokens are parked in Redis for five minutes and spent by the
+      // list picker, which only opens from these query params — the browser
+      // callback redirects to exactly this URL. Without navigating here the
+      // token expires unspent and Tasks silently never connects, which is the
+      // whole feature for a LAN-only install. Told the user to "choose which
+      // lists" and then leaving them no way to get there is not a fix.
+      if (data.needsTaskListSelection) {
+        window.location.href = TASK_LIST_PICKER_URL;
+      }
     } catch (err) {
       toast({
         title: 'Could not connect',

--- a/src/lib/integrations/tasks/__tests__/googleTasksCredentials.test.ts
+++ b/src/lib/integrations/tasks/__tests__/googleTasksCredentials.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Google Tasks must read credentials from the same place everything else does.
+ *
+ * Three call sites in the Tasks path read process.env.GOOGLE_CLIENT_ID
+ * directly while Calendar, Gmail, oauth-status and the paste-a-token flow all
+ * went through getGoogleCredentials(). On an install configured through the
+ * app rather than the environment that meant:
+ *
+ *   - Connect dead-ended: no env var, so it redirected to a setup wizard that
+ *     no longer offers Google once setup is complete
+ *   - and worse, token refresh returned null, so sync worked for about an hour
+ *     and then stopped for good
+ *
+ * The second is why this is tested rather than just fixed: it is invisible
+ * until an access token expires.
+ */
+const mockGetCreds = jest.fn();
+jest.mock('@/lib/integrations/credentialStore', () => ({
+  getGoogleCredentials: (...a: unknown[]) => mockGetCreds(...a),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import googleTasksProvider from '../google-tasks';
+
+const ENV_KEYS = ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The environment is deliberately empty: this is the configuration that used
+  // to fail, and the one every in-app configured install actually has.
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  mockGetCreds.mockResolvedValue({
+    clientId: 'db-client-id',
+    clientSecret: 'db-client-secret',
+    redirectUri: '',
+    gmailRedirectUri: '',
+  });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ access_token: 'fresh', expires_in: 3600 }),
+  });
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('googleTasksProvider.refreshTokens', () => {
+  it('refreshes using database credentials when the environment has none', async () => {
+    const result = await googleTasksProvider.refreshTokens!({
+      accessToken: 'old',
+      refreshToken: 'rt',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.accessToken).toBe('fresh');
+    expect(mockGetCreds).toHaveBeenCalled();
+  });
+
+  it('sends the stored client pair to Google, not an empty one', async () => {
+    await googleTasksProvider.refreshTokens!({ accessToken: 'old', refreshToken: 'rt' });
+
+    const body = String(mockFetch.mock.calls[0][1].body);
+    expect(body).toContain('client_id=db-client-id');
+    expect(body).toContain('client_secret=db-client-secret');
+  });
+
+  it('still returns null when nothing is configured anywhere', async () => {
+    mockGetCreds.mockResolvedValue(null);
+    const result = await googleTasksProvider.refreshTokens!({
+      accessToken: 'old',
+      refreshToken: 'rt',
+    });
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not call Google without a refresh token', async () => {
+    const result = await googleTasksProvider.refreshTokens!({ accessToken: 'old' });
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/integrations/tasks/google-tasks.ts
+++ b/src/lib/integrations/tasks/google-tasks.ts
@@ -7,6 +7,7 @@
  * API Reference: https://developers.google.com/tasks/reference/rest
  */
 
+import { getGoogleCredentials } from '@/lib/integrations/credentialStore';
 import type {
   TaskProvider,
   TaskProviderTokens,
@@ -221,8 +222,13 @@ export const googleTasksProvider: TaskProvider = {
       return null;
     }
 
-    const clientId = process.env.GOOGLE_CLIENT_ID;
-    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    // The worst of the three: reading the env var here meant sync worked until
+    // the access token expired, about an hour, and then stopped for good on any
+    // install whose credentials live in the database — which is every install
+    // that used the in-app form or the paste-a-token flow.
+    const credentials = await getGoogleCredentials();
+    const clientId = credentials?.clientId;
+    const clientSecret = credentials?.clientSecret;
 
     if (!clientId || !clientSecret) {
       console.error('Google OAuth credentials not configured');


### PR DESCRIPTION
Three call sites in the Google Tasks path read `process.env.GOOGLE_CLIENT_ID` directly, while Calendar, Gmail, `oauth-status` and the paste-a-token flow all go through `getGoogleCredentials()`.

On an install configured **through the app** rather than the environment — which is every install that used the in-app credentials form or the paste-a-token flow added in 1.16.2 — the env var is absent. So:

| Call site | Consequence |
|---|---|
| `auth/google-tasks/route.ts:21` | Connect redirects to the setup wizard, which no longer offers Google once setup is complete. Round and round. |
| `auth/google-tasks/callback/route.ts:20` | The code exchange would fail for the same reason. |
| `tasks/google-tasks.ts:224` | **`refreshTokens` returns null** — sync works until the access token expires (~1 hour), then stops for good, reporting only "Google OAuth credentials not configured". |

The third is the one that matters. It made the Tasks half of the 1.18.2 paste-a-token feature appear to work and then quietly stop — the exact failure mode this area keeps producing, and it would have hit the user who asked for Google Tasks in the first place.

## The fix

All three read the same store as everything else. `getGoogleCredentials()` already falls back to the environment, so env-configured installs are unaffected.

## How it was found

Setting up a Google Tasks connection on the demo instance, which has credentials in the database and none in its environment. The connect loop was visible immediately; the refresh failure was not, and is why this has tests rather than just a fix.

## Testing

Four cases on `refreshTokens` with the environment deliberately empty — the configuration that used to fail: it refreshes from stored credentials, sends the stored pair rather than an empty one, still returns null when nothing is configured anywhere, and never calls Google without a refresh token.

1,487 tests pass, typecheck clean.
