### PR TITLE
fix(screensaver): revert continuous root size, and yield to Away/Babysitter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Fixed
+- **The screensaver no longer covers Away or Babysitter mode.** Both put a full screen up deliberately, and both matter most when nobody is standing at the display — which is exactly when the screensaver used to slide over the top of them. A home left in Away mode showed photos instead of the away screen, and a babysitter's notes disappeared after a couple of minutes with nobody there to touch the screen and bring them back. Being idle now yields to both.
+
+### Fixed
 - **A theme installed from the gallery no longer flashes the default palette on every load.** Built-in palettes were drawn correctly from the first frame, but a theme you installed yourself was not: the page rendered in Prism's own colours and only corrected itself a moment later. The same fix that stopped built-in themes flashing now covers installed ones.
 - **The dashboard no longer shifts as it finishes loading.** Prism ships a stand-in font whose letter widths are matched to the real one, so that text does not jump when the real font arrives. It was being built and then skipped over, so every cold start nudged the whole layout by a few percent as it settled. Most noticeable on a wall display, which reloads on its own.
 - **Pages that remember a view no longer redraw themselves on every load.** Restoring a saved grouping or filter made the browser throw away the page it had just been sent and build it again, so a display briefly showed the ungrouped list before settling. Nothing looked broken, which is why it went unnoticed. Tasks was affected as well as the pages above.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,9 +5,6 @@ All notable changes to Prism are documented in this file.
 ## Unreleased
 
 ### Fixed
-- **Text keeps up with the screen on large panels.** The dashboard's widgets already grow to fill whatever screen they are on, but the text stopped growing at 1920 wide. On a 4K panel that meant boxes four times the area holding text of exactly the same size — and since a 4K and a 1080p panel of the same measurement are the same size in the room, that text was physically half as big to read. It now scales with the screen. Nothing changes at 1920 or below.
-
-### Fixed
 - **A theme installed from the gallery no longer flashes the default palette on every load.** Built-in palettes were drawn correctly from the first frame, but a theme you installed yourself was not: the page rendered in Prism's own colours and only corrected itself a moment later. The same fix that stopped built-in themes flashing now covers installed ones.
 - **The dashboard no longer shifts as it finishes loading.** Prism ships a stand-in font whose letter widths are matched to the real one, so that text does not jump when the real font arrives. It was being built and then skipped over, so every cold start nudged the whole layout by a few percent as it settled. Most noticeable on a wall display, which reloads on its own.
 - **Pages that remember a view no longer redraw themselves on every load.** Restoring a saved grouping or filter made the browser throw away the page it had just been sent and build it again, so a display briefly showed the ungrouped list before settling. Nothing looked broken, which is why it went unnoticed. Tasks was affected as well as the pages above.

--- a/src/components/screensaver/Screensaver.tsx
+++ b/src/components/screensaver/Screensaver.tsx
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { useIdleDetection } from '@/lib/hooks/useIdleDetection';
+import { useAwayMode } from '@/lib/hooks/useAwayMode';
+import { useBabysitterMode } from '@/lib/hooks/useBabysitterMode';
 import { usePhotos } from '@/lib/hooks/usePhotos';
 import { useAutoOrientationSetting, usePinnedPhoto, useScreensaverInterval } from '@/components/layout/WallpaperBackground';
 import { useScreenOrientation } from '@/lib/hooks/useScreenOrientation';
@@ -14,6 +16,7 @@ import { GRID_COLS } from '@/lib/constants/grid';
 import { CssGridDisplay } from '@/components/layout/grid/CssGridDisplay';
 import { CalendarPrefsScopeContext } from '@/lib/hooks/useCalendarWidgetPrefs';
 import { loadScreensaverLayout } from './screensaverStorage';
