### PR TITLE
fix(photos): serve Immich web JPEGs instead of iPhone HEIC

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **Immich photos display in Firefox and other browsers that cannot decode HEIC.** Lightbox, screensaver, and wallpaper were proxying the iPhone original (`image/heic`). Prism now asks Immich for a web-safe full-size JPEG/WebP (falling back to the preview), converts leftover HEIC with sharp, and ignores previously cached originals.
+
 ## [1.19.0] – 2026-08-29
 
 ### Added

--- a/docs/features/PHOTOS.md
+++ b/docs/features/PHOTOS.md
@@ -182,6 +182,8 @@ Saves render cycles + bandwidth on a Raspberry Pi or older tablet.
 
 Each synced OneDrive photo is downloaded once and stored locally. A `photos-cache` Docker volume (default 1 GB-ish; size depends on your photo library) holds the cached files.
 
+**Immich** photos are not copied as iPhone originals. Lightbox, screensaver, and wallpaper request Immich's web-safe `fullsize` (or `preview`) JPEG/WebP so Firefox and other browsers that cannot decode HEIC still show the picture. Cached HEIC from an older Prism version is ignored.
+
 If you delete the volume, the next sync re-downloads everything. The DB rows survive (they reference the path), so tags + GPS data + pin states are preserved.
 
 ---

--- a/src/lib/integrations/__tests__/immich.test.ts
+++ b/src/lib/integrations/__tests__/immich.test.ts
@@ -7,6 +7,14 @@
  * pick up the session cookie).
  */
 
