### PR TITLE
feat(themes): gallery support, with a choice of how to share

### DIFF
--- a/community/themes/README.md
+++ b/community/themes/README.md
@@ -1,0 +1,69 @@
+# Community themes
+
+A theme is a set of colours. Nineteen values for light mode, nineteen for dark,
+a name and a short description. No CSS, no fonts, no images — a theme cannot
+contain anything but colour values, deliberately.
+
+## Two ways to share one
+
+Pick whichever suits you. They differ in who owns the theme afterwards, and it
+is worth understanding the difference before choosing.
+
+### The gallery — your theme stays yours
+
+Open a submission from inside Prism (*Settings → Appearance → Palette → Share*)
+and it becomes available for anyone to install. You keep the rights to it. It
+is licensed to this project for distribution in the gallery and nothing more.
+
+Choose this if you want people to be able to use your theme and you would
+rather keep it.
+
+### A pull request under the CLA — it ships with Prism
+
+If you would like your theme to be one of the palettes everyone gets in the
+box, open a pull request adding it to `src/lib/themes/appThemes.ts` and sign
+the Contributor License Agreement.
+
+The CLA is required for this route and not for the other, because a built-in
+theme becomes part of what Prism itself distributes. That means the project
+needs the right to keep shipping it, including if Prism is ever hosted
+commercially or moves to a different licence.
+
+Choose this if you would rather your theme just *be* one of Prism's looks.
+
+Neither route is better. The first keeps your work yours; the second puts it
+in front of everyone.
+
+## What is checked
+
+Automatically, on submission:
+
+- **Every colour is a bare HSL triple.** Anything else is rejected. This is
+  what makes a theme unable to carry CSS.
+- **Text has to be readable.** Contrast is measured on eight foreground and
+  background pairs in both modes. Below 3:1 is rejected. Between 3:1 and 4.5:1
+  is accepted but shown on the gallery card, so whoever installs it can judge.
+  Prism is read from across a room, often by someone without their glasses.
+- **Name, description, tags** are length-limited and must be plain text.
+
+By a person, before it merges:
+
+Every submission becomes a pull request that a maintainer reviews. Themes are
+declined if they are profane, bigoted, politically partisan, or built to divide
+people. This is a display in a family kitchen, and it is read by children.
+
+Themes named after a franchise, or reproducing a recognisable brand's look, are
+also declined — not because a palette can be owned, but because the name is
+what attracts a complaint. Name it after a season, a feeling, or a period.
+"Arcade" is fine; a console's name is not.
+
+If a rights holder ever asks for something to be removed, it is removed. No
+argument, no delay.
+
+## Contrast, in practice
+
+The bar is deliberately not WCAG AA everywhere. Hard-failing every pair below
+4.5:1 would reject a lot of themes that are genuinely pleasant to look at, and
+the first thing it would reject is the work of the people most likely to
+contribute. So the rule is: below 3:1 nobody can read it and it does not ship;
+between 3:1 and 4.5:1 it ships with the warning visible.

--- a/community/themes/index.json
+++ b/community/themes/index.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "themes": []
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -10,6 +10,7 @@ import { logError } from '@/lib/utils/logError';
 import { PIN_LENGTH_SETTING_KEY } from '@/lib/constants';
 import { isSetupComplete } from '@/lib/setup';
 import { getBuiltinTheme } from '@/lib/themes/appThemes';
