### PR TITLE
chore(release): 1.20.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.20.1] – 2026-08-31
+
 ### Fixed
-- **Immich photos display in Firefox and other browsers that cannot decode HEIC.** Lightbox, screensaver, and wallpaper were proxying the iPhone original (`image/heic`). Prism now asks Immich for a web-safe full-size JPEG/WebP (falling back to the preview), converts leftover HEIC with sharp, and ignores previously cached originals.
+- **Immich photos display in Firefox and other browsers that cannot decode HEIC.** Lightbox, screensaver, and wallpaper were proxying the iPhone original (`image/heic`). Prism now asks Immich for a web-safe full-size JPEG/WebP (falling back to the preview), converts leftover HEIC with sharp, and ignores previously cached originals. Thanks to Brian Adams.
 
 ## [1.20.0] – 2026-08-30
 

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.20.0"
+version: "1.20.1"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Patch release: Immich photos now display in browsers that cannot decode HEIC (#349), contributed by @ba221400.

Relevant to anyone running a Linux kiosk browser on a wall display — Immich's `/original` returns iPhone HEIC, which Firefox and most Linux Chromium cannot decode, so photos were blank.