### PR TITLE
fix(calendar): roll the event window over at midnight

### DIFF
--- a/src/lib/hooks/__tests__/useLocalDateKey.test.ts
+++ b/src/lib/hooks/__tests__/useLocalDateKey.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Rolling the calendar's request window over at midnight.
+ *
+ * Several hooks compute a window from `new Date()` inside a memo whose deps
+ * are constants, so it is fixed at mount. A wall display is never reloaded, so
+ * "today" on screen quietly stops being today — and nobody notices, because
+ * the dashboard still looks like a dashboard.
+ */
+import { localDateKey, msUntilNextLocalMidnight } from '../useLocalDateKey';
+
+describe('localDateKey', () => {
+  it('changes when the local date changes', () => {
+    const before = localDateKey(new Date(2026, 7, 30, 23, 59, 59));
+    const after = localDateKey(new Date(2026, 7, 31, 0, 0, 1));
+    expect(before).not.toBe(after);
+  });
+
+  it('does not change during a day, so it cannot cause a stray refetch', () => {
+    expect(localDateKey(new Date(2026, 7, 30, 0, 0, 1)))
+      .toBe(localDateKey(new Date(2026, 7, 30, 23, 59, 59)));
+  });
+
+  it('uses local components, not UTC', () => {
+    // toISOString() would roll over at UTC midnight, which is the wrong moment
+    // for anyone not on UTC — the calendar would flip mid-evening or mid-morning.
+    const evening = new Date(2026, 7, 30, 20, 0, 0);
+    expect(localDateKey(evening)).toBe('2026-08-30');
+  });
+
+  it('pads month and day so the key sorts and compares predictably', () => {
+    expect(localDateKey(new Date(2026, 0, 5, 12, 0, 0))).toBe('2026-01-05');
+  });
+});
+
+describe('msUntilNextLocalMidnight', () => {
+  it('is a little over a day when it has just gone midnight', () => {
+    const ms = msUntilNextLocalMidnight(new Date(2026, 7, 30, 0, 0, 2));
+    expect(ms).toBeGreaterThan(23.9 * 60 * 60 * 1000);
+    expect(ms).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 2000);
+  });
+
+  it('is small just before midnight', () => {
+    const ms = msUntilNextLocalMidnight(new Date(2026, 7, 30, 23, 59, 50));
+    expect(ms).toBeLessThan(15_000);
+  });
+
+  it('never returns zero or negative, so the timer cannot spin', () => {
+    // A timer scheduled for 0ms that recomputes to 0ms again is a busy loop on
+    // a device that is never closed.
+    expect(msUntilNextLocalMidnight(new Date(2026, 7, 30, 23, 59, 59, 999)))
+      .toBeGreaterThanOrEqual(1000);
+  });
+
+  it('lands on the next day rather than skipping one, across a month boundary', () => {
+    const now = new Date(2026, 7, 31, 22, 0, 0);
+    const next = new Date(now.getTime() + msUntilNextLocalMidnight(now));
+    expect(localDateKey(next)).toBe('2026-09-01');
+  });
+
+  it('lands correctly across a leap day', () => {
+    const now = new Date(2028, 1, 28, 22, 0, 0);
+    const next = new Date(now.getTime() + msUntilNextLocalMidnight(now));
+    expect(localDateKey(next)).toBe('2028-02-29');
+  });
+});

--- a/src/lib/hooks/useCalendarEvents.ts
+++ b/src/lib/hooks/useCalendarEvents.ts
@@ -11,6 +11,7 @@ import { addDays, subDays, startOfDay, endOfDay } from 'date-fns';
 import type { CalendarEvent } from '@/types/calendar';
 import { useVisibilityPolling } from '@/lib/hooks/useVisibilityPolling';
 import { navCacheGet, navCacheSet } from '@/lib/utils/navCache';
