### PR TITLE
fix(family): stop telling unauthenticated callers who has no PIN

### DIFF
--- a/src/app/api/family/__tests__/familyPublicShape.test.ts
+++ b/src/app/api/family/__tests__/familyPublicShape.test.ts
@@ -1,0 +1,41 @@
+/**
+ * What /api/family discloses to a caller with no session.
+ *
+ * A wall display sits on a home network, and this endpoint answers before
+ * anyone has authenticated — the login pad needs the member list to render.
+ * So whatever it returns is readable by anything on the LAN.
+ *
+ * Names, faces and roles are already on the screen, so listing them changes
+ * nothing. `hasPin` is different: it names which members are undefended, which
+ * is exactly what someone would want to know before choosing who to target,
+ * and it is not visible on the display. It belongs to the authenticated
+ * response only.
+ */
+import { PUBLIC_MEMBER_FIELDS } from '../publicShape';
+
+describe('the unauthenticated family payload', () => {
+  it('does not disclose which members have a PIN', () => {
+    expect(PUBLIC_MEMBER_FIELDS).not.toContain('hasPin');
+  });
+
+  it('does not disclose real user ids', () => {
+    // loginIndex is the login selector; the UUID is withheld deliberately.
+    expect(PUBLIC_MEMBER_FIELDS).not.toContain('userId');
+  });
+
+  it('still carries what the login pad needs to render', () => {
+    // Removing any of these breaks sign-in on a display that has never
+    // authenticated, which is worse than the disclosure being fixed.
+    for (const field of ['name', 'avatarUrl', 'role', 'loginIndex', 'pinLength']) {
+      expect(PUBLIC_MEMBER_FIELDS).toContain(field);
+    }
+  });
+
+  it('is a closed list, so a new field cannot be added without a decision', () => {
+    // The guard: this test fails when someone widens the payload, forcing
+    // them to justify the addition rather than discovering it in production.
+    expect([...PUBLIC_MEMBER_FIELDS].sort()).toEqual(
+      ['avatarUrl', 'color', 'id', 'loginIndex', 'name', 'pinLength', 'role'].sort(),
+    );
+  });
+});

--- a/src/app/api/family/publicShape.ts
+++ b/src/app/api/family/publicShape.ts
@@ -1,0 +1,19 @@
+/**
+ * The exact fields /api/family returns to an unauthenticated caller.
+ *
+ * Declared separately from the route so it can be asserted in a test. This
+ * endpoint answers before anyone has signed in — the login pad needs the
+ * member list to render — so anything listed here is readable by any device
+ * on the network. Adding a field is a disclosure decision, not a detail.
+ */
+export const PUBLIC_MEMBER_FIELDS = [
+  'id', // always '' — the real UUID is withheld; loginIndex is the selector
+  'loginIndex',
+  'name',
+  'role',
+  'color',
+  'avatarUrl',
+  'pinLength',
+] as const;
+
+export type PublicMemberField = (typeof PUBLIC_MEMBER_FIELDS)[number];

--- a/src/app/api/family/route.ts
+++ b/src/app/api/family/route.ts
@@ -10,6 +10,7 @@ import { logActivity } from '@/lib/services/auditLog';
 import { logError } from '@/lib/utils/logError';
 import { MIN_PIN_LENGTH, MAX_PIN_LENGTH, DEFAULT_PIN_LENGTH } from '@/lib/constants';
 import { isSetupComplete } from '@/lib/setup';
+import type { PublicMemberField } from './publicShape';
 
 interface FamilyMemberResponse {
   id: string;
@@ -25,22 +26,49 @@ interface FamilyMemberResponse {
 }
 
 /** Display-only shape returned to unauthenticated callers (no UUIDs). */
-interface PublicFamilyMemberResponse {
-  id: ''; // empty — never a real UUID; loginIndex is the login token
+type PublicFamilyMemberResponse = {
+  /** Always '' — never a real UUID; loginIndex is the login token. */
+  id: '';
   loginIndex: number;
   name: string;
-  // Role isn't sensitive (just parent/child/guest) and callers like the
-  // Settings PIN gate need it to filter to parents-only *before* the user
-  // has authenticated — omitting it previously made every member look like
-  // a parent (see the unauthenticated branch's `!m.role` fallback).
+  /**
+   * Not sensitive on its own — the avatars on screen already show who is a
+   * parent — and the Settings PIN gate needs it to filter before the user has
+   * authenticated.
+   */
   role: 'parent' | 'child' | 'guest';
   color: string;
   avatarUrl: string | null;
-  hasPin: boolean;
-  /** Per-member PIN length (4/5/6). Not sensitive — the login pad needs it
-   *  to know how many digits to expect before the user has authenticated. */
+  /**
+   * Per-member PIN length. The login pad needs it to know how many digits to
+   * expect before anyone has authenticated.
+   *
+   * This IS a small disclosure — it tells an observer how many digits to watch
+   * for — but the pad cannot render its dots or auto-submit without it.
+   * Removing it means changing three hand-rolled pads, not this endpoint.
+   */
   pinLength: number;
-}
+};
+
+// Every key above must appear in PUBLIC_MEMBER_FIELDS and vice versa. Adding a
+// field to one without the other fails here, which is the point: the list is
+// what the disclosure test reads, so it cannot drift from what is served.
+type _FieldsMatch = PublicMemberField extends keyof PublicFamilyMemberResponse
+  ? keyof PublicFamilyMemberResponse extends PublicMemberField
+    ? true
+    : ['field in response but not in PUBLIC_MEMBER_FIELDS']
+  : ['field in PUBLIC_MEMBER_FIELDS but not in response'];
+const _fieldsMatch: _FieldsMatch = true;
+void _fieldsMatch;
+
+/**
+ * Deliberately NOT in the unauthenticated response: `hasPin`.
+ *
+ * It names which members are undefended, which is precisely the thing worth
+ * knowing before choosing who to target, and it is not visible on the display
+ * the way names, faces and roles already are. Every consumer of it lives in
+ * /settings or /setup, both of which read the authenticated branch below.
+ */
 
 export async function GET(request: NextRequest) {
   try {
@@ -95,16 +123,20 @@ export async function GET(request: NextRequest) {
           .from(users)
           .orderBy(users.sortOrder, users.createdAt);
 
-        const members: PublicFamilyMemberResponse[] = results.map((user, index) => ({
-          id: '' as const,
-          loginIndex: index,
-          name: user.name,
-          role: user.role as 'parent' | 'child' | 'guest',
-          color: user.color,
-          avatarUrl: user.avatarUrl,
-          hasPin: !!user.pin,
-          pinLength: user.pinLength,
-        }));
+        const members: PublicFamilyMemberResponse[] = results.map((user, index) => {
+          // The type is keyed off PUBLIC_MEMBER_FIELDS, so adding a property
+          // here without adding it to that list is a compile error — and that
+          // list is what the disclosure test asserts against.
+          return {
+            id: '' as const,
+            loginIndex: index,
+            name: user.name,
+            role: user.role as 'parent' | 'child' | 'guest',
+            color: user.color,
+            avatarUrl: user.avatarUrl,
+            pinLength: user.pinLength,
+          };
+        });
 
         return { members, total: members.length };
       }, 600);


### PR DESCRIPTION
`GET /api/family` answers **before anyone has signed in** — the login pad needs the member list to render — so everything it returns is readable by any device on the network.

Confirmed against a running instance. No cookie, four members returned, fields:

```
avatarUrl, color, hasPin, id, loginIndex, name, pinLength, role
```

## Why `hasPin` is the one that matters

Names, faces and roles are already on the display, so listing them discloses nothing new.

`hasPin` **names which members are undefended** — precisely what someone would want to know before choosing who to target — and it isn't otherwise visible.

Every consumer of it lives in `/settings` or `/setup`, both of which read the authenticated branch. Nothing pre-authentication used it.

## The guard is real, not a tautology

The response shape is type-linked to `PUBLIC_MEMBER_FIELDS`, and a test asserts what that list contains. Adding a field to the response without adding it to the list is a **compile error** — verified by re-adding `hasPin` and watching typecheck fail in two places.

So the test can't rot: widening the payload forces someone to edit the list a test is reading, rather than discovering it in production.

## What is knowingly kept

`pinLength` is a smaller disclosure of the same kind — it tells an observer how many digits to watch for. But the pad cannot render its dots or auto-submit without it, so removing it means changing three hand-rolled PIN pads rather than this endpoint.

That trade-off is recorded in the type comment rather than left implicit, so the next person meets the decision instead of the leftover.

## How it was found

An adversarial review of physical access to a wall display — what an observer can obtain from the room, before touching anything.

## Testing

1,555 tests pass, typecheck and lint clean. Four new cases pinning the public payload: no `hasPin`, no real ids, everything the login pad needs still present, and the list is closed.
