### PR TITLE
test(ui-audit): detect content a widget hides inside itself

### DIFF
--- a/e2e/helpers/ui-detectors.ts
+++ b/e2e/helpers/ui-detectors.ts
@@ -35,6 +35,26 @@ export interface LayoutProbeResult {
   /** True when the fixed side/portrait nav is clipped or spills the viewport. */
   navClipped: boolean;
   navDetail: string | null;
+  /**
+   * Widgets hiding content inside their own box, worst first.
+   *
+   * The rig could not see this class of problem at all. Its detectors looked
+   * for things spilling the viewport, but a widget shell carries
+   * `overflow-hidden` on both the frame and the content region, so content that
+   * outgrows its cell does not spill — it silently disappears. That is the
+   * failure mode when text size goes up: the board still looks tidy, with rows
+   * missing from the bottom of a widget and nothing to say so.
+   */
+  clippedWidgets: ClippedWidget[];
+}
+
+export interface ClippedWidget {
+  /** The widget's `data-widget` value — its type, or its title as a fallback. */
+  widget: string;
+  /** Vertical pixels of content the widget is hiding. */
+  hiddenY: number;
+  /** Height of the box doing the clipping, for scale. */
+  boxH: number;
 }
 
 /** Runs in the browser. `tolerance` is the px slack before flagging. */
@@ -113,6 +133,35 @@ export function layoutProbe(tolerance: number): LayoutProbeResult {
     }
   }
 
+  // Content clipped INSIDE a widget, rather than spilling out of it.
+  //
+  // Reported against the innermost `data-widget` element: the grid cell and the
+  // widget shell both carry the attribute, and the inner one is named for the
+  // widget type rather than its layout id, which is what a punch-list needs.
+  const clippedWidgets: ClippedWidget[] = [];
+  for (const host of Array.from(document.querySelectorAll('[data-widget]'))) {
+    if (host.querySelector('[data-widget]')) continue;
+    let hiddenY = 0;
+    let boxH = 0;
+    for (const el of [host, ...Array.from(host.querySelectorAll('*'))]) {
+      const cs = window.getComputedStyle(el);
+      if (cs.overflowY !== 'hidden' && cs.overflow !== 'hidden') continue;
+      const hidden = el.scrollHeight - el.clientHeight;
+      if (hidden > tolerance && hidden > hiddenY) {
+        hiddenY = hidden;
+        boxH = el.clientHeight;
+      }
+    }
+    if (hiddenY > 0) {
+      clippedWidgets.push({
+        widget: host.getAttribute('data-widget') || '(unnamed)',
+        hiddenY: Math.round(hiddenY),
+        boxH: Math.round(boxH),
+      });
+    }
+  }
+  clippedWidgets.sort((a, b) => b.hiddenY - a.hiddenY);
+
   return {
     viewportW: vw,
     viewportH: vh,
@@ -121,6 +170,7 @@ export function layoutProbe(tolerance: number): LayoutProbeResult {
     overflowers: overflowers.slice(0, 8),
     navClipped,
     navDetail,
+    clippedWidgets,
   };
 }
 
@@ -131,6 +181,17 @@ export function gradeProbe(p: LayoutProbeResult): { severity: Severity; summary:
   if (p.navClipped) return { severity: 'high', summary: p.navDetail || 'navigation clipped' };
   if (p.pageOverflowX > 4)
     return { severity: 'high', summary: `page scrolls horizontally by ${p.pageOverflowX}px` };
+  // Ranked above a right-edge overhang: an element sticking out is visible and
+  // someone will report it. Content cut off inside a widget looks like the
+  // widget simply had less to show, so it is never reported at all.
+  const clip = p.clippedWidgets[0];
+  if (clip)
+    return {
+      severity: 'medium',
+      summary:
+        `${p.clippedWidgets.length} widget(s) hiding content ` +
+        `(worst: ${clip.widget}, ${clip.hiddenY}px cut from a ${clip.boxH}px box)`,
+    };
   const worst = p.overflowers[0];
   if (worst)
     return {

--- a/scripts/ui-audit-board.mjs
+++ b/scripts/ui-audit-board.mjs
@@ -36,6 +36,11 @@ function card(f) {
   const overflowers = (f.probe?.overflowers || [])
     .map((o) => `<li><code>${esc(o.desc)}</code> — overhang ${o.overflow}px (w ${o.w})</li>`)
     .join('');
+  // Listed separately from overhang: this is content the widget hides inside
+  // itself, which leaves no visible trace in the screenshot above.
+  const clipped = (f.probe?.clippedWidgets || [])
+    .map((c) => `<li><code>${esc(c.widget)}</code> — ${c.hiddenY}px cut from a ${c.boxH}px box</li>`)
+    .join('');
   return `
   <article class="card sev-${f.severity}">
     <header>
@@ -45,6 +50,7 @@ function card(f) {
     </header>
     <p class="summary">${esc(f.summary)}</p>
     ${overflowers ? `<details><summary>overhanging elements</summary><ul>${overflowers}</ul></details>` : ''}
+    ${clipped ? `<details><summary>widgets hiding content</summary><ul>${clipped}</ul></details>` : ''}
     ${uri ? `<a href="${uri}" target="_blank"><img loading="lazy" src="${uri}" alt="${esc(f.route)} ${esc(f.viewport)}"></a>` : '<p class="noshot">(no screenshot)</p>'}
   </article>`;
 }


### PR DESCRIPTION
Phase 1 of the widget reflow work: make the loss measurable before deciding
whether to chase it. Detection only — no widget behaviour changes.

## What it does

The audit rig already sweeps routes x viewports x display-scales, but it
could not see the failure those scales actually cause. Its detectors looked
for things spilling the viewport. A widget shell carries `overflow-hidden`
on both the frame and the content region, so content that outgrows its cell
does not spill — it silently disappears. The board still looks tidy, with
rows missing from the bottom of a widget and nothing to say so.

This reports, per widget, how much content is being hidden. It is graded
above a right-edge overhang, on the reasoning that an element sticking out
is visible and someone will eventually report it, whereas content cut off
inside a widget looks like the widget simply had less to show.

The findings already carry the whole probe object, so this lands in
report.json with no plumbing. The board renders it as its own section,
since it leaves no trace in the screenshot beside it.

## Ran against a deployed dashboard

    scale 125%   Weather  95px hidden
    scale 150%   Weather 179px
    scale 175%   Weather 179px, Clock   8px
    scale 200%   Weather 179px, Clock  20px

One thing worth carrying into the conversion work: Weather is one of only
two widgets that already measures its own available space, and it is the
first to clip. Its capacity math uses a hardcoded row height fitted at a
single text size, so measuring the container is not sufficient on its own —
the constants have to be measured too, or a converted widget just fails
later instead of sooner.

Sample here is one five-widget dashboard; a denser layout will surface more.

## Scope

Phases 2-4 (extracting the capacity pattern, converting list-shaped widgets,
and deciding what should give on widgets where "+N more" is meaningless) are
backlog, not in this PR.

No unit test: jest is scoped to src/ and there is no precedent for testing
e2e helpers, so this is verified by running it rather than by a fixture.