+import { shouldShowScreensaver } from './shouldShowScreensaver';
 
 /**
  * Wrapper classes that make any dashboard widget legible as a screensaver
@@ -41,7 +44,19 @@ export {
 } from './screensaverStorage';
 
 export function Screensaver() {
-  const { isIdle } = useIdleDetection();
+  const { isIdle: idleNow } = useIdleDetection();
+  // Away and Babysitter are deliberate, someone-chose-this states, and each
+  // puts its own full-screen overlay up. The screensaver is rendered after both
+  // in LazyOverlays, so on an untouched display it simply covered them: a home
+  // left in Away mode showed holiday photos instead of the away screen, and the
+  // babysitter's information disappeared behind them exactly when nobody was
+  // there to touch the screen and bring it back.
+  //
+  // Idleness is the weakest of the three signals — it means only that nobody
+  // has touched anything — so it yields to both.
+  const { isAway } = useAwayMode();
+  const { isActive: isBabysitter } = useBabysitterMode();
+  const isIdle = shouldShowScreensaver({ idle: idleNow, away: isAway, babysitter: isBabysitter });
   const { enabled: autoOrientation } = useAutoOrientationSetting();
   const { pinnedId } = usePinnedPhoto('screensaver');
   const { interval: screensaverInterval } = useScreensaverInterval();

--- a/src/components/screensaver/__tests__/shouldShowScreensaver.test.ts
+++ b/src/components/screensaver/__tests__/shouldShowScreensaver.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The screensaver yields to the two deliberate modes.
+ *
+ * Both put up a full-screen overlay and both are rendered BEFORE the
+ * screensaver, so anything that lets it show while they are active means it
+ * covers them — on a display nobody is touching, which is the whole point of
+ * those modes.
+ */
+import { shouldShowScreensaver } from '../shouldShowScreensaver';
+
+const state = (o: Partial<Parameters<typeof shouldShowScreensaver>[0]> = {}) => ({
+  idle: false, away: false, babysitter: false, ...o,
+});
+
+describe('shouldShowScreensaver', () => {
+  it('shows when the display is simply idle', () => {
+    expect(shouldShowScreensaver(state({ idle: true }))).toBe(true);
+  });
+
+  it('does not show while Away mode is on', () => {
+    expect(shouldShowScreensaver(state({ idle: true, away: true }))).toBe(false);
+  });
+
+  it('does not show while Babysitter mode is on', () => {
+    expect(shouldShowScreensaver(state({ idle: true, babysitter: true }))).toBe(false);
+  });
+
+  it('does not show when both modes are on', () => {
+    expect(shouldShowScreensaver(state({ idle: true, away: true, babysitter: true }))).toBe(false);
+  });
+
+  it('never shows before the display is idle, whatever the modes say', () => {
+    for (const away of [false, true]) {
+      for (const babysitter of [false, true]) {
+        expect(shouldShowScreensaver(state({ idle: false, away, babysitter }))).toBe(false);
+      }
+    }
+  });
+});

--- a/src/components/screensaver/shouldShowScreensaver.ts
+++ b/src/components/screensaver/shouldShowScreensaver.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether the screensaver may take over the display.
+ *
+ * Three states can want the screen at once, and they are not equal. Away and
+ * Babysitter are deliberate — someone chose them, each puts up its own
+ * full-screen overlay, and each is showing information that matters precisely
+ * while nobody is standing at the display. Idleness is the weakest signal of
+ * the three: it means only that nobody has touched anything for a while.
+ *
+ * The screensaver is rendered after both overlays in LazyOverlays, so without
+ * this it simply covered them. A home left in Away mode showed holiday photos
+ * instead of the away screen, and a babysitter's notes vanished behind them
+ * after two minutes — exactly when there was nobody there to touch the screen
+ * and bring them back.
+ *
+ * Extracted rather than inlined so the rule can be tested without standing up
+ * the whole screensaver, which pulls in photos, dashboard data and the widget
+ * registry.
+ */
+export function shouldShowScreensaver(state: {
+  /** Nobody has interacted for longer than the screensaver timeout. */
+  idle: boolean;
+  /** Away mode is on. */
+  away: boolean;
+  /** Babysitter mode is on. */
+  babysitter: boolean;
+}): boolean {
+  return state.idle && !state.away && !state.babysitter;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -137,27 +137,19 @@
     }
   }
 
