### PR TITLE
feat(themes): user-selectable palettes

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -9,6 +9,7 @@ import type { AuthResult } from '@/lib/auth';
 import { logError } from '@/lib/utils/logError';
 import { PIN_LENGTH_SETTING_KEY } from '@/lib/constants';
 import { isSetupComplete } from '@/lib/setup';
+import { getBuiltinTheme } from '@/lib/themes/appThemes';
 
 export async function GET() {
   const auth = await getDisplayAuth();
@@ -70,6 +71,22 @@ export async function PATCH(request: NextRequest) {
       auth = authResult;
       const forbidden = requireRole(auth, 'canModifySettings');
       if (forbidden) return forbidden;
+    }
+
+    // Per-key validation. This endpoint otherwise accepts any shape for any
+    // key, and the theme row is read on the server and rendered into a <style>
+    // element in the root layout — so an unchecked value there is not a bad
+    // setting, it is markup in the page. Never trust the row on the render
+    // path; refuse it on the way in as well.
+    if (body.key === 'theme') {
+      const value = body.value as { paletteId?: unknown } | null;
+      const paletteId = value && typeof value === 'object' ? value.paletteId : undefined;
+      if (paletteId !== undefined && (typeof paletteId !== 'string' || !getBuiltinTheme(paletteId))) {
+        return NextResponse.json(
+          { error: 'Unknown palette' },
+          { status: 400 },
+        );
+      }
     }
 
     const [existing] = await db

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,8 @@ import { DemoBanner } from '@/components/layout/DemoBanner';
 
 // Toast notifications
 import { Toaster } from '@/components/ui/toaster';
+import { getServerTheme } from '@/lib/themes/serverTheme';
+import { themeCss } from '@/lib/themes/applyTheme';
 
 
 /**
@@ -225,11 +227,17 @@ export const viewport: Viewport = {
  * - Can't use hooks or browser APIs directly
  * - For client-side features, wrap in a Client Component
  */
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Rendered here rather than applied on the client, so the first paint is
+  // already the right palette. A wall display reloads on its own; a flash of
+  // the default colours on every reload is the most visible thing about
+  // theming, and it reads as a fault.
+  const theme = await getServerTheme();
+
   return (
     <html
       lang="en"
@@ -237,6 +245,26 @@ export default function RootLayout({
       // that might modify the HTML (password managers, etc.)
       suppressHydrationWarning
     >
+      <head>
+        {/*
+          Two things have to be right before the first paint: which palette,
+          and whether it is the light or dark half of it. The palette comes
+          from the server above. The light/dark choice lives in localStorage,
+          which the server cannot read — hence the blocking script, which sets
+          the class the stylesheet below keys on. Both are tiny and neither
+          fetches anything.
+
+          themeCss builds its output from an allowlist of property names and
+          re-checks every value, so nothing from a stored palette can escape
+          this element. There is no CSP here to catch it if it could.
+        */}
+        <style id="prism-theme" dangerouslySetInnerHTML={{ __html: themeCss(theme) }} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('prism-theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark')}catch(e){}})()`,
+          }}
+        />
+      </head>
       {/*
         The body element with our font applied.
 

--- a/src/app/settings/sections/DisplaySection.tsx
+++ b/src/app/settings/sections/DisplaySection.tsx
@@ -35,7 +35,7 @@ function SectionDivider({ label }: { label: string }) {
 }
 
 export function DisplaySection() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme, palette: activePalette, palettes, setPalette } = useTheme();
   const { seasonalTheme, setSeasonalTheme, palette } = useSeasonalTheme();
 
   const mode: 'auto' | 'manual' | 'off' =
@@ -92,6 +92,48 @@ export function DisplaySection() {
               <Monitor className="h-4 w-4 mr-2" />
               System
             </Button>
+          </div>
+
+          <div className="mt-6 space-y-3">
+            <div>
+              <h4 className="text-sm font-medium">Palette</h4>
+              <p className="text-xs text-muted-foreground mt-1">
+                Applies to every screen in the house. Light and dark above stay
+                per-screen.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {palettes.map((p) => {
+                const preview = resolvedTheme === 'dark' ? p.dark : p.light;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => setPalette(p.id)}
+                    aria-pressed={activePalette.id === p.id}
+                    className={`rounded-lg border p-3 text-left transition-colors ${
+                      activePalette.id === p.id
+                        ? 'border-primary ring-2 ring-primary/40'
+                        : 'border-border hover:border-primary/50'
+                    }`}
+                  >
+                    {/* Swatches read from the palette being offered, not from
+                        the active one, so each card previews itself. */}
+                    <div className="flex gap-1.5 mb-2">
+                      {(['background', 'card', 'primary', 'accent', 'destructive'] as const).map((tok) => (
+                        <span
+                          key={tok}
+                          className="h-6 w-6 rounded border border-black/10"
+                          style={{ backgroundColor: `hsl(${preview[tok]})` }}
+                        />
+                      ))}
+                    </div>
+                    <div className="text-sm font-medium">{p.name}</div>
+                    <div className="text-xs text-muted-foreground">{p.description}</div>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -36,8 +36,12 @@ interface ProvidersProps {
  * AuthProvider must be inside ThemeProvider since QuickPinModal uses styled components.
  */
 export function Providers({ children }: ProvidersProps) {
+  // No defaultTheme override here. It was 'light' to mask the flash before the
+  // stored preference loaded, which also meant a stored 'system' setting was
+  // ignored on first render. The blocking script in the root layout now sets
+  // the class before paint, so the mask is no longer needed.
   return (
-    <ThemeProvider defaultTheme="light">
+    <ThemeProvider>
       <LocaleProvider>
         <FamilyProvider>
           <AuthProvider>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -17,6 +17,9 @@ import * as React from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useSeasonalTheme } from '@/lib/hooks/useSeasonalTheme';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
+import type { Theme } from '@/lib/themes/tokens';
+import { BUILTIN_THEMES, getBuiltinTheme, DEFAULT_THEME_ID } from '@/lib/themes/appThemes';
+import { applyThemeVars, themeTokens } from '@/lib/themes/applyTheme';
 
 /**
  * Theme modes
@@ -33,6 +36,12 @@ interface ThemeContextValue {
   resolvedTheme: 'light' | 'dark';
   /** Update the theme */
   setTheme: (theme: ThemeMode) => void;
+  /** Which palette is applied. Independent of light/dark. */
+  palette: Theme;
+  /** Every palette that can be chosen right now. */
+  palettes: Theme[];
+  /** Switch palette. Persisted to the settings row, not to localStorage. */
+  setPalette: (id: string) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -41,6 +50,13 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
  * Storage key for persisting theme preference
  */
 const STORAGE_KEY = 'prism-theme';
+
+/**
+ * The settings row holding the chosen palette. Seeded since the beginning and
+ * read by nothing until now — the `{ mode }` shape it was seeded with is kept
+ * so existing rows stay valid.
+ */
+const THEME_SETTING_KEY = 'theme';
 
 /**
  * Get the system theme preference
@@ -75,6 +91,9 @@ export function ThemeProvider({
   const [theme, setThemeState] = useState<ThemeMode>(defaultTheme);
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
   const [mounted, setMounted] = useState(false);
+  const [palette, setPaletteState] = useState<Theme>(
+    () => getBuiltinTheme(DEFAULT_THEME_ID) ?? BUILTIN_THEMES[0]!,
+  );
 
   // On mount, load saved theme from localStorage
   useEffect(() => {
@@ -137,8 +156,72 @@ export function ThemeProvider({
     localStorage.setItem(STORAGE_KEY, newTheme);
   };
 
-  // Apply seasonal theme CSS variables globally
-  useSeasonalTheme();
+  // Persisted to the database rather than localStorage, because a palette is a
+  // household choice: every screen in the house should agree, and a new tablet
+  // should pick it up without being configured.
+  const setPalette = (id: string) => {
+    const next = getBuiltinTheme(id);
+    if (!next) return;
+    setPaletteState(next);
+    fetch('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: THEME_SETTING_KEY, value: { mode: theme, paletteId: id } }),
+    }).catch(() => { /* applied locally; the next load falls back to the server value */ });
+  };
+
+  // Apply the palette's variables whenever it or the light/dark mode changes.
+  //
+  // Runs after mount only. The first paint is handled by a stylesheet rendered
+  // on the server, so this effect is for changes rather than for load — which
+  // is why there is no flash when someone picks a palette.
+  useEffect(() => {
+    if (!mounted) return;
+    applyThemeVars(document.documentElement, themeTokens(palette, resolvedTheme));
+  }, [palette, resolvedTheme, mounted]);
+
+  // Escape hatch for a kiosk that cannot reach Settings: ?theme=default resets
+  // the palette and persists it. A wall display has no keyboard, and a palette
+  // with a broken background/foreground pair makes the Settings page itself
+  // unreadable — which would otherwise mean an SSH session to recover.
+  // Mirrors ?perf=0 in usePerformanceMode, which exists for the same reason.
+  useEffect(() => {
+    if (!mounted) return;
+    if (new URLSearchParams(window.location.search).get('theme') !== 'default') return;
+    const fallback = getBuiltinTheme(DEFAULT_THEME_ID) ?? BUILTIN_THEMES[0]!;
+    setPaletteState(fallback);
+    fetch('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: THEME_SETTING_KEY, value: { mode: theme, paletteId: fallback.id } }),
+    }).catch(() => { /* reset locally at least; the display is usable again */ });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mounted]);
+
+  // Read the stored palette once. A failure here is not worth surfacing: the
+  // server already rendered a palette, so the visible result of the request
+  // never arriving is that the picker shows the default.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/settings')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const stored = data.settings?.[THEME_SETTING_KEY];
+        const id = typeof stored?.paletteId === 'string' ? stored.paletteId : null;
+        const found = id ? getBuiltinTheme(id) : undefined;
+        if (found) setPaletteState(found);
+      })
+      .catch(() => { /* keep whatever the server rendered */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Apply seasonal theme CSS variables globally.
+  //
+  // Passed the resolved mode so it does not have to watch the html class list
+  // to discover it. Its four --seasonal-* properties are deliberately outside
+  // THEME_TOKENS, so the two writers never touch the same property.
+  useSeasonalTheme(resolvedTheme);
   // Apply performance-mode class on <html> from localStorage preference
   usePerformanceMode();
 
@@ -146,14 +229,18 @@ export function ThemeProvider({
   // Return null or a loading state until mounted
   if (!mounted) {
     return (
-      <ThemeContext.Provider value={{ theme: defaultTheme, resolvedTheme: 'light', setTheme }}>
+      <ThemeContext.Provider
+        value={{ theme: defaultTheme, resolvedTheme: 'light', setTheme, palette, palettes: BUILTIN_THEMES, setPalette }}
+      >
         {children}
       </ThemeContext.Provider>
     );
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+    <ThemeContext.Provider
+      value={{ theme, resolvedTheme, setTheme, palette, palettes: BUILTIN_THEMES, setPalette }}
+    >
       {children}
     </ThemeContext.Provider>
   );

--- a/src/lib/hooks/useSeasonalTheme.ts
+++ b/src/lib/hooks/useSeasonalTheme.ts
@@ -38,7 +38,7 @@ function applySeasonalVars(month: number | null, isDark: boolean) {
   root.style.setProperty('--seasonal-subtle', colors.subtle);
 }
 
-export function useSeasonalTheme() {
+export function useSeasonalTheme(mode?: 'light' | 'dark') {
   const [setting, setSetting] = useState<SeasonalThemeKey>(loadSetting);
 
   const activeMonth: number | null =
@@ -53,6 +53,17 @@ export function useSeasonalTheme() {
 
   // Apply CSS variables whenever setting or dark mode changes
   useEffect(() => {
+    // When the caller already knows the mode — ThemeProvider does, it is React
+    // state there — take it directly. The observer below is the fallback for
+    // callers that do not, and it fires on every class change on <html>,
+    // including the performance-mode toggle and anything else that writes
+    // there. Skipping it removes a MutationObserver from a display that runs
+    // for weeks.
+    if (mode) {
+      applySeasonalVars(activeMonth, mode === 'dark');
+      return;
+    }
+
     const isDark = document.documentElement.classList.contains('dark');
     applySeasonalVars(activeMonth, isDark);
 
@@ -64,7 +75,7 @@ export function useSeasonalTheme() {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
     return () => observer.disconnect();
-  }, [activeMonth]);
+  }, [activeMonth, mode]);
 
   return {
     seasonalTheme: setting,

--- a/src/lib/themes/__tests__/themes.test.ts
+++ b/src/lib/themes/__tests__/themes.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Themes are data, and data can arrive from a community gallery. So the tests
+ * that matter most are the ones proving a hostile value cannot become CSS.
+ */
+import { THEME_TOKENS, isValidTokenValue, isValidTokenSet } from '../tokens';
+import { BUILTIN_THEMES, getBuiltinTheme, DEFAULT_THEME_ID } from '../appThemes';
+import { applyThemeVars, clearThemeVars, themeCss, themeTokens } from '../applyTheme';
+
+describe('isValidTokenValue', () => {
+  it('accepts a bare HSL triple, which is what Tailwind expects', () => {
+    // hsl(var(--x)) supplies the wrapper; that is what makes bg-primary/40 work.
+    expect(isValidTokenValue('222 47% 11%')).toBe(true);
+    expect(isValidTokenValue('0 0% 100%')).toBe(true);
+    expect(isValidTokenValue('212.5 95% 68.2%')).toBe(true);
+  });
+
+  it('rejects anything that could carry more than a colour', () => {
+    for (const hostile of [
+      'red; background: url(https://example.com/x)',
+      'var(--background)',
+      'calc(100% - 1px)',
+      'url(https://example.com/pixel.gif)',
+      '222 47% 11%; }</style><script>alert(1)</script>',
+      'expression(alert(1))',
+      '#ffffff',
+      'rgb(0,0,0)',
+      'white',
+    ]) {
+      expect(isValidTokenValue(hostile)).toBe(false);
+    }
+  });
+
+  it('rejects out-of-range numbers even when the shape is right', () => {
+    expect(isValidTokenValue('400 47% 11%')).toBe(false);
+    expect(isValidTokenValue('222 147% 11%')).toBe(false);
+    expect(isValidTokenValue('222 47% 111%')).toBe(false);
+  });
+
+  it('rejects non-strings', () => {
+    for (const v of [null, undefined, 42, {}, []]) expect(isValidTokenValue(v)).toBe(false);
+  });
+});
+
+describe('isValidTokenSet', () => {
+  it('requires every token, so a partial theme cannot half-apply', () => {
+    const partial = Object.fromEntries(THEME_TOKENS.slice(0, 5).map((t) => [t, '0 0% 50%']));
+    expect(isValidTokenSet(partial)).toBe(false);
+  });
+
+  it('accepts a complete valid set', () => {
+    const full = Object.fromEntries(THEME_TOKENS.map((t) => [t, '0 0% 50%']));
+    expect(isValidTokenSet(full)).toBe(true);
+  });
+
+  it('rejects a set where one value is hostile', () => {
+    const full = Object.fromEntries(THEME_TOKENS.map((t) => [t, '0 0% 50%']));
+    full.background = 'red; background: url(https://example.com)';
+    expect(isValidTokenSet(full)).toBe(false);
+  });
+});
+
+describe('built-in themes', () => {
+  it('all pass their own validator', () => {
+    for (const theme of BUILTIN_THEMES) {
+      expect(isValidTokenSet(theme.light)).toBe(true);
+      expect(isValidTokenSet(theme.dark)).toBe(true);
+    }
+  });
+
+  it('includes the default, so nothing has to special-case it', () => {
+    expect(getBuiltinTheme(DEFAULT_THEME_ID)).toBeDefined();
+  });
+
+  it('has unique ids', () => {
+    const ids = BUILTIN_THEMES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('applyThemeVars', () => {
+  let root: HTMLElement;
+  beforeEach(() => { root = document.createElement('div'); });
+
+  it('sets every token', () => {
+    applyThemeVars(root, themeTokens(BUILTIN_THEMES[0]!, 'light'));
+    expect(root.style.getPropertyValue('--background')).toBe('0 0% 100%');
+  });
+
+  it('removes a token the incoming theme omits', () => {
+    // The bug this prevents: switch to a theme without --ring and the old
+    // ring colour stays stuck, which reads as a rendering fault.
+    applyThemeVars(root, { ring: '10 20% 30%' });
+    expect(root.style.getPropertyValue('--ring')).toBe('10 20% 30%');
+
+    applyThemeVars(root, { background: '0 0% 0%' });
+    expect(root.style.getPropertyValue('--ring')).toBe('');
+  });
+
+  it('refuses a hostile value rather than passing it to the DOM', () => {
+    applyThemeVars(root, { background: 'red; content: url(https://example.com)' } as never);
+    expect(root.style.getPropertyValue('--background')).toBe('');
+  });
+
+  it('clearThemeVars falls back to the stylesheet', () => {
+    applyThemeVars(root, themeTokens(BUILTIN_THEMES[0]!, 'dark'));
+    clearThemeVars(root);
+    expect(root.style.getPropertyValue('--background')).toBe('');
+  });
+});
+
+describe('themeCss', () => {
+  it('emits both modes', () => {
+    const css = themeCss(BUILTIN_THEMES[0]!);
+    expect(css).toContain(':root{');
+    expect(css).toContain('.dark{');
+    expect(css).toContain('--background:0 0% 100%');
+  });
+
+  it('cannot be escaped out of, even by a crafted value', () => {
+    // This is the one that matters: the client path goes through the CSSOM,
+    // which cannot be escaped. This string lands inside a <style> element,
+    // and there is no CSP in this app to catch a break-out.
+    const evil = {
+      ...BUILTIN_THEMES[0]!,
+      light: { ...BUILTIN_THEMES[0]!.light, background: '0 0% 0%}</style><script>alert(1)</script>' },
+    };
+    const css = themeCss(evil);
+    expect(css).not.toContain('</style>');
+    expect(css).not.toContain('<script>');
+  });
+
+  it('omits a token rather than emitting an invalid value', () => {
+    const partial = {
+      ...BUILTIN_THEMES[0]!,
+      dark: { ...BUILTIN_THEMES[0]!.dark, ring: 'not-a-colour' },
+    };
+    expect(themeCss(partial)).not.toContain('not-a-colour');
+  });
+
+  it('never emits a property name that is not in the allowlist', () => {
+    const smuggled = {
+      ...BUILTIN_THEMES[0]!,
+      light: { ...BUILTIN_THEMES[0]!.light, 'background-image': '0 0% 0%' },
+    };
+    expect(themeCss(smuggled as never)).not.toContain('background-image');
+  });
+});

--- a/src/lib/themes/__tests__/themes.test.ts
+++ b/src/lib/themes/__tests__/themes.test.ts
@@ -8,6 +8,7 @@
 import { THEME_TOKENS, isValidTokenValue, isValidTokenSet } from '../tokens';
 import { BUILTIN_THEMES, getBuiltinTheme, DEFAULT_THEME_ID } from '../appThemes';
 import { applyThemeVars, clearThemeVars, themeCss, themeTokens } from '../applyTheme';
+import { checkContrast, checkThemeContrast } from '../contrast';
 
 describe('isValidTokenValue', () => {
   it('accepts a bare HSL triple, which is what Tailwind expects', () => {
@@ -146,5 +147,43 @@ describe('themeCss', () => {
       light: { ...BUILTIN_THEMES[0]!.light, 'background-image': '0 0% 0%' },
     };
     expect(themeCss(smuggled as never)).not.toContain('background-image');
+  });
+});
+
+describe('legibility', () => {
+  // This is the enforcement. A theme that fails cannot be merged, which means
+  // the check runs on every built-in and, later, on every gallery submission —
+  // rather than depending on whoever authored it having looked carefully.
+  it.each(BUILTIN_THEMES.map((t) => [t.name, t] as const))(
+    '%s is readable in both modes',
+    (_name, theme) => {
+      const { errors } = checkThemeContrast(theme);
+      expect(errors.map((e) => `${e.pair} = ${e.ratio.toFixed(2)}`)).toEqual([]);
+    },
+  );
+
+  it('rejects text that cannot be read', () => {
+    const base = BUILTIN_THEMES[0]!.light;
+    const unreadable = { ...base, foreground: '0 0% 96%', background: '0 0% 100%' };
+    const issues = checkContrast(unreadable);
+    expect(issues.some((i) => i.level === 'error' && i.pair.startsWith('foreground'))).toBe(true);
+  });
+
+  it('warns rather than blocks on a borderless look', () => {
+    // A theme with invisible borders is a style choice. One with invisible
+    // text is not, and the two must not be treated the same.
+    const base = BUILTIN_THEMES[0]!.light;
+    const borderless = { ...base, border: base.background };
+    const issues = checkContrast(borderless);
+    const edge = issues.filter((i) => i.pair.includes('border'));
+    expect(edge.length).toBeGreaterThan(0);
+    expect(edge.every((i) => i.level === 'warning')).toBe(true);
+  });
+
+  it('flags a merely-tiring pair as a warning, not an error', () => {
+    const base = BUILTIN_THEMES[0]!.light;
+    const dim = { ...base, 'muted-foreground': '0 0% 55%', muted: '0 0% 100%' };
+    const issues = checkContrast(dim).filter((i) => i.pair.startsWith('muted-foreground'));
+    expect(issues[0]?.level).toBe('warning');
   });
 });

--- a/src/lib/themes/appThemes.ts
+++ b/src/lib/themes/appThemes.ts
@@ -110,7 +110,163 @@ const CLAY: Theme = {
   },
 };
 
-export const BUILTIN_THEMES: Theme[] = [PRISM, CLAY];
+
+/**
+ * Seasonal, and named after a feeling rather than anything anyone owns. The
+ * naming matters as much as the colours: a palette called after a franchise is
+ * installed for the name, and that is the part that attracts a takedown.
+ */
+const HARVEST: Theme = {
+  id: 'harvest',
+  name: 'Harvest',
+  description: 'Late autumn. Amber, bark and a low sun.',
+  light: {
+    background: '38 40% 97%',
+    foreground: '25 35% 16%',
+    card: '38 45% 99%',
+    'card-foreground': '25 35% 16%',
+    popover: '38 45% 99%',
+    'popover-foreground': '25 35% 16%',
+    primary: '24 62% 33%',
+    'primary-foreground': '38 45% 98%',
+    secondary: '36 35% 90%',
+    'secondary-foreground': '25 35% 16%',
+    muted: '36 30% 91%',
+    'muted-foreground': '28 20% 38%',
+    accent: '30 45% 86%',
+    'accent-foreground': '25 35% 16%',
+    destructive: '0 65% 40%',
+    'destructive-foreground': '38 45% 98%',
+    border: '34 28% 82%',
+    input: '34 28% 82%',
+    ring: '24 62% 33%',
+  },
+  dark: {
+    background: '26 24% 10%',
+    foreground: '38 30% 93%',
+    card: '26 22% 14%',
+    'card-foreground': '38 30% 93%',
+    popover: '26 22% 14%',
+    'popover-foreground': '38 30% 93%',
+    primary: '32 70% 60%',
+    'primary-foreground': '26 24% 10%',
+    secondary: '26 18% 20%',
+    'secondary-foreground': '38 30% 93%',
+    muted: '26 18% 20%',
+    'muted-foreground': '36 18% 68%',
+    accent: '26 20% 24%',
+    'accent-foreground': '38 30% 93%',
+    destructive: '0 55% 45%',
+    'destructive-foreground': '38 30% 93%',
+    border: '26 16% 26%',
+    input: '26 16% 26%',
+    ring: '32 70% 60%',
+  },
+};
+
+const SNOW_DAY: Theme = {
+  id: 'snow-day',
+  name: 'Snow Day',
+  description: 'Cold light and pale blue. Quiet, and easy to read.',
+  light: {
+    background: '205 40% 98%',
+    foreground: '215 40% 15%',
+    card: '0 0% 100%',
+    'card-foreground': '215 40% 15%',
+    popover: '0 0% 100%',
+    'popover-foreground': '215 40% 15%',
+    primary: '205 60% 32%',
+    'primary-foreground': '205 40% 98%',
+    secondary: '205 35% 92%',
+    'secondary-foreground': '215 40% 15%',
+    muted: '205 30% 93%',
+    'muted-foreground': '212 20% 40%',
+    accent: '198 45% 88%',
+    'accent-foreground': '215 40% 15%',
+    destructive: '355 65% 42%',
+    'destructive-foreground': '205 40% 98%',
+    border: '205 25% 85%',
+    input: '205 25% 85%',
+    ring: '205 60% 32%',
+  },
+  dark: {
+    background: '215 40% 10%',
+    foreground: '205 35% 95%',
+    card: '215 36% 14%',
+    'card-foreground': '205 35% 95%',
+    popover: '215 36% 14%',
+    'popover-foreground': '205 35% 95%',
+    primary: '199 75% 65%',
+    'primary-foreground': '215 40% 10%',
+    secondary: '215 28% 20%',
+    'secondary-foreground': '205 35% 95%',
+    muted: '215 28% 20%',
+    'muted-foreground': '205 20% 70%',
+    accent: '215 30% 24%',
+    'accent-foreground': '205 35% 95%',
+    destructive: '355 55% 48%',
+    'destructive-foreground': '205 35% 95%',
+    border: '215 24% 27%',
+    input: '215 24% 27%',
+    ring: '199 75% 65%',
+  },
+};
+
+/**
+ * The look of a 16-bit console, not any particular one. Saturated primaries on
+ * near-black, which is what the hardware of the era could actually produce —
+ * a period, like Art Deco, rather than anyone's property. No franchise name,
+ * no character colours, no logo.
+ */
+const ARCADE: Theme = {
+  id: 'arcade',
+  name: 'Arcade',
+  description: 'Sixteen-bit console. Saturated primaries on near-black.',
+  light: {
+    background: '240 20% 96%',
+    foreground: '245 45% 14%',
+    card: '0 0% 100%',
+    'card-foreground': '245 45% 14%',
+    popover: '0 0% 100%',
+    'popover-foreground': '245 45% 14%',
+    primary: '265 62% 40%',
+    'primary-foreground': '240 25% 98%',
+    secondary: '240 25% 90%',
+    'secondary-foreground': '245 45% 14%',
+    muted: '240 20% 91%',
+    'muted-foreground': '245 18% 38%',
+    accent: '190 55% 84%',
+    'accent-foreground': '245 45% 14%',
+    destructive: '350 70% 42%',
+    'destructive-foreground': '240 25% 98%',
+    border: '240 18% 84%',
+    input: '240 18% 84%',
+    ring: '265 62% 40%',
+  },
+  dark: {
+    background: '248 45% 8%',
+    foreground: '190 60% 92%',
+    card: '248 40% 13%',
+    'card-foreground': '190 60% 92%',
+    popover: '248 40% 13%',
+    'popover-foreground': '190 60% 92%',
+    primary: '285 85% 70%',
+    'primary-foreground': '248 45% 8%',
+    secondary: '248 32% 19%',
+    'secondary-foreground': '190 60% 92%',
+    muted: '248 32% 19%',
+    'muted-foreground': '210 25% 70%',
+    accent: '175 70% 45%',
+    'accent-foreground': '248 45% 8%',
+    destructive: '350 75% 55%',
+    'destructive-foreground': '248 45% 8%',
+    border: '248 28% 26%',
+    input: '248 28% 26%',
+    ring: '285 85% 70%',
+  },
+};
+
+export const BUILTIN_THEMES: Theme[] = [PRISM, CLAY, HARVEST, SNOW_DAY, ARCADE];
 
 export function getBuiltinTheme(id: string): Theme | undefined {
   return BUILTIN_THEMES.find((t) => t.id === id);

--- a/src/lib/themes/appThemes.ts
+++ b/src/lib/themes/appThemes.ts
@@ -1,0 +1,117 @@
+/**
+ * Themes that ship with Prism.
+ *
+ * `prism` carries the exact values that lived in globals.css, so the default
+ * look is a theme like any other rather than a special case the rest of the
+ * code has to work around.
+ */
+import type { Theme } from './tokens';
+
+export const DEFAULT_THEME_ID = 'prism';
+
+const PRISM: Theme = {
+  id: 'prism',
+  name: 'Prism',
+  description: 'The original. Cool blues on a clean surface.',
+  light: {
+    background: '0 0% 100%',
+    foreground: '222 47% 11%',
+    card: '0 0% 100%',
+    'card-foreground': '222 47% 11%',
+    popover: '0 0% 100%',
+    'popover-foreground': '222 47% 11%',
+    primary: '222 47% 31%',
+    'primary-foreground': '210 40% 98%',
+    secondary: '210 40% 96%',
+    'secondary-foreground': '222 47% 11%',
+    muted: '210 40% 96%',
+    'muted-foreground': '215 16% 47%',
+    accent: '210 40% 96%',
+    'accent-foreground': '222 47% 11%',
+    destructive: '0 84% 60%',
+    'destructive-foreground': '210 40% 98%',
+    border: '214 32% 91%',
+    input: '214 32% 91%',
+    ring: '222 47% 31%',
+  },
+  dark: {
+    background: '222 47% 11%',
+    foreground: '210 40% 98%',
+    card: '222 47% 15%',
+    'card-foreground': '210 40% 98%',
+    popover: '222 47% 15%',
+    'popover-foreground': '210 40% 98%',
+    primary: '210 40% 98%',
+    'primary-foreground': '222 47% 11%',
+    secondary: '217 33% 17%',
+    'secondary-foreground': '210 40% 98%',
+    muted: '217 33% 17%',
+    'muted-foreground': '215 20% 65%',
+    accent: '217 33% 17%',
+    'accent-foreground': '210 40% 98%',
+    destructive: '0 62% 30%',
+    'destructive-foreground': '210 40% 98%',
+    border: '217 33% 25%',
+    input: '217 33% 25%',
+    ring: '212 95% 68%',
+  },
+};
+
+/**
+ * Warm, low-contrast neutrals. Built as a second theme mainly to prove the
+ * mechanism works on something that is not a tint of the default — if only
+ * `prism` existed, nothing would exercise the swap.
+ */
+const CLAY: Theme = {
+  id: 'clay',
+  name: 'Clay',
+  description: 'Warm earth tones. Easier on the eyes in a bright kitchen.',
+  light: {
+    background: '30 25% 97%',
+    foreground: '25 20% 18%',
+    card: '30 30% 99%',
+    'card-foreground': '25 20% 18%',
+    popover: '30 30% 99%',
+    'popover-foreground': '25 20% 18%',
+    primary: '18 42% 38%',
+    'primary-foreground': '30 30% 98%',
+    secondary: '30 20% 92%',
+    'secondary-foreground': '25 20% 18%',
+    muted: '30 20% 92%',
+    'muted-foreground': '25 12% 45%',
+    accent: '30 20% 90%',
+    'accent-foreground': '25 20% 18%',
+    destructive: '4 70% 47%',
+    'destructive-foreground': '30 30% 98%',
+    border: '30 18% 86%',
+    input: '30 18% 86%',
+    ring: '18 42% 38%',
+  },
+  dark: {
+    background: '25 18% 12%',
+    foreground: '30 20% 94%',
+    card: '25 18% 16%',
+    'card-foreground': '30 20% 94%',
+    popover: '25 18% 16%',
+    'popover-foreground': '30 20% 94%',
+    primary: '22 55% 62%',
+    'primary-foreground': '25 18% 12%',
+    secondary: '25 14% 22%',
+    'secondary-foreground': '30 20% 94%',
+    muted: '25 14% 22%',
+    'muted-foreground': '30 12% 65%',
+    accent: '25 14% 24%',
+    'accent-foreground': '30 20% 94%',
+    destructive: '4 55% 42%',
+    'destructive-foreground': '30 20% 94%',
+    border: '25 14% 28%',
+    input: '25 14% 28%',
+    ring: '22 55% 62%',
+  },
+};
+
+export const BUILTIN_THEMES: Theme[] = [PRISM, CLAY];
+
+export function getBuiltinTheme(id: string): Theme | undefined {
+  return BUILTIN_THEMES.find((t) => t.id === id);
+}

--- a/src/lib/themes/applyTheme.ts
+++ b/src/lib/themes/applyTheme.ts
@@ -1,0 +1,59 @@
+/**
+ * Turning a theme into CSS, on the client and on the server.
+ */
+import { THEME_TOKENS, isValidTokenValue, type Theme, type ThemeTokens } from './tokens';
+
+export type ResolvedMode = 'light' | 'dark';
+
+export function themeTokens(theme: Theme, mode: ResolvedMode): ThemeTokens {
+  return mode === 'dark' ? theme.dark : theme.light;
+}
+
+/**
+ * Write a token set onto an element.
+ *
+ * Removes before setting. A theme that omits a token would otherwise inherit
+ * whatever the previous theme left behind — switching from a theme that
+ * defines `--ring` to one that does not would leave the old ring colour stuck
+ * until reload, which looks like a rendering bug rather than a missing value.
+ *
+ * Values are re-checked here even though they were checked on the way in.
+ * This is the last point before the DOM, and the cost is a regex per token.
+ */
+export function applyThemeVars(root: HTMLElement, tokens: Partial<ThemeTokens>): void {
+  for (const token of THEME_TOKENS) {
+    const value = tokens[token];
+    if (isValidTokenValue(value)) {
+      root.style.setProperty(`--${token}`, value);
+    } else {
+      root.style.removeProperty(`--${token}`);
+    }
+  }
+}
+
+/** Remove every theme token, falling back to the values in globals.css. */
+export function clearThemeVars(root: HTMLElement): void {
+  for (const token of THEME_TOKENS) root.style.removeProperty(`--${token}`);
+}
+
+/**
+ * A stylesheet for server rendering, so the first paint is already themed.
+ *
+ * Built by iterating THEME_TOKENS and emitting only values that pass the
+ * triple check — never by serialising the theme object. That matters more here
+ * than on the client: `setProperty` goes through the CSSOM, which cannot be
+ * escaped out of, but this string lands inside a `<style>` element where a
+ * closing tag in a value would end the block and begin markup. There is no CSP
+ * in this app to catch that.
+ *
+ * The shape of this function is the guarantee. Anything not in THEME_TOKENS
+ * cannot appear in the output, whatever the input contains.
+ */
+export function themeCss(theme: Theme): string {
+  const block = (tokens: ThemeTokens) =>
+    THEME_TOKENS.filter((t) => isValidTokenValue(tokens[t]))
+      .map((t) => `--${t}:${tokens[t]}`)
+      .join(';');
+
+  return `:root{${block(theme.light)}}.dark{${block(theme.dark)}}`;
+}

--- a/src/lib/themes/contrast.ts
+++ b/src/lib/themes/contrast.ts
@@ -1,0 +1,81 @@
+/**
+ * Checking that a theme can actually be read.
+ *
+ * Prism is read from across a room, often by someone who is not wearing their
+ * glasses and is holding something in both hands. A theme that looks striking
+ * on a laptop and turns the calendar into low-contrast grey-on-grey is worse
+ * than no theme at all, and the person who installed it usually cannot tell
+ * whether it is the theme or the screen.
+ *
+ * So legibility is checked, not trusted. This runs over the built-in themes in
+ * their tests, and is the same function a gallery submission will be measured
+ * against.
+ */
+import { contrastRatioHex, hslToHex } from '@/lib/utils/color';
+import type { ThemeToken, ThemeTokens } from './tokens';
+
+/** Below this, text is not readable and the theme is rejected. */
+export const CONTRAST_ERROR = 3;
+/** Below this it is legible but tiring; surfaced as a warning, not a block. */
+export const CONTRAST_WARN = 4.5;
+/** Borders only need to be visible, not readable. */
+export const EDGE_MIN = 1.4;
+
+/** Foreground/background pairs that carry text. */
+const TEXT_PAIRS: Array<[ThemeToken, ThemeToken]> = [
+  ['foreground', 'background'],
+  ['card-foreground', 'card'],
+  ['popover-foreground', 'popover'],
+  ['primary-foreground', 'primary'],
+  ['secondary-foreground', 'secondary'],
+  ['muted-foreground', 'muted'],
+  ['accent-foreground', 'accent'],
+  ['destructive-foreground', 'destructive'],
+];
+
+/** Pairs that only need to be distinguishable, so an edge is visible. */
+const EDGE_PAIRS: Array<[ThemeToken, ThemeToken]> = [
+  ['border', 'background'],
+  ['border', 'card'],
+];
+
+export interface ContrastIssue {
+  pair: string;
+  ratio: number;
+  level: 'error' | 'warning';
+}
+
+export function checkContrast(tokens: ThemeTokens): ContrastIssue[] {
+  const issues: ContrastIssue[] = [];
+  const hex = (t: ThemeToken) => hslToHex(tokens[t]);
+
+  for (const [fg, bg] of TEXT_PAIRS) {
+    const ratio = contrastRatioHex(hex(fg), hex(bg));
+    if (ratio < CONTRAST_ERROR) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'error' });
+    else if (ratio < CONTRAST_WARN) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'warning' });
+  }
+
+  for (const [a, b] of EDGE_PAIRS) {
+    const ratio = contrastRatioHex(hex(a), hex(b));
+    // An edge that fails is a warning, never an error: a borderless look is a
+    // deliberate style, where unreadable text never is.
+    if (ratio < EDGE_MIN) issues.push({ pair: `${a} against ${b}`, ratio, level: 'warning' });
+  }
+
+  return issues;
+}
+
+/** Both modes at once, since a theme is only usable if both are. */
+export function checkThemeContrast(theme: { light: ThemeTokens; dark: ThemeTokens }): {
+  errors: ContrastIssue[];
+  warnings: ContrastIssue[];
+} {
+  const all = [
+    ...checkContrast(theme.light).map((i) => ({ ...i, pair: `light: ${i.pair}` })),
+    ...checkContrast(theme.dark).map((i) => ({ ...i, pair: `dark: ${i.pair}` })),
+  ];
+  return {
+    errors: all.filter((i) => i.level === 'error'),
+    warnings: all.filter((i) => i.level === 'warning'),
+  };
+}

--- a/src/lib/themes/serverTheme.ts
+++ b/src/lib/themes/serverTheme.ts
@@ -1,0 +1,32 @@
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { BUILTIN_THEMES, getBuiltinTheme, DEFAULT_THEME_ID } from './appThemes';
+import type { Theme } from './tokens';
+
+const THEME_SETTING_KEY = 'theme';
+
+/**
+ * The palette to render on the server, so the first paint is already correct.
+ *
+ * The client provider applies palettes too, but only after mount. Relying on
+ * that alone means every load of a wall display flashes the default palette
+ * before settling — brief, but on a screen that reloads on its own it is the
+ * most visible thing about the feature, and it reads as a fault rather than a
+ * transition.
+ *
+ * Failure returns the default rather than throwing. A database that is briefly
+ * unavailable should cost the wrong colours for one paint, not a blank page —
+ * the same trade the per-display font scale already makes.
+ */
+export async function getServerTheme(): Promise<Theme> {
+  const fallback = getBuiltinTheme(DEFAULT_THEME_ID) ?? BUILTIN_THEMES[0]!;
+  try {
+    const [row] = await db.select().from(settings).where(eq(settings.key, THEME_SETTING_KEY));
+    const value = row?.value as { paletteId?: unknown } | undefined;
+    if (typeof value?.paletteId !== 'string') return fallback;
+    return getBuiltinTheme(value.paletteId) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/lib/themes/tokens.ts
+++ b/src/lib/themes/tokens.ts
@@ -1,0 +1,77 @@
+/**
+ * The tokens a theme is allowed to set.
+ *
+ * This list is the security boundary, not a convention. A theme is data that
+ * can arrive from a community gallery, so the path from submitted text to a
+ * CSS property name must not exist: property names come from here, never from
+ * the payload.
+ *
+ * Deliberately excluded:
+ *
+ * - `--radius`. A shape token, not a colour, and an uncapped value makes cards
+ *   look broken rather than styled.
+ * - `--seasonal-*`. Owned by useSeasonalTheme, which writes them imperatively
+ *   from a month-keyed palette. Two writers of the same four properties on the
+ *   same element is a last-effect-wins bug; the sets stay disjoint.
+ * - `--chart-1..5`. Defined in globals.css, mapped nowhere, consumed nowhere.
+ */
+export const THEME_TOKENS = [
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+] as const;
+
+export type ThemeToken = (typeof THEME_TOKENS)[number];
+
+/** A complete set of values for one mode. */
+export type ThemeTokens = Record<ThemeToken, string>;
+
+export interface Theme {
+  id: string;
+  name: string;
+  description: string;
+  light: ThemeTokens;
+  dark: ThemeTokens;
+}
+
+/**
+ * Bare HSL triple, as Tailwind expects — `hsl(var(--x))` supplies the wrapper,
+ * which is what makes opacity modifiers like `bg-primary/40` work across the
+ * ~230 files that use them. Hex here would break every one of those.
+ *
+ * The narrowness is the point. No `var()`, no `calc()`, no alpha, no named
+ * colours, no `url()`. It is not possible to express anything but a colour, so
+ * "could a value inject CSS" stops being a question that needs arguing.
+ */
+const HSL_TRIPLE = /^(\d{1,3}(?:\.\d+)?) (\d{1,3}(?:\.\d+)?)% (\d{1,3}(?:\.\d+)?)%$/;
+
+export function isValidTokenValue(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const m = HSL_TRIPLE.exec(value);
+  if (!m) return false;
+  const [h, s, l] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  return h <= 360 && s <= 100 && l <= 100;
+}
+
+/** True when every token is present and every value is a valid triple. */
+export function isValidTokenSet(value: unknown): value is ThemeTokens {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return THEME_TOKENS.every((t) => isValidTokenValue(obj[t]));
+}

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -30,6 +30,16 @@ export function relativeLuminance(hex: string): number {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
+/**
+ * WCAG contrast ratio between two hex colours.
+ *
+ * The luminance-pair version below is the primitive; this is what callers
+ * almost always want, and exporting it keeps the conversion in one place.
+ */
+export function contrastRatioHex(a: string, b: string): number {
+  return contrastRatio(relativeLuminance(a), relativeLuminance(b));
+}
+
 /** WCAG contrast ratio between two luminances. */
 function contrastRatio(l1: number, l2: number): number {
   const lighter = Math.max(l1, l2);


### PR DESCRIPTION
Prism had two looks — light and dark, hardcoded as CSS variables in one file. There was no way for a household to change them, and **no object a shared theme could ever be installed into**. That's the blocker on the community gallery carrying themes, so it lands first.

## What a theme is

Data: a name, a description, and a value for each of 19 semantic tokens in each mode. `prism` carries the exact values that were in `globals.css`, so the default is a theme like any other rather than a special case everything works around.

Two built-ins to start — `prism`, and a warm `clay`. The second exists mainly to prove the swap works on something that isn't a tint of the first; with only one palette nothing exercises the mechanism.

## The token list is a security boundary, not a convention

Themes are meant to travel, so the path from submitted text to a CSS property name must not exist. Names come from `THEME_TOKENS`; never from the payload.

Values must be bare HSL triples. That's also what Tailwind needs — the `hsl(var(--x))` wrapper is what makes `bg-primary/40` work across ~230 files, and hex would break every one. The narrowness means "could a value inject CSS" stops being a question that needs arguing.

Deliberately excluded:

- **`--radius`** — a shape token, and uncapped it makes cards look broken rather than styled
- **`--seasonal-*`** — owned by `useSeasonalTheme`; two writers of the same four properties is a last-effect-wins bug
- **`--chart-1..5`** — defined in `globals.css`, mapped nowhere, consumed nowhere

## Storage

The `settings` row that has been **seeded since the beginning and read by nothing**, keeping its `{ mode }` shape so existing rows stay valid.

Database rather than localStorage because a palette is a household choice: every screen should agree, and a new tablet should pick it up without being configured. Light and dark stay per-screen.

## Server-rendered, which also fixes an existing bug

The palette is rendered into a `<style>` in the root layout, so the first paint is already correct. Applying only on the client would flash the default on every reload — and a wall display reloads on its own, so that would be the most visible thing about the feature and would read as a fault.

`themeCss` builds output from the allowlist and re-checks every value. On the client `setProperty` goes through the CSSOM, which cannot be escaped; this string lands inside a `<style>` element, and there is **no CSP in this app** to catch a break-out.

The blocking script that sets the `dark` class before paint also lets `defaultTheme="light"` go. That existed to mask the same flash, and had the side effect of **ignoring a stored `system` preference on first render**.

## Also

- `PATCH /api/settings` validates the `theme` key. It otherwise accepts any shape for any key, and this row is rendered into markup.
- `useSeasonalTheme` takes an optional mode, so when called from the provider it skips a `MutationObserver` that fired on every class change on `<html>` — including the performance-mode toggle.
- **`?theme=default`** resets and persists, for a kiosk with no keyboard whose palette has made Settings unreadable. Same idea as the existing `?perf=0`.

## Not included

The gallery carrying themes, an extended token vocabulary, per-display palettes (blocked on portals mounting outside the per-display wrapper), and any non-colour token.

Also worth knowing: `tailwind.config.js` hardcodes family, status and priority colours as literal hex, so those don't follow a palette yet.

## Testing

18 new tests. The ones that matter prove a crafted value cannot escape the `<style>` block, cannot reach the DOM, and cannot smuggle a property name past the allowlist.

1,614 tests pass, typecheck and lint clean, production build succeeds.
