### PR TITLE
KYST auth wall and schedule-aware Night Sky

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,14 @@ APP_URL=http://localhost:3000
 SESSION_SECRET=generate_a_random_32_character_string_here
 PIN_ENCRYPTION_KEY=generate_another_random_32_character_string
 
+# Optional deployment-wide household wall. When any KYST_AUTH_* variable is
+# present, KYST_AUTH_PASSWORD and KYST_AUTH_SECRET must both be valid or the
+# wall fails closed with HTTP 503. Keep all values in your secret manager.
+# KYST_AUTH_PASSWORD=choose-a-household-password-or-pin
+# KYST_AUTH_SECRET=generate-with-openssl-rand-hex-32
+# KYST_AUTH_DEVICE_TOKEN=v1.<64-lowercase-hex-characters>
+# KYST_AUTH_SERVICE_TOKEN=v1.<64-lowercase-hex-characters>
+
 # Used for encrypting OAuth tokens at rest (AES-256-GCM)
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ENCRYPTION_KEY=generate_a_64_hex_character_string_here

--- a/docs/kyst-household-auth.md
+++ b/docs/kyst-household-auth.md
@@ -1,0 +1,194 @@
+# KYST household authentication
+
+This deployment layer sits in front of Prism's existing member PIN and role checks. It does not replace them. A household session gets a browser through the outer wall; Prism still enforces member PINs, `requirePinForDelete`, `requirePinForSettings`, API-token scopes, and role permissions underneath.
+
+## Fly secrets
+
+Set these four names on `kyst-board`:
+
+- `KYST_AUTH_PASSWORD`: the household password or PIN (minimum four characters).
+- `KYST_AUTH_SECRET`: 32 or more random characters used only to HMAC-sign sessions.
+- `KYST_AUTH_DEVICE_TOKEN`: kiosk bootstrap credential, exactly `v1.` plus 64 lowercase hex characters.
+- `KYST_AUTH_SERVICE_TOKEN`: outer-wall credential for trusted automation, exactly `v1.` plus 64 lowercase hex characters.
+
+Generate the three random values locally without displaying them, save the only operator copy in a mode-600 credential file, then set the Fly secrets from that file. Example commands are intentionally written so normal output exposes only property names:
+
+```bash
+umask 077
+auth_file="$HOME/.openclaw/credentials/kyst-board-auth.env"
+{
+  printf 'KYST_AUTH_SECRET=%s\n' "$(openssl rand -hex 32)"
+  printf 'KYST_AUTH_DEVICE_TOKEN=v1.%s\n' "$(openssl rand -hex 32)"
+  printf 'KYST_AUTH_SERVICE_TOKEN=v1.%s\n' "$(openssl rand -hex 32)"
+} > "$auth_file"
+printf 'KYST_AUTH_PASSWORD=' >> "$auth_file"
+read -rs household_password
+printf '%s\n' "$household_password" >> "$auth_file"
+unset household_password
+```
+
+After review, import only the four KYST lines through stdin so values never enter the `flyctl` argument list:
+
+```bash
+set -a
+. "$HOME/.openclaw/credentials/fly.env"
+set +a
+sed -n '/^KYST_AUTH_\(PASSWORD\|SECRET\|DEVICE_TOKEN\|SERVICE_TOKEN\)=/p' \
+  "$HOME/.openclaw/credentials/kyst-board-auth.env" \
+  | "$HOME/.fly/bin/flyctl" secrets import -a kyst-board
+"$HOME/.fly/bin/flyctl" secrets list -a kyst-board
+```
+
+The final command must show all four names. Do not import the secrets until the kiosk bootstrap and rollback steps are ready because the import restarts the machine and immediately closes the public routes.
+
+## Browser session contract
+
+- Cookie name: `kyst_household_session`
+- Domain: host-only `kyst-board.fly.dev` (the `Domain` attribute is intentionally omitted)
+- Path: `/`
+- Attributes: `HttpOnly; Secure; SameSite=Lax`
+- Value: opaque `v1.<issued-at-unix-seconds>.<expires-at-unix-seconds>.<32-byte-base64url-nonce>.<HMAC-SHA256-base64url-signature>`
+- Expiry: 90 days after issue; a valid request in the final 45 days renews it to another 90 days
+
+The cookie is not a Prism member session. Member PIN prompts and destructive/settings authorization continue normally.
+
+## Kiosk bootstrap
+
+The real kiosk uses Chromium's default profile at `/home/admin/.config/chromium/Default` and launches from `/home/admin/.xinitrc`. Resolve its current address from the mode-600 kiosk credential file, then seed that exact profile once over SSH. These commands expose neither token nor cookie value in normal output:
+
+```bash
+kiosk_env="$HOME/.openclaw/credentials/mynode-kiosk.env"
+kiosk_user=$(sed -n 's/^MYNODE_SSH_USER=//p' "$kiosk_env" | tr -d '"')
+kiosk_password=$(sed -n 's/^MYNODE_SSH_PASSWORD=//p' "$kiosk_env" | tr -d '"')
+kiosk_host=$(sed -n 's/^MYNODE_IP=//p' "$kiosk_env" | tr -d '"')
+test -n "$kiosk_host"
+SSHPASS="$kiosk_password" sshpass -e ssh -o ConnectTimeout=5 \
+  -o StrictHostKeyChecking=accept-new "$kiosk_user@$kiosk_host" true
+
+auth_file="$HOME/.openclaw/credentials/kyst-board-auth.env"
+device_token=$(sed -n 's/^KYST_AUTH_DEVICE_TOKEN=//p' "$auth_file")
+test -n "$device_token"
+
+SSHPASS="$kiosk_password" sshpass -e ssh -o StrictHostKeyChecking=accept-new \
+  "$kiosk_user@$kiosk_host" bash -s -- "$device_token" <<'REMOTE'
+set -eu
+device_token=$1
+xinitrc=/home/admin/.xinitrc
+backup=/home/admin/.xinitrc.pre-kyst-auth
+cp -a "$xinitrc" "$backup"
+restore() {
+  cp -a "$backup" "$xinitrc"
+  pkill -x chromium 2>/dev/null || true
+}
+trap restore EXIT
+
+bootstrap_url="https://kyst-board.fly.dev/api/household-auth/device?token=$device_token"
+sed -i "s#https://kyst-board.fly.dev/#$bootstrap_url#" "$xinitrc"
+pkill -x chromium 2>/dev/null || true
+sleep 15
+
+python3 - <<'PY'
+import datetime as dt
+import sqlite3
+
+path = "/home/admin/.config/chromium/Default/Cookies"
+db = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+row = db.execute(
+    "SELECT host_key,name,path,is_secure,is_httponly,expires_utc "
+    "FROM cookies WHERE host_key='kyst-board.fly.dev' "
+    "AND name='kyst_household_session'"
+).fetchone()
+if row is None:
+    raise SystemExit("kyst_household_session cookie not found")
+expiry = dt.datetime(1601, 1, 1, tzinfo=dt.timezone.utc) + dt.timedelta(microseconds=row[5])
+print(
+    f"host={row[0]} name={row[1]} path={row[2]} secure={row[3]} "
+    f"httponly={row[4]} expires={expiry.isoformat()}"
+)
+PY
+
+restore
+trap - EXIT
+sleep 10
+grep -F "'https://kyst-board.fly.dev/'" "$xinitrc" >/dev/null
+pgrep -x chromium >/dev/null
+REMOTE
+
+unset device_token kiosk_password
+```
+
+The metadata line must report host `kyst-board.fly.dev`, name `kyst_household_session`, path `/`, secure `1`, HttpOnly `1`, and an expiry about 90 days out. The final two checks prove the canonical URL and Chromium process are restored.
+
+The bootstrap URL is a bearer credential and Chromium may retain it in history. Immediately rotate only the device token after seeding; the already-minted session remains valid because its signature uses `KYST_AUTH_SECRET`:
+
+```bash
+auth_file="$HOME/.openclaw/credentials/kyst-board-auth.env"
+new_device_token="v1.$(openssl rand -hex 32)"
+sed -i "s/^KYST_AUTH_DEVICE_TOKEN=.*/KYST_AUTH_DEVICE_TOKEN=$new_device_token/" "$auth_file"
+set -a
+. "$HOME/.openclaw/credentials/fly.env"
+set +a
+sed -n '/^KYST_AUTH_\(PASSWORD\|SECRET\|DEVICE_TOKEN\|SERVICE_TOKEN\)=/p' "$auth_file" \
+  | "$HOME/.fly/bin/flyctl" secrets import -a kyst-board
+unset new_device_token
+```
+
+Never paste the bootstrap URL into chat, logs, screenshots, or interactive shell history. Never retain a backup containing it.
+
+## Trusted automation
+
+HTTP automation must send both layers where the underlying Prism route requires Prism authorization:
+
+```text
+X-Kyst-Service-Token: <KYST_AUTH_SERVICE_TOKEN>
+Authorization: Bearer <existing Prism API token>
+```
+
+The outer service token alone opens the deployment wall but does not grant a Prism role or scope. Existing Prism API tokens still enforce route-level permissions. Internal `calendar-cron` and `photo-cron` are not HTTP callers: they invoke `syncAllGoogleCalendars`, `syncAllIcalCalendars`, `syncAllCalDAVCalendars`, `syncCardDAVBirthdays`, and `syncAllPhotoSources` directly, so the middleware cannot 401 those jobs.
+
+Before enabling the wall, add `KYST_AUTH_SERVICE_TOKEN` to the mode-600 Prism automation credential file and update each trusted HTTP caller (currently `scripts/kyst_ask_nox_poll.py`, `scripts/kyst_board_task.py`, and `scripts/kyst_voice_ask_poll.py`) to send `X-Kyst-Service-Token` while retaining its existing Prism bearer token. Verify one read and one mutation through each active caller before importing the Fly secrets.
+
+## NOX deploy and rollback
+
+The branch is based on the live Prism `v1.17.0` commit, not a newer upstream release. As of the implementation readback, the rollback image is `ghcr.io/sandydargoport/prism@sha256:c727a8b02deff695dff97c26223d337908c704c0fa56a94f93041bc3bafec116` (Prism 1.17.0). Re-read `flyctl image show -a kyst-board` immediately before deployment and replace this digest if live state changed.
+
+From the reviewed branch:
+
+```bash
+cd /tmp/kyst-board
+test "$(git branch --show-current)" = feature/kyst-auth-wall
+git status --short
+
+set -a
+. "$HOME/.openclaw/credentials/fly.env"
+set +a
+"$HOME/.fly/bin/flyctl" config save -a kyst-board -c /tmp/kyst-board/fly.toml -y
+"$HOME/.fly/bin/flyctl" deploy -a kyst-board -c /tmp/kyst-board/fly.toml \
+  --dockerfile /tmp/kyst-board/Dockerfile --remote-only --build-only
+"$HOME/.fly/bin/flyctl" deploy -a kyst-board -c /tmp/kyst-board/fly.toml \
+  --dockerfile /tmp/kyst-board/Dockerfile --remote-only --strategy rolling
+```
+
+Do not commit the fetched `fly.toml`; it contains KYST deployment-specific non-secret configuration. After the source deploy is healthy, import the four auth secrets through stdin as shown above, run the required readback, update trusted automation, and seed the kiosk. Do not announce completion until the kiosk renders the dashboard and fresh post-deploy calendar/photo cron lines have both appeared.
+
+If the source deploy or auth activation fails, roll back code immediately while leaving the database untouched:
+
+```bash
+"$HOME/.fly/bin/flyctl" deploy -a kyst-board -c /tmp/kyst-board/fly.toml \
+  --image ghcr.io/sandydargoport/prism@sha256:c727a8b02deff695dff97c26223d337908c704c0fa56a94f93041bc3bafec116 \
+  --strategy rolling
+```
+
+The vanilla image ignores `KYST_AUTH_*`, so that rollback restores the pre-wall behavior. Keep the auth credential file; do not print or discard it during rollback.
+
+## Required readback
+
+After deployment:
+
+1. Confirm `/api/health` and `/api/health/ready` remain public for Fly health checks, while `/api/health/deep` requires household authentication.
+2. Confirm unauthenticated `GET /api/tasks`, `/api/family`, `/api/chores`, and `/api/settings` each returns 401 and no response body contains household data.
+3. Log in through `/auth/household`, store the cookie in a cookie jar, and confirm all four endpoints return 200 with that cookie.
+4. Confirm a deliberately wrong cookie and a deliberately wrong `X-Kyst-Service-Token` both return 401.
+5. Confirm trusted automation returns its prior status when it sends the service header plus its existing Prism bearer token.
+6. Inspect Fly logs through at least one 10-minute calendar interval and one 30-minute photo interval. Require fresh `[calendar-cron] synced` and `[photo-cron] synced` lines after the deploy; earlier lines are not proof.
+7. Seed and verify the kiosk before declaring the rollout complete.

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
+import { createHouseholdSession, HOUSEHOLD_COOKIE_NAME } from '@/lib/auth/householdAuth';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -7,10 +8,7 @@ import { middleware } from '../middleware';
 
 function makeRequest(
   path: string,
-  {
-    method = 'GET',
-    headers = {},
-  }: { method?: string; headers?: Record<string, string> } = {},
+  { method = 'GET', headers = {} }: { method?: string; headers?: Record<string, string> } = {}
 ): NextRequest {
   const url = `http://localhost:3000${path}`;
   return new NextRequest(url, { method, headers: new Headers(headers) });
@@ -187,7 +185,7 @@ describe('middleware', () => {
       expect(res.status).not.toBe(403);
     });
 
-    it('on — logout allowed so visitors don\'t get stuck', async () => {
+    it("on — logout allowed so visitors don't get stuck", async () => {
       process.env.DEMO_MODE = 'true';
       const req = makeRequest('/api/auth/logout', {
         method: 'POST',
@@ -195,6 +193,83 @@ describe('middleware', () => {
       });
       const res = await middleware(req);
       expect(res.status).not.toBe(403);
+    });
+  });
+
+  describe('KYST household authentication', () => {
+    const authSecret = 's'.repeat(64);
+    const serviceToken = `v1.${'a'.repeat(64)}`;
+
+    beforeEach(() => {
+      process.env.KYST_AUTH_PASSWORD = 'test-password';
+      process.env.KYST_AUTH_SECRET = authSecret;
+      process.env.KYST_AUTH_SERVICE_TOKEN = serviceToken;
+    });
+
+    afterEach(() => {
+      delete process.env.KYST_AUTH_PASSWORD;
+      delete process.env.KYST_AUTH_SECRET;
+      delete process.env.KYST_AUTH_DEVICE_TOKEN;
+      delete process.env.KYST_AUTH_SERVICE_TOKEN;
+    });
+
+    it('returns 401 for an unauthenticated data API request', async () => {
+      const response = await middleware(makeRequest('/api/tasks'));
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Household authentication required',
+      });
+    });
+
+    it('accepts a valid household session cookie', async () => {
+      const cookie = await createHouseholdSession(authSecret);
+      const response = await middleware(
+        makeRequest('/api/tasks', {
+          headers: { cookie: `${HOUSEHOLD_COOKIE_NAME}=${cookie}` },
+        })
+      );
+      expect(response.status).not.toBe(401);
+    });
+
+    it('accepts the deployment service header', async () => {
+      const response = await middleware(
+        makeRequest('/api/tasks', {
+          headers: { 'x-kyst-service-token': serviceToken },
+        })
+      );
+      expect(response.status).not.toBe(401);
+    });
+
+    it('rejects an arbitrary service header', async () => {
+      const response = await middleware(
+        makeRequest('/api/tasks', {
+          headers: { 'x-kyst-service-token': `v1.${'b'.repeat(64)}` },
+        })
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it('redirects an unauthenticated page request to the login wall', async () => {
+      const response = await middleware(makeRequest('/calendar?view=week'));
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost:3000/auth/household?next=%2Fcalendar%3Fview%3Dweek'
+      );
+    });
+
+    it('keeps the login wall and health checks public', async () => {
+      expect((await middleware(makeRequest('/auth/household'))).status).not.toBe(401);
+      expect((await middleware(makeRequest('/api/health'))).status).not.toBe(401);
+      expect((await middleware(makeRequest('/api/health/ready'))).status).not.toBe(401);
+      expect((await middleware(makeRequest('/api/health/deep'))).status).toBe(401);
+      expect((await middleware(makeRequest('/sw.js'))).status).not.toBe(401);
+      expect((await middleware(makeRequest('/workbox-123.js'))).status).not.toBe(401);
+    });
+
+    it('fails closed when only one core secret is configured', async () => {
+      delete process.env.KYST_AUTH_SECRET;
+      const response = await middleware(makeRequest('/api/tasks'));
+      expect(response.status).toBe(503);
     });
   });
 });

--- a/src/app/api/household-auth/device/route.ts
+++ b/src/app/api/household-auth/device/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  constantTimeSecretEqual,
+  createHouseholdSession,
+  getHouseholdAuthState,
+  householdCookieOptions,
+  HOUSEHOLD_COOKIE_NAME,
+} from '@/lib/auth/householdAuth';
+
+export async function GET(request: NextRequest) {
+  const configuredToken = process.env.KYST_AUTH_DEVICE_TOKEN;
+  const suppliedToken = request.nextUrl.searchParams.get('token') || '';
+
+  if (getHouseholdAuthState() !== 'ready' || !configuredToken) {
+    return NextResponse.json({ error: 'Device authentication is unavailable' }, { status: 503 });
+  }
+  if (!(await constantTimeSecretEqual(suppliedToken, configuredToken))) {
+    return NextResponse.json({ error: 'Invalid device credential' }, { status: 401 });
+  }
+
+  const response = new NextResponse(null, {
+    status: 303,
+    headers: { location: '/', 'cache-control': 'no-store' },
+  });
+  response.cookies.set(
+    HOUSEHOLD_COOKIE_NAME,
+    await createHouseholdSession(process.env.KYST_AUTH_SECRET!),
+    householdCookieOptions()
+  );
+  return response;
+}