-  /* Above this the ladder stops stepping and starts scaling.
-     
-     Grid cells are measured and size themselves continuously, so on a bigger
-     panel they simply get bigger. Text did not: it hit 22px here and stopped,
-     so a 4K panel drew boxes four times the area of a 1080p one holding text
-     of exactly the same size. Measured drift in the text-to-row ratio across
-     1366 -> 3840 was 268%, all of it above 1920.
-     
-     That is also the physically wrong answer. A 4K and a 1080p panel of the
-     same diagonal are the same size in the room, so 22px on the 4K is half as
-     large to whoever is reading it; it should roughly double, not hold.
-     
-     Tracks the SMALLER of the two axes so an ultrawide, where the width grows
-     but the rows do not, does not get text sized for a screen it does not
-     have. Tuned to land on exactly 22px at 1920x1080, so nothing at or below
-     that resolution moves; the clamp floor holds the old value down to 1400
-     and the ceiling stops it running away past 4K. */
   @media (min-width: 1400px) and (pointer: coarse),
     (min-width: 1400px) and (pointer: none) {
     html {
-      font-size: clamp(22px, min(1.1458vw, 2.037vh), 44px);
+      /* Flat, not scaled with the viewport. Making this continuous does fix a
+         real problem — above 1920 the boxes keep growing and the text does not,
+         so a 4K panel draws boxes four times the area holding text of the same
+         size (measured: 142% drift in the text-to-row ratio, 1920 -> 3840).
+         But the screensaver renders the same layout in `containMode`, whose
+         cell size is pure geometry with no root dependency, so a larger root
+         put bigger text into identically sized cells and pushed its content off
+         the screen. Fixing it here without fixing contain mode first trades a
+         subtle problem for a visible one. See PR #360 for the measurements. */
+      font-size: 22px;
     }
   }
 


### PR DESCRIPTION
Two fixes to the screensaver: undoing a regression I introduced, and closing a
gap that predates it.

## Revert the continuous root size (#360)

That change made the top of the font-size ladder scale with the screen instead
of sitting flat at 22px. It fixed something real — above 1920 the grid keeps
growing and the text does not, so a 4K panel draws boxes four times the area
holding text of identical size — but it broke something more visible.

The screensaver renders the same layout in `containMode`, where the cell size
is computed from geometry alone and has no root dependency. A larger root
therefore put bigger text into identically sized cells: +33% at 2560, +100% at
3840, with the canvas unchanged. Content ran off the screen.

That change existed to make the per-display text size setting redundant so it
could be retired. We since decided to keep the setting, so its remaining
justification does not outweigh a regression on the surface people actually
look at. The measurements are kept in a comment at the site and in #360, so
this is recoverable rather than lost.

Doing it properly means first fixing contain mode to scale text with its
canvas, which is the underlying gap this exposed — not in this PR.

## The screensaver no longer covers Away and Babysitter mode

All three overlays are siblings in `LazyOverlays`, and the screensaver is
rendered last at z-9999 against the other two at z-9998. Nothing gated it on
anything but idleness, so on an untouched display it slid over the top of
them. A home left in Away mode showed photos instead of the away screen, and a
babysitter's notes vanished a couple of minutes in — with nobody there to
touch the screen and bring them back, which is the point of that mode.

Idleness is the weakest of the three signals: it means only that nobody has
interacted recently, while the other two are states someone chose. It yields
to both.

The rule is extracted into a small function rather than inlined, so it can be
tested without standing up the screensaver, which pulls in photos, dashboard
data and the widget registry.

## Verification

Checked against the running app with the two mode endpoints stubbed, so no
real display state was touched:

    idle, no modes      -> screensaver showing
    idle + Away         -> screensaver hidden, away overlay still up
    idle + Babysitter   -> screensaver hidden

Detected by the overlays' own z-index. Worth noting that two earlier attempts
reported a false failure here — once from stubbing the wrong API field, once
from matching the dashboard wallpaper instead of the screensaver, which uses a
background image rather than an img. Both looked like real failures.

1660 unit tests pass, type-check and lint clean.