+jest.mock('sharp', () => {
+  const toBuffer = jest.fn().mockResolvedValue(Buffer.from([0xff, 0xd8, 0xff]));
+  const jpeg = jest.fn().mockReturnValue({ toBuffer });
+  const rotate = jest.fn().mockReturnValue({ jpeg });
+  const sharpFn = jest.fn().mockReturnValue({ rotate, jpeg, toBuffer });
+  return { __esModule: true, default: sharpFn };
+});
+
 import {
   parseImmichShareUrl,
   fetchSharedLink,
@@ -348,7 +356,7 @@ describe('fetchSharedLink (password-protected)', () => {
 });
 
 describe('downloadImmichAsset', () => {
-  it('downloads the original via /assets/:id/original with the key', async () => {
+  it('downloads a web-safe fullsize thumbnail, not /original', async () => {
     mockFetchOnce(() => ({
       ok: true,
       status: 200,
@@ -362,9 +370,50 @@ describe('downloadImmichAsset', () => {
     );
 
     const url = (global.fetch as jest.Mock).mock.calls[0][0];
-    expect(url).toBe('https://x/api/assets/asset-1/original?key=k');
+    expect(url).toBe('https://x/api/assets/asset-1/thumbnail?key=k&size=fullsize');
     expect(result.contentType).toBe('image/jpeg');
-    expect(result.buffer).toBeInstanceOf(Buffer);
+    expect(result.buffer).toBeInstanceOf(Uint8Array);
+  });
+
+  it('falls back to preview when fullsize is unavailable', async () => {
+    mockFetchSequence([
+      () => ({ ok: false, status: 404, statusText: 'Not Found' }),
+      () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'image/webp' }),
+        arrayBuffer: () => Promise.resolve(new Uint8Array([0x52, 0x49]).buffer),
+      }),
+    ]);
+
+    const result = await downloadImmichAsset(
+      { serverUrl: 'https://x', shareKey: 'k' },
+      'asset-1',
+    );
+
+    const urls = (global.fetch as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(urls).toEqual([
+      'https://x/api/assets/asset-1/thumbnail?key=k&size=fullsize',
+      'https://x/api/assets/asset-1/thumbnail?key=k&size=preview',
+    ]);
+    expect(result.contentType).toBe('image/webp');
+  });
+
+  it('converts leftover HEIC bytes to JPEG', async () => {
+    mockFetchOnce(() => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'image/heic' }),
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63]).buffer),
+    }));
+
+    const result = await downloadImmichAsset(
+      { serverUrl: 'https://x', shareKey: 'k' },
+      'asset-1',
+    );
+
+    expect(result.contentType).toBe('image/jpeg');
+    expect(Buffer.from(result.buffer).subarray(0, 2).equals(Buffer.from([0xff, 0xd8]))).toBe(true);
   });
 
   it('downloads the thumbnail when thumb=true', async () => {
@@ -459,9 +508,9 @@ describe('downloadImmichAsset cookie cache (password-protected, with sourceId)',
     // First call is the login.
     expect(calls[0][0]).toBe('https://x/api/shared-links/login?key=k');
     // Second and third are downloads, both carrying the cached cookie.
-    expect(calls[1][0]).toContain('/api/assets/asset-1/original');
+    expect(calls[1][0]).toContain('/api/assets/asset-1/thumbnail?key=k&size=fullsize');
     expect(calls[1][1].headers.Cookie).toContain('immich_auth=cached-token');
-    expect(calls[2][0]).toContain('/api/assets/asset-2/original');
+    expect(calls[2][0]).toContain('/api/assets/asset-2/thumbnail?key=k&size=fullsize');
     expect(calls[2][1].headers.Cookie).toContain('immich_auth=cached-token');
   });
 

--- a/src/lib/integrations/immich.ts
+++ b/src/lib/integrations/immich.ts
@@ -15,6 +15,7 @@
  * the share URL field and use Prism as a proxy to probe the home network.
  */
 
+import sharp from 'sharp';
 import { validatePublicUrl, safeFetch, UnsafeUrlError } from '@/lib/utils/safeFetch';
 
 export interface ImmichShareCredentials {
@@ -339,9 +340,49 @@ export async function fetchSharedLink(
   return mapSharedLink(raw, assetsRaw);
 }
 
+function thumbnailPath(
+  serverUrl: string,
+  assetId: string,
+  shareKey: string,
+  size: 'preview' | 'fullsize',
+): string {
+  return `${serverUrl}/api/assets/${assetId}/thumbnail?key=${encodeURIComponent(shareKey)}&size=${size}`;
+}
+
+/** True when Immich (or a cached original) handed us HEIC/HEIF bytes. */
+function isHeic(contentType: string, buffer: Uint8Array): boolean {
+  const mime = (contentType.split(';')[0] ?? '').trim().toLowerCase();
+  if (mime === 'image/heic' || mime === 'image/heif' || mime === 'image/heic-sequence') {
+    return true;
+  }
+  // ISO BMFF: size(4) + 'ftyp' + brand (heic / heif / mif1 / msf1)
+  if (buffer.length < 12) return false;
+  const brand = String.fromCharCode(buffer[4]!, buffer[5]!, buffer[6]!, buffer[7]!);
+  if (brand !== 'ftyp') return false;
+  const major = String.fromCharCode(buffer[8]!, buffer[9]!, buffer[10]!, buffer[11]!).toLowerCase();
+  return major === 'heic' || major === 'heif' || major === 'mif1' || major === 'msf1';
+}
+
 /**
- * Download an asset's binary via the shared link. Returns the raw buffer +
- * upstream Content-Type so the proxy can pass it through unchanged.
+ * Browsers like Firefox (and most Linux Chromium) cannot decode HEIC.
+ * Re-encode to JPEG the same way local uploads do.
+ */
+async function toWebJpeg(buffer: Uint8Array): Promise<{ buffer: Uint8Array<ArrayBuffer>; contentType: string }> {
+  const jpeg = await sharp(buffer).rotate().jpeg({ quality: 85 }).toBuffer();
+  const bytes = new Uint8Array(jpeg.byteLength);
+  bytes.set(jpeg);
+  return { buffer: bytes, contentType: 'image/jpeg' };
+}
+
+/**
+ * Download an asset's binary via the shared link for on-screen display.
+ *
+ * We never fetch `/original`. That endpoint needs the share's "allow
+ * download" flag (Immich 404s without it) and returns iPhone HEIC, which
+ * Firefox and kiosk browsers cannot paint. Thumbnails use Immich's
+ * `preview`; full-size display uses `fullsize` (JPEG/WebP when Immich has
+ * generated it, otherwise Immich falls back to preview). Leftover HEIC is
+ * converted with sharp before we return.
  *
  * For password-protected shares, uses the cached session cookie when one
  * is available for creds.sourceId; falls back to a fresh login on cache
@@ -365,17 +406,22 @@ export async function downloadImmichAsset(
     }
   }
 
-  const path = opts.thumb
-    ? `/api/assets/${assetId}/thumbnail?key=${encodeURIComponent(creds.shareKey)}&size=preview`
-    : `/api/assets/${assetId}/original?key=${encodeURIComponent(creds.shareKey)}`;
-
   const headers: Record<string, string> = {};
   if (cookie) headers.Cookie = cookie;
+
+  const get = (size: 'preview' | 'fullsize') =>
+    safeFetch(thumbnailPath(creds.serverUrl, assetId, creds.shareKey, size), { headers });
 
   // safeFetch re-validates any redirect Location, so a share URL that 30x-
   // redirects to an internal host can no longer be used to exfiltrate the
   // internal response (was `redirect: 'follow'`, which bypassed the guard).
-  const res = await safeFetch(`${creds.serverUrl}${path}`, { headers });
+  let res = await get(opts.thumb ? 'preview' : 'fullsize');
+  // Older Immich (no fullsize size) or derivative not generated yet → preview.
+  // Only 404/400: 401/403 mean a bad share session (drop the cookie below);
+  // 5xx should fail closed rather than hide an Immich outage behind a retry.
+  if (!res.ok && !opts.thumb && (res.status === 404 || res.status === 400)) {
+    res = await get('preview');
+  }
   if (!res.ok) {
     // If the cache returned a stale cookie that the server rejected, drop
     // it and let the next call re-login. We don't auto-retry here because
@@ -389,8 +435,15 @@ export async function downloadImmichAsset(
   }
 
   const arrayBuffer = await res.arrayBuffer();
+  const raw = Buffer.from(arrayBuffer);
   const contentType = res.headers.get('content-type') ?? 'application/octet-stream';
-  return { buffer: Buffer.from(arrayBuffer), contentType };
+
+  if (isHeic(contentType, raw)) {
+    return toWebJpeg(raw);
+  }
+  const bytes = new Uint8Array(raw.byteLength);
+  bytes.set(raw);
+  return { buffer: bytes, contentType };
 }
 
 // Re-export so route handlers can branch on UnsafeUrlError specifically

--- a/src/lib/services/photo-cache.ts
+++ b/src/lib/services/photo-cache.ts
@@ -1,7 +1,9 @@
 /**
  * On-disk cache for proxied photo bytes.
  *
- * Originals: data/photos/cache/<sourceId>/<externalId>
+ * Display (web-safe JPEG/WebP): data/photos/cache/<sourceId>/web/<externalId>
+ *   (Older caches stored Immich /original HEIC at <sourceId>/<externalId>;
+ *   that path is no longer read so Firefox/kiosk browsers are not served HEIC.)
  * Thumbs:    data/photos/cache/<sourceId>/thumbs/<externalId>
  *
  * Used by /api/photos/[id]/file when serving Immich-backed photos so we don't
@@ -31,8 +33,13 @@ function sanitize(segment: string): string {
 function cachePath(sourceId: string, externalId: string, thumb: boolean): string {
   const dir = thumb
     ? path.join(CACHE_ROOT, sanitize(sourceId), 'thumbs')
-    : path.join(CACHE_ROOT, sanitize(sourceId));
+    : path.join(CACHE_ROOT, sanitize(sourceId), 'web');
   return path.join(dir, sanitize(externalId));
+}
+
+/** Pre-web-derivative location for a full-size file (Immich /original HEIC). */
+function legacyOriginalPath(sourceId: string, externalId: string): string {
+  return path.join(CACHE_ROOT, sanitize(sourceId), sanitize(externalId));
 }
 
 function metaPath(filePath: string): string {
@@ -56,6 +63,8 @@ export async function readPhotoCache(
       fs.readFile(metaPath(file), 'utf8').catch(() => ''),
     ]);
     const contentType = meta.trim() || 'application/octet-stream';
+    // Never serve a leftover HEIC from a partial upgrade of the web cache.
+    if (/image\/hei[cf]/i.test(contentType)) return null;
     return { buffer, contentType };
   } catch {
     return null;
@@ -92,12 +101,15 @@ export async function clearSourceCache(sourceId: string): Promise<void> {
  * is gone from the upstream album.
  */
 export async function clearPhotoCache(sourceId: string, externalId: string): Promise<void> {
-  const original = cachePath(sourceId, externalId, false);
+  const web = cachePath(sourceId, externalId, false);
   const thumb = cachePath(sourceId, externalId, true);
+  const legacy = legacyOriginalPath(sourceId, externalId);
   await Promise.all([
-    fs.rm(original, { force: true }),
-    fs.rm(metaPath(original), { force: true }),
+    fs.rm(web, { force: true }),
+    fs.rm(metaPath(web), { force: true }),
     fs.rm(thumb, { force: true }),
     fs.rm(metaPath(thumb), { force: true }),
+    fs.rm(legacy, { force: true }),
+    fs.rm(metaPath(legacy), { force: true }),
   ]);
 }


### PR DESCRIPTION
## Summary
- Immich lightbox, screensaver, and wallpaper were proxying `/original`, which is iPhone HEIC. Firefox and most Linux kiosk browsers cannot decode that, so the picture stayed blank even after the share had “Allow download” enabled.
- Display now requests Immich’s web-safe `fullsize` thumbnail (falls back to `preview` on 404/400). Leftover HEIC is converted to JPEG with sharp, the same as local uploads.
- Full-size cache moved to `data/photos/cache/<sourceId>/web/` so previously stored originals are not served. Cached `image/heic` is ignored.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint` (existing warnings only)
- [x] `npx jest` (102 suites)
- [x] Open an Immich photo: `/api/photos/{id}/file` (no `thumb`) is 200 with `content-type: image/jpeg` or `image/webp`, not `image/heic`
- [x] Lightbox shows the picture in Chrome
- [ ] Confirm screensaver and wallpaper still show Immich photos after a rebuild
- [ ] Hard-refresh after deploy so a tab is not still holding the old HEIC


Made with [Cursor](https://cursor.com)