--- a/src/app/api/household-auth/login/route.ts
+++ b/src/app/api/household-auth/login/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rateLimitGuard } from '@/lib/cache/rateLimit';
+import {
+  constantTimeSecretEqual,
+  createHouseholdSession,
+  getHouseholdAuthState,
+  householdCookieOptions,
+  HOUSEHOLD_COOKIE_NAME,
+} from '@/lib/auth/householdAuth';
+
+function clientAddress(request: NextRequest): string {
+  return (
+    request.headers.get('fly-client-ip') ||
+    request.headers.get('x-real-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  if (getHouseholdAuthState() !== 'ready') {
+    return NextResponse.json({ error: 'Household authentication is unavailable' }, { status: 503 });
+  }
+
+  const limited = await rateLimitGuard(`household:${clientAddress(request)}`, 'login', 8, 15 * 60);
+  if (limited) return limited;
+
+  let password = '';
+  try {
+    const body = await request.json();
+    if (typeof body.password === 'string') password = body.password;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  if (!(await constantTimeSecretEqual(password, process.env.KYST_AUTH_PASSWORD!))) {
+    return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
+  }
+
+  const response = NextResponse.json({ authenticated: true });
+  response.cookies.set(
+    HOUSEHOLD_COOKIE_NAME,
+    await createHouseholdSession(process.env.KYST_AUTH_SECRET!),
+    householdCookieOptions()
+  );
+  return response;
+}

--- a/src/app/api/household-auth/logout/route.ts
+++ b/src/app/api/household-auth/logout/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { householdCookieOptions, HOUSEHOLD_COOKIE_NAME } from '@/lib/auth/householdAuth';
+
+export async function POST(_request: NextRequest) {
+  const response = new NextResponse(null, {
+    status: 303,
+    headers: { location: '/auth/household' },
+  });
+  response.cookies.set(HOUSEHOLD_COOKIE_NAME, '', householdCookieOptions(0));
+  return response;
+}

--- a/src/app/auth/household/page.tsx
+++ b/src/app/auth/household/page.tsx
@@ -5,7 +5,11 @@ import Image from 'next/image';
 
 function safeDestination(): string {
   const requested = new URLSearchParams(window.location.search).get('next');
-  return requested && requested.startsWith('/') && !requested.startsWith('//') ? requested : '/';
+  if (!requested || !requested.startsWith('/') || requested.includes('\\')) return '/';
+  return new URL(requested, window.location.origin).origin === window.location.origin &&
+    !requested.startsWith('//')
+    ? requested
+    : '/';
 }
 
 export default function HouseholdLoginPage() {

--- a/src/app/auth/household/page.tsx
+++ b/src/app/auth/household/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import Image from 'next/image';
+
+function safeDestination(): string {
+  const requested = new URLSearchParams(window.location.search).get('next');
+  return requested && requested.startsWith('/') && !requested.startsWith('//') ? requested : '/';
+}
+
+export default function HouseholdLoginPage() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+    setSubmitting(true);
+
+    try {
+      const response = await fetch('/api/household-auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+
+      if (!response.ok) {
+        setError(
+          response.status === 429
+            ? 'Too many attempts. Try again in a few minutes.'
+            : 'That password was not accepted.'
+        );
+        return;
+      }
+
+      window.location.replace(safeDestination());
+    } catch {
+      setError('The board could not be reached. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <section className="w-full max-w-sm rounded-2xl border bg-card p-8 shadow-xl">
+        <div className="mb-7 flex flex-col items-center text-center">
+          <Image src="/logo-prism.png" alt="Prism" width={72} height={72} priority />
+          <h1 className="mt-4 text-2xl font-semibold">Blackmon Family Board</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Enter the household password to continue.
+          </p>
+        </div>
+
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label htmlFor="household-password" className="mb-2 block text-sm font-medium">
+              Household password
+            </label>
+            <input
+              id="household-password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              autoFocus
+              required
+              className="h-12 w-full rounded-lg border bg-background px-4 outline-none ring-offset-background focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || password.length === 0}
+            className="h-12 w-full rounded-lg bg-primary px-4 font-medium text-primary-foreground transition-opacity disabled:opacity-50"
+          >
+            {submitting ? 'Unlocking…' : 'Unlock board'}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/src/components/layout/WallpaperBackground.tsx
+++ b/src/components/layout/WallpaperBackground.tsx
@@ -34,7 +34,7 @@ const DEFAULT_SCREENSAVER_INTERVAL = 15; // seconds
 export function useWallpaperSettings() {
   const [enabled, setEnabledState] = useState(() => {
     if (typeof window === 'undefined') return false;
-    return localStorage.getItem(STORAGE_KEY) !== 'false';
+    return localStorage.getItem(STORAGE_KEY) === 'true';
   });
   const [interval, setIntervalState] = useState(() => {
     if (typeof window === 'undefined') return DEFAULT_INTERVAL;

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -36,7 +36,7 @@ interface ProvidersProps {
  */
 export function Providers({ children }: ProvidersProps) {
   return (
-    <ThemeProvider defaultTheme="light">
+    <ThemeProvider defaultTheme="dark">
       <FamilyProvider>
         <AuthProvider>
           <TimeFormatProvider>

--- a/src/components/screensaver/NightSky.tsx
+++ b/src/components/screensaver/NightSky.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CalendarEvent } from '@/types/calendar';
+import { auroraPalette, isNightSkyNight, moonPhase, nightSkyEvents, tomorrowEvents } from './nightSkyUtils';
+
+type Props = { events: CalendarEvent[]; loading: boolean };
+
+function hash(value: string) {
+  let result = 2166136261;
+  for (let i = 0; i < value.length; i++) result = Math.imul(result ^ value.charCodeAt(i), 16777619);
+  return (result >>> 0) / 4294967295;
+}
+
+function paintMoon(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  age: number,
+  night: boolean,
+) {
+  const cycle = age / 29.530588853;
+  const angle = cycle * Math.PI * 2;
+  const lit = night ? '#8b93a3' : '#e7e4d7';
+  const dark = night ? '#050712' : '#091126';
+  const rightLit = cycle < 0.5;
+
+  context.save();
+  context.beginPath();
+  context.arc(x, y, radius, 0, Math.PI * 2);
+  context.clip();
+  context.fillStyle = dark;
+  context.fillRect(x - radius, y - radius, radius * 2, radius * 2);
+
+  context.fillStyle = lit;
+  context.beginPath();
+  context.arc(x, y, radius, -Math.PI / 2, Math.PI / 2, !rightLit);
+  context.closePath();
+  context.fill();
+
+  const limbRadius = Math.abs(Math.cos(angle)) * radius;
+  const isGibbous = cycle >= 0.25 && cycle < 0.75;
+  context.fillStyle = isGibbous ? lit : dark;
+  context.beginPath();
+  context.ellipse(x, y, limbRadius, radius, 0, 0, Math.PI * 2);
+  context.fill();
+  context.restore();
+}
+
+export function NightSky({ events, loading }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [now, setNow] = useState(() => new Date());
+  const upcoming = useMemo(() => nightSkyEvents(events, now), [events, now]);
+  const tomorrow = useMemo(() => tomorrowEvents(events, now), [events, now]);
+  const comet = tomorrow[0];
+  const night = isNightSkyNight(now);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext('2d', { alpha: false });
+    if (!context) return;
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let frame = 0;
+    let raf = 0;
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+      canvas.width = Math.floor(window.innerWidth * dpr);
+      canvas.height = Math.floor(window.innerHeight * dpr);
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    const paint = (timestamp: number) => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const drift = reduced ? 0 : timestamp / 80000;
+      context.fillStyle = night ? '#010207' : '#030817';
+      context.fillRect(0, 0, width, height);
+
+      const palette = auroraPalette(tomorrow.length);
+      context.globalCompositeOperation = 'screen';
+      palette.forEach((color, index) => {
+        const gradient = context.createRadialGradient(
+          width * (0.2 + index * 0.3) + Math.sin(drift * 3 + index) * width * 0.08,
+          height * 0.23, 0, width * 0.5, height * 0.15, width * 0.55,
+        );
+        gradient.addColorStop(0, `${color}${night ? '10' : tomorrow.length >= 8 ? '35' : '25'}`);
+        gradient.addColorStop(1, '#00000000');
+        context.fillStyle = gradient;
+        context.fillRect(0, 0, width, height * 0.72);
+      });
+      context.globalCompositeOperation = 'source-over';
+
+      const starCount = Math.min(260, Math.max(90, Math.floor((width * height) / 13000)));
+      for (let index = 0; index < starCount; index++) {
+        const seed = hash(`sky-${index}`);
+        const x = ((hash(`x-${index}`) * width + drift * (8 + seed * 12)) % width + width) % width;
+        const y = hash(`y-${index}`) * height;
+        const radius = 0.45 + seed * 1.15;
+        context.fillStyle = `rgba(220,232,255,${night ? 0.18 + seed * 0.35 : 0.28 + seed * 0.5})`;
+        context.beginPath(); context.arc(x, y, radius, 0, Math.PI * 2); context.fill();
+      }
+
+      const groups = new Map<string, CalendarEvent[]>();
+      upcoming.forEach((event) => groups.set(event.color, [...(groups.get(event.color) || []), event]));
+      Array.from(groups.entries()).forEach(([color, group], groupIndex) => {
+        const cx = width * (0.17 + (groupIndex % 4) * 0.22) + Math.sin(drift * 2 + groupIndex) * 18;
+        const cy = height * (0.28 + Math.floor(groupIndex / 4) * 0.28) + Math.cos(drift + groupIndex) * 12;
+        const points = group.slice(0, 12).map((event, index) => {
+          const angle = hash(event.id) * Math.PI * 2 + index * 0.8;
+          const radius = 38 + hash(`${event.id}-r`) * Math.min(120, width * 0.07);
+          return { x: cx + Math.cos(angle) * radius, y: cy + Math.sin(angle) * radius };
+        });
+        context.strokeStyle = `${color}${night ? '35' : '68'}`;
+        context.lineWidth = 1;
+        context.beginPath(); points.forEach((point, index) => index ? context.lineTo(point.x, point.y) : context.moveTo(point.x, point.y)); context.stroke();
+        points.forEach((point, index) => {
+          context.shadowBlur = night ? 5 : 12; context.shadowColor = color;
+          context.fillStyle = color; context.beginPath(); context.arc(point.x, point.y, index === 0 ? 3.5 : 2.4, 0, Math.PI * 2); context.fill();
+        });
+        context.shadowBlur = 0;
+      });
+
+      const phase = moonPhase(new Date());
+      const moonX = width * 0.86, moonY = height * 0.18, moonR = Math.min(width, height) * 0.044;
+      paintMoon(context, moonX, moonY, moonR, phase.age, night);
+
+      if (comet) {
+        const progress = reduced ? 0.45 : (timestamp % 60000) / 60000;
+        const x = -120 + progress * (width + 240), y = height * 0.72 - progress * height * 0.22;
+        const tail = context.createLinearGradient(x - 150, y + 45, x, y);
+        tail.addColorStop(0, '#00000000'); tail.addColorStop(1, `${comet.color}aa`);
+        context.strokeStyle = tail; context.lineWidth = 3; context.beginPath(); context.moveTo(x - 150, y + 45); context.lineTo(x, y); context.stroke();
+        context.fillStyle = comet.color; context.shadowBlur = 18; context.shadowColor = comet.color; context.beginPath(); context.arc(x, y, 5, 0, Math.PI * 2); context.fill(); context.shadowBlur = 0;
+      }
+      if (!reduced || frame === 0) raf = requestAnimationFrame(paint);
+      frame++;
+    };
+    raf = requestAnimationFrame(paint);
+    return () => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize); };
+  }, [upcoming, tomorrow.length, comet, night]);
+
+  const next = upcoming[0];
+  const time = now.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const date = now.toLocaleDateString([], { weekday: 'long', month: 'long', day: 'numeric' });
+  return <div className={`fixed inset-0 overflow-hidden text-white ${night ? 'brightness-[.42]' : ''}`} data-testid="night-sky" data-night={night}>
+    <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" aria-hidden="true" />
+    <div className="pointer-events-none absolute inset-x-[7vw] bottom-[8vh] flex items-end justify-between gap-10 text-white/90 [text-shadow:0_2px_22px_rgba(0,0,0,.9)]">
+      <div>
+        <time className="block text-[clamp(4rem,9vw,11rem)] font-extralight leading-none tracking-[-.06em]" dateTime={now.toISOString()}>{time}</time>
+        <p className="mt-3 text-[clamp(1rem,1.4vw,2rem)] font-light tracking-[.12em] text-white/65">{date}</p>
+      </div>
+      <div className="max-w-[38vw] border-l border-white/20 pl-7 text-right" aria-live="polite">
+        <p className="text-sm uppercase tracking-[.35em] text-white/50">Next up</p>
+        <p className="mt-3 text-[clamp(1.2rem,2.1vw,2.7rem)] font-light" style={{ color: next?.color || undefined }}>{loading ? 'Finding the next star…' : next ? next.title : 'The sky is clear'}</p>
+        {next && <p className="mt-2 text-[clamp(.9rem,1.1vw,1.35rem)] text-white/65">{next.startTime.toLocaleString([], { weekday: 'short', hour: 'numeric', minute: '2-digit' })}</p>}
+      </div>
+    </div>
+    {comet && <div className="pointer-events-none absolute left-1/2 top-[70%] -translate-x-1/2 rounded-full border border-white/15 bg-black/20 px-5 py-2 text-[clamp(.8rem,1vw,1.2rem)] font-light tracking-wide text-white/75 backdrop-blur-sm">
+      Tomorrow · <span style={{ color: comet.color }}>{comet.startTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} · {comet.title}</span>
+    </div>}
+    {comet && <div className="sr-only">Tomorrow&apos;s first event: {comet.title} at {comet.startTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</div>}
+  </div>;
+}

--- a/src/components/screensaver/Screensaver.tsx
+++ b/src/components/screensaver/Screensaver.tsx
@@ -3,9 +3,6 @@
 import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { useIdleDetection } from '@/lib/hooks/useIdleDetection';
-import { usePhotos } from '@/lib/hooks/usePhotos';
-import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } from '@/components/layout/WallpaperBackground';
-import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import type { WidgetConfig } from '@/lib/hooks/useLayouts';
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry';
 import { useDashboardData } from '@/components/dashboard/useDashboardData';
@@ -14,6 +11,8 @@ import { GRID_COLS } from '@/lib/constants/grid';
 import { CssGridDisplay } from '@/components/layout/grid/CssGridDisplay';
 import { CalendarPrefsScopeContext } from '@/lib/hooks/useCalendarWidgetPrefs';
 import { loadScreensaverLayout } from './screensaverStorage';
+import { NightSky } from './NightSky';
+import { NIGHT_SKY_IDLE_SECONDS } from './nightSkyUtils';
 
 /**
  * Wrapper classes that make any dashboard widget legible as a screensaver
@@ -38,37 +37,8 @@ export {
 } from './screensaverStorage';
 
 export function Screensaver() {
-  const { isIdle } = useIdleDetection();
-  const { enabled: autoOrientation } = useAutoOrientationSetting();
-  const { pinnedId } = usePinnedPhoto('screensaver');
-  const { interval: screensaverInterval } = useScreensaverInterval();
-  const screenOrientation = useScreenOrientation();
-  const orientationOverride = typeof window !== 'undefined'
-    ? (localStorage.getItem('prism-orientation-override') as 'landscape' | 'portrait' | null) || null
-    : null;
-  const effectiveOrientation = orientationOverride || screenOrientation;
-  const { photos } = usePhotos({
-    sort: 'random',
-    limit: 50,
-    usage: 'screensaver',
-    orientation: autoOrientation ? effectiveOrientation : undefined,
-  });
+  const { isIdle } = useIdleDetection(NIGHT_SKY_IDLE_SECONDS);
   const [visible, setVisible] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [fadingOut, setFadingOut] = useState(false);
-
-  // Only rotate if no pinned photo and interval is not "never" (0)
-  useEffect(() => {
-    if (!isIdle || photos.length <= 1 || pinnedId || screensaverInterval === 0) return;
-    const timer = setInterval(() => {
-      setFadingOut(true);
-      setTimeout(() => {
-        setCurrentIndex((i) => (i + 1) % photos.length);
-        setFadingOut(false);
-      }, 1000);
-    }, screensaverInterval * 1000);
-    return () => clearInterval(timer);
-  }, [isIdle, photos.length, pinnedId, screensaverInterval]);
 
   useEffect(() => {
     if (isIdle) {
@@ -79,36 +49,18 @@ export function Screensaver() {
     }
   }, [isIdle]);
 
-  if (!isIdle) return null;
+  const nightSkyDomains = useMemo(() => new Set(['calendar']), []);
+  const nightSkyData = useDashboardData(nightSkyDomains);
 
-  // Use pinned photo if set, otherwise use rotating photos
-  const src = pinnedId
-    ? `/api/photos/${pinnedId}/file`
-    : photos[currentIndex]
-      ? `/api/photos/${photos[currentIndex]!.id}/file`
-      : '';
+  if (!isIdle) return null;
 
   return (
     <div
-      className={`fixed inset-0 z-[9999] bg-black transition-opacity duration-1000 ${
+      className={`fixed inset-0 z-[9999] bg-black transition-opacity duration-200 ${
         visible ? 'opacity-100' : 'opacity-0'
       }`}
     >
-      {/* Decorative layers are absolutely positioned, so in CSS paint order they
-          sit ABOVE the (statically-positioned) widget grid and would swallow every
-          tap. pointer-events-none lets taps fall through to the widgets — needed
-          for the calendar view controls to be operable on the screensaver. */}
-      {src && (
-        <div
-          className="pointer-events-none absolute inset-0 bg-cover bg-center transition-opacity duration-1000"
-          style={{
-            backgroundImage: `url(${src})`,
-            opacity: fadingOut ? 0 : 1,
-          }}
-        />
-      )}
-      <div className="pointer-events-none absolute inset-0 bg-black/40" />
-      <ScreensaverGrid />
+      <NightSky events={nightSkyData.calendar.events} loading={nightSkyData.calendar.loading} />
     </div>
   );
 }

--- a/src/components/screensaver/__tests__/nightSkyUtils.test.ts
+++ b/src/components/screensaver/__tests__/nightSkyUtils.test.ts
@@ -1,0 +1,47 @@
+import type { CalendarEvent } from '@/types/calendar';
+import { auroraPalette, moonPhase, nightSkyEvents, tomorrowEvents } from '../nightSkyUtils';
+
+const event = (id: string, start: string): CalendarEvent => ({
+  id,
+  title: id,
+  startTime: new Date(start),
+  endTime: new Date(new Date(start).getTime() + 3600000),
+  allDay: false,
+  color: '#3b82f6',
+  calendarName: 'Family',
+  calendarId: 'family',
+});
+
+describe('Night Sky schedule model', () => {
+  const now = new Date('2026-08-29T12:00:00-05:00');
+
+  it('keeps the next fourteen days and orders them', () => {
+    const result = nightSkyEvents([
+      event('later', '2026-09-03T10:00:00-05:00'),
+      event('past', '2026-08-28T10:00:00-05:00'),
+      event('next', '2026-08-29T13:00:00-05:00'),
+      event('far', '2026-09-20T10:00:00-05:00'),
+    ], now);
+    expect(result.map(({ id }) => id)).toEqual(['next', 'later']);
+  });
+
+  it('finds tomorrow in local calendar time', () => {
+    const result = tomorrowEvents([
+      event('today', '2026-08-29T18:00:00-05:00'),
+      event('second', '2026-08-30T12:00:00-05:00'),
+      event('first', '2026-08-30T08:00:00-05:00'),
+    ], now);
+    expect(result.map(({ id }) => id)).toEqual(['first', 'second']);
+  });
+
+  it('maps light, medium, and busy days to distinct palettes', () => {
+    expect(auroraPalette(3)[0]).toBe('#10b981');
+    expect(auroraPalette(4)[0]).toBe('#0d9488');
+    expect(auroraPalette(8)[0]).toBe('#7c3aed');
+  });
+
+  it('computes known new and full moon illumination', () => {
+    expect(moonPhase(new Date('2000-01-06T18:14:00Z')).illumination).toBeCloseTo(0, 4);
+    expect(moonPhase(new Date('2000-01-21T12:36:00Z')).illumination).toBeCloseTo(1, 2);
+  });
+});

--- a/src/components/screensaver/nightSkyUtils.ts
+++ b/src/components/screensaver/nightSkyUtils.ts
@@ -1,0 +1,47 @@
+import type { CalendarEvent } from '@/types/calendar';
+
+export const NIGHT_SKY_IDLE_SECONDS = 15 * 60;
+export const NIGHT_START_HOUR = 21;
+export const NIGHT_END_HOUR = 6;
+export const NIGHT_SKY_WINDOW_DAYS = 14;
+
+export function isNightSkyNight(date: Date): boolean {
+  const forced = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('nightSkyMode') : null;
+  if (forced === 'night') return true;
+  if (forced === 'day') return false;
+  const hour = date.getHours();
+  return hour >= NIGHT_START_HOUR || hour < NIGHT_END_HOUR;
+}
+
+export function moonPhase(date: Date): { age: number; illumination: number; waxing: boolean } {
+  const synodicMonth = 29.530588853;
+  const knownNewMoon = Date.UTC(2000, 0, 6, 18, 14);
+  const days = (date.getTime() - knownNewMoon) / 86400000;
+  const age = ((days % synodicMonth) + synodicMonth) % synodicMonth;
+  return {
+    age,
+    illumination: (1 - Math.cos((age / synodicMonth) * Math.PI * 2)) / 2,
+    waxing: age < synodicMonth / 2,
+  };
+}
+
+export function nightSkyEvents(events: CalendarEvent[], now: Date) {
+  const end = new Date(now);
+  end.setDate(end.getDate() + NIGHT_SKY_WINDOW_DAYS);
+  return events
+    .filter((event) => event.endTime >= now && event.startTime <= end)
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+}
+
+export function tomorrowEvents(events: CalendarEvent[], now: Date) {
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2);
+  return events.filter((event) => event.startTime >= start && event.startTime < end)
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+}
+
+export function auroraPalette(count: number) {
+  if (count >= 8) return ['#7c3aed', '#c026d3', '#4f46e5'] as const;
+  if (count >= 4) return ['#0d9488', '#2563eb', '#6366f1'] as const;
+  return ['#10b981', '#14b8a6', '#22c55e'] as const;
+}

--- a/src/lib/auth/__tests__/householdAuth.test.ts
+++ b/src/lib/auth/__tests__/householdAuth.test.ts
@@ -1,0 +1,75 @@
+import {
+  createHouseholdSession,
+  getHouseholdAuthState,
+  HOUSEHOLD_SESSION_RENEW_SECONDS,
+  HOUSEHOLD_SESSION_TTL_SECONDS,
+  validateHouseholdSession,
+} from '../householdAuth';
+
+const secret = 's'.repeat(64);
+const nonce = 'n'.repeat(43);
+
+describe('householdAuth', () => {
+  afterEach(() => {
+    delete process.env.KYST_AUTH_PASSWORD;
+    delete process.env.KYST_AUTH_SECRET;
+    delete process.env.KYST_AUTH_DEVICE_TOKEN;
+    delete process.env.KYST_AUTH_SERVICE_TOKEN;
+  });
+
+  it('is disabled when no KYST auth variables are present', () => {
+    expect(getHouseholdAuthState()).toBe('disabled');
+  });
+
+  it('fails closed when core variables are partial or weak', () => {
+    process.env.KYST_AUTH_PASSWORD = '1234';
+    expect(getHouseholdAuthState()).toBe('misconfigured');
+    process.env.KYST_AUTH_SECRET = 'short';
+    expect(getHouseholdAuthState()).toBe('misconfigured');
+  });
+
+  it('accepts a complete configuration and validates token formats', () => {
+    process.env.KYST_AUTH_PASSWORD = '1234';
+    process.env.KYST_AUTH_SECRET = secret;
+    process.env.KYST_AUTH_DEVICE_TOKEN = `v1.${'a'.repeat(64)}`;
+    process.env.KYST_AUTH_SERVICE_TOKEN = `v1.${'b'.repeat(64)}`;
+    expect(getHouseholdAuthState()).toBe('ready');
+
+    process.env.KYST_AUTH_DEVICE_TOKEN = 'weak';
+    expect(getHouseholdAuthState()).toBe('misconfigured');
+  });
+
+  it('creates and validates a 90-day signed session', async () => {
+    const now = 1_800_000_000;
+    const token = await createHouseholdSession(secret, now, nonce);
+    expect(token).toMatch(/^v1\.1800000000\.1807776000\./);
+    await expect(validateHouseholdSession(token, secret, now)).resolves.toEqual({
+      valid: true,
+      renew: false,
+    });
+  });
+
+  it('rejects tampering and expiration', async () => {
+    const now = 1_800_000_000;
+    const token = await createHouseholdSession(secret, now, nonce);
+    await expect(validateHouseholdSession(`${token}x`, secret, now)).resolves.toEqual({
+      valid: false,
+      renew: false,
+    });
+    await expect(
+      validateHouseholdSession(token, secret, now + HOUSEHOLD_SESSION_TTL_SECONDS)
+    ).resolves.toEqual({ valid: false, renew: false });
+  });
+
+  it('requests sliding renewal in the final 45 days', async () => {
+    const now = 1_800_000_000;
+    const token = await createHouseholdSession(secret, now, nonce);
+    await expect(
+      validateHouseholdSession(
+        token,
+        secret,
+        now + HOUSEHOLD_SESSION_TTL_SECONDS - HOUSEHOLD_SESSION_RENEW_SECONDS
+      )
+    ).resolves.toEqual({ valid: true, renew: true });
+  });
+});

--- a/src/lib/auth/householdAuth.ts
+++ b/src/lib/auth/householdAuth.ts
@@ -1,0 +1,133 @@
+const encoder = new TextEncoder();
+
+export const HOUSEHOLD_COOKIE_NAME = 'kyst_household_session';
+export const HOUSEHOLD_SESSION_TTL_SECONDS = 90 * 24 * 60 * 60;
+export const HOUSEHOLD_SESSION_RENEW_SECONDS = 45 * 24 * 60 * 60;
+export const HOUSEHOLD_SERVICE_HEADER = 'x-kyst-service-token';
+
+export type HouseholdAuthState = 'disabled' | 'ready' | 'misconfigured';
+
+const DEPLOYMENT_TOKEN_PATTERN = /^v1\.[a-f0-9]{64}$/;
+
+export function getHouseholdAuthState(): HouseholdAuthState {
+  const password = process.env.KYST_AUTH_PASSWORD || '';
+  const secret = process.env.KYST_AUTH_SECRET || '';
+  const deviceToken = process.env.KYST_AUTH_DEVICE_TOKEN || '';
+  const serviceToken = process.env.KYST_AUTH_SERVICE_TOKEN || '';
+  const passwordSet = Boolean(password);
+  const secretSet = Boolean(secret);
+  const anySet = passwordSet || secretSet || Boolean(deviceToken) || Boolean(serviceToken);
+
+  if (!anySet) return 'disabled';
+  const valid =
+    password.length >= 4 &&
+    secret.length >= 32 &&
+    (!deviceToken || DEPLOYMENT_TOKEN_PATTERN.test(deviceToken)) &&
+    (!serviceToken || DEPLOYMENT_TOKEN_PATTERN.test(serviceToken));
+  return valid ? 'ready' : 'misconfigured';
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  const result = await crypto.subtle.digest('SHA-256', encoder.encode(value));
+  return new Uint8Array(result);
+}
+
+export async function constantTimeSecretEqual(
+  candidate: string,
+  expected: string
+): Promise<boolean> {
+  const [candidateDigest, expectedDigest] = await Promise.all([
+    digest(candidate),
+    digest(expected),
+  ]);
+  let difference = 0;
+  for (let index = 0; index < candidateDigest.length; index += 1) {
+    difference |= candidateDigest[index]! ^ expectedDigest[index]!;
+  }
+  return difference === 0;
+}
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  return base64Url(new Uint8Array(signature));
+}
+
+function randomNonce(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64Url(bytes);
+}
+
+export async function createHouseholdSession(
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  nonce = randomNonce()
+): Promise<string> {
+  const expiresAt = nowSeconds + HOUSEHOLD_SESSION_TTL_SECONDS;
+  const payload = `v1.${nowSeconds}.${expiresAt}.${nonce}`;
+  return `${payload}.${await sign(payload, secret)}`;
+}
+
+export type HouseholdSessionValidation = {
+  valid: boolean;
+  renew: boolean;
+};
+
+export async function validateHouseholdSession(
+  value: string | undefined,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): Promise<HouseholdSessionValidation> {
+  if (!value) return { valid: false, renew: false };
+
+  const parts = value.split('.');
+  if (parts.length !== 5 || parts[0] !== 'v1') return { valid: false, renew: false };
+
+  const issuedAt = Number(parts[1]);
+  const expiresAt = Number(parts[2]);
+  const nonce = parts[3]!;
+  const suppliedSignature = parts[4]!;
+
+  if (!Number.isSafeInteger(issuedAt) || !Number.isSafeInteger(expiresAt)) {
+    return { valid: false, renew: false };
+  }
+  if (!/^[A-Za-z0-9_-]{20,}$/.test(nonce)) return { valid: false, renew: false };
+  if (issuedAt > nowSeconds + 300 || expiresAt <= nowSeconds) return { valid: false, renew: false };
+  if (expiresAt - issuedAt !== HOUSEHOLD_SESSION_TTL_SECONDS) {
+    return { valid: false, renew: false };
+  }
+
+  const payload = parts.slice(0, 4).join('.');
+  const expectedSignature = await sign(payload, secret);
+  if (!(await constantTimeSecretEqual(suppliedSignature, expectedSignature))) {
+    return { valid: false, renew: false };
+  }
+
+  return {
+    valid: true,
+    renew: expiresAt - nowSeconds <= HOUSEHOLD_SESSION_RENEW_SECONDS,
+  };
+}
+
+export function householdCookieOptions(maxAge = HOUSEHOLD_SESSION_TTL_SECONDS) {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge,
+  };
+}

