### PR TITLE
fix(tasks): give the task list a delete button

### DIFF
--- a/src/app/tasks/GroupedTaskGrid.tsx
+++ b/src/app/tasks/GroupedTaskGrid.tsx
@@ -16,6 +16,7 @@ export function GroupedTaskGrid({
   groups,
   toggleTask,
   editTask,
+  deleteTask,
   setCelebratingUser,
   taskLists,
   isMobile = false,
@@ -23,6 +24,7 @@ export function GroupedTaskGrid({
   groups: GroupDef[];
   toggleTask: (id: string) => Promise<boolean>;
   editTask: (task: Task) => void;
+  deleteTask: (taskId: string) => void;
   setCelebratingUser: (user: { id: string; name: string } | null) => void;
   taskLists: Array<{ id: string; name: string; color?: string | null }>;
   isMobile?: boolean;
@@ -153,6 +155,7 @@ export function GroupedTaskGrid({
                     }
                   }}
                   onEdit={() => editTask(task)}
+                  onDelete={() => deleteTask(task.id)}
                   showList={true}
                   taskLists={taskLists}
                 />

--- a/src/app/tasks/NestedGroupedTaskGrid.tsx
+++ b/src/app/tasks/NestedGroupedTaskGrid.tsx
@@ -16,12 +16,14 @@ export function NestedGroupedTaskGrid({
   primaryGroups,
   toggleTask,
   editTask,
+  deleteTask,
   setCelebratingUser,
   isMobile = false,
 }: {
   primaryGroups: NestedGroupDef[];
   toggleTask: (id: string) => Promise<boolean>;
   editTask: (task: Task) => void;
+  deleteTask: (taskId: string) => void;
   setCelebratingUser: (user: { id: string; name: string } | null) => void;
   isMobile?: boolean;
 }) {
@@ -156,6 +158,7 @@ export function NestedGroupedTaskGrid({
                           }
                         }}
                         onEdit={() => editTask(task)}
+                  onDelete={() => deleteTask(task.id)}
                       />
                     ))}
                   </div>

--- a/src/app/tasks/TaskContentArea.tsx
+++ b/src/app/tasks/TaskContentArea.tsx
@@ -30,6 +30,7 @@ interface TaskContentAreaProps {
   handleInlineAdd: (assignedTo?: string, listId?: string) => void;
   toggleTask: (id: string) => Promise<boolean>;
   editTask: (task: Task) => void;
+  deleteTask: (taskId: string) => void;
   setCelebratingUser: (user: { id: string; name: string } | null) => void;
   taskLists: Array<{ id: string; name: string; color?: string | null }>;
   isMobile: boolean;
@@ -55,6 +56,7 @@ export function TaskContentArea({
   handleInlineAdd,
   toggleTask,
   editTask,
+  deleteTask,
   setCelebratingUser,
   taskLists,
   isMobile,
@@ -108,6 +110,7 @@ export function TaskContentArea({
         }))}
         toggleTask={toggleTask}
         editTask={editTask}
+        deleteTask={deleteTask}
         setCelebratingUser={setCelebratingUser}
         taskLists={taskLists}
         isMobile={isMobile}
@@ -130,6 +133,7 @@ export function TaskContentArea({
         }))}
         toggleTask={toggleTask}
         editTask={editTask}
+        deleteTask={deleteTask}
         setCelebratingUser={setCelebratingUser}
         taskLists={taskLists}
         isMobile={isMobile}
@@ -156,6 +160,7 @@ export function TaskContentArea({
         }))}
         toggleTask={toggleTask}
         editTask={editTask}
+        deleteTask={deleteTask}
         setCelebratingUser={setCelebratingUser}
         isMobile={isMobile}
       />
@@ -178,6 +183,7 @@ export function TaskContentArea({
         }))}
         toggleTask={toggleTask}
         editTask={editTask}
+        deleteTask={deleteTask}
         setCelebratingUser={setCelebratingUser}
         isMobile={isMobile}
       />
