### PR TITLE
chore(release): 1.20.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.20.0] – 2026-08-30
+
+### Added
+- **The display can now sign itself out after a stretch of inactivity.** Once someone signs in at a wall display it has been staying signed in as them for weeks, so anyone who walked up afterwards could add, change or delete things as that person. It now signs out after 30 minutes untouched, which you can change or turn off under *Settings → Appearance → Timers*. Nothing disappears when it does: the calendar, tasks and messages stay on screen for anyone to read. What comes back is the PIN prompt on anything that changes something.
+
+### Fixed
+- **On-screen keyboard keys were blank in dark mode.** The letters only appeared while a key was held down. Thanks to Brian Adams for finding and fixing this.
+- **Prism was fetching some things twice.** Two parts of the app that ask for the same information at the same moment now share one request instead of making two, and the short-term cache no longer grows without limit on a display left running for weeks.
+
 ## [1.19.1] – 2026-08-30
 
 ### Fixed

--- a/docs/features/DISPLAY-MODES.md
+++ b/docs/features/DISPLAY-MODES.md
@@ -26,6 +26,23 @@ Screensaver timing lives under *Settings → Appearance → Timers & Auto-Activa
 
 - **Screensaver Timeout**: how long idle before activating. Options: 30 seconds / 1 minute / 2 minutes / 10 minutes / 1 hour / Never (default 2 minutes).
 - **Photo Rotation Interval**: how fast photos cycle within the screensaver (5 seconds up to 1 hour, or Never for a static image).
+- **Sign out after**: how long the display can sit untouched before it stops
+  being signed in as whoever last used it (5 minutes up to 4 hours, or Never;
+  default 30 minutes). Per device, like the other timers here.
+
+  Signing out does not blank anything. `getDisplayAuth` keeps serving the
+  dashboard from the configured display user, so the calendar, tasks and
+  messages stay readable to anyone who walks up. What comes back is the PIN
+  prompt on anything that *changes* something.
+
+  Worth knowing why this exists: a parent session lasts 7 days and its window
+  is refreshed on every request, and the dashboard polls constantly — so
+  without this, one sign-in leaves the display authenticated as that person
+  until the 30-day absolute cap, and whoever walks up next inherits it.
+
+  It is deliberately not tied to the screensaver. That timer is cosmetic and
+  often set to two minutes; being asked for a PIN that often teaches people to
+  resent it.
 
 Which photos appear is configured under *Settings → Photos:*
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.19.1"
+version: "1.20.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -527,6 +527,18 @@ function ScreensaverHelp() {
         <Li><strong>Photo rotation</strong>: Set the &quot;Rotate photos every&quot; interval, or pin one static photo</Li>
         <Li><strong>Edit layout</strong>: In dashboard edit mode, toggle &quot;Screensaver&quot;</Li>
       </Ul>
+      <H2>Signing out when nobody is there</H2>
+      <P>
+        Under the same Timers section, <strong>Sign out after</strong> controls how long
+        the display can sit untouched before it stops being signed in as whoever last
+        used it. Thirty minutes by default; you can change it or turn it off.
+      </P>
+      <P>
+        Nothing disappears when it happens. The calendar, tasks and messages stay on
+        screen for anyone to read. What comes back is the PIN prompt on anything that
+        changes something, so a task added on the display is added by whoever is
+        actually standing there.
+      </P>
     </>
   );
 }


### PR DESCRIPTION
Minor release: the display now signs itself out after a stretch of inactivity (#345), plus the on-screen keyboard dark-mode fix contributed by @ba221400 (#343) and request deduplication (#346).

Minor rather than patch because #345 adds a setting and changes behaviour — displays will start signing themselves out after 30 minutes, which people should read about rather than discover.

Also updates DISPLAY-MODES.md and the in-app help for the new setting, including why it is not tied to the screensaver timer.