### PR TITLE
perf(fetch): join concurrent identical requests, and bound the cache

### DIFF
--- a/src/lib/hooks/useFetch.ts
+++ b/src/lib/hooks/useFetch.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { useVisibilityPolling } from './useVisibilityPolling';
-import { navCacheGet, navCacheSet } from '@/lib/utils/navCache';
+import { navCacheGet, navCacheSet, navCacheDedupe } from '@/lib/utils/navCache';
 
 interface UseFetchOptions<T> {
   url: string;
@@ -50,10 +50,15 @@ export function useFetch<T>(options: UseFetchOptions<T>): UseFetchResult<T> {
     if (loadedUrlRef.current !== url && !navCacheGet(url)) setLoading(true);
     try {
       setError(null);
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`Failed to fetch ${labelRef.current}`);
-      const json = await response.json();
-      const result = transformRef.current ? transformRef.current(json) : (json as T);
+      // Joined rather than duplicated: two components polling the same URL on
+      // the same tick make one request. The transform runs per consumer, since
+      // two callers of the same endpoint can shape the response differently.
+      const json = await navCacheDedupe(url, async () => {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`Failed to fetch ${labelRef.current}`);
+        return response.json();
+      });
+      const result = transformRef.current ? transformRef.current(json as never) : (json as T);
       navCacheSet(url, result);
       loadedUrlRef.current = url;
       // Structural-shared polling: when the new payload is byte-identical

--- a/src/lib/utils/__tests__/navCache.test.ts
+++ b/src/lib/utils/__tests__/navCache.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Joining concurrent requests, and keeping the cache from growing forever.
+ *
+ * Both matter for the same reason: this runs on a wall display that is never
+ * closed. Duplicate requests are cheap once and expensive ten thousand times,
+ * and a cache that only evicts on read grows until something falls over.
+ */
+import {
+  navCacheDedupe,
+  navCacheInFlightCount,
+  navCacheGet,
+  navCacheSet,
+} from '../navCache';
+
+describe('navCacheDedupe', () => {
+  it('makes one request when two callers ask at the same moment', async () => {
+    // The real case: the screensaver and the away-mode overlay are both
+    // mounted on every page and ask for photos with identical parameters.
+    let calls = 0;
+    const fetcher = () => { calls++; return Promise.resolve('photos'); };
+
+    const [a, b] = await Promise.all([
+      navCacheDedupe('/api/photos?x=1', fetcher),
+      navCacheDedupe('/api/photos?x=1', fetcher),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(a).toBe('photos');
+    expect(b).toBe('photos');
+  });
+
+  it('keeps different URLs separate', async () => {
+    let calls = 0;
+    const fetcher = () => { calls++; return Promise.resolve(null); };
+    await Promise.all([
+      navCacheDedupe('/api/a', fetcher),
+      navCacheDedupe('/api/b', fetcher),
+    ]);
+    expect(calls).toBe(2);
+  });
+
+  it('does not join a later caller once the first has finished', async () => {
+    // It joins genuinely concurrent callers only. It is not a second cache.
+    let calls = 0;
+    const fetcher = () => { calls++; return Promise.resolve(null); };
+    await navCacheDedupe('/api/seq', fetcher);
+    await navCacheDedupe('/api/seq', fetcher);
+    expect(calls).toBe(2);
+  });
+
+  it('shares a rejection with everyone waiting, and remembers nothing', async () => {
+    // A failure must not be cached — the next attempt has to be able to
+    // succeed, or one blip would stick until reload.
+    let calls = 0;
+    const failing = () => { calls++; return Promise.reject(new Error('down')); };
+
+    const results = await Promise.allSettled([
+      navCacheDedupe('/api/fail', failing),
+      navCacheDedupe('/api/fail', failing),
+    ]);
+    expect(calls).toBe(1);
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+
+    await navCacheDedupe('/api/fail', () => Promise.resolve('ok')).catch(() => {});
+    expect(calls).toBe(1);
+  });
+
+  it('leaves nothing behind once requests settle', async () => {
+    await navCacheDedupe('/api/clean', () => Promise.resolve(1));
+    await navCacheDedupe('/api/clean2', () => Promise.reject(new Error('x'))).catch(() => {});
+    expect(navCacheInFlightCount()).toBe(0);
+  });
+});
+
+describe('navCache bounded size', () => {
+  it('evicts old entries instead of growing forever', () => {
+    for (let i = 0; i < 150; i++) navCacheSet(`/api/item/${i}`, i);
+
+    // The earliest are gone, the most recent are kept.
+    expect(navCacheGet('/api/item/0')).toBeUndefined();
+    expect(navCacheGet('/api/item/149')).toBe(149);
+  });
+});

--- a/src/lib/utils/navCache.ts
+++ b/src/lib/utils/navCache.ts
@@ -12,6 +12,24 @@
 const store = new Map<string, { data: unknown; ts: number }>();
 const TTL_MS = 60_000;
 
+/**
+ * Cap on stored entries. Eviction was previously lazy — an entry only went
+ * when a read found it stale — so any URL that stopped being read was never
+ * freed. On a wall display left running for weeks that grows without bound,
+ * and a calendar payload can hold 500 events.
+ */
+const MAX_ENTRIES = 100;
+
+/**
+ * Requests currently in flight, keyed the same way as the cache.
+ *
+ * Without this, two components asking for the same URL at the same moment make
+ * two requests; the cache only helps once one has already returned. That is not
+ * hypothetical — the screensaver and the away-mode overlay are both mounted on
+ * every page and ask for photos with byte-identical parameters.
+ */
+const inFlight = new Map<string, Promise<unknown>>();
+
 export function navCacheGet<T>(key: string): T | undefined {
   const entry = store.get(key);
   if (!entry) return undefined;
@@ -24,6 +42,37 @@ export function navCacheGet<T>(key: string): T | undefined {
 
 export function navCacheSet(key: string, data: unknown): void {
   store.set(key, { data, ts: Date.now() });
+  // Oldest-inserted first. Map preserves insertion order, and re-setting a key
+  // does not move it — so a hot key can still be evicted. Acceptable: the cost
+  // is one refetch, and a strict LRU would mean touching the map on every read.
+  while (store.size > MAX_ENTRIES) {
+    const oldest = store.keys().next().value;
+    if (oldest === undefined) break;
+    store.delete(oldest);
+  }
+}
+
+/**
+ * Run `fetcher` for `key`, or join the request already running for it.
+ *
+ * The entry is removed as soon as the promise settles, so this only ever joins
+ * genuinely concurrent callers — it is not a second cache with its own
+ * lifetime, and a failure is not remembered.
+ */
+export function navCacheDedupe<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  const existing = inFlight.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const promise = fetcher().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/** Visible for tests. */
+export function navCacheInFlightCount(): number {
+  return inFlight.size;
 }
 
 /** Invalidate all keys matching a regex — call after mutations. */


### PR DESCRIPTION
Closes #337.

`navCache` stored results correctly but tracked nothing **in flight**, so two components asking for the same URL at the same moment made two requests — the cache only helped once one had already returned.

Not hypothetical: `LazyOverlays` mounts the screensaver and the away-mode overlay on every page, and both ask for photos with byte-identical parameters. That request has always gone out twice, on every page load.

## Deduplication

`navCacheDedupe` joins callers on the same key. Two details that matter:

- The entry is dropped as soon as the promise **settles**, so it only joins genuinely concurrent callers. It is not a second cache with its own lifetime.
- A **failure is not remembered**. One blip must not stick until reload.

The transform still runs per consumer, since two callers of the same endpoint can shape the response differently.

## Bounded cache

Eviction was lazy — an entry only went when a read found it stale — so any URL that stopped being read was never freed. On a display left running for weeks that grows monotonically, and a calendar payload can hold 500 events.

Now capped at 100, oldest-inserted first. Not a strict LRU: evicting a hot key costs one refetch, where an LRU would mean touching the map on every read.

## Not server-side caching

Worth stating since it looks similar. Weather is already cached in Redis for 30 minutes, so the provider is called once for the whole house. What was duplicated is the round trip from each client.

## Testing

Six cases: two concurrent callers make one request, different URLs stay separate, a later caller is not joined, a rejection is shared but not remembered, nothing is left behind once requests settle, and the cache evicts rather than growing.

1,583 tests pass, typecheck clean. Two lint warnings on the touched files are pre-existing.