### PR TITLE
chore(release): 1.19.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.19.0] – 2026-08-29
+
+### Added
+- **Tasks removed in Google or Microsoft are now held for your review instead of disappearing.** When a task you sync stops being listed by the other app, Prism no longer deletes it. It stays put and a *Review* button appears on the Tasks page, where you choose to delete it or keep it as a local task. If an unusual number vanish at once — the shape of an outage rather than someone ticking things off — nothing is flagged at all and the sync says why, so a bad connection cannot quietly empty your list. A task that comes back on its own clears itself with no action from you.
+- **Tasks can be deleted from the Tasks page.** There was previously no delete anywhere in the task list or its edit window; you could only mark something complete. Both now have one.
+- **A read-only Google calendar can be connected on its own.** See 1.18.3; this release extends the same idea to task sources.
+
+### Fixed
+- **Deleting a task in Prism now removes it from the app it syncs with.** It previously vanished locally and came back within about five minutes, with nothing to explain why.
+- **Google Tasks could not be connected without a public web address.** Two separate faults: the connection read its credentials from a place they are not stored when Prism is set up through the app rather than a configuration file, and after pasting a token there was no way to reach the screen that picks which lists to show. The first also meant that, where the connection did work, it stopped about an hour later and reported only that credentials were missing.
+- **Apple Reminders tasks removed on the server are held for review too**, rather than deleted outright.
+- **The Tasks page kept its own settings.** Grouping, sorting and *show completed* survive a refresh now. The list filter does too, but is forgotten once the display has been idle a while, so walking up to a sleeping screen gives you the whole list back rather than a filtered one you do not remember setting.
+- **The task list filter said "No List" where it meant "All".** Choosing the obvious-looking option emptied the screen, and clearing the filter was only possible by unticking everything. There is now an explicit *All*, with the old option renamed *Unassigned*.
+- **The Tasks page stopped updating for child profiles.** It was repeatedly attempting a sync only a parent is allowed to run, and failing silently.
+- **A child asked to review a removed task was refused without being told why.**
+- **Weather and Kroger API keys could be overwritten without signing in.** Both now require an authenticated parent, matching the equivalent Google and Microsoft settings.
+
 ## [1.18.3] – 2026-08-28
 
 ### Added

--- a/docs/features/TASKS.md
+++ b/docs/features/TASKS.md
@@ -57,6 +57,18 @@ If the task syncs to MS To Do / Google Tasks, the completed status propagates to
 
 ---
 
+## Deleting tasks
+
+Parents only. Two places: the trash icon on the task row, and the **Delete**
+button inside the task's edit window. Both confirm first.
+
+Deleting a synced task also deletes it in the provider. That happens
+immediately, not on the next sync. If the provider cannot be reached the task
+is still removed from Prism and a tombstone stops the next sync re-adding it,
+so the deletion sticks either way.
+
+---
+
 ## Filtering + sorting
 
 - **By list**: picker dropdown, "All lists" / "Unassigned" / specific list.
@@ -102,7 +114,11 @@ Pick one provider per Prism instance:
 1. *Settings → Integrations → Microsoft* card: connect your account.
 2. In the same card, for each Prism list pick an MS To Do list to sync it with.
 
-Bidirectional, newest-wins. Fields synced: title, notes (= description), completed, due date. Subtasks in MS To Do are flattened into the notes field (Prism doesn't have a subtask concept).
+Bidirectional, newest-wins. Fields synced: title, notes (= description), completed, due date.
+
+Steps (MS To Do's sub-items) are **not** imported — Prism has no subtask
+concept, so they are skipped rather than flattened. Attachments are not
+imported either.
 
 ### Google Tasks (bidirectional)
 
@@ -110,9 +126,45 @@ Bidirectional, newest-wins. Fields synced: title, notes (= description), complet
 2. In the same card, pick which Google Tasks list maps to which Prism list.
 
 Same shape as MS: bidirectional, newest-wins, title + notes + completed + due date.
+Subtasks and attachments are not imported.
+
+**No public web address?** Google's browser sign-in needs a redirect address
+it will accept, which a home-network-only install does not have. Use
+*Connect without a public URL (advanced)* on the same card and paste a refresh
+token minted in Google's OAuth Playground — include
+`https://www.googleapis.com/auth/tasks` in the scopes. Prism then takes you
+straight to the list picker. See CALENDAR.md for the full walkthrough; the
+only difference is the scope.
+
+### Removed tasks are held for review
+
+When a task you sync stops being listed by the provider, Prism does **not**
+delete it. It stays visible and a **Review** button appears in the Tasks
+header, where a parent chooses per task:
+
+- **Delete** — remove it from Prism too.
+- **Keep** — turn it into a local task. It stops syncing, and is never pushed
+  back to the provider it was removed from.
+
+Two safeguards sit in front of that:
+
+- A task must have been missing for longer than one sync interval before it is
+  flagged, so a task you just created is never reported as deleted, and a
+  single missed response flags nothing.
+- If an unusual number vanish at once — more than ten, or at least half of a
+  set of four or more — **nothing is flagged at all** and the source records an
+  error instead. That is the shape of an outage rather than of housekeeping,
+  and burying you in entries would invite a bulk confirm.
+
+A task that reappears at the provider clears its own flag on the next sync,
+with no action from you.
+
+Apple Reminders (CalDAV) task sources behave the same way.
 
 ### Auto-sync
 
+- Parents only. A child profile does not run sync; the page still shows tasks,
+  it just does not fetch new ones.
 - Fires on dashboard mount if last sync is stale (>5 minutes ago).
 - Background sync every 5 minutes via the polling hook.
 - Pauses when the browser tab is hidden.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.18.3"
+version: "1.19.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.18.3",
+  "version": "1.19.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -317,10 +317,23 @@ function TasksHelp() {
       <Ul>
         <Li><strong>Add</strong> via the &quot;Add Task&quot; button or inline text input</Li>
         <Li><strong>Complete</strong> by tapping the checkbox</Li>
+        <Li><strong>Delete</strong> with the trash icon on a task, or from its edit window (parents only)</Li>
         <Li><strong>Filter</strong> by person, priority, or list</Li>
         <Li><strong>Group by Person</strong> to see tasks organized by family member</Li>
         <Li><strong>Sync</strong> with Microsoft To Do or Google Tasks (configure per-list in Settings &gt; Integrations)</Li>
       </Ul>
+      <H2>Removed tasks are held for review</H2>
+      <P>
+        If a task disappears from the app you sync with, Prism keeps it and shows a
+        <strong> Review</strong> button on the Tasks page. A parent chooses to delete it
+        or keep it as a local task. If a lot vanish at once — the shape of a connection
+        problem rather than someone tidying up — nothing is flagged and the sync says why,
+        so a bad connection cannot quietly empty your list.
+      </P>
+      <P>
+        Deleting a task in Prism also removes it from the app it syncs with. Your view
+        settings — grouping, sorting and show-completed — are remembered between visits.
+      </P>
     </>
   );
 }


### PR DESCRIPTION
Task sync deletion review, Google Tasks connection fixes, task delete UI, view persistence, credential-route auth. Version bump, changelog, TASKS.md and in-app help.