+import { isInstallableTheme } from '@/lib/themes/tokens';
 
 export async function GET() {
   const auth = await getDisplayAuth();
@@ -79,13 +80,33 @@ export async function PATCH(request: NextRequest) {
     // setting, it is markup in the page. Never trust the row on the render
     // path; refuse it on the way in as well.
     if (body.key === 'theme') {
-      const value = body.value as { paletteId?: unknown } | null;
-      const paletteId = value && typeof value === 'object' ? value.paletteId : undefined;
-      if (paletteId !== undefined && (typeof paletteId !== 'string' || !getBuiltinTheme(paletteId))) {
-        return NextResponse.json(
-          { error: 'Unknown palette' },
-          { status: 400 },
-        );
+      const value = (body.value ?? {}) as { paletteId?: unknown; installed?: unknown };
+
+      // Installed themes are stored inline so a display without a network can
+      // still render what it was left on. That means arbitrary colour values
+      // reach a <style> element rendered on the server, so they are checked
+      // here rather than trusted because they came from our own gallery.
+      const installed = value.installed;
+      if (installed !== undefined) {
+        if (!Array.isArray(installed) || installed.length > 40) {
+          return NextResponse.json({ error: 'Invalid installed themes' }, { status: 400 });
+        }
+        if (!installed.every(isInstallableTheme)) {
+          return NextResponse.json({ error: 'Invalid installed theme' }, { status: 400 });
+        }
+      }
+
+      // The chosen palette must be one that exists — built in, or one of the
+      // installed themes in this same write.
+      const paletteId = value.paletteId;
+      if (paletteId !== undefined) {
+        const known =
+          typeof paletteId === 'string' &&
+          (Boolean(getBuiltinTheme(paletteId)) ||
+            (Array.isArray(installed) && installed.some((t) => (t as { id?: unknown }).id === paletteId)));
+        if (!known) {
+          return NextResponse.json({ error: 'Unknown palette' }, { status: 400 });
+        }
       }
     }
 

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useSeasonalTheme } from '@/lib/hooks/useSeasonalTheme';
 import { usePerformanceMode } from '@/lib/hooks/usePerformanceMode';
-import type { Theme } from '@/lib/themes/tokens';
+import { isInstallableTheme, type Theme } from '@/lib/themes/tokens';
 import { BUILTIN_THEMES, getBuiltinTheme, DEFAULT_THEME_ID } from '@/lib/themes/appThemes';
 import { applyThemeVars, themeTokens } from '@/lib/themes/applyTheme';
 
@@ -91,6 +91,7 @@ export function ThemeProvider({
   const [theme, setThemeState] = useState<ThemeMode>(defaultTheme);
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
   const [mounted, setMounted] = useState(false);
+  const [installedThemes, setInstalledThemes] = useState<Theme[]>([]);
   const [palette, setPaletteState] = useState<Theme>(
     () => getBuiltinTheme(DEFAULT_THEME_ID) ?? BUILTIN_THEMES[0]!,
   );
@@ -160,7 +161,7 @@ export function ThemeProvider({
   // household choice: every screen in the house should agree, and a new tablet
   // should pick it up without being configured.
   const setPalette = (id: string) => {
-    const next = getBuiltinTheme(id);
+    const next = getBuiltinTheme(id) ?? installedThemes.find((t) => t.id === id);
     if (!next) return;
     setPaletteState(next);
     fetch('/api/settings', {
@@ -208,8 +209,19 @@ export function ThemeProvider({
       .then((data) => {
         if (cancelled || !data) return;
         const stored = data.settings?.[THEME_SETTING_KEY];
+
+        // Themes installed from the gallery are stored inline rather than
+        // fetched, so a display that boots without a network still renders the
+        // palette it was left on. Re-validated on read: the row is written by
+        // an API that checks, but this is the last point before it becomes CSS
+        // and the check costs a regex per token.
+        const installed = Array.isArray(stored?.installed)
+          ? (stored.installed as unknown[]).filter(isInstallableTheme)
+          : [];
+        if (installed.length > 0) setInstalledThemes(installed);
+
         const id = typeof stored?.paletteId === 'string' ? stored.paletteId : null;
-        const found = id ? getBuiltinTheme(id) : undefined;
+        const found = id ? (getBuiltinTheme(id) ?? installed.find((t) => t.id === id)) : undefined;
         if (found) setPaletteState(found);
       })
       .catch(() => { /* keep whatever the server rendered */ });
@@ -230,7 +242,7 @@ export function ThemeProvider({
   if (!mounted) {
     return (
       <ThemeContext.Provider
-        value={{ theme: defaultTheme, resolvedTheme: 'light', setTheme, palette, palettes: BUILTIN_THEMES, setPalette }}
+        value={{ theme: defaultTheme, resolvedTheme: 'light', setTheme, palette, palettes: [...BUILTIN_THEMES, ...installedThemes], setPalette }}
       >
         {children}
       </ThemeContext.Provider>
@@ -239,7 +251,7 @@ export function ThemeProvider({
 
   return (
     <ThemeContext.Provider
-      value={{ theme, resolvedTheme, setTheme, palette, palettes: BUILTIN_THEMES, setPalette }}
+      value={{ theme, resolvedTheme, setTheme, palette, palettes: [...BUILTIN_THEMES, ...installedThemes], setPalette }}
     >
       {children}
     </ThemeContext.Provider>

--- a/src/lib/community/__tests__/validateTheme.test.ts
+++ b/src/lib/community/__tests__/validateTheme.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Validating a theme that arrives from outside.
+ *
+ * The submission path ends in a file committed to this repository and later
+ * rendered into a <style> element on every instance that installs it. So the
+ * tests that matter are the ones proving what cannot get through.
+ */
+import { validateCommunityTheme, projectCommunityTheme } from '../validateTheme';
+import { THEME_TOKENS } from '@/lib/themes/tokens';
+import { BUILTIN_THEMES } from '@/lib/themes/appThemes';
+
+const base = BUILTIN_THEMES[0]!;
+
+function submission(over: Record<string, unknown> = {}) {
+  return {
+    type: 'prism-theme',
+    version: 1,
+    name: 'Midnight',
+    description: 'Deep blues for a bedroom display.',
+    author: 'Someone',
+    tags: ['dark', 'calm'],
+    light: { ...base.light },
+    dark: { ...base.dark },
+    ...over,
+  };
+}
+
+describe('validateCommunityTheme — shape', () => {
+  it('accepts a well-formed submission', () => {
+    const r = validateCommunityTheme(submission());
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  it('requires every token, so a half-theme cannot land', () => {
+    const partial = { ...base.light } as Record<string, unknown>;
+    delete partial.ring;
+    const r = validateCommunityTheme(submission({ light: partial }));
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('ring'))).toBe(true);
+  });
+
+  it('rejects a value that could carry more than a colour', () => {
+    const evil = { ...base.light, background: '0 0% 0%}</style><script>alert(1)</script>' };
+    const r = validateCommunityTheme(submission({ light: evil }));
+    expect(r.valid).toBe(false);
+  });
+
+  it('does not echo a rejected value back into the error message', () => {
+    // Errors are rendered into a GitHub comment. Reflecting submitter text
+    // there turns a validation message into a delivery mechanism.
+    const evil = { ...base.light, background: '<img src=x onerror=alert(1)>' };
+    const r = validateCommunityTheme(submission({ light: evil }));
+    expect(r.errors.join(' ')).not.toContain('onerror');
+    expect(r.errors.join(' ')).not.toContain('<img');
+  });
+});
+
+describe('validateCommunityTheme — legibility', () => {
+  it('rejects a theme whose text cannot be read', () => {
+    const unreadable = { ...base.light, foreground: '0 0% 97%', background: '0 0% 100%' };
+    const r = validateCommunityTheme(submission({ light: unreadable }));
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('contrast ratio'))).toBe(true);
+  });
+
+  it('accepts a tiring theme but reports the warning', () => {
+    // Hard-failing everything below AA would reject a lot of legitimately
+    // attractive themes. The person installing it can see the count and judge.
+    const dim = { ...base.light, 'muted-foreground': '0 0% 55%', muted: '0 0% 100%' };
+    const r = validateCommunityTheme(submission({ light: dim }));
+    expect(r.valid).toBe(true);
+    expect(r.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('validateCommunityTheme — metadata', () => {
+  it('rejects an overlong name', () => {
+    expect(validateCommunityTheme(submission({ name: 'x'.repeat(41) })).valid).toBe(false);
+  });
+
+  it('rejects markup in a name', () => {
+    expect(validateCommunityTheme(submission({ name: '<b>Hi</b>' })).valid).toBe(false);
+  });
+
+  it('rejects more than five tags', () => {
+    expect(validateCommunityTheme(submission({ tags: ['a','b','c','d','e','f'] })).valid).toBe(false);
+  });
+
+  it('rejects a tag that is not a simple slug', () => {
+    expect(validateCommunityTheme(submission({ tags: ['Dark Mode!'] })).valid).toBe(false);
+  });
+
+  it('rejects an overlong description', () => {
+    expect(validateCommunityTheme(submission({ description: 'x'.repeat(161) })).valid).toBe(false);
+  });
+});
+
+describe('projectCommunityTheme', () => {
+  it('drops any key the schema does not know about', () => {
+    // The point of a projection over a filter: an unknown key has no path in,
+    // rather than being removed by a rule someone could forget to write.
+    const smuggled = submission({
+      script: '<script>alert(1)</script>',
+      light: { ...base.light, 'background-image': 'url(https://example.com)' },
+    });
+    const out = projectCommunityTheme(smuggled, 'midnight');
+    // Check the keys, not the serialised string — 'script' is a substring of
+    // 'description', which made an earlier version of this test pass for the
+    // wrong reason.
+    expect(Object.keys(out)).not.toContain('script');
+    expect(Object.keys(out.light)).not.toContain('background-image');
+    expect(JSON.stringify(out)).not.toContain('alert(1)');
+    expect(JSON.stringify(out)).not.toContain('example.com');
+  });
+
+  it('carries exactly the allowlisted tokens', () => {
+    const out = projectCommunityTheme(submission(), 'midnight');
+    expect(Object.keys(out.light).sort()).toEqual([...THEME_TOKENS].sort());
+    expect(Object.keys(out.dark).sort()).toEqual([...THEME_TOKENS].sort());
+  });
+
+  it('uses the id the caller derived, not one from the payload', () => {
+    // Otherwise a submission chooses its own filename.
+    const out = projectCommunityTheme(submission({ id: '../../etc/passwd' }), 'midnight');
+    expect(out.id).toBe('midnight');
+  });
+
+  it('caps tags even if validation was skipped', () => {
+    const out = projectCommunityTheme(submission({ tags: ['a','b','c','d','e','f','g'] }), 'x');
+    expect(out.tags).toHaveLength(5);
+  });
+});

--- a/src/lib/community/index.ts
+++ b/src/lib/community/index.ts
@@ -109,3 +109,76 @@ export async function filterCommunityLayouts(
 
   return layouts;
 }
+
+// ---------------------------------------------------------------------------
+// Themes
+//
+// A second index rather than a new shape for the existing one. The raw URL
+// below is pinned to master and baked into every deployed client, so a change
+// to layouts/index.json would break instances that have not updated. An
+// additional file cannot.
+// ---------------------------------------------------------------------------
+
+const THEMES_RAW_BASE =
+  'https://raw.githubusercontent.com/sandydargoport/prism/master/community/themes/';
+
+export interface CommunityThemeIndexEntry {
+  id: string;
+  file: string;
+  name: string;
+  description: string;
+  author: string;
+  tags: string[];
+  createdAt: string;
+  /** Pairs that are legible but tiring. Shown so the installer can judge. */
+  contrastWarnings: number;
+}
+
+export interface CommunityThemeIndex {
+  version: number;
+  themes: CommunityThemeIndexEntry[];
+}
+
+let themeIndexCache: { data: CommunityThemeIndex; fetchedAt: number } | null = null;
+
+/** Bounded, unlike the layout cache — a display runs for weeks. */
+const themeCache = new Map<string, unknown>();
+const MAX_CACHED_THEMES = 40;
+
+export async function getCommunityThemeIndex(): Promise<CommunityThemeIndex> {
+  const now = Date.now();
+  if (themeIndexCache && now - themeIndexCache.fetchedAt < INDEX_TTL_MS) {
+    return themeIndexCache.data;
+  }
+  try {
+    const res = await fetch(`${THEMES_RAW_BASE}index.json`, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as CommunityThemeIndex;
+    themeIndexCache = { data, fetchedAt: now };
+    return data;
+  } catch {
+    // Stale beats empty: a gallery that blanks on a flaky connection looks
+    // like the feature broke.
+    if (themeIndexCache) return themeIndexCache.data;
+    return { version: 1, themes: [] };
+  }
+}
+
+export async function getCommunityTheme(file: string): Promise<unknown | null> {
+  const cached = themeCache.get(file);
+  if (cached) return cached;
+  try {
+    const res = await fetch(`${THEMES_RAW_BASE}${file}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    themeCache.set(file, data);
+    while (themeCache.size > MAX_CACHED_THEMES) {
+      const oldest = themeCache.keys().next().value;
+      if (oldest === undefined) break;
+      themeCache.delete(oldest);
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/community/validateTheme.ts
+++ b/src/lib/community/validateTheme.ts
@@ -1,0 +1,177 @@
+/**
+ * Validating a theme submitted to the community gallery.
+ *
+ * Three things are being defended here, in order of how badly they fail:
+ *
+ * 1. A theme reaches a `<style>` element rendered on the server. A value that
+ *    can close that element is markup in the page, and there is no CSP to
+ *    catch it. Handled by the token allowlist and the HSL grammar.
+ * 2. A theme nobody can read is worse than no theme, and the person who
+ *    installed it usually cannot tell whether the fault is the theme or the
+ *    screen. Handled by the contrast check.
+ * 3. This is a family kitchen display. Handled by the metadata limits, and
+ *    by a human reading the pull request — see the note on that below.
+ */
+import { THEME_TOKENS, isValidTokenValue, type Theme, type ThemeTokens } from '@/lib/themes/tokens';
+import { checkThemeContrast, type ContrastIssue } from '@/lib/themes/contrast';
+
+export interface ThemeValidationResult {
+  valid: boolean;
+  errors: string[];
+  /** Legible but tiring pairs. Shown on the gallery card, not blocking. */
+  warnings: ContrastIssue[];
+}
+
+export interface CommunityThemeEntry {
+  id: string;
+  file: string;
+  name: string;
+  description: string;
+  author: string;
+  tags: string[];
+  createdAt: string;
+  /** Surfaced on the card so someone installing can judge for themselves. */
+  contrastWarnings: number;
+}
+
+const NAME_RE = /^[\w\s'&.-]{1,40}$/;
+const TAG_RE = /^[a-z0-9-]{1,20}$/;
+const AUTHOR_RE = /^[\w\s'&.-]{1,50}$/;
+
+/**
+ * Words that make a submission not worth reviewing.
+ *
+ * Deliberately small and deliberately not the whole policy. A list like this
+ * catches the careless and none of the deliberate — it will flag "Scunthorpe"
+ * and miss anything written to get past it. The policy that actually applies
+ * (nothing bigoted, nothing partisan, nothing designed to divide people) is
+ * enforced by a person reading the pull request before it merges, which every
+ * submission goes through. This is a filter, not the standard.
+ */
+const BLOCKLIST = [
+  'shit', 'fuck', 'ass', 'asshole', 'bitch', 'bastard', 'damn', 'crap',
+  'dick', 'cock', 'pussy', 'slut', 'whore', 'nigger', 'faggot', 'retard',
+];
+
+function containsBlocked(text: string): boolean {
+  const lower = text.toLowerCase();
+  return BLOCKLIST.some((word) => lower.includes(word));
+}
+
+function validateTokenSet(tokens: unknown, mode: string, errors: string[]): tokens is ThemeTokens {
+  if (!tokens || typeof tokens !== 'object') {
+    errors.push(`Missing "${mode}" colours.`);
+    return false;
+  }
+  const obj = tokens as Record<string, unknown>;
+  let ok = true;
+  for (const token of THEME_TOKENS) {
+    const value = obj[token];
+    if (value === undefined) {
+      errors.push(`"${mode}" is missing ${token}.`);
+      ok = false;
+    } else if (!isValidTokenValue(value)) {
+      // The value is not echoed back. It is submitter-controlled text and this
+      // message is rendered into a GitHub comment.
+      errors.push(`"${mode}" has an invalid value for ${token}. Expected a bare HSL triple, e.g. "222 47% 11%".`);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+export function validateCommunityTheme(data: unknown): ThemeValidationResult {
+  const errors: string[] = [];
+  let warnings: ContrastIssue[] = [];
+
+  if (!data || typeof data !== 'object') {
+    return { valid: false, errors: ['Submission is not an object.'], warnings };
+  }
+  const obj = data as Record<string, unknown>;
+
+  if (obj.type !== 'prism-theme') errors.push('Missing "type": "prism-theme".');
+  if (obj.version !== 1) errors.push('Unsupported version. Expected 1.');
+
+  const name = obj.name;
+  if (typeof name !== 'string' || !NAME_RE.test(name)) {
+    errors.push('Name must be 1-40 characters, letters, numbers, spaces and basic punctuation.');
+  } else if (containsBlocked(name)) {
+    errors.push('Please choose a different name.');
+  }
+
+  const description = obj.description;
+  if (typeof description !== 'string' || description.length < 1 || description.length > 160) {
+    errors.push('Description must be 1-160 characters.');
+  } else if (containsBlocked(description)) {
+    errors.push('Please reword the description.');
+  }
+
+  const author = obj.author;
+  if (typeof author !== 'string' || !AUTHOR_RE.test(author)) {
+    errors.push('Author must be 1-50 characters.');
+  }
+
+  const tags = obj.tags;
+  if (tags !== undefined) {
+    if (!Array.isArray(tags) || tags.length > 5) {
+      errors.push('At most 5 tags.');
+    } else if (!tags.every((t) => typeof t === 'string' && TAG_RE.test(t))) {
+      errors.push('Tags must be lowercase letters, numbers and hyphens, up to 20 characters.');
+    }
+  }
+
+  const lightOk = validateTokenSet(obj.light, 'light', errors);
+  const darkOk = validateTokenSet(obj.dark, 'dark', errors);
+
+  if (lightOk && darkOk) {
+    const contrast = checkThemeContrast({ light: obj.light as ThemeTokens, dark: obj.dark as ThemeTokens });
+    warnings = contrast.warnings;
+    for (const issue of contrast.errors) {
+      errors.push(
+        `${issue.pair} has a contrast ratio of ${issue.ratio.toFixed(2)}:1. ` +
+        'Prism is read from across a room, so text needs at least 3:1.',
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Build the object that gets committed.
+ *
+ * A projection, not the parsed submission. Every field is copied by name from
+ * a fixed list, so a key the schema does not know about has no path into the
+ * repository — it is structurally absent rather than filtered out.
+ *
+ * This is the same discipline the gallery already uses when applying a layout,
+ * where only i/x/y/w/h are read from the payload. Moved to the write side,
+ * which is where it matters more: the read side protects one user, the write
+ * side protects everyone who fetches the file afterwards.
+ */
+export function projectCommunityTheme(data: unknown, id: string): Theme & {
+  type: 'prism-theme';
+  version: 1;
+  author: string;
+  tags: string[];
+} {
+  const obj = data as Record<string, unknown>;
+  const pickTokens = (src: unknown): ThemeTokens => {
+    const s = src as Record<string, unknown>;
+    const out = {} as ThemeTokens;
+    for (const token of THEME_TOKENS) out[token] = s[token] as string;
+    return out;
+  };
+
+  return {
+    type: 'prism-theme',
+    version: 1,
+    id,
+    name: obj.name as string,
+    description: obj.description as string,
+    author: obj.author as string,
+    tags: Array.isArray(obj.tags) ? (obj.tags as string[]).slice(0, 5) : [],
+    light: pickTokens(obj.light),
+    dark: pickTokens(obj.dark),
+  };
+}

--- a/src/lib/themes/tokens.ts
+++ b/src/lib/themes/tokens.ts
@@ -75,3 +75,22 @@ export function isValidTokenSet(value: unknown): value is ThemeTokens {
   const obj = value as Record<string, unknown>;
   return THEME_TOKENS.every((t) => isValidTokenValue(obj[t]));
 }
+
+/**
+ * A complete, installable theme from an untrusted source.
+ *
+ * Used when reading themes back out of storage. The API validates on the way
+ * in, but this is the last point before the values become CSS, and a stored
+ * row is not the same thing as a trusted one.
+ */
+export function isInstallableTheme(value: unknown): value is Theme {
+  if (!value || typeof value !== 'object') return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.id === 'string' && t.id.length > 0 && t.id.length <= 64 &&
+    typeof t.name === 'string' && t.name.length > 0 && t.name.length <= 40 &&
+    typeof t.description === 'string' && t.description.length <= 160 &&
+    isValidTokenSet(t.light) &&
+    isValidTokenSet(t.dark)
+  );
+}


### PR DESCRIPTION
Follow-up to #352, which built the theme system. This is the part that lets themes travel.

## Two routes, and the difference matters

| | Gallery | Pull request under the CLA |
|---|---|---|
| Who owns it | You do | Licensed to the project |
| Who gets it | People who install it | Everyone, in the box |
| CLA needed | No | Yes |

A gallery theme stays the author's — licensed for distribution there and nothing more, same as layouts today.

A built-in needs the CLA because it becomes part of what Prism itself distributes, so the project needs the right to keep shipping it, including if Prism is ever hosted commercially or relicensed.

Someone who wants their theme to simply *be* one of Prism's looks should be able to offer that. Someone who would rather keep their work shouldn't have to give it up. The README says neither is better, so the choice gets made knowingly rather than by whichever path is easier to find.

## Enforced automatically

- **Every colour is a bare HSL triple.** This is what makes a theme unable to carry CSS — checked again at render time rather than trusted.
- **Contrast on eight pairs, both modes.** Below 3:1 rejected; 3:1–4.5:1 ships with the warning shown on the card. Hard-failing everything below AA would reject a lot of genuinely attractive themes, and the person installing one can see the count and judge.
- **Metadata** is length-limited plain text.

Errors never echo the submitted value back — they're rendered into a GitHub comment, and reflecting submitter text there turns a validation message into a delivery mechanism.

## The projection

`projectCommunityTheme` builds the committed object by copying named fields rather than filtering the parsed one, so an unknown key has **no path into the repository** — structurally absent rather than removed by a rule someone could forget to write. The id comes from the caller, not the payload, so a submission can't choose its own filename.

That's the fix for the hole found in the layout pipeline, applied from the start here.

## Storage

Installed themes are stored **inline** in the settings row rather than fetched, so a display that boots without a network still renders what it was left on. That means untrusted colour values reach a server-rendered `<style>`, so they're validated on write **and** on read.

The theme index is a second file, not a new shape for the layout index — that URL is pinned to `master` and baked into every deployed client, so changing the existing file would break instances that haven't updated.

## What a person checks, because a validator can't

Nothing profane, bigoted, partisan, or built to divide people. It's a display in a family kitchen and children read it. Every submission becomes a PR that gets reviewed.

Also no franchise names. The palette is never the problem — the name is what attracts a complaint. "Arcade" is fine; a console's name isn't.

## Not included

The submission workflow, issue template, share dialog and gallery tab. Those come next; this is the part that has to be right first.

## Testing

15 new cases on validation and projection, including that an unknown key can't survive, that a rejected value isn't reflected back, and that a submission can't pick its own id.

1,637 tests pass, typecheck clean. Lint warnings on touched files are unchanged from master.