### PR TITLE
fix(auth): stop a PIN lockout reporting itself as a wrong PIN

### DIFF
--- a/src/components/auth/QuickPinModal.tsx
+++ b/src/components/auth/QuickPinModal.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
 import { DEFAULT_PIN_LENGTH } from '@/lib/constants';
+import { pinErrorMessage } from '@/lib/utils/pinErrorMessage';
 
 /**
  * FAMILY MEMBER TYPE
@@ -188,7 +189,11 @@ export function QuickPinModal({
           // Refresh FamilyProvider so member IDs + roles reflect the now-authenticated session
           window.dispatchEvent(new Event('prism:auth-changed'));
         } else {
-          setError('Incorrect PIN');
+          // Read the body rather than assuming a wrong PIN: a lockout returns
+          // 403 while the CORRECT PIN is being refused, and saying "incorrect"
+          // there sends someone hunting for a problem that isn't theirs.
+          const body = await response.json().catch(() => null);
+          setError(pinErrorMessage(response.status, body));
           setIsShaking(true);
           setTimeout(() => setIsShaking(false), 500);
           setPin([]);

--- a/src/components/away-mode/ExitAwayModeModal.tsx
+++ b/src/components/away-mode/ExitAwayModeModal.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
 import { DEFAULT_PIN_LENGTH } from '@/lib/constants';
+import { pinErrorMessage } from '@/lib/utils/pinErrorMessage';
 
 interface ExitAwayModeModalProps {
   open: boolean;
@@ -112,7 +113,11 @@ export function ExitAwayModeModal({
         if (response.ok) {
           onSuccess();
         } else {
-          setError('Incorrect PIN');
+          // Read the body rather than assuming a wrong PIN: a lockout returns
+          // 403 while the CORRECT PIN is being refused, and saying "incorrect"
+          // there sends someone hunting for a problem that isn't theirs.
+          const body = await response.json().catch(() => null);
+          setError(pinErrorMessage(response.status, body));
           setIsShaking(true);
           setTimeout(() => setIsShaking(false), 500);
           setPin([]);

--- a/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
+++ b/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/ui/avatar';
 import { useFamily } from '@/components/providers';
 import { DEFAULT_PIN_LENGTH } from '@/lib/constants';
+import { pinErrorMessage } from '@/lib/utils/pinErrorMessage';
 
 interface ExitBabysitterModeModalProps {
   open: boolean;
@@ -112,7 +113,11 @@ export function ExitBabysitterModeModal({
         if (response.ok) {
           onSuccess();
         } else {
-          setError('Incorrect PIN');
+          // Read the body rather than assuming a wrong PIN: a lockout returns
+          // 403 while the CORRECT PIN is being refused, and saying "incorrect"
+          // there sends someone hunting for a problem that isn't theirs.
+          const body = await response.json().catch(() => null);
+          setError(pinErrorMessage(response.status, body));
           setIsShaking(true);
           setTimeout(() => setIsShaking(false), 500);
           setPin([]);

--- a/src/lib/utils/__tests__/pinErrorMessage.test.ts
+++ b/src/lib/utils/__tests__/pinErrorMessage.test.ts
@@ -1,0 +1,70 @@
+/**
+ * What a failed PIN entry tells the person standing at the display.
+ *
+ * The case that motivated this: after five wrong attempts the account locks
+ * out, and during the lockout the CORRECT PIN also fails. Every pad said
+ * "Incorrect PIN", so someone who had just typed their own PIN correctly was
+ * told for up to four hours that it was wrong, with no hint that waiting would
+ * help. On a kitchen display that reads as a broken screen, not a lockout.
+ */
+import { pinErrorMessage } from '../pinErrorMessage';
+
+const NOW = new Date('2026-08-30T16:10:00');
+
+describe('pinErrorMessage — lockout', () => {
+  it('says it is a lockout and when to come back, not that the PIN is wrong', () => {
+    const msg = pinErrorMessage(403, { lockedOut: true, retryAfter: 300 }, NOW);
+    expect(msg).toContain('Too many tries');
+    expect(msg).toContain('4:15'); // 16:10 + 5 minutes, in local format
+    expect(msg.toLowerCase()).not.toContain("didn't work");
+  });
+
+  it('still says something useful when the server omits a retry time', () => {
+    const msg = pinErrorMessage(403, { lockedOut: true }, NOW);
+    expect(msg).toContain('Too many tries');
+    expect(msg).toContain('shortly');
+  });
+});
+
+describe('pinErrorMessage — ordinary wrong PIN', () => {
+  it('counts down the tries left, so the lockout is not a surprise', () => {
+    expect(pinErrorMessage(401, { remainingAttempts: 3 }, NOW)).toBe(
+      "That PIN didn't work. 3 tries left.",
+    );
+  });
+
+  it('warns on the last try, in the singular', () => {
+    const msg = pinErrorMessage(401, { remainingAttempts: 1 }, NOW);
+    expect(msg).toContain('1 try left');
+    expect(msg).toContain('locks');
+  });
+
+  it('treats zero remaining as a lockout rather than reporting "0 tries left"', () => {
+    expect(pinErrorMessage(401, { remainingAttempts: 0 }, NOW)).toContain('Too many tries');
+  });
+});
+
+describe('pinErrorMessage — member has no PIN', () => {
+  it('names who can fix it and where, instead of "contact a parent"', () => {
+    const msg = pinErrorMessage(403, { pinRequired: true, error: 'PIN not set.' }, NOW);
+    expect(msg).toContain('Settings');
+    expect(msg).toContain('Family Members');
+  });
+});
+
+describe('pinErrorMessage — nothing useful came back', () => {
+  it('does not accuse the user when the request never landed', () => {
+    // A hub that is down is not a wrong PIN, and saying so sends someone
+    // hunting for a credential problem that does not exist.
+    const msg = pinErrorMessage(0, null, NOW);
+    expect(msg).toContain("Can't reach Prism");
+  });
+
+  it('falls back to the server wording rather than inventing its own', () => {
+    expect(pinErrorMessage(401, { error: 'Account disabled' }, NOW)).toBe('Account disabled');
+  });
+
+  it('has a plain default when the server says nothing at all', () => {
+    expect(pinErrorMessage(401, {}, NOW)).toBe("That PIN didn't work.");
+  });
+});