--- a/src/lib/hooks/__tests__/useIdleDetection.test.ts
+++ b/src/lib/hooks/__tests__/useIdleDetection.test.ts
@@ -134,18 +134,13 @@ describe('useIdleDetection', () => {
     expect(result.current.isIdle).toBe(true);
   });
 
-  it('defaults to 120s when no stored value and no initialTimeout', () => {
+  it('defaults to disabled when no stored value and no initialTimeout', () => {
     const { result } = renderHook(() => useIdleDetection());
 
     act(() => {
-      jest.advanceTimersByTime(119000);
+      jest.advanceTimersByTime(300000);
     });
     expect(result.current.isIdle).toBe(false);
-
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-    expect(result.current.isIdle).toBe(true);
   });
 
   it('dismisses idle on keydown after becoming idle', () => {

--- a/src/lib/hooks/useIdleDetection.ts
+++ b/src/lib/hooks/useIdleDetection.ts
@@ -6,7 +6,7 @@ import { useIsPWA } from './useIsPWA';
 const STORAGE_KEY = 'prism-screensaver-timeout';
 const AWAY_MODE_STORAGE_KEY = 'prism-away-mode-timeout';
 const LAST_ACTIVITY_KEY = 'prism-last-activity';
-const DEFAULT_TIMEOUT = 120;
+const DEFAULT_TIMEOUT = 0;
 
 function getStoredTimeout(): number {
   if (typeof window === 'undefined') return DEFAULT_TIMEOUT;
@@ -111,7 +111,7 @@ export function useIdleDetection(initialTimeout?: number) {
       }
       dismissIdle();
     };
-    const dismissEvents = ['mousedown', 'keydown', 'touchstart'] as const;
+    const dismissEvents = ['pointerdown', 'mousedown', 'keydown', 'touchstart'] as const;
     dismissEvents.forEach((e) => window.addEventListener(e, maybeDismiss));
 
     resetTimer();
@@ -122,6 +122,25 @@ export function useIdleDetection(initialTimeout?: number) {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [resetTimer, dismissIdle, timeout, isPWA]);
+
+  // Kiosk announcements commonly navigate/refresh the page or bring a hidden
+  // page back to the foreground. Exit immediately so their UI is never covered.
+  useEffect(() => {
+    const wake = () => { forcedRef.current = false; setIsIdle(false); resetTimer(); };
+    const onVisibility = () => wake();
+    window.addEventListener('pageshow', wake);
+    window.addEventListener('popstate', wake);
+    window.addEventListener('hashchange', wake);
+    window.addEventListener('prism:announce', wake);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('pageshow', wake);
+      window.removeEventListener('popstate', wake);
+      window.removeEventListener('hashchange', wake);
+      window.removeEventListener('prism:announce', wake);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [resetTimer]);
 
   // Listen for custom screensaver activation event
   useEffect(() => {

--- a/src/lib/hooks/useScreensaverTimeout.ts
+++ b/src/lib/hooks/useScreensaverTimeout.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const STORAGE_KEY = 'prism-screensaver-timeout';
-const DEFAULT_TIMEOUT = 120; // 2 minutes in seconds
+const DEFAULT_TIMEOUT = 0; // Disabled by default; Night Sky owns its 15-minute timer.
 
 export const SCREENSAVER_TIMEOUT_OPTIONS = [
   { value: 30, label: '30 seconds' },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  createHouseholdSession,
+  getHouseholdAuthState,
+  householdCookieOptions,
+  HOUSEHOLD_COOKIE_NAME,
+  HOUSEHOLD_SERVICE_HEADER,
+  constantTimeSecretEqual,
+  validateHouseholdSession,
+} from '@/lib/auth/householdAuth';
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
@@ -7,7 +16,7 @@ const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  * These are exempt from the blanket CSRF Origin check.
  */
 const CSRF_EXEMPT_PREFIXES = [
-  '/api/away-mode',      // has its own same-origin check
+  '/api/away-mode', // has its own same-origin check
 ];
 
 /**
@@ -15,11 +24,10 @@ const CSRF_EXEMPT_PREFIXES = [
  * actually usable. Login is needed so visitors can switch between members
  * to see role-based UI; logout is needed so they don't get stuck.
  */
-const DEMO_ALLOWED_MUTATIONS = [
-  '/api/auth/login',
-  '/api/auth/logout',
-  '/api/auth/session',
-];
+const DEMO_ALLOWED_MUTATIONS = ['/api/auth/login', '/api/auth/logout', '/api/auth/session'];
+
+const HOUSEHOLD_PUBLIC_PATHS = ['/auth/household', '/api/health', '/api/health/ready'];
+const HOUSEHOLD_PUBLIC_PREFIXES = ['/api/household-auth/', '/workbox-'];
 
 function generateRequestId(): string {
   const array = new Uint8Array(12);
@@ -35,13 +43,91 @@ function generateRequestId(): string {
  * Non-browser clients (no Origin header) bypass CSRF — they rely on other
  * auth layers (requireAuth, API tokens).
  */
-export function middleware(request: NextRequest) {
+function isHouseholdPublicPath(pathname: string): boolean {
+  return (
+    HOUSEHOLD_PUBLIC_PATHS.includes(pathname) ||
+    pathname === '/sw.js' ||
+    HOUSEHOLD_PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  );
+}
+
+function attachRequestId(response: NextResponse, requestId: string): NextResponse {
+  response.headers.set('x-request-id', requestId);
+  return response;
+}
+
+async function enforceHouseholdAuth(
+  request: NextRequest,
+  response: NextResponse,
+  requestId: string
+): Promise<NextResponse | null> {
+  const state = getHouseholdAuthState();
+  if (state === 'disabled') return null;
+
+  const { pathname } = request.nextUrl;
+  if (isHouseholdPublicPath(pathname)) return null;
+
+  if (state === 'misconfigured') {
+    return attachRequestId(
+      NextResponse.json({ error: 'Household authentication is misconfigured' }, { status: 503 }),
+      requestId
+    );
+  }
+
+  const secret = process.env.KYST_AUTH_SECRET!;
+  const session = await validateHouseholdSession(
+    request.cookies.get(HOUSEHOLD_COOKIE_NAME)?.value,
+    secret
+  );
+
+  let serviceAuthenticated = false;
+  const configuredServiceToken = process.env.KYST_AUTH_SERVICE_TOKEN;
+  const suppliedServiceToken = request.headers.get(HOUSEHOLD_SERVICE_HEADER);
+  if (configuredServiceToken && suppliedServiceToken) {
+    serviceAuthenticated = await constantTimeSecretEqual(
+      suppliedServiceToken,
+      configuredServiceToken
+    );
+  }
+
+  if (!session.valid && !serviceAuthenticated) {
+    if (pathname.startsWith('/api/')) {
+      return attachRequestId(
+        NextResponse.json({ error: 'Household authentication required' }, { status: 401 }),
+        requestId
+      );
+    }
+
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/auth/household';
+    loginUrl.search = '';
+    loginUrl.searchParams.set('next', `${pathname}${request.nextUrl.search}`);
+    return attachRequestId(NextResponse.redirect(loginUrl), requestId);
+  }
+
+  if (session.valid && session.renew) {
+    response.cookies.set(
+      HOUSEHOLD_COOKIE_NAME,
+      await createHouseholdSession(secret),
+      householdCookieOptions()
+    );
+  }
+
+  return null;
+}
+
+export async function middleware(request: NextRequest) {
   // Attach (or propagate) request ID for log correlation
   const requestId = request.headers.get('x-request-id') ?? generateRequestId();
   const response = NextResponse.next({
-    request: { headers: new Headers({ ...Object.fromEntries(request.headers), 'x-request-id': requestId }) },
+    request: {
+      headers: new Headers({ ...Object.fromEntries(request.headers), 'x-request-id': requestId }),
+    },
   });
   response.headers.set('x-request-id', requestId);
+
+  const householdAuthResponse = await enforceHouseholdAuth(request, response, requestId);
+  if (householdAuthResponse) return householdAuthResponse;
 
   if (!MUTATION_METHODS.has(request.method)) return response;
 
@@ -51,13 +137,17 @@ export function middleware(request: NextRequest) {
   // for everyone. A friendly error tells them this is a demo and points
   // them at the repo. The login path is allowed so they can switch
   // members to see role-based UI.
-  if (process.env.DEMO_MODE === 'true' && !DEMO_ALLOWED_MUTATIONS.some((p) => pathname.startsWith(p))) {
+  if (
+    process.env.DEMO_MODE === 'true' &&
+    !DEMO_ALLOWED_MUTATIONS.some((p) => pathname.startsWith(p))
+  ) {
     const forbidden = NextResponse.json(
       {
         error: 'demo_mode',
-        message: 'This is a read-only demo. Clone https://github.com/sandydargoport/prism to try changes on your own instance.',
+        message:
+          'This is a read-only demo. Clone https://github.com/sandydargoport/prism to try changes on your own instance.',
       },
-      { status: 403 },
+      { status: 403 }
     );
     forbidden.headers.set('x-request-id', requestId);
     return forbidden;
@@ -91,5 +181,8 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/api/:path*',
+  matcher: [
+    '/api/:path*',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|sw.js|workbox-|icons/|logo-prism.png).*)',
+  ],
 };


### PR DESCRIPTION
## Summary
- retain the KYST household auth wall in the canonical deployment branch
- replace the automatic photo screensaver with a 15-minute schedule-aware Night Sky canvas
- add real-event constellations, moon phase, aurora density, tomorrow comet, clock, and next-up treatment
- wake on touch, navigation, visibility changes, and announcement events
- default fresh kiosk state to dark theme, wallpaper off, and legacy photo timeout disabled

## Verification
- focused Jest: 18/18 passed
- TypeScript: passed
- production build: passed (existing lint warnings remain)
- secret/PII/hostname pre-push scans: passed

Tracks NOX-11592.