### PR TITLE
fix(screensaver): a screensaver you opened by hand can always be closed again

### DIFF
--- a/src/lib/hooks/__tests__/useIdleDetection.test.tsx
+++ b/src/lib/hooks/__tests__/useIdleDetection.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * The screensaver must always be dismissable, even where it never
+ * auto-activates.
+ *
+ * The toolbar button opens the screensaver deliberately and is not gated on
+ * PWA mode or on the timeout setting. Dismissal used to be registered in the
+ * same effect as the idle timer, behind `if (timeout <= 0 || isPWA) return`,
+ * so in an installed app — or with the timeout set to Never — the button
+ * opened a screensaver that nothing could close.
+ */
+import { renderHook, act } from '@testing-library/react';
+
+let mockIsPWA = false;
+jest.mock('../useIsPWA', () => ({ useIsPWA: () => mockIsPWA }));
+
+let mockTimeout = 120;
+jest.mock('../useScreensaverTimeout', () => ({
+  useScreensaverTimeout: () => ({ timeout: mockTimeout, setTimeout: jest.fn() }),
+  SCREENSAVER_TIMEOUT_OPTIONS: [],
+}));
+
+import { useIdleDetection } from '../useIdleDetection';
+
+/** The toolbar button's effect: open the screensaver on demand. */
+const openScreensaver = () => window.dispatchEvent(new Event('prism:screensaver'));
+
+/** A deliberate interaction, as the dismiss listeners see it. */
+const tap = () => window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+beforeEach(() => {
+  mockIsPWA = false;
+  mockTimeout = 120;
+  window.localStorage.clear();
+});
+
+describe('useIdleDetection — dismissing what the button opened', () => {
+  it('closes on a tap in an ordinary browser', () => {
+    const { result } = renderHook(() => useIdleDetection());
+
+    act(() => { openScreensaver(); });
+    expect(result.current.isIdle).toBe(true);
+
+    // First interaction clears the "forced" flag, the second dismisses — this
+    // is deliberate, so the button's own mouseup doesn't close it instantly.
+    act(() => { tap(); tap(); });
+    expect(result.current.isIdle).toBe(false);
+  });
+
+  it('closes on a tap in an installed PWA, where the timer never runs', () => {
+    // The regression: the app was stuck on the screensaver until force-closed.
+    mockIsPWA = true;
+    const { result } = renderHook(() => useIdleDetection());
+
+    act(() => { openScreensaver(); });
+    expect(result.current.isIdle).toBe(true);
+
+    act(() => { tap(); tap(); });
+    expect(result.current.isIdle).toBe(false);
+  });
+
+  it('closes on a tap when the timeout is set to Never', () => {
+    // Same trap by a different route: "Never" also skipped registration.
+    mockTimeout = 0;
+    const { result } = renderHook(() => useIdleDetection());
+
+    act(() => { openScreensaver(); });
+    expect(result.current.isIdle).toBe(true);
+
+    act(() => { tap(); tap(); });
+    expect(result.current.isIdle).toBe(false);
+  });
+
+  it('leaves a keep-alive control alone rather than dismissing', () => {
+    const keeper = document.createElement('button');
+    keeper.setAttribute('data-screensaver-keep', '');
+    document.body.appendChild(keeper);
+
+    const { result } = renderHook(() => useIdleDetection());
+    act(() => { openScreensaver(); });
+
+    act(() => {
+      keeper.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      keeper.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(result.current.isIdle).toBe(true);
+
+    document.body.removeChild(keeper);
+  });
+});

--- a/src/lib/hooks/useIdleDetection.ts
+++ b/src/lib/hooks/useIdleDetection.ts
@@ -91,19 +91,18 @@ export function useIdleDetection(initialTimeout?: number) {
     setIsIdle(true);
   }, []);
 
+  // Dismissal is registered ALWAYS — including in a PWA, and including when
+  // the timeout is "Never".
+  //
+  // The screensaver can be opened deliberately from the toolbar button, which
+  // dispatches 'prism:screensaver' and is not gated on either condition. When
+  // this effect skipped registration, that button had no counterpart: nothing
+  // anywhere could clear isIdle, so an installed app was stuck on the
+  // screensaver until it was force-closed. The auto-idle TIMER below is still
+  // skipped on a PWA, which is the documented intent (a phone has no idle
+  // state, and auto-locking someone out of their own device is wrong) — but
+  // that intent never implied "cannot be dismissed".
   useEffect(() => {
-    if (timeout <= 0 || isPWA) return;
-
-    // Mousemove/scroll only reset the idle timer, they don't dismiss the screensaver
-    const moveEvents = ['mousemove', 'scroll'] as const;
-    moveEvents.forEach((e) => window.addEventListener(e, resetTimer));
-
-    // Click/key/touch dismiss the screensaver AND reset the timer — EXCEPT when
-    // the interaction targets an opt-in "keep-alive" control (e.g. the calendar
-    // view switcher), so those can be operated in place without exiting the
-    // screensaver. Checking the native event target covers portaled controls
-    // (like the view popover, which renders under <body>) that stopPropagation
-    // on the React tree would miss.
     const maybeDismiss = (e: Event) => {
       const target = e.target as Element | null;
       if (target && typeof target.closest === 'function' && target.closest('[data-screensaver-keep]')) {
@@ -112,16 +111,29 @@ export function useIdleDetection(initialTimeout?: number) {
       dismissIdle();
     };
     const dismissEvents = ['mousedown', 'keydown', 'touchstart'] as const;
-    dismissEvents.forEach((e) => window.addEventListener(e, maybeDismiss));
+    // Passive: none of these call preventDefault, and a non-passive touchstart
+    // on window makes the browser wait on JS before it can scroll. Every other
+    // activity hook in the codebase already does this.
+    dismissEvents.forEach((e) => window.addEventListener(e, maybeDismiss, { passive: true }));
+    return () => {
+      dismissEvents.forEach((e) => window.removeEventListener(e, maybeDismiss));
+    };
+  }, [dismissIdle]);
+
+  useEffect(() => {
+    if (timeout <= 0 || isPWA) return;
+
+    // Mousemove/scroll only reset the idle timer, they don't dismiss the screensaver
+    const moveEvents = ['mousemove', 'scroll'] as const;
+    moveEvents.forEach((e) => window.addEventListener(e, resetTimer, { passive: true }));
 
     resetTimer();
 
     return () => {
       moveEvents.forEach((e) => window.removeEventListener(e, resetTimer));
-      dismissEvents.forEach((e) => window.removeEventListener(e, maybeDismiss));
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [resetTimer, dismissIdle, timeout, isPWA]);
+  }, [resetTimer, timeout, isPWA]);
 
   // Listen for custom screensaver activation event
   useEffect(() => {


### PR DESCRIPTION
The toolbar button opens the screensaver deliberately — `prism:screensaver` → `forceIdle()`. It is gated on nothing.

Dismissal was registered in the **same effect as the idle timer**, behind `if (timeout <= 0 || isPWA) return`. So in either of those states the button opened a screensaver that **nothing could close** — no listener existed anywhere to clear `isIdle`. The only way out was force-quitting the app or reloading the page.

## Two configurations reach it, and the second is more likely

- an installed **PWA**, where the timer is skipped by design
- a screensaver timeout of **"Never"**, in any ordinary browser

"Never" is a perfectly reasonable setting for a wall display whose owner wants the screensaver **only on demand** — which is precisely the person who uses that button. The PWA case was what the review flagged; the "Never" case came out of writing the test.

## The fix

Dismissal is now its own effect, registered unconditionally.

The auto-idle **timer** keeps both guards, because the documented intent behind them is sound: a phone genuinely has no idle state, and auto-activating on someone's own device would lock them out of it. That intent never implied *"cannot be dismissed"*.

Also passes `{ passive: true }` on these listeners, matching every other activity hook in the codebase. None of them call `preventDefault`, and a non-passive `touchstart` on `window` makes the browser wait on JS before it can scroll.

## How it was found

Reviewing the screensaver PIN lock proposal. The lock would have been built directly on top of this — a lock screen that already couldn't be dismissed.

## Testing

Four cases: dismissal works in an ordinary browser, in a PWA, and with the timeout set to Never; and a `data-screensaver-keep` control still doesn't dismiss.

1,555 tests pass, typecheck clean.