@@ -205,6 +211,7 @@ export function TaskContentArea({
           task={task}
           onToggle={() => toggleTask(task.id)}
           onEdit={() => editTask(task)}
+          onDelete={() => deleteTask(task.id)}
           showAvatar={true}
           showList={true}
           taskLists={taskLists}

--- a/src/app/tasks/TaskModal.tsx
+++ b/src/app/tasks/TaskModal.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import type { Task, FamilyMember } from '@/types';
+import { Trash2 } from 'lucide-react';
 
 interface TaskList {
   id: string;
@@ -22,12 +23,15 @@ export function TaskModal({
   task,
   onClose,
   onSave,
+  onDelete,
   familyMembers,
   taskLists = [],
   defaultListId,
 }: {
   task?: Task;
   onClose: () => void;
+  /** Omitted when creating, and where a caller has no delete path. */
+  onDelete?: () => void;
   // dueDate may be `null` to signal explicit clearing (server distinguishes
   // null = clear from undefined = leave untouched).
   onSave: (task: Omit<Task, 'id' | 'dueDate'> & { dueDate: Date | null; listId?: string }) => void;
@@ -210,7 +214,22 @@ export function TaskModal({
             </div>
           )}
 
-          <div className="flex justify-end gap-2 pt-4">
+          <div className="flex items-center gap-2 pt-4">
+            {/* Only when editing an existing task. Matches ChoreModal, which
+                is the closest equivalent: destructive action on the left,
+                separated from the confirming actions on the right. */}
+            {task && onDelete && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive hover:text-destructive hover:bg-destructive/10 gap-1"
+                onClick={onDelete}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </Button>
+            )}
+            <div className="flex-1" />
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/src/app/tasks/TaskRow.tsx
+++ b/src/app/tasks/TaskRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { format, isPast, differenceInDays, formatDistanceToNow } from 'date-fns';
-import { CalendarDays, Settings } from 'lucide-react';
+import { CalendarDays, Settings, Trash2 } from 'lucide-react';
 import { UserAvatar } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -12,6 +12,7 @@ export function TaskRow({
   task,
   onToggle,
   onEdit,
+  onDelete,
   showAvatar = false,
   showList = false,
   taskLists = [],
@@ -19,6 +20,8 @@ export function TaskRow({
   task: Task;
   onToggle: () => void;
   onEdit: () => void;
+  /** Omitted where a row is not deletable; the button is then not rendered. */
+  onDelete?: () => void;
   showAvatar?: boolean;
   showList?: boolean;
   taskLists?: Array<{ id: string; name: string; color?: string | null }>;
@@ -90,9 +93,26 @@ export function TaskRow({
               e.stopPropagation();
               onEdit();
             }}
+            aria-label="Edit task"
           >
             <Settings className="h-3 w-3" />
           </Button>
+          {onDelete && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0 opacity-50 hover:opacity-100 hover:text-destructive"
+              onClick={(e) => {
+                // The row itself toggles completion, so a delete tap must not
+                // also mark the task done on its way out.
+                e.stopPropagation();
+                onDelete();
+              }}
+              aria-label="Delete task"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -212,6 +212,13 @@ export function TasksView() {
           <TaskModal
             task={editingTask}
             onClose={() => setEditingTask(null)}
+            onDelete={() => {
+              // Close first: deleteTask opens its own confirmation, and two
+              // stacked dialogs on a wall display is a trap.
+              const id = editingTask.id;
+              setEditingTask(null);
+              deleteTask(id);
+            }}
             onSave={async (updatedTask) => {
               try {
                 const res = await fetch(`/api/tasks/${editingTask.id}`, {

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -36,7 +36,7 @@ export function TasksView() {
     showAddModal, setShowAddModal,
     editingTask, setEditingTask,
     filteredTasks,
-    toggleTask, editTask, handleAddClick,
+    toggleTask, editTask, deleteTask, handleAddClick,
     completedCount, totalCount,
     taskLists,
     autoSyncing,
@@ -166,6 +166,7 @@ export function TasksView() {
 
         <div className="flex-1 overflow-y-auto p-4">
           <TaskContentArea
+            deleteTask={deleteTask}
             loading={loading} error={error} filteredTasks={filteredTasks}
             groupMode={groupMode}
             tasksByUser={tasksByUser} tasksByList={tasksByList}

--- a/src/app/tasks/__tests__/TaskRow.test.tsx
+++ b/src/app/tasks/__tests__/TaskRow.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * TaskRow's actions.
+ *
+ * The Tasks page renders TaskRow, which offered edit only — there was no way
+ * to delete a task anywhere in the UI. The handler, the confirmation dialog
+ * and the API route all existed; nothing rendered a control that reached them.
+ *
+ * The row itself toggles completion on click, so the risk with adding a
+ * delete button is that tapping it also marks the task done on the way out.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TaskRow } from '../TaskRow';
+import type { Task } from '@/types';
+
+const task = {
+  id: 't1',
+  title: 'Take out the bins',
+  completed: false,
+  priority: 'normal',
+  dueDate: null,
+} as unknown as Task;
+
+describe('TaskRow', () => {
+  it('offers a delete action when a handler is given', () => {
+    render(<TaskRow task={task} onToggle={jest.fn()} onEdit={jest.fn()} onDelete={jest.fn()} />);
+    // jest-dom matchers are not set up in this repo; getBy* throws when absent.
+    expect(screen.getByLabelText('Delete task')).toBeTruthy();
+  });
+
+  it('omits it entirely when no handler is given', () => {
+    // Rows in read-only contexts must not show a control that does nothing.
+    render(<TaskRow task={task} onToggle={jest.fn()} onEdit={jest.fn()} />);
+    expect(screen.queryByLabelText('Delete task')).toBeNull();
+  });
+
+  it('deletes without also toggling the task complete', () => {
+    const onDelete = jest.fn();
+    const onToggle = jest.fn();
+    render(<TaskRow task={task} onToggle={onToggle} onEdit={jest.fn()} onDelete={onDelete} />);
+
+    fireEvent.click(screen.getByLabelText('Delete task'));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('edits without also toggling', () => {
+    const onEdit = jest.fn();
+    const onToggle = jest.fn();
+    render(<TaskRow task={task} onToggle={onToggle} onEdit={onEdit} onDelete={jest.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Edit task'));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('still toggles when the row body is clicked', () => {
+    const onToggle = jest.fn();
+    render(<TaskRow task={task} onToggle={onToggle} onEdit={jest.fn()} onDelete={jest.fn()} />);
+
+    fireEvent.click(screen.getByText('Take out the bins'));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
**There was no way to delete a task anywhere in the UI.**

The Tasks page renders `TaskRow`, which offered edit only. `TaskItem` *does* have a delete button — but nothing renders `TaskItem`. It's dead code.

Everything behind the button already existed:

- `useTasksViewData.deleteTask` — confirmation dialog, parent-role check, optimistic update, rollback on failure
- `DELETE /api/tasks/[id]` — working all along

The handler was exported and had **zero consumers**. The two were never connected.

## The fix

`TaskRow` takes an optional `onDelete` and renders a trash button when given, threaded through `TaskContentArea` and both grid layouts. Optional rather than required, so a read-only context doesn't show a control that does nothing.

The click handler stops propagation — the row body toggles completion, so without it deleting a task would also mark it done on the way out. That's the one real hazard here and it has a test.

## How it was found

Trying to test delete propagation to Google Tasks through the UI, which turned out to be unreachable. Worth noting for #317: the delete-propagation fix there is correct, but until this lands it's only reachable by direct API call.

## Testing

Five cases: the button appears when a handler is given, is absent when not, delete fires without toggling, edit fires without toggling, and the row body still toggles.

1,488 tests pass, typecheck clean.