+import { useLocalDateKey } from '@/lib/hooks/useLocalDateKey';
 
 interface UseCalendarEventsOptions {
   /** Number of days to fetch events for (used only when rangeStart/rangeEnd are omitted). */
@@ -53,6 +54,7 @@ export function useCalendarEvents(
   // The request URL doubles as the cache key. When an explicit range is given
   // it wins; otherwise fall back to the today-anchored daysToShow window.
   // Stable across remounts within the same day (deps are primitives).
+  const dateKey = useLocalDateKey();
   const rangeStartMs = rangeStart?.getTime();
   const rangeEndMs = rangeEnd?.getTime();
   const cacheKey = useMemo(() => {
@@ -67,7 +69,13 @@ export function useCalendarEvents(
       endDate = endOfDay(addDays(today, daysToShow));
     }
     return `/api/events?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}&limit=${limit}`;
-  }, [daysToShow, rangeStartMs, rangeEndMs, limit]);
+    // dateKey is in the dependency list on purpose. Without it this memo's
+    // deps are all constants, so the window computed from `new Date()` above
+    // is frozen at mount — invisible on a page someone opens and closes, and
+    // wrong for weeks on a display that is never reloaded. It changes exactly
+    // once per local midnight, so it cannot trigger a refetch for any other
+    // reason. Irrelevant when an explicit range was passed, but harmless.
+  }, [daysToShow, rangeStartMs, rangeEndMs, limit, dateKey]);
 
   const cached = navCacheGet<CalendarEvent[]>(cacheKey);
   const [events, setEvents] = useState<CalendarEvent[]>(() => cached ?? []);

--- a/src/lib/hooks/useLocalDateKey.ts
+++ b/src/lib/hooks/useLocalDateKey.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * A value that changes when the local date does.
+ *
+ * Several hooks compute a request window from `new Date()` inside a `useMemo`
+ * whose dependencies are all constants, so the window is fixed at mount. On a
+ * page someone opens and closes that is invisible. On a wall display, which is
+ * never reloaded, it means the dashboard is still asking for the window it
+ * computed whenever it last started — days or weeks ago. "Today" on screen
+ * quietly stops being today.
+ *
+ * Depending on this key in that memo makes the window roll over at midnight.
+ *
+ * Deliberately a date string rather than a timestamp: it changes exactly once
+ * per day, so it cannot cause a refetch for any other reason.
+ */
+export function localDateKey(now: Date = new Date()): string {
+  // Local components, not toISOString — that is UTC, and would roll over at
+  // the wrong moment for anyone not on UTC.
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Milliseconds until the next local midnight, plus a second of slack. */
+export function msUntilNextLocalMidnight(now: Date = new Date()): number {
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 1, 0);
+  // Date arithmetic on local components handles daylight-saving shifts: the
+  // clock jumping an hour changes the distance to midnight, not the date.
+  return Math.max(1000, next.getTime() - now.getTime());
+}
+
+export function useLocalDateKey(): string {
+  const [key, setKey] = useState(() => localDateKey());
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const schedule = () => {
+      timer = setTimeout(() => {
+        // Recomputed from the clock rather than incremented, so a device that
+        // slept through midnight still lands on the correct date.
+        setKey(localDateKey());
+        schedule();
+      }, msUntilNextLocalMidnight());
+    };
+
+    schedule();
+
+    // A machine waking from sleep may have missed the timer entirely.
+    const onWake = () => setKey(localDateKey());
+    document.addEventListener('visibilitychange', onWake);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onWake);
+    };
+  }, []);
+
+  return key;
+}


### PR DESCRIPTION
`useCalendarEvents` builds its request window from `new Date()` inside a `useMemo` whose dependencies — `daysToShow`, the optional explicit range, `limit` — are **all constants** for the dashboard. So the window is fixed at mount, and there is no rollover mechanism anywhere in the codebase.

On a page someone opens and closes, this never shows. A wall display isn't reloaded for weeks, so it keeps asking for the window it computed whenever it last started.

**"Today" on screen quietly stops being today** — and nothing looks broken. The dashboard still renders a dashboard, just of the wrong days.

## The screensaver has been hiding it

`Screensaver.tsx:85` — `if (!isIdle) return null` — unmounts and remounts the grid on every idle cycle, recomputing the window each time. That's an accident, not a mechanism, and anything that keeps the overlay mounted longer removes it.

That's how this surfaced: it was found while assessing what a screensaver *lock* would break, because a lock would hold the overlay up for hours.

## The fix

`useLocalDateKey` returns a value that changes exactly once per local midnight, and the memo depends on it. A date string rather than a timestamp, so it can't trigger a refetch for any other reason.

Local components rather than `toISOString()`, because UTC rolls over at the wrong moment for anyone not on UTC — the calendar would flip mid-evening.

Three details that matter on a device that is never closed:

- the timer is **re-armed from the clock** after each fire rather than incremented, so a machine that slept through midnight still lands on the right date
- `visibilitychange` re-checks, for a wake that missed the timer entirely
- the delay is **floored at 1s**, so a timer scheduled at 23:59:59.999 can't recompute to zero and spin

## Testing

Nine cases: the key changes at local midnight and not during a day, uses local time rather than UTC, and the delay is never zero, lands on the next day across a month boundary, and handles a leap day.

1,560 tests pass, typecheck clean.
