### PR TITLE
perf(screensaver): fetch only what the screensaver draws

### DIFF
--- a/src/components/dashboard/useDashboardData.ts
+++ b/src/components/dashboard/useDashboardData.ts
@@ -20,12 +20,33 @@ const WIDGET_DOMAIN_MAP: Record<string, string[]> = {
   points: ['goals', 'points'],
 };
 
-export function useDashboardData(visibleWidgets?: Set<string>) {
+/**
+ * @param visibleWidgets  Which widgets are on screen. Omitted means "unknown",
+ *   which enables every data domain.
+ * @param opts.deferRest  Whether to quietly enable the remaining domains a
+ *   couple of seconds after mount. True on the dashboard, where the user may
+ *   reveal a hidden widget at any moment. False for a consumer whose widget
+ *   set cannot change while it is mounted — the screensaver — because there
+ *   the deferral just undoes the gating two seconds in and fetches data
+ *   nothing will draw, for as long as the overlay is up.
+ */
+/**
+ * When a task-source sync last ran, shared across every consumer of this hook.
+ * Deliberately module-level: it must survive a component remounting, or an
+ * overlay appearing re-triggers a provider write.
+ */
+let lastAutoSyncAt = 0;
+
+export function useDashboardData(
+  visibleWidgets?: Set<string>,
+  opts: { deferRest?: boolean } = {},
+) {
+  const { deferRest = true } = opts;
   // After a short delay, enable ALL domains (background loading for non-visible widgets)
   const [deferredEnabled, setDeferredEnabled] = useState(false);
 
   useEffect(() => {
-    if (!visibleWidgets) return; // No visibility info → all enabled already
+    if (!visibleWidgets || !deferRest) return; // No visibility info → all enabled already
     const timer = setTimeout(() => setDeferredEnabled(true), DEFERRED_LOAD_DELAY_MS);
     return () => clearTimeout(timer);
   }, []); // Only on mount
@@ -129,14 +150,13 @@ export function useDashboardData(visibleWidgets?: Set<string>) {
   } = useLayouts();
 
   // Auto-sync task sources when dashboard is visible
-  const lastAutoSyncRef = useRef<number>(0);
 
   const autoSyncTasks = useCallback(async () => {
     // Skip sync in guest/display mode — no session cookie means no write access
     if (typeof document !== 'undefined' && !document.cookie.includes('prism_session')) return;
 
     const now = Date.now();
-    if (now - lastAutoSyncRef.current < AUTO_SYNC_INTERVAL_MS) return;
+    if (now - lastAutoSyncAt < AUTO_SYNC_INTERVAL_MS) return;
 
     try {
       const res = await fetch(`/api/task-sources/sync-all?staleMinutes=${AUTO_SYNC_STALE_MINUTES}`, {
@@ -147,7 +167,7 @@ export function useDashboardData(visibleWidgets?: Set<string>) {
         if (data.synced > 0) {
           refreshTasks();
         }
-        lastAutoSyncRef.current = now;
+        lastAutoSyncAt = now;
       }
     } catch {
       // Silently fail auto-sync

--- a/src/components/screensaver/Screensaver.tsx
+++ b/src/components/screensaver/Screensaver.tsx
@@ -118,7 +118,21 @@ export function Screensaver() {
 
 function ScreensaverGrid() {
   const layout = useMemo(() => loadScreensaverLayout(), []);
-  const data = useDashboardData();
+
+  // Only fetch what this overlay actually draws. Called bare, the hook enables
+  // every data domain — eleven of them — while the default screensaver layout
+  // renders three, and the dashboard underneath is already fetching its own
+  // copy of all of it. The overlay used to be up for seconds at a time, so the
+  // waste was a burst; it is worth fixing on a display that is never closed.
+  //
+  // deferRest is off because the screensaver's widget set is fixed for as long
+  // as it is mounted, so the usual two-second "enable everything" catch-up has
+  // nothing to catch up on and would simply undo the gating.
+  const visibleWidgets = useMemo(
+    () => new Set(layout.filter((w) => w.visible !== false).map((w) => w.i)),
+    [layout],
+  );
+  const data = useDashboardData(visibleWidgets, { deferRest: false });
   const widgetProps = useMemo(() =>
     buildWidgetProps(
       data,


### PR DESCRIPTION
`useDashboardData()` called with **no argument** enables every data domain — a missing set means "visibility unknown", which is correct for a caller that doesn't know.

The screensaver *does* know. It has its layout in hand.

So the overlay polled calendar, weather, messages, tasks, chores, shopping, meals, birthdays, goals and points — while the default layout renders **three** of them, and the dashboard underneath was already fetching its own copy of all of it.

Roughly **180 requests an hour**, about half for data nothing draws.

That was tolerable when the screensaver was up for seconds at a time. On a display that is never closed — and where the overlay can sit for hours — it's worth fixing.

## `deferRest`

The hook quietly enables the remaining domains two seconds after mount, so a hidden widget that gets revealed has its data ready. The dashboard keeps that.

The screensaver turns it off: its widget set is **fixed for as long as it is mounted**, so the deferral has nothing to catch up on and would simply undo the gating two seconds in.

## The task-sync side effect

Separately, the sync throttle was a **per-instance ref**, so it reset on every mount. The screensaver appearing therefore fired `POST /api/task-sources/sync-all` — a write path against Google and Microsoft — **every time the display went idle**.

Now module-scoped, so two consumers of this hook can't trigger each other's syncs by appearing.

## How it was found

A performance review framed around the display as a 24/7 device rather than a page someone opens — "does it still work on day 30" rather than "is it fast to click".

## Testing

1,551 tests pass, typecheck clean. Lint warning count on both touched files is identical to master — all 13 pre-existing.
