### PR TITLE
fix(settings): surface the connect method that can actually work, and tidy backups

### DIFF
--- a/src/app/settings/sections/BackupSection.tsx
+++ b/src/app/settings/sections/BackupSection.tsx
@@ -19,6 +19,9 @@ import { useBackups } from '@/lib/hooks/useBackups';
 
 type DangerStep = null | 'warn-truncate' | 'confirm-truncate' | 'warn-seed' | 'confirm-seed';
 
+/** How many backups to show before collapsing the rest behind a toggle. */
+const RECENT_BACKUP_COUNT = 5;
+
 export function BackupSection() {
   const {
     backups,
@@ -37,6 +40,11 @@ export function BackupSection() {
     truncateDatabase,
     seedDatabase,
   } = useBackups();
+
+  // Older ones are collapsed rather than dropped: nothing is deleted here, and
+  // an old backup is still restorable. The list has no retention policy, so it
+  // grows forever and buries the actions above it.
+  const [showAllBackups, setShowAllBackups] = useState(false);
 
   const [confirmRestore, setConfirmRestore] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
@@ -100,6 +108,44 @@ export function BackupSection() {
 
   return (
     <div className="space-y-6">
+      {/* Cache Management */}
+      <div className="border border-border rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h4 className="font-semibold flex items-center gap-2">
+              <RefreshCw className="h-4 w-4 text-primary" />
+              Clear Cache &amp; Reload
+            </h4>
+            <p className="text-sm text-muted-foreground mt-1">
+              Unregisters the service worker and clears cached assets. Use after an update if the app seems stale.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              try {
+                if ('serviceWorker' in navigator) {
+                  const registrations = await navigator.serviceWorker.getRegistrations();
+                  await Promise.all(registrations.map(r => r.unregister()));
+                }
+                if ('caches' in window) {
+                  const keys = await caches.keys();
+                  await Promise.all(keys.map(k => caches.delete(k)));
+                }
+                window.location.reload();
+              } catch {
+                window.location.reload();
+              }
+            }}
+            className="ml-4 flex-shrink-0"
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
       {/* Header with Create Backup button */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -167,7 +213,7 @@ export function BackupSection() {
           </div>
         ) : (
           <div className="divide-y divide-border">
-            {backups.map((backup) => (
+            {(showAllBackups ? backups : backups.slice(0, RECENT_BACKUP_COUNT)).map((backup) => (
               <div
                 key={backup.filename}
                 className="p-4 flex items-center justify-between hover:bg-muted/50"
@@ -275,6 +321,19 @@ export function BackupSection() {
                 </div>
               </div>
             ))}
+            {backups.length > RECENT_BACKUP_COUNT && (
+              <button
+                type="button"
+                onClick={() => setShowAllBackups((v) => !v)}
+                className="w-full p-3 text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+              >
+                {showAllBackups
+                  ? 'Show fewer'
+                  : `Show ${backups.length - RECENT_BACKUP_COUNT} older backup${
+                      backups.length - RECENT_BACKUP_COUNT === 1 ? '' : 's'
+                    }`}
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -284,44 +343,6 @@ export function BackupSection() {
         Backups contain all database data including family members, chores, tasks, calendar events, and settings.
         Restoring a backup will overwrite all current data.
       </p>
-
-      {/* Cache Management */}
-      <div className="border border-border rounded-lg p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h4 className="font-semibold flex items-center gap-2">
-              <RefreshCw className="h-4 w-4 text-primary" />
-              Clear Cache &amp; Reload
-            </h4>
-            <p className="text-sm text-muted-foreground mt-1">
-              Unregisters the service worker and clears cached assets. Use after an update if the app seems stale.
-            </p>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={async () => {
-              try {
-                if ('serviceWorker' in navigator) {
-                  const registrations = await navigator.serviceWorker.getRegistrations();
-                  await Promise.all(registrations.map(r => r.unregister()));
-                }
-                if ('caches' in window) {
-                  const keys = await caches.keys();
-                  await Promise.all(keys.map(k => caches.delete(k)));
-                }
-                window.location.reload();
-              } catch {
-                window.location.reload();
-              }
-            }}
-            className="ml-4 flex-shrink-0"
-          >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Refresh
-          </Button>
-        </div>
-      </div>
 
       {/* Danger Zone */}
       <div className="border border-red-200 dark:border-red-800 rounded-lg p-4 space-y-4">

--- a/src/app/settings/sections/TaskIntegrationsSection.tsx
+++ b/src/app/settings/sections/TaskIntegrationsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { toast } from '@/components/ui/use-toast';
 import {
   Plus,
@@ -33,6 +33,7 @@ import {
   EntityListCard,
   ConfirmDialog,
 } from './integrations/components';
+import { browserOAuthUsable } from '@/lib/utils/googleRedirectSupport';
 
 interface TaskIntegrationsSectionProps {
   /** Hide the section header (h2 + description) when rendered inside a card sub-section. */
@@ -69,6 +70,14 @@ export function TaskIntegrationsSection({
   const displayedSources = providerFilter
     ? integration.sources.filter((s) => s.provider === providerFilter)
     : integration.sources;
+
+  // Google's browser sign-in cannot work from a private address — it refuses
+  // the redirect URI before showing a consent screen. Checked after mount so
+  // the server render does not disagree with the client.
+  const [origin, setOrigin] = useState<string | null>(null);
+  useEffect(() => setOrigin(window.location.origin), []);
+  const googleBrowserFlowUnusable =
+    providerFilter === 'google_tasks' && origin !== null && !browserOAuthUsable(origin);
 
   const handleConnectEntity = (entityId: string) => {
     if (providerFilter === 'microsoft_todo') {
@@ -389,6 +398,24 @@ export function TaskIntegrationsSection({
               >
                 <Link2 className="h-4 w-4" />
                 Connect
+              </Button>
+            ) : googleBrowserFlowUnusable ? (
+              // Google refuses a redirect URI on this address, so Connect
+              // would bounce off its consent screen with an error only Google
+              // words. Say so here instead of offering a button that cannot
+              // work; the paste-a-token flow needs no redirect URI at all.
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled
+                className="gap-1 text-muted-foreground"
+                title={
+                  'Google will not accept this address as a sign-in redirect. ' +
+                  'Use "Connect without a public URL (advanced)" on the Google card instead.'
+                }
+              >
+                <Link2 className="h-4 w-4" />
+                Needs a public address
               </Button>
             ) : (
               <Button

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -11,6 +11,7 @@ import { ProviderCardShell } from '../shared/ProviderCardShell';
 import { CollapsibleSubSection } from '../shared/CollapsibleSubSection';
 import { GoogleCredentialsForm } from './GoogleCredentialsForm';
 import { GoogleManualTokenForm } from './GoogleManualTokenForm';
+import { browserOAuthUsable } from '@/lib/utils/googleRedirectSupport';
 import type { IntegrationStatus } from '../shared/useIntegrationStatus';
 import type { ConnectionStatus } from '../shared/ConnectionStatusBadge';
 import { connectedAsLabel } from '../shared/connectedAs';
@@ -63,6 +64,13 @@ export function GoogleProviderCard({
   // Treat "still loading" as configured so the common case (already set up)
   // never flashes the gated state — only downgrade once we know for sure.
   const configured = oauthStatus === null ? true : oauthStatus.google;
+
+  // Google refuses a private address as a sign-in redirect, so on a LAN-only
+  // install the browser flow cannot work at all. Checked after mount so the
+  // server render does not disagree with the client.
+  const [origin, setOrigin] = React.useState<string | null>(null);
+  React.useEffect(() => setOrigin(window.location.origin), []);
+  const browserFlowUnusable = origin !== null && !browserOAuthUsable(origin);
 
   const g = status?.google;
   const connected = !!g?.connected;
@@ -212,8 +220,15 @@ export function GoogleProviderCard({
         <CollapsibleSubSection
           id="google-manual-token"
           label="Connect without a public URL (advanced)"
-          summary="Paste a refresh token from Google's OAuth Playground — for LAN-only installs, or to re-paste an expired one"
-          forceOpen={forceSubSectionOpen === 'google-manual-token'}
+          summary={
+            browserFlowUnusable
+              ? "The way to connect on this address — Google will not accept a private address for its sign-in"
+              : "Paste a refresh token from Google's OAuth Playground — for LAN-only installs, or to re-paste an expired one"
+          }
+          // Opened by default where it is the only flow that can work, so a
+          // LAN user is not left hunting behind a collapsed "advanced" label
+          // for the one thing that will succeed.
+          forceOpen={forceSubSectionOpen === 'google-manual-token' || browserFlowUnusable}
         >
           <GoogleManualTokenForm onSaved={() => window.location.reload()} />
         </CollapsibleSubSection>

--- a/src/lib/utils/__tests__/googleRedirectSupport.test.ts
+++ b/src/lib/utils/__tests__/googleRedirectSupport.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Whether Google's browser sign-in can work from a given address.
+ *
+ * Getting this wrong in the permissive direction is what produces the dead end
+ * this exists to avoid: a Connect button that sends the user to Google, which
+ * refuses in its own words with nothing on the Prism side explaining why.
+ */
+import { browserOAuthUsable } from '../googleRedirectSupport';
+
+describe('browserOAuthUsable', () => {
+  it('accepts a public https domain', () => {
+    expect(browserOAuthUsable('https://prism.example.com')).toBe(true);
+    expect(browserOAuthUsable('https://prism.example.com:8443')).toBe(true);
+  });
+
+  it('accepts loopback over http, which is Google’s one exception', () => {
+    expect(browserOAuthUsable('http://localhost:8091')).toBe(true);
+    expect(browserOAuthUsable('http://127.0.0.1:3000')).toBe(true);
+  });
+
+  it('rejects a private LAN address', () => {
+    // The common home install, and the first thing that failed in testing.
+    expect(browserOAuthUsable('http://192.168.50.10:3000')).toBe(false);
+    expect(browserOAuthUsable('http://10.0.0.5:3000')).toBe(false);
+  });
+
+  it('rejects a Tailscale address', () => {
+    expect(browserOAuthUsable('http://100.115.92.7:8091')).toBe(false);
+  });
+
+  it('rejects a bare IP even over https', () => {
+    // Google wants a domain, not an address, whatever the scheme.
+    expect(browserOAuthUsable('https://192.168.50.10')).toBe(false);
+  });
+
+  it('rejects .local and friends', () => {
+    expect(browserOAuthUsable('http://homeassistant.local:8123')).toBe(false);
+    expect(browserOAuthUsable('https://prism.local')).toBe(false);
+    expect(browserOAuthUsable('https://prism.internal')).toBe(false);
+  });
+
+  it('rejects a single-label host with no dot at all', () => {
+    expect(browserOAuthUsable('https://prism')).toBe(false);
+  });
+
+  it('rejects http on a public domain, since Google requires TLS', () => {
+    expect(browserOAuthUsable('http://prism.example.com')).toBe(false);
+  });
+
+  it('treats anything unparseable or absent as unusable', () => {
+    // Conservative on purpose: steer to the flow that always works.
+    expect(browserOAuthUsable('not a url')).toBe(false);
+    expect(browserOAuthUsable('')).toBe(false);
+    expect(browserOAuthUsable(null)).toBe(false);
+    expect(browserOAuthUsable(undefined)).toBe(false);
+  });
+});

--- a/src/lib/utils/googleRedirectSupport.ts
+++ b/src/lib/utils/googleRedirectSupport.ts
@@ -1,0 +1,49 @@
+/**
+ * Can Google's browser sign-in work from the address the user is on?
+ *
+ * Google validates redirect URIs before it will show a consent screen. It
+ * accepts https on a public domain, and makes one exception for loopback
+ * (http://localhost and http://127.0.0.1, any port). Everything a home install
+ * typically uses — http://192.168.x.x:3000, a Tailscale IP, homeassistant.local
+ * — is refused outright with `invalid_request` before the user can do anything
+ * about it.
+ *
+ * Offering a Connect button that cannot succeed is the wrong end of the
+ * problem: the user clicks it, Google refuses in its own words, and nothing on
+ * the Prism side explains why. Knowing in advance lets the UI point at the
+ * paste-a-token flow, which needs no redirect URI at all.
+ */
+
+/** Loopback is the one non-https address Google allows. */
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * True when Google would accept a redirect URI built from this origin.
+ *
+ * Deliberately conservative: anything unparseable is treated as unusable, so
+ * the UI steers toward the flow that always works rather than the one that
+ * might not.
+ */
+export function browserOAuthUsable(origin: string | null | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const url = new URL(origin);
+    const host = url.hostname.toLowerCase();
+
+    if (LOOPBACK.has(host)) return true;
+    if (url.protocol !== 'https:') return false;
+
+    // A bare IP is refused even over https — Google requires a domain.
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.startsWith('[')) return false;
+
+    // Google requires a public top-level domain. `.local`, single-label hosts
+    // and `.internal` are all rejected by the console and the auth endpoint.
+    if (!host.includes('.')) return false;
+    const tld = host.slice(host.lastIndexOf('.') + 1);
+    if (['local', 'internal', 'lan', 'home', 'localdomain'].includes(tld)) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Three settings changes.

## 1. Stop offering a Connect button that cannot work

Google refuses a private address as a sign-in redirect **before** showing a consent screen, with an error only Google words. Prism offered a Connect button anyway, so a LAN user clicked it, bounced off Google, and had nothing on this side explaining why.

That happened repeatedly while testing 1.19.0 — `invalid_request` on a Tailscale address, then again on a bare IP.

`browserOAuthUsable()` encodes what Google actually accepts: https on a public domain, plus the loopback exception for `localhost` and `127.0.0.1`. Where it says no:

- the per-list **Connect** is replaced by a disabled control naming the reason
- the paste-a-token section **opens by default**, with a summary saying it's *the* way to connect here rather than an "advanced" aside

Conservative by design — anything unparseable counts as unusable, so the UI steers toward the flow that always works rather than the one that might not.

## 2. Clear Cache & Reload moved above the backups list

It's the routine post-update action. Backups are occasional and destructive, and were burying it.

## 3. The backups list is collapsed

`listBackups()` returns every file with no cap and no retention policy, so the list grows forever and pushes the actions off screen.

Now shows the five most recent with the rest behind a toggle. **Nothing is deleted** and older backups stay one click away — this is a display change only.

## Testing

Nine cases on `browserOAuthUsable`, covering both directions: public https and loopback accepted; LAN addresses, Tailscale addresses, bare IPs even over https, `.local`, single-label hosts, plain http on a public domain, and unparseable input all rejected.

1,551 tests pass, typecheck clean.

Fixture addresses are invented, not taken from any running instance.