--- a/src/lib/utils/pinErrorMessage.ts
+++ b/src/lib/utils/pinErrorMessage.ts
@@ -1,0 +1,79 @@
+/**
+ * Turning a failed PIN response into something a person can act on.
+ *
+ * Three PIN pads each hardcoded `setError('Incorrect PIN')` and discarded the
+ * response body. The API sends more than that: a reason, how many tries are
+ * left, and — when the account is locked out — how long for.
+ *
+ * The consequence was worst exactly where it mattered. After five wrong
+ * attempts the lockout escalates (5 minutes, then 15, then an hour, then
+ * four), and during that window the CORRECT PIN also fails. The display said
+ * "Incorrect PIN". Someone who had just typed their own PIN correctly was
+ * told, for up to four hours, that it was wrong — with nothing suggesting
+ * waiting would help.
+ *
+ * On a kitchen wall display the person hitting this is usually the one least
+ * able to reason about it.
+ */
+
+export interface PinFailureResponse {
+  error?: string;
+  lockedOut?: boolean;
+  /** Seconds until another attempt is allowed. */
+  retryAfter?: number;
+  remainingAttempts?: number;
+  pinRequired?: boolean;
+}
+
+/**
+ * A clock time reads better than a duration on a wall display: "try again at
+ * 4:15" needs no arithmetic and stays true if you walk away and come back,
+ * where "try again in 300 seconds" is stale the moment you read it.
+ */
+function formatRetryTime(retryAfterSeconds: number, now: Date): string {
+  const when = new Date(now.getTime() + retryAfterSeconds * 1000);
+  return when.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+/**
+ * @param status  HTTP status from the PIN endpoint.
+ * @param body    Parsed response body, or null if it could not be read.
+ * @param now     Injected for testing.
+ */
+export function pinErrorMessage(
+  status: number,
+  body: PinFailureResponse | null,
+  now: Date = new Date(),
+): string {
+  // Nothing readable came back — usually the hub being unreachable rather than
+  // anything to do with the PIN, so do not accuse the user of getting it wrong.
+  if (!body) {
+    return status === 0
+      ? "Can't reach Prism right now. Try again in a moment."
+      : 'Something went wrong. Try again in a moment.';
+  }
+
+  if (body.lockedOut) {
+    const when = typeof body.retryAfter === 'number' && body.retryAfter > 0
+      ? ` Try again at ${formatRetryTime(body.retryAfter, now)}.`
+      : ' Try again shortly.';
+    return `Too many tries.${when}`;
+  }
+
+  // The member has no PIN at all. The API's own wording is written for a
+  // support ticket; this says who can fix it and where.
+  if (body.pinRequired) {
+    return 'No PIN set for this person yet. A parent can add one in Settings, Family Members.';
+  }
+
+  if (typeof body.remainingAttempts === 'number') {
+    if (body.remainingAttempts <= 0) return 'Too many tries. Try again shortly.';
+    if (body.remainingAttempts === 1) {
+      return "That PIN didn't work. 1 try left before this locks for a few minutes.";
+    }
+    return `That PIN didn't work. ${body.remainingAttempts} tries left.`;
+  }
+
+  // Fall back to whatever the server said before inventing our own wording.
+  return body.error || "That PIN didn't work.";
+}


### PR DESCRIPTION
Three PIN pads hardcoded `setError('Incorrect PIN')` and threw the response body away — `QuickPinModal`, `ExitAwayModeModal`, `ExitBabysitterModeModal`. The API sends a reason, how many attempts remain, and how long a lockout lasts. **None of it reached a screen.**

## Why this matters more than it looks

After five failures the lockout escalates through 5 minutes, 15, an hour, four hours — and during that window **the correct PIN is refused too**.

So someone who had just typed their own PIN correctly was told, for up to four hours, that it was wrong, with nothing suggesting that waiting would help. On a kitchen wall display the natural conclusion is that the screen is broken or someone changed the PIN.

The person who hits this is usually the one least able to reason about it.

## What it says now

| Case | Before | After |
|---|---|---|
| Locked out | Incorrect PIN | **Too many tries. Try again at 4:15.** |
| Wrong PIN | Incorrect PIN | **That PIN didn't work. 3 tries left.** |
| Last attempt | Incorrect PIN | **...1 try left before this locks for a few minutes.** |
| No PIN set | Incorrect PIN | **A parent can add one in Settings, Family Members.** |
| Hub unreachable | Incorrect PIN | **Can't reach Prism right now.** |

Two deliberate choices:

- **A clock time, not a duration.** "Try again in 300 seconds" is stale the moment it's read and needs arithmetic. "At 4:15" survives walking away and coming back.
- **A failed request no longer reports a wrong PIN.** A hub that's down is not a credential problem, and saying so sends people hunting for one that doesn't exist.

`SettingsPinGate` already did this correctly. The other three now match it.

## How it was found

A usability review asking whether a child or a grandparent could operate the display unaided.

## Testing

Nine cases covering each branch, including the two that were silently wrong before: a lockout must not read as a wrong PIN, and zero remaining attempts must not render as "0 tries left".

1,560 tests pass, typecheck clean. Lint warning count on the touched files is unchanged from master — all four are pre-existing.
