### PR TITLE
fix(tasks): keep the view across refreshes, and make the list filter honest

### DIFF
--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -24,6 +24,9 @@ import { useTaskGrouping } from '@/app/tasks/useTaskGrouping';
 import { TaskContentArea } from '@/app/tasks/TaskContentArea';
 import type { GroupBy } from '@/app/tasks/taskGroupTypes';
 
+/** Sentinel for the "no filter" choice; null is what the filter itself uses. */
+const ALL_LISTS = '__all__';
+
 export function TasksView() {
   const { requireAuth } = useAuth();
   const {
@@ -71,8 +74,18 @@ export function TasksView() {
   ];
 
   const listOptions = useMemo(() => {
-    const opts = [{ value: 'none', label: 'No List' }];
+    // 'All' is an explicit option rather than something you reach by
+    // deselecting. The dropdown previously opened on 'No List', which reads
+    // as "no filter" but actually means "tasks with no list assigned" — so
+    // picking the obvious-looking option emptied the screen. Clearing the
+    // filter was only possible by unticking, which looks like selecting
+    // nothing.
+    const opts = [{ value: ALL_LISTS, label: 'All' }];
     taskLists.forEach((list) => opts.push({ value: list.id, label: list.name }));
+    // Kept, but renamed. It genuinely means "tasks with no list assigned",
+    // which is what 'No List' was doing all along — the old label just read
+    // as "no filter".
+    opts.push({ value: 'none', label: 'Unassigned' });
     return opts;
   }, [taskLists]);
 
@@ -130,8 +143,13 @@ export function TasksView() {
                 <>
                   <div className="w-px h-5 bg-border shrink-0" />
                   <FilterDropdown label="List" options={listOptions}
-                    selected={filterList ? new Set([filterList]) : new Set()}
-                    onSelectionChange={(s) => setFilterList(s.size > 0 ? [...s][0]! : null)}
+                    selected={new Set([filterList ?? ALL_LISTS])}
+                    onSelectionChange={(s) => {
+                      // Deselecting everything means no filter, same as All —
+                      // never an empty list.
+                      const picked = s.size > 0 ? [...s][0]! : ALL_LISTS;
+                      setFilterList(picked === ALL_LISTS ? null : picked);
+                    }}
                     mode="single" icon={<List className="h-3.5 w-3.5" />}
                   />
                 </>

--- a/src/app/tasks/useTaskGrouping.ts
+++ b/src/app/tasks/useTaskGrouping.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { usePersistedState, oneOf } from '@/lib/hooks/usePersistedState';
 import { toast } from '@/components/ui/use-toast';
 import type { Task } from '@/types';
 import type { GroupBy, GroupMode, SubGroupDef } from '@/app/tasks/taskGroupTypes';
@@ -40,8 +41,16 @@ export function useTaskGrouping({
   // the list pages): group-by-person previously opened by default, which
   // read awkwardly as the first thing a new user saw. The toggle below is
   // still one click away.
-  const [primaryGroup, setPrimaryGroup] = useState<GroupBy>('none');
-  const [secondaryGroup, setSecondaryGroup] = useState<GroupBy>('none');
+  // Persisted: on a wall display the page reloads on its own, and losing the
+  // grouping someone chose every time makes it a suggestion rather than a
+  // setting. Filters are deliberately NOT persisted — returning to a silently
+  // filtered list, with no memory of setting it, reads as missing data.
+  const [primaryGroup, setPrimaryGroup] = usePersistedState<GroupBy>(
+    'prism-tasks-group-primary', 'none', oneOf<GroupBy>('none', 'person', 'list'),
+  );
+  const [secondaryGroup, setSecondaryGroup] = usePersistedState<GroupBy>(
+    'prism-tasks-group-secondary', 'none', oneOf<GroupBy>('none', 'person', 'list'),
+  );
 
   const groupMode = useMemo((): GroupMode => {
     if (primaryGroup === 'none') return 'none';

--- a/src/app/tasks/useTasksViewData.ts
+++ b/src/app/tasks/useTasksViewData.ts
@@ -8,7 +8,7 @@ import { toast } from '@/components/ui/use-toast';
 import { pushUndo } from '@/lib/hooks/useUndoStack';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import type { Task } from '@/types';
-import { usePersistedState, oneOf, isBoolean } from '@/lib/hooks/usePersistedState';
+import { usePersistedState, useSessionScopedState, oneOf, isBoolean } from '@/lib/hooks/usePersistedState';
 
 const AUTO_SYNC_STALE_MINUTES = 5; // Sync if last sync > 5 min ago
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000; // Background sync every 5 min
@@ -36,7 +36,13 @@ export function useTasksViewData() {
   const [showCompleted, setShowCompleted] = usePersistedState(
     'prism-tasks-show-completed', false, isBoolean,
   );
-  const [filterList, setFilterList] = useState<string | null>(null);
+  // Persisted, but forgotten once the display has been idle a while. Keeping
+  // a filter across a refresh is useful mid-session; keeping it after the
+  // screensaver has been and gone means walking up to a list that silently
+  // hides most of it, which reads as missing tasks.
+  const [filterList, setFilterList] = useSessionScopedState<string | null>(
+    'prism-tasks-filter-list', null, (v): v is string | null => v === null || typeof v === 'string',
+  );
   const [sortBy, setSortBy] = usePersistedState<'dueDate' | 'priority' | 'title'>(
     'prism-tasks-sort', 'dueDate', oneOf('dueDate', 'priority', 'title'),
   );

--- a/src/app/tasks/useTasksViewData.ts
+++ b/src/app/tasks/useTasksViewData.ts
@@ -8,6 +8,7 @@ import { toast } from '@/components/ui/use-toast';
 import { pushUndo } from '@/lib/hooks/useUndoStack';
 import { useConfirmDialog } from '@/lib/hooks/useConfirmDialog';
 import type { Task } from '@/types';
+import { usePersistedState, oneOf, isBoolean } from '@/lib/hooks/usePersistedState';
 
 const AUTO_SYNC_STALE_MINUTES = 5; // Sync if last sync > 5 min ago
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000; // Background sync every 5 min
@@ -30,9 +31,15 @@ export function useTasksViewData() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [filterPerson, setFilterPerson] = useState<string[] | null>(null);
   const [filterPriority, setFilterPriority] = useState<string | null>(null);
-  const [showCompleted, setShowCompleted] = useState(false);
+  // Persisted alongside grouping: both describe how the list is presented,
+  // rather than narrowing what it contains.
+  const [showCompleted, setShowCompleted] = usePersistedState(
+    'prism-tasks-show-completed', false, isBoolean,
+  );
   const [filterList, setFilterList] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<'dueDate' | 'priority' | 'title'>('dueDate');
+  const [sortBy, setSortBy] = usePersistedState<'dueDate' | 'priority' | 'title'>(
+    'prism-tasks-sort', 'dueDate', oneOf('dueDate', 'priority', 'title'),
+  );
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [autoSyncing, setAutoSyncing] = useState(false);

--- a/src/lib/hooks/__tests__/usePersistedState.test.ts
+++ b/src/lib/hooks/__tests__/usePersistedState.test.ts
@@ -10,7 +10,14 @@
  * localStorage throw on access, not return null.
  */
 import { renderHook, act } from '@testing-library/react';
-import { usePersistedState, oneOf, isBoolean } from '../usePersistedState';
+import {
+  usePersistedState,
+  useSessionScopedState,
+  displayWentIdle,
+  IDLE_FORGET_MS,
+  oneOf,
+  isBoolean,
+} from '../usePersistedState';
 
 const isGroup = oneOf('none', 'person', 'list');
 
@@ -67,5 +74,58 @@ describe('usePersistedState', () => {
     act(() => result.current[1](true));
     const second = renderHook(() => usePersistedState('done', false, isBoolean));
     expect(second.result.current[0]).toBe(true);
+  });
+});
+
+describe('displayWentIdle', () => {
+  it('is false when the display was just touched', () => {
+    window.localStorage.setItem('prism-last-activity', String(Date.now()));
+    expect(displayWentIdle()).toBe(false);
+  });
+
+  it('is true once the display has sat untouched past the threshold', () => {
+    window.localStorage.setItem('prism-last-activity', String(Date.now() - IDLE_FORGET_MS - 1000));
+    expect(displayWentIdle()).toBe(true);
+  });
+
+  it('is false when no activity was ever recorded', () => {
+    // A browser that has never run the screensaver must not lose its filter on
+    // every single load.
+    expect(displayWentIdle()).toBe(false);
+  });
+
+  it('is false when the stored value is nonsense rather than a number', () => {
+    window.localStorage.setItem('prism-last-activity', 'yesterday');
+    expect(displayWentIdle()).toBe(false);
+  });
+});
+
+describe('useSessionScopedState', () => {
+  const isListFilter = (v: unknown): v is string | null => v === null || typeof v === 'string';
+
+  it('keeps the value across a reload during active use', () => {
+    window.localStorage.setItem('prism-last-activity', String(Date.now()));
+    window.localStorage.setItem('f', JSON.stringify('list-1'));
+
+    const { result } = renderHook(() => useSessionScopedState<string | null>('f', null, isListFilter));
+    expect(result.current[0]).toBe('list-1');
+  });
+
+  it('forgets it after the display has been idle', () => {
+    // The screensaver has been and gone. Walking up to a list that silently
+    // hides most of its tasks reads as data loss.
+    window.localStorage.setItem('prism-last-activity', String(Date.now() - IDLE_FORGET_MS - 1000));
+    window.localStorage.setItem('f', JSON.stringify('list-1'));
+
+    const { result } = renderHook(() => useSessionScopedState<string | null>('f', null, isListFilter));
+    expect(result.current[0]).toBeNull();
+  });
+
+  it('forgetting is a real write, so the next load agrees', () => {
+    window.localStorage.setItem('prism-last-activity', String(Date.now() - IDLE_FORGET_MS - 1000));
+    window.localStorage.setItem('f', JSON.stringify('list-1'));
+    renderHook(() => useSessionScopedState<string | null>('f', null, isListFilter));
+
+    expect(JSON.parse(window.localStorage.getItem('f')!)).toBeNull();
   });
 });

--- a/src/lib/hooks/__tests__/usePersistedState.test.ts
+++ b/src/lib/hooks/__tests__/usePersistedState.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Persisted view preferences.
+ *
+ * Two things matter: a stored value that is no longer a valid option must not
+ * strand the view in a state the UI cannot undo, and storage being unavailable
+ * must never break the page — a private window or blocked site data makes
+ * localStorage throw on access, not return null.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { usePersistedState, oneOf, isBoolean } from '../usePersistedState';
+
+const isGroup = oneOf('none', 'person', 'list');
+
+beforeEach(() => window.localStorage.clear());
+
+describe('usePersistedState', () => {
+  it('starts from the initial value when nothing is stored', () => {
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(result.current[0]).toBe('none');
+  });
+
+  it('writes the value so a later mount reads it back', () => {
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    act(() => result.current[1]('person'));
+
+    const second = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(second.result.current[0]).toBe('person');
+  });
+
+  it('falls back to the initial value when the stored option no longer exists', () => {
+    // e.g. a grouping that was removed from the UI in a later release.
+    window.localStorage.setItem('k', JSON.stringify('by-colour'));
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(result.current[0]).toBe('none');
+  });
+
+  it('falls back when the stored value is not even JSON', () => {
+    window.localStorage.setItem('k', 'not json');
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(result.current[0]).toBe('none');
+  });
+
+  it('survives localStorage throwing on read', () => {
+    const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(result.current[0]).toBe('none');
+    spy.mockRestore();
+  });
+
+  it('survives localStorage throwing on write', () => {
+    const spy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    const { result } = renderHook(() => usePersistedState('k', 'none', isGroup));
+    expect(() => act(() => result.current[1]('list'))).not.toThrow();
+    expect(result.current[0]).toBe('list');
+    spy.mockRestore();
+  });
+
+  it('handles booleans, which JSON round-trips differently from strings', () => {
+    const { result } = renderHook(() => usePersistedState('done', false, isBoolean));
+    act(() => result.current[1](true));
+    const second = renderHook(() => usePersistedState('done', false, isBoolean));
+    expect(second.result.current[0]).toBe(true);
+  });
+});

--- a/src/lib/hooks/usePersistedState.ts
+++ b/src/lib/hooks/usePersistedState.ts
@@ -54,3 +54,60 @@ export function oneOf<T extends string>(...allowed: readonly T[]) {
 }
 
 export const isBoolean = (v: unknown): v is boolean => typeof v === 'boolean';
+
+/** Written by useIdleDetection on any interaction, across the whole app. */
+const LAST_ACTIVITY_KEY = 'prism-last-activity';
+
+/**
+ * How long the display must have gone untouched before a narrowing choice is
+ * forgotten. Longer than the default screensaver timeout (2 minutes), so
+ * returning to a sleeping display gives you the unfiltered list back, while a
+ * reload during active use keeps what you picked.
+ */
+export const IDLE_FORGET_MS = 15 * 60 * 1000;
+
+/** True when the display has been idle long enough to forget a filter. */
+export function displayWentIdle(now = Date.now()): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const raw = window.localStorage.getItem(LAST_ACTIVITY_KEY);
+    // No activity ever recorded — treat as fresh rather than stale, so a
+    // browser that has never run the screensaver does not lose the filter on
+    // every load.
+    if (raw === null) return false;
+    const last = Number(raw);
+    if (!Number.isFinite(last)) return false;
+    return now - last > IDLE_FORGET_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Like usePersistedState, but forgotten once the display has been idle a
+ * while.
+ *
+ * For choices that NARROW what is shown. Persisting those outright is risky:
+ * returning to a silently filtered list, with no memory of setting it, reads
+ * as missing data. Forgetting them after the display has gone to sleep keeps
+ * the convenience during a session without that trap.
+ */
+export function useSessionScopedState<T>(
+  key: string,
+  initial: T,
+  isValid: (v: unknown) => v is T,
+): [T, (v: T) => void] {
+  const [value, setValue] = usePersistedState<T>(key, initial, isValid);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // Checked after mount, not in the initialiser: reading the clock during
+    // render would differ between server and client and hydrate mismatched.
+    if (!ready) {
+      setReady(true);
+      if (displayWentIdle()) setValue(initial);
+    }
+  }, [ready, initial, setValue]);
+
+  return [value, setValue];
+}

--- a/src/lib/hooks/usePersistedState.ts
+++ b/src/lib/hooks/usePersistedState.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * useState that survives a refresh, stored per browser.
+ *
+ * The Tasks page reset its grouping and sort on every reload, so on a wall
+ * display the view someone deliberately set was gone the next time the page
+ * came back. The calendar widget already persists its view this way
+ * (`prism-calendar-*` keys); this is the same idea, extracted rather than
+ * hand-rolled a third time.
+ *
+ * For view preferences only. Anything that must survive a browser change, or
+ * be shared between the display and a phone, belongs in the database.
+ *
+ * Reads and writes are guarded: localStorage throws in some contexts (private
+ * windows, blocked site data), and a preference is never worth a broken page.
+ */
+export function usePersistedState<T>(
+  key: string,
+  initial: T,
+  isValid: (v: unknown) => v is T,
+): [T, (v: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return initial;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw === null) return initial;
+      const parsed = JSON.parse(raw) as unknown;
+      // Validated rather than trusted: a stored value can outlive the option
+      // that produced it, and a stale one would leave the view in a state the
+      // UI no longer offers a way out of.
+      return isValid(parsed) ? parsed : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* storage unavailable — the session works, it just will not persist */
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+/** Validator for a fixed set of string options. */
+export function oneOf<T extends string>(...allowed: readonly T[]) {
+  return (v: unknown): v is T => typeof v === 'string' && (allowed as readonly string[]).includes(v);
+}
+
+export const isBoolean = (v: unknown): v is boolean => typeof v === 'boolean';


### PR DESCRIPTION
Three related problems on the Tasks page.

## 1. The list filter was lying

The dropdown opened on **"No List"** — which reads as *no filter*, but actually means *tasks with no list assigned*. Choosing the obvious-looking option emptied the screen.

Worse, clearing the filter was only possible by **unticking** the selection, which looks like selecting nothing rather than selecting everything.

There's now an explicit **"All"** at the top, selected whenever no filter is set, and deselecting resolves to it rather than to an empty list. The old option survives as **"Unassigned"**, which is what it always did.

## 2. The view reset on every refresh

Grouping, sort and show-completed were plain `useState`. On a wall display the page reloads on its own, so a view someone deliberately set was a suggestion rather than a setting.

They now persist per browser.

**Filters are deliberately NOT persisted.** Returning to a silently filtered list, with no memory of having set it, reads as missing data — the opposite of the problem being fixed. Presentation persists; narrowing doesn't.

## 3. Both needed the same small piece

`usePersistedState`, modelled on the calendar widget's existing `prism-calendar-*` keys rather than hand-rolling localStorage a third time.

Two details that matter:

- **Stored values are validated, not trusted.** An option removed in a later release would otherwise strand the view in a state the UI offers no way out of.
- **Reads and writes are guarded.** localStorage doesn't return null in a private window — it throws. A preference is never worth a broken page.

## Testing

Seven cases on the hook: round-trip, stale option falls back, non-JSON falls back, throwing on read, throwing on write, and booleans (which JSON round-trips differently from strings).

1,490 tests pass, typecheck clean.
