### PR TITLE
fix(display): scale root text with the screen above 1920

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Fixed
+- **Text keeps up with the screen on large panels.** The dashboard's widgets already grow to fill whatever screen they are on, but the text stopped growing at 1920 wide. On a 4K panel that meant boxes four times the area holding text of exactly the same size — and since a 4K and a 1080p panel of the same measurement are the same size in the room, that text was physically half as big to read. It now scales with the screen. Nothing changes at 1920 or below.
+
+### Fixed
 - **A theme installed from the gallery no longer flashes the default palette on every load.** Built-in palettes were drawn correctly from the first frame, but a theme you installed yourself was not: the page rendered in Prism's own colours and only corrected itself a moment later. The same fix that stopped built-in themes flashing now covers installed ones.
 - **The dashboard no longer shifts as it finishes loading.** Prism ships a stand-in font whose letter widths are matched to the real one, so that text does not jump when the real font arrives. It was being built and then skipped over, so every cold start nudged the whole layout by a few percent as it settled. Most noticeable on a wall display, which reloads on its own.
 - **Pages that remember a view no longer redraw themselves on every load.** Restoring a saved grouping or filter made the browser throw away the page it had just been sent and build it again, so a display briefly showed the ungrouped list before settling. Nothing looked broken, which is why it went unnoticed. Tasks was affected as well as the pages above.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -137,10 +137,27 @@
     }
   }
 
+  /* Above this the ladder stops stepping and starts scaling.
+     
+     Grid cells are measured and size themselves continuously, so on a bigger
+     panel they simply get bigger. Text did not: it hit 22px here and stopped,
+     so a 4K panel drew boxes four times the area of a 1080p one holding text
+     of exactly the same size. Measured drift in the text-to-row ratio across
+     1366 -> 3840 was 268%, all of it above 1920.
+     
+     That is also the physically wrong answer. A 4K and a 1080p panel of the
+     same diagonal are the same size in the room, so 22px on the 4K is half as
+     large to whoever is reading it; it should roughly double, not hold.
+     
+     Tracks the SMALLER of the two axes so an ultrawide, where the width grows
+     but the rows do not, does not get text sized for a screen it does not
+     have. Tuned to land on exactly 22px at 1920x1080, so nothing at or below
+     that resolution moves; the clamp floor holds the old value down to 1400
+     and the ceiling stops it running away past 4K. */
   @media (min-width: 1400px) and (pointer: coarse),
     (min-width: 1400px) and (pointer: none) {
     html {
-      font-size: 22px;
+      font-size: clamp(22px, min(1.1458vw, 2.037vh), 44px);
     }
   }
 


### PR DESCRIPTION
Step one of retiring the per-display text size setting: make the thing it was
compensating for stop happening.

## The gap

Widgets are measured and size themselves continuously, so a bigger panel gets
bigger widgets. Text did not — the ladder's top step was a flat 22px, so above
1920 the boxes kept growing and the text stopped.

    viewport      root   grid row   text   text/row
    1366x768      20px       16.8   20.0      1.190
    1920x1080     22px       28.1   22.0      0.783
    2560x1440     22px       41.4   22.0      0.531
    3840x2160     22px       68.1   22.0      0.323

A 4K panel drew boxes four times the area of a 1080p one, holding text of
identical size. That is also the physically wrong answer: two panels of the
same diagonal are the same size in the room, so 22px on the 4K is half as
large to whoever is reading it and should roughly double.

## The change

The top step scales continuously instead of sitting flat. It tracks the
smaller of the two axes, so an ultrawide — width grows, rows do not — is not
given text sized for a screen it does not have. Tuned to land on exactly 22px
at 1920x1080, with the clamp floor holding the previous value from 1400 up.

**Nothing at or below 1920 changes.** Verified: the 1366 and 1920 rows above
are byte-identical before and after.

After, in the range this touches, the text-to-row ratio drifts 16% across
1920 -> 3840, down from 142%. The remaining spread in the full table is the
sub-1400 breakpoints, deliberately untouched.

## Did it trade drift for clipping?

Bigger text could just mean more content cut off, so this was measured with
the widget-clipping detector from #357:

    1920x1080   0 widgets hiding content
    2560x1440   1  (Birthdays, 93px)
    3840x2160   0

Unchanged in character. Boxes and text now grow together, which is the point.

## What this does not solve

Resolution, not viewing distance. Nothing in CSS can tell whether a screen is
read from the counter or across the room, and this does not change that. Worth
saying plainly, because it is the open question about whether the per-display
text size setting can be retired outright — that decision is not in this PR.
