### PR TITLE
fix(settings): do not imply pasting a token is the only way to connect Google

### DIFF
--- a/src/app/settings/sections/TaskIntegrationsSection.tsx
+++ b/src/app/settings/sections/TaskIntegrationsSection.tsx
@@ -411,11 +411,13 @@ export function TaskIntegrationsSection({
                 className="gap-1 text-muted-foreground"
                 title={
                   'Google will not accept this address as a sign-in redirect. ' +
-                  'Use "Connect without a public URL (advanced)" on the Google card instead.'
+                  'Reopen Prism on a public https address, or on localhost (an SSH tunnel works), ' +
+                  'and Connect will work here. Otherwise use "Connect without a public URL ' +
+                  '(advanced)" on the Google card, which needs no redirect address at all.'
                 }
               >
                 <Link2 className="h-4 w-4" />
-                Needs a public address
+                Not from this address
               </Button>
             ) : (
               <Button

--- a/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleProviderCard.tsx
@@ -222,7 +222,7 @@ export function GoogleProviderCard({
           label="Connect without a public URL (advanced)"
           summary={
             browserFlowUnusable
-              ? "The way to connect on this address — Google will not accept a private address for its sign-in"
+              ? "Google will not accept this address for its sign-in. Use this, or reopen Prism on a public https address or localhost"
               : "Paste a refresh token from Google's OAuth Playground — for LAN-only installs, or to re-paste an expired one"
           }
           // Opened by default where it is the only flow that can work, so a


### PR DESCRIPTION
Follow-up to #325.

The wording overstated the situation. Being on a private address right now does not mean the browser flow is unavailable — an SSH tunnel to localhost works, and so does reopening Prism on a public https address. Plenty of people reach their instance both ways.

## Changes

- The paste-a-token summary no longer calls itself *"the way to connect on this address"*. It states the fact — Google will not accept this address — and names both alternatives, leaving the choice open.
- The Tasks button reads **"Not from this address"** rather than "Needs a public address", which implied a public address was the only answer. Its tooltip names the tunnel and public-URL routes **before** mentioning pasting a token.
- The **(advanced)** label was never removed and stays, since it is the more involved route.

The section still opens by default where the browser flow cannot work — surfacing it is useful. What changed is that it no longer claims to be the only option.

1,551 tests pass, typecheck clean.