### PR TITLE
chore(release): 1.21.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.21.0] – 2026-08-31
+
+### Added
+- **Colour themes.** Prism has had light and dark; it now has palettes. Five to start — Prism, Clay, Harvest, Snow Day and Arcade — chosen under *Settings → Appearance*. The palette applies to every screen in the house, while light and dark stay per-screen, because one is a decision about how the home looks and the other is about the room a particular screen is in. Every palette is checked for readability before it can ship: Prism is read from across a kitchen, often by someone who is not wearing their glasses.
+- **Groundwork for sharing themes.** Themes are plain colour values, which means they can be passed between households the way dashboard layouts already are. Two ways to share one, and they differ in what happens to your work: through the gallery it stays yours, or as a contribution it ships with Prism for everyone. Neither is better. The submission side of this is not finished yet; what is here is the part that has to be right first.
+
+### Fixed
+- **A security fix in the layout submission workflow.** A submitted layout name was passed to a command line without being quoted, so a carefully chosen name could run commands on the machine that processes submissions. Anyone with a GitHub account more than a week old could have reached it. Nothing suggests this was used; it was found while reviewing whether the same workflow could handle themes. If you run a fork with community submissions enabled, take this update.
+- **The theme no longer flashes on load.** Opening Prism showed the light palette for a moment before settling on your actual choice. Unnoticeable on a laptop, obvious on a wall display that reloads by itself. It also meant a saved "match my system" preference was ignored for the first moment of every page.
+
 ## [1.20.1] – 2026-08-31
 
 ### Fixed

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -95,6 +95,10 @@ School bus arrival predictions via Gmail/FirstView email parsing. Adaptive polli
 
 Screensaver, Away Mode, and Babysitter Mode: three overlay modes that layer on top of the dashboard for idle, privacy, and caregiver scenarios.
 
+### [Themes](features/THEMES.md)
+
+Five colour palettes, chosen under Settings. The palette is set once for the whole house; light and dark stay per-screen. Every palette is checked for readability before it ships, and `?theme=default` recovers a display with no keyboard.
+
 ### [Mobile & PWA](features/MOBILE.md)
 
 Installable as a PWA on iOS, Android, and desktop. Phone viewports get a Floating Action Button (FAB), simplified single-column dashboard, and agenda-only calendar.

--- a/docs/features/THEMES.md
+++ b/docs/features/THEMES.md
@@ -1,0 +1,77 @@
+# Themes
+
+Prism ships five palettes. Choose one under *Settings → Appearance → Palette*.
+
+| | |
+|---|---|
+| **Prism** | The original. Cool blues on a clean surface. |
+| **Clay** | Warm earth tones. Easier on the eyes in a bright kitchen. |
+| **Harvest** | Late autumn. Amber, bark and a low sun. |
+| **Snow Day** | Cold light and pale blue. Quiet, and easy to read. |
+| **Arcade** | Sixteen-bit console. Saturated primaries on near-black. |
+
+## What is per-screen and what is not
+
+**The palette is for the whole house.** Change it on a phone and the kitchen
+display changes too. It is a decision about how your home looks, and a house
+where every screen is a different colour is a house where something looks
+broken.
+
+**Light and dark are per-screen.** That is a decision about the room a
+particular screen is in — a hallway display at night and a tablet in a bright
+kitchen want different answers, and both are right at the same time.
+
+The same split applies to the screensaver timeout and font scale, which are
+also per-screen.
+
+## Readability
+
+Every palette is checked before it can ship. Contrast is measured on eight
+text pairs in both light and dark; anything that falls below a readable ratio
+is rejected rather than shipped and apologised for.
+
+This is stricter than it sounds for a reason. Prism is read from across a
+room, often by someone who is not wearing their glasses, sometimes by a child.
+A palette that looks striking on a laptop and turns the calendar into grey on
+grey is worse than no palette at all, because the person looking at it usually
+cannot tell whether the fault is the theme or the screen.
+
+## If a palette makes Prism unreadable
+
+Add `?theme=default` to the address:
+
+```
+http://your-prism-address/?theme=default
+```
+
+That resets to the default palette and saves the change, so the screen comes
+back the next time it loads too.
+
+It exists because a wall display has no keyboard, and a palette with a broken
+background and text pairing can make the Settings page itself unreadable —
+which would otherwise mean opening a terminal to recover a colour choice.
+
+## Sharing a theme
+
+A theme is nothing but colour values, so it can be passed between households.
+Two ways, and they differ in what happens to your work:
+
+- **Through the gallery** — anyone can install it, and it stays yours.
+- **As a contribution** — it ships with Prism for everyone, which needs the
+  Contributor License Agreement, because Prism then distributes it.
+
+Neither is better. `community/themes/README.md` has the detail, including what
+is checked and what is not allowed.
+
+The submission side is not finished yet.
+
+## What a theme cannot change
+
+Themes set surface and text colours. They do not currently change:
+
+- family member colours, which are per-person and set on each member
+- the fixed colours used for chore status and task priority
+- fonts, spacing or corner radius
+
+Family member colours are deliberately excluded: they identify a person across
+the whole app, and a palette should not be able to reassign who is green.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.20.1"
+version: "1.21.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -527,6 +527,16 @@ function ScreensaverHelp() {
         <Li><strong>Photo rotation</strong>: Set the &quot;Rotate photos every&quot; interval, or pin one static photo</Li>
         <Li><strong>Edit layout</strong>: In dashboard edit mode, toggle &quot;Screensaver&quot;</Li>
       </Ul>
+      <H2>Palettes</H2>
+      <P>
+        <strong>Settings &gt; Appearance &gt; Palette</strong> changes the colours. The
+        palette applies to every screen in the house; light and dark stay per-screen,
+        since that depends on the room a screen is in.
+      </P>
+      <P>
+        If a palette ever makes Prism hard to read, add <code>?theme=default</code> to the
+        address to reset it. That works on a display with no keyboard.
+      </P>
       <H2>Signing out when nobody is there</H2>
       <P>
         Under the same Timers section, <strong>Sign out after</strong> controls how long


### PR DESCRIPTION
Minor release: colour themes (#352), the groundwork for sharing them (#353), and a security fix in the layout submission workflow (#351).

Minor rather than patch because themes are a visible new feature with a new Settings surface.

The security fix is worth calling out in the notes even though it is unlikely anyone hit it: a submitted layout name reached a shell unquoted, so anyone with a GitHub account over a week old could have run commands in the workflow. Fixed before any theme workflow was built on top of it.

Adds `docs/features/THEMES.md`, an entry in the docs index, and an in-app Help section — including `?theme=default`, which is how a keyboard-less display recovers from an unreadable palette.