### PR TITLE
feat(auth): sign the display out after a stretch of inactivity

### DIFF
--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -14,6 +14,7 @@ import { useWallpaperSettings, useAutoOrientationSetting, useScreensaverInterval
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
 import { useOrientationOverride } from '../SettingsView';
 import { useScreensaverTimeout } from '@/lib/hooks/useScreensaverTimeout';
+import { useIdleLogoutSetting, IDLE_LOGOUT_OPTIONS } from '@/lib/hooks/useIdleLogout';
 import { useAutoHideUI } from '@/lib/hooks/useAutoHideUI';
 import { useAwayModeTimeout } from '@/lib/hooks/useAwayModeTimeout';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
@@ -316,6 +317,7 @@ function TimersCard() {
   const { interval: photoInterval, setInterval: setPhotoInterval } = useScreensaverInterval();
   const { autoHideEnabled, setAutoHideEnabled } = useAutoHideUI();
   const { timeout: awayTimeout, setTimeout: setAwayTimeout } = useAwayModeTimeout();
+  const [idleLogout, setIdleLogout] = useIdleLogoutSetting();
 
   return (
     <Card>
@@ -344,6 +346,23 @@ function TimersCard() {
               <option value={0}>Never</option>
             </select>
           </div>
+          <div className="flex items-center gap-3 pl-2">
+            <span className="text-sm text-muted-foreground">Sign out after</span>
+            <select
+              value={idleLogout}
+              onChange={(e) => setIdleLogout(Number(e.target.value))}
+              className="border border-border rounded px-2 py-1 text-sm bg-background"
+            >
+              {IDLE_LOGOUT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <p className="text-xs text-muted-foreground pl-2">
+            After this long untouched, the display stops being signed in as
+            whoever last used it. The dashboard stays readable; adding or
+            changing anything asks for a PIN. This screen only.
+          </p>
           <div className="flex items-center gap-3 pl-2">
             <span className="text-sm text-muted-foreground">Rotate photos every</span>
             <select

--- a/src/components/layout/LazyOverlays.tsx
+++ b/src/components/layout/LazyOverlays.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useIdleLogout } from '@/lib/hooks/useIdleLogout';
 
 const Screensaver = dynamic(
   () => import('@/components/screensaver/Screensaver').then(m => ({ default: m.Screensaver })),
@@ -16,6 +17,10 @@ const BabysitterModeOverlay = dynamic(
 );
 
 export function LazyOverlays() {
+  // Mounted here because this component is already in the root layout, so the
+  // check runs on every page rather than only on the dashboard.
+  useIdleLogout();
+
   return (
     <>
       <BabysitterModeOverlay />

--- a/src/lib/hooks/__tests__/useIdleLogout.test.ts
+++ b/src/lib/hooks/__tests__/useIdleLogout.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Signing the display out after a stretch of inactivity.
+ *
+ * A parent session lasts 7 days, its window is refreshed on every request, and
+ * the dashboard polls constantly — so a wall display stays authenticated as
+ * whoever last signed in until the 30-day cap, and anyone who walks up inherits
+ * it. This bounds that to actual presence.
+ */
+import { shouldLogOut, getIdleLogoutMinutes, DEFAULT_IDLE_LOGOUT_MINUTES } from '../useIdleLogout';
+
+const MIN = 60 * 1000;
+const NOW = 1_000_000_000;
+
+beforeEach(() => window.localStorage.clear());
+
+describe('shouldLogOut', () => {
+  it('signs out once the display has been idle past the setting', () => {
+    expect(shouldLogOut(30, NOW - 31 * MIN, NOW)).toBe(true);
+  });
+
+  it('leaves an active session alone', () => {
+    expect(shouldLogOut(30, NOW - 29 * MIN, NOW)).toBe(false);
+  });
+
+  it('does not fire exactly on the boundary, so a rounding wobble cannot', () => {
+    expect(shouldLogOut(30, NOW - 30 * MIN, NOW)).toBe(false);
+  });
+
+  it('never signs out when set to Never', () => {
+    expect(shouldLogOut(0, NOW - 24 * 60 * MIN, NOW)).toBe(false);
+  });
+
+  it('treats a negative setting as Never rather than as immediate', () => {
+    // A corrupted value must not lock someone out of their own display.
+    expect(shouldLogOut(-5, NOW - 24 * 60 * MIN, NOW)).toBe(false);
+  });
+});
+
+describe('getIdleLogoutMinutes', () => {
+  it('defaults to 30 minutes when nothing is stored', () => {
+    expect(getIdleLogoutMinutes()).toBe(DEFAULT_IDLE_LOGOUT_MINUTES);
+  });
+
+  it('reads a stored value', () => {
+    window.localStorage.setItem('prism-idle-logout-minutes', '15');
+    expect(getIdleLogoutMinutes()).toBe(15);
+  });
+
+  it('reads a stored Never', () => {
+    window.localStorage.setItem('prism-idle-logout-minutes', '0');
+    expect(getIdleLogoutMinutes()).toBe(0);
+  });
+
+  it('falls back to the default on a nonsense value', () => {
+    window.localStorage.setItem('prism-idle-logout-minutes', 'soon');
+    expect(getIdleLogoutMinutes()).toBe(DEFAULT_IDLE_LOGOUT_MINUTES);
+  });
+
+  it('falls back rather than accepting a negative', () => {
+    window.localStorage.setItem('prism-idle-logout-minutes', '-1');
+    expect(getIdleLogoutMinutes()).toBe(DEFAULT_IDLE_LOGOUT_MINUTES);
+  });
+
+  it('survives storage throwing', () => {
+    const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(getIdleLogoutMinutes()).toBe(DEFAULT_IDLE_LOGOUT_MINUTES);
+    spy.mockRestore();
+  });
+});

--- a/src/lib/hooks/useIdleLogout.ts
+++ b/src/lib/hooks/useIdleLogout.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/components/providers';
+
+/** Written by useIdleDetection on any interaction anywhere in the app. */
+const LAST_ACTIVITY_KEY = 'prism-last-activity';
+
+/** Minutes of inactivity before the display signs itself out. */
+export const IDLE_LOGOUT_KEY = 'prism-idle-logout-minutes';
+export const DEFAULT_IDLE_LOGOUT_MINUTES = 30;
+
+export const IDLE_LOGOUT_OPTIONS = [
+  { value: 0, label: 'Never' },
+  { value: 5, label: '5 minutes' },
+  { value: 15, label: '15 minutes' },
+  { value: 30, label: '30 minutes' },
+  { value: 60, label: '1 hour' },
+  { value: 240, label: '4 hours' },
+] as const;
+
+export function getIdleLogoutMinutes(): number {
+  if (typeof window === 'undefined') return DEFAULT_IDLE_LOGOUT_MINUTES;
+  try {
+    const stored = window.localStorage.getItem(IDLE_LOGOUT_KEY);
+    if (stored === null) return DEFAULT_IDLE_LOGOUT_MINUTES;
+    const n = Number(stored);
+    return Number.isFinite(n) && n >= 0 ? n : DEFAULT_IDLE_LOGOUT_MINUTES;
+  } catch {
+    return DEFAULT_IDLE_LOGOUT_MINUTES;
+  }
+}
+
+/** True when the display has gone untouched for longer than the setting. */
+export function shouldLogOut(minutes: number, lastActivity: number, now: number): boolean {
+  if (minutes <= 0) return false;
+  return now - lastActivity > minutes * 60 * 1000;
+}
+
+/**
+ * Sign the display out after a stretch of inactivity.
+ *
+ * A parent session lasts 7 days and its window is refreshed on every request,
+ * and the dashboard polls constantly — so once someone signs in at a wall
+ * display, that display is authenticated as them until the 30-day absolute cap.
+ * Anyone who walks up inherits it.
+ *
+ * Reading is unaffected: `getDisplayAuth` serves the dashboard from the
+ * configured display user when there is no session, so the calendar, tasks and
+ * messages stay on screen. What comes back is the PIN prompt on anything that
+ * writes, which is where a credential actually means something.
+ *
+ * Deliberately on its own timer rather than hooked to the screensaver. The
+ * screensaver is cosmetic and often set to two minutes; being asked for a PIN
+ * that often would train people to resent it. This is the longer question of
+ * whether anyone is still here.
+ */
+/** Read/write the setting, with the change event other tabs listen for. */
+export function useIdleLogoutSetting(): [number, (v: number) => void] {
+  const [minutes, setMinutes] = useState<number>(() => getIdleLogoutMinutes());
+  useEffect(() => setMinutes(getIdleLogoutMinutes()), []);
+  const update = (v: number) => {
+    setMinutes(v);
+    try {
+      window.localStorage.setItem(IDLE_LOGOUT_KEY, String(v));
+    } catch {
+      /* storage unavailable — the choice holds for this session only */
+    }
+  };
+  return [minutes, update];
+}
+
+export function useIdleLogout() {
+  const { activeUser, clearActiveUser } = useAuth();
+  const activeRef = useRef(activeUser);
+  activeRef.current = activeUser;
+
+  useEffect(() => {
+    const minutes = getIdleLogoutMinutes();
+    if (minutes <= 0) return;
+
+    const check = () => {
+      // Nothing to do when nobody is signed in — avoids a pointless logout
+      // request every minute on a display that is already anonymous.
+      if (!activeRef.current) return;
+      try {
+        const raw = window.localStorage.getItem(LAST_ACTIVITY_KEY);
+        if (raw === null) return;
+        const last = Number(raw);
+        if (!Number.isFinite(last)) return;
+        if (shouldLogOut(minutes, last, Date.now())) clearActiveUser();
+      } catch {
+        /* storage unavailable — leave the session alone rather than guessing */
+      }
+    };
+
+    const timer = setInterval(check, 60_000);
+    return () => clearInterval(timer);
+  }, [clearActiveUser]);
+}


### PR DESCRIPTION
Closes #335.

A parent session lasts 7 days, its window is refreshed on every successful validation, and the dashboard polls constantly — so once someone signs in at a wall display, that display stays authenticated as them until the 30-day absolute cap. Anyone who walks up inherits it.

The display now signs itself out after **30 minutes untouched**, configurable in Settings under Appearance, or Never.

## Reading is unaffected

`getDisplayAuth` serves the dashboard from the configured display user when there is no session, so the calendar, tasks and messages stay on screen. A visiting grandparent notices nothing. What comes back is the PIN prompt on anything that **writes**.

## Why its own timer, not the screensaver

The screensaver is cosmetic and often set to two minutes. Being asked for a PIN that often teaches people to resent it. This asks the longer question of whether anyone is still here.

Keyed on `prism-last-activity`, which `useIdleDetection` already writes on any interaction anywhere in the app — so it measures inactivity rather than elapsed time, and cannot fire under someone actively using the display. The check skips entirely when nobody is signed in.

## Failure mode

A corrupted or negative setting reads as **Never**, not as immediate. This feature must not be able to lock someone out of their own display.

## Chosen over the screensaver PIN lock

That was specced and rejected: the screensaver timeout is client-side with no server permission, and the ambient session meant the PIN would have been decorative.

## Testing

11 cases on the threshold and the setting — including the boundary, Never, a negative value, nonsense input, and storage throwing.

1,588 tests pass, typecheck and lint clean.