### PR TITLE
fix(tasks): hold CalDAV task deletions for review too

### DIFF
--- a/src/app/api/tasks/pending-deletions/route.ts
+++ b/src/app/api/tasks/pending-deletions/route.ts
@@ -44,6 +44,10 @@ export async function GET() {
         provider: taskSources.provider,
         listName: taskSources.externalListName,
         prismList: taskLists.name,
+        // CalDAV task rows carry no task_source_id, so the join above yields
+        // nothing for them. Their origin is encoded in the external id
+        // instead: caldav:<sourceId>:<uid>.
+        externalId: tasks.externalId,
       })
       .from(tasks)
       .leftJoin(taskSources, eq(tasks.taskSourceId, taskSources.id))
@@ -51,9 +55,10 @@ export async function GET() {
       .where(isNotNull(tasks.pendingDeletion))
       .orderBy(tasks.title);
 
-    const providerLabel = (p: string | null) => {
+    const providerLabel = (p: string | null, externalId: string | null) => {
       if (p === 'google_tasks') return 'Google Tasks';
       if (p === 'microsoft_todo') return 'Microsoft To Do';
+      if (externalId?.startsWith('caldav:')) return 'Reminders (CalDAV)';
       return p ?? 'its source';
     };
 
@@ -63,7 +68,9 @@ export async function GET() {
         title: r.title,
         dueDate: r.dueDate,
         completed: r.completed,
-        source: r.listName ? `${providerLabel(r.provider)} — ${r.listName}` : providerLabel(r.provider),
+        source: r.listName
+          ? `${providerLabel(r.provider, r.externalId)} — ${r.listName}`
+          : providerLabel(r.provider, r.externalId),
         list: r.prismList,
       })),
       count: rows.length,

--- a/src/app/tasks/useTasksViewData.ts
+++ b/src/app/tasks/useTasksViewData.ts
@@ -14,7 +14,7 @@ const AUTO_SYNC_STALE_MINUTES = 5; // Sync if last sync > 5 min ago
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000; // Background sync every 5 min
 
 export function useTasksViewData() {
-  const { requireAuth } = useAuth();
+  const { requireAuth, activeUser } = useAuth();
   const { confirm, dialogProps: confirmDialogProps } = useConfirmDialog();
 
   const {
@@ -59,6 +59,15 @@ export function useTasksViewData() {
       return;
     }
 
+    // sync-all requires canManageIntegrations, which only a parent has. A
+    // child profile would fire this every five minutes, be refused, and land
+    // in the silent catch below — so the page quietly stopped updating with
+    // nothing to indicate why. Not attempting it is honest; the refusal was
+    // never going to become a sync.
+    if (activeUser && activeUser.role !== 'parent') {
+      return;
+    }
+
     setAutoSyncing(true);
     try {
       const res = await fetch(`/api/task-sources/sync-all?staleMinutes=${AUTO_SYNC_STALE_MINUTES}`, {
@@ -77,7 +86,7 @@ export function useTasksViewData() {
     } finally {
       setAutoSyncing(false);
     }
-  }, [refreshTasks]);
+  }, [refreshTasks, activeUser]);
 
   // Auto-sync on mount
   useEffect(() => {

--- a/src/lib/services/__tests__/taskDeletionReview.test.ts
+++ b/src/lib/services/__tests__/taskDeletionReview.test.ts
@@ -89,3 +89,13 @@ describe('decideDeletionReview — thresholds', () => {
     expect(MASS_DELETE_FRACTION).toBe(0.5);
   });
 });
+
+describe('decideDeletionReview — shared by both task sync paths', () => {
+  it('applies the same policy to a CalDAV source as to a provider source', () => {
+    // calendar-sync.ts used to hard-delete CalDAV task rows outright, with no
+    // review and no guard, while the provider path held them. Same decision
+    // function now, so the two cannot drift apart again.
+    expect(decideDeletionReview({ syncedCount: 12, missingCount: 12 }).guardTripped).toBe(true);
+    expect(decideDeletionReview({ syncedCount: 12, missingCount: 1 }).flag).toBe(true);
+  });
+});

--- a/src/lib/services/calendar-sync.ts
+++ b/src/lib/services/calendar-sync.ts
@@ -1,4 +1,12 @@
 import { db } from '@/lib/db/client';
+import { decideDeletionReview } from '@/lib/services/taskDeletionReview';
+
+/**
+ * How long a CalDAV task must have been absent before it is flagged. Matches
+ * the provider task sync: one missed or partial response cannot flag anything
+ * on its own.
+ */
+const CALDAV_MISSING_GRACE_MS = 6 * 60 * 1000;
 import { calendarSources, events, tasks, taskLists, dismissedEvents } from '@/lib/db/schema';
 import { eq, and, gte, lte, sql, inArray, isNotNull } from 'drizzle-orm';
 import {
@@ -1119,6 +1127,9 @@ export async function syncCalDAVTasks(
         externalUpdatedAt: new Date(),
         lastSynced: new Date(),
         updatedAt: new Date(),
+        // Present again, so it is not missing. Clearing here is what makes a
+        // single bad response self-healing rather than leaving a flag behind.
+        pendingDeletion: null,
       };
 
       if (existing) {
@@ -1130,16 +1141,38 @@ export async function syncCalDAVTasks(
       synced++;
     }
 
-    // Mirror upstream deletions: any caldav-prefixed task for this source
-    // that wasn't in the fetch round-trips out of Prism too. Also catches
-    // existing placeholder rows that pre-date the title filter above.
+    // Upstream deletions are held for review rather than applied. This used to
+    // delete outright, which is unrecoverable and silent: `realTasks` is a
+    // FILTERED list, so a change to that filter — or a CalDAV server having a
+    // bad day — wiped every task from this source with no undo and nothing
+    // said. Same treatment the provider task sources got, for the same reason.
     const allLocal = await db.query.tasks.findMany({
       where: sql`${tasks.externalId} LIKE ${`caldav:${source.id}:%`}`,
-      columns: { id: true, externalId: true },
+      columns: { id: true, externalId: true, lastSynced: true, pendingDeletion: true },
     });
-    const stale = allLocal.filter(t => t.externalId && !seenExternalIds.has(t.externalId));
-    if (stale.length > 0) {
-      await db.delete(tasks).where(inArray(tasks.id, stale.map(t => t.id)));
+    const missing = allLocal.filter(t => t.externalId && !seenExternalIds.has(t.externalId));
+
+    const nowTs = Date.now();
+    const flaggable = missing.filter(
+      t => t.lastSynced && nowTs - t.lastSynced.getTime() > CALDAV_MISSING_GRACE_MS,
+    );
+    const review = decideDeletionReview({
+      syncedCount: allLocal.length,
+      missingCount: flaggable.length,
+    });
+
+    if (review.guardTripped) {
+      // Said out loud rather than withheld quietly: a guard that silently
+      // does nothing is its own mystery.
+      console.error(
+        `[Sync] ${review.withheld} CalDAV tasks missing at once — too many to be a normal ` +
+        'change, so none were touched. Check the connection, then sync again.',
+      );
+    } else if (review.flag) {
+      const toFlag = flaggable.filter(t => !t.pendingDeletion).map(t => t.id);
+      if (toFlag.length > 0) {
+        await db.update(tasks).set({ pendingDeletion: new Date() }).where(inArray(tasks.id, toFlag));
+      }
     }
 
     // Refresh the source's health signal on success. For task-only sources


### PR DESCRIPTION
Two gaps left over from #317.

## CalDAV task rows were still deleted outright

#317 scoped itself to provider task sources, so `calendar-sync.ts` kept hard-deleting any `caldav:`-prefixed task missing from a fetch — no review, no guard, no undo.

**That path is riskier than the provider one.** `realTasks` is a *filtered* list (Apple placeholder VTODOs are stripped), so a change to that filter — or a CalDAV server having a bad day — wiped every task from the source and said nothing.

It now uses:

- the same `decideDeletionReview` policy
- the same six-minute grace window
- the same un-flag-on-reappearance clearing

The two paths **share the decision function** rather than each carrying a copy, and there's a test pinning that so they can't drift apart again.

## The review list couldn't name where those tasks came from

CalDAV task rows carry no `task_source_id`, so the join in the review route yields nothing and every one of them read as "its source". It now reads the `caldav:` prefix on the external id and labels them **"Reminders (CalDAV)"**.

## Child profiles fired a sync that could never succeed

The Tasks page called `sync-all` every five minutes regardless of role. It requires `canManageIntegrations`, which only a parent has, so for a child every attempt was refused — and the rejection landed in a silent catch. The page simply stopped updating, with nothing to indicate why.

It no longer attempts a request that cannot succeed.

Found while testing #317: signing in as a child stopped sync entirely, and it took a database check to notice.

## Testing

1,541 tests pass, typecheck clean. New case asserts both sync paths get the same policy for the same inputs.

Note this path can't be exercised on demo without an iCloud Reminders source, so the CalDAV half is covered by the shared-policy test rather than a live run.
