### PR TITLE
chore(contributors): let outside pull requests run CI, and ask for the CLA up front

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+<!--
+Thanks for contributing to Prism.
+
+Two things are worth knowing before you scroll past this:
+
+1. The CLA. Prism needs one signature from you, once, ever. The quickest way
+   is to post it as a comment on this pull request as soon as you open it —
+   see the section at the bottom. A bot will ask if you forget.
+
+2. CI. If this is your first pull request here and your GitHub account is new,
+   the checks wait for a maintainer to approve the run. That is GitHub's
+   default for forks, not something being withheld from you.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What was wrong, or what is now possible. -->
+
+## Why
+
+<!-- The reasoning. If this fixes something, what was the actual cause? A
+     diagnosis is more useful than a description of the symptom. -->
+
+## How it was tested
+
+<!-- What you actually ran or clicked. "Typecheck passes" and "I used it on my
+     wall display for a day" are both useful; they are just different. -->
+
+- [ ] `npx tsc --noEmit`
+- [ ] `npx jest`
+- [ ] `npx next lint` (pre-existing warnings are fine, new ones are not)
+- [ ] Tried it on a real display or device
+
+## Anything you are unsure about
+
+<!-- Optional, and genuinely welcome. Flagging a decision you were torn on
+     saves a review round trip. -->
+
+---
+
+## Contributor License Agreement
+
+Prism requires one CLA signature per contributor, for all time. If you have
+signed before, ignore this.
+
+**To sign:** post a new comment on this pull request containing exactly:
+
+```
+I have read the CLA and I agree
+```
+
+It has to be a comment rather than a tick-box here, because the signature
+needs to be your own affirmative act rather than something copied out of a
+template on your behalf. The full text is in
+[CLA.md](https://github.com/sandydargoport/prism/blob/master/CLA.md).
+
+Posting it when you open the pull request saves a round trip — otherwise a bot
+will ask, and the merge waits on it either way.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,6 +47,9 @@ jobs:
           # bot cannot push to master (branch protection ruleset).
           branch: 'cla-signatures'
           allowlist: sandydargoport,dependabot[bot],github-actions[bot]
-          custom-notsigned-prcomment: 'Thanks for the contribution! Before it can be merged, please read our [Contributor License Agreement](https://github.com/sandydargoport/prism/blob/master/CLA.md) and, if you agree, post a comment below with exactly this text:'
-          custom-pr-sign-comment: 'I have read the CLA and I agree'
+          custom-notsigned-prcomment: 'Thanks for the contribution! One thing before it can be merged: Prism needs a CLA signature from you, once, for all time. Read the [Contributor License Agreement](https://github.com/sandydargoport/prism/blob/master/CLA.md) and, if you agree, post a comment below with exactly this text. It has to be your own comment rather than a tick-box, because the signature needs to be your affirmative act:'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you! ✅'
+          # The bot only re-evaluates on a new comment or a push. Someone who
+          # signs and then waits sees a red check with no way to clear it, so
+          # say what unsticks it.
+          custom-pr-sign-comment: 'I have read the CLA and I agree'


### PR DESCRIPTION
Two problems, both hit by the first real outside contribution in #328.

## CI never ran on it

The fork-PR approval policy was `first_time_contributors` — GitHub's default — so no workflow ran until a maintainer clicked approve, and nothing on the pull request indicates that is what is happening.

Meanwhile master's ruleset requires six status checks. Checks that never ran are **absent rather than failing**, so the pull request sat permanently `BLOCKED` with a green CLA and no explanation of what was missing. That is the worst possible state to leave a first-time contributor in.

Policy is now `first_time_contributors_new_to_github`: an established account gets CI immediately, a brand-new account still waits for approval, which is the case the setting actually exists for. Fork pull requests run with a read-only token and no secrets, so the exposure here is compute, not credentials.

**Changed via the API, not this PR.** To revert:

```
gh api -X PUT repos/OWNER/REPO/actions/permissions/fork-pr-contributor-approval \
  -f approval_policy=first_time_contributors
```

## The CLA was only mentioned after the fact

There was no pull request template at all. The CLA arrived as a bot comment once the PR already existed, which reads as a hoop rather than a step.

There is a template now. It leads with the exact text to paste and explains that CI approval is a GitHub default rather than something being withheld.

## Why the signature is still a comment

It cannot be a tick-box in the template. Ticking a box someone else wrote is not an affirmative act, and the CLA only means anything if the signature is the contributor's own. Both the template and the bot now say that, rather than leaving it looking arbitrary.

## Testing

YAML validated. The template is markdown only. Neither affects the app.