### PR TITLE
docs(changelog): record the Google connect and backups page fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **Prism no longer offers a Google sign-in button that cannot work.** Google refuses a private address as a sign-in redirect, so on a home-network-only install the button sent you to Google and Google turned you away in its own words, with nothing on the Prism side explaining why. Where the address you are using cannot work, Prism now says so, names the ways round it — reopen Prism on a public https address or on localhost, or paste a token instead — and opens the paste-a-token section for you. On a public address nothing changes.
+- **The backups page put its most-used button last.** *Clear Cache & Reload* now sits above the list of backups rather than below it, and the list shows the five most recent with the rest behind a *Show older backups* toggle. Nothing is deleted; the list simply no longer grows until it pushes everything else off the screen.
+
 ## [1.19.0] – 2026-08-29
 
 ### Added


### PR DESCRIPTION
Unreleased entries for #325 and #326, written for someone reading release notes rather than a diff.