### PR TITLE
refactor(settings): de-emphasise the per-display text size control

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Changed
+- **The per-display text size setting is now called *Text Size*, sits near the bottom of Settings, and starts collapsed.** Reading a dashboard from right across a room is a real situation but an uncommon one, and the control was sitting open near the top of Settings for everyone in order to serve the few who need it. It stays expanded on any display where it has been changed from 100%, so a screen you have already tuned never hides that from you.
+
 ### Fixed
 - **The screensaver no longer covers Away or Babysitter mode.** Both put a full screen up deliberately, and both matter most when nobody is standing at the display — which is exactly when the screensaver used to slide over the top of them. A home left in Away mode showed photos instead of the away screen, and a babysitter's notes disappeared after a couple of minutes with nobody there to touch the screen and bring them back. Being idle now yields to both.
 
@@ -16,7 +19,7 @@ All notable changes to Prism are documented in this file.
 - **Prism no longer downloads ~4 MB of emoji font up front.** The offline cache was told to fetch every font in the build the moment it installed, including all ten chunks of the colour-emoji fallback — undoing the careful arrangement that only fetches the emoji ranges a screen actually draws. Emoji are unchanged; they now arrive when something needs them. First load drops from about 4 MB of fonts to about 210 KB.
 - **The per-display *Font Scale* setting is now called *Text size*.** It only ever set how large the dashboard reads from where the screen is viewed, and the old name described the mechanism rather than the decision. Nothing about your displays changes — the setting keeps its value, it is only labelled more plainly, and it now says out loud that larger text means fewer rows fit.
 - **Turning up the display text size no longer pushes the dashboard off the screen.** The setting made text bigger and the board taller in equal measure, so at 150% the bottom widget was simply below the edge of the screen — on a display nobody can scroll. The dashboard now re-fits itself as the text grows: fewer rows, all of them on screen. Nobody's saved scale changes, and a display that was overflowing stops.
-- **Text is the right size again on a display with no mouse or touchscreen.** Prism picks its text size from what it can tell about the screen it is on, and a display with no pointing device attached — a Pi or a streaming stick driving a wall panel — fell through to the size meant for a phone held at arm's length. That is the one kind of screen guaranteed to be read from across a room, and it was getting nearly the smallest text Prism has. It now scales up with the screen the way a touchscreen already did. If you turned the text size up under *Settings → Displays* to work around this, you will want to bring it back down.
+- **Text is the right size again on a display with no mouse or touchscreen.** Prism picks its text size from what it can tell about the screen it is on, and a display with no pointing device attached — a Pi or a streaming stick driving a wall panel — fell through to the size meant for a phone held at arm's length. That is the one kind of screen guaranteed to be read from across a room, and it was getting nearly the smallest text Prism has. It now scales up with the screen the way a touchscreen already did. If you turned the text size up under *Settings → Text Size* to work around this, you will want to bring it back down.
 
 ## [1.21.0] – 2026-08-31
 

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -139,7 +139,7 @@ A short tour of *Settings*. (Each section's deep behavior is documented in the l
 - **Family Members**: add / edit / remove members. Names, colors, avatars, roles, sort order.
 - **General**: weather location (city or postal code), time zone, Week Starts On.
 - **Integrations**: one card per provider brand: Google (Calendar, Tasks), Microsoft (To Do, OneDrive), Gmail (bus tracking), Apple / CalDAV, Kroger (shopping cart push), plus Photo Sources. Per-list Task / Shopping / Wish List sync is mapped inside the Microsoft or Google provider card.
-- **Displays**: per-dashboard text size.
+- **Text Size**: how large everything reads on each dashboard.
 - **Appearance**: Color Scheme (Light / Dark / System), Theme Palette, Seasonal Theme, Performance Mode, Screensaver / Photo Rotation / Auto-Hide Navigation / Away Mode timers, Orientation Override.
 - **Photos**: manage sources (Local, OneDrive, Immich); folder picker; display filters (orientation, resolution); GPS backfill; pinned wallpaper / screensaver.
 - **Bus Tracking**: Gmail connection, route configuration, route auto-discovery, Gmail label filter.

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -576,7 +576,7 @@ function SettingsHelp({ isMobile }: { isMobile: boolean }) {
       </Ul>
       {!isMobile && (
         <>
-          <H3>Displays</H3>
+          <H3>Text Size</H3>
           <P>Wallpaper and per-display kiosk options.</P>
         </>
       )}

--- a/src/app/settings/SettingsView.tsx
+++ b/src/app/settings/SettingsView.tsx
@@ -190,7 +190,6 @@ export function SettingsView() {
     { id: 'general', label: 'General', icon: SlidersHorizontal },
     { id: 'integrations', label: 'Integrations', icon: Link2 },
     // Calendar management moved onto the Calendar page (Manage calendars button).
-    { id: 'displays', label: 'Displays', icon: Monitor },
     { id: 'display', label: 'Appearance', icon: Palette },
     { id: 'photos', label: 'Photos', icon: ImageIcon },
     { id: 'bus', label: 'Bus Tracking', icon: Bus },
@@ -200,6 +199,7 @@ export function SettingsView() {
     { id: 'security', label: 'Security', icon: Shield },
     { id: 'backups', label: 'Backups & Data', icon: Database },
     { id: 'activity', label: 'Activity Log', icon: ClipboardList },
+    { id: 'displays', label: 'Text Size', icon: Monitor },
     { id: 'about', label: 'About', icon: Info },
   ];
 

--- a/src/app/settings/sections/DisplaysSection.tsx
+++ b/src/app/settings/sections/DisplaysSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Monitor, ExternalLink } from 'lucide-react';
+import { Monitor, ExternalLink, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -56,10 +56,12 @@ export function DisplaysSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-2xl font-bold">Displays</h2>
+        <h2 className="text-2xl font-bold">Text Size</h2>
         <p className="text-muted-foreground">
-          Configure per-display settings for each of your named dashboards.
-          Text size sets how large this dashboard reads from wherever the screen is actually viewed.
+          How large everything reads on each of your dashboards. This scales the whole
+          board at once, which is different from the per-widget text size in the layout
+          editor. Most screens never need it — reach for it only if one is read from
+          further away than the rest.
         </p>
       </div>
 
@@ -106,16 +108,26 @@ export function DisplaysSection() {
                   )}
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  <div className="space-y-1.5">
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm font-medium">Text size</span>
+                  {/* Collapsed by default. Reading a dashboard from across a room is a
+                      real case but an uncommon one, and leaving the control open put a
+                      slider in front of everyone to serve the few who need it.
+                      Deliberately open when the value is not 100%: a display someone has
+                      already tuned should not have that hidden, or the setting becomes
+                      something you can change and then never find again. */}
+                  <details open={scale !== 100} className="group">
+                    <summary className="flex cursor-pointer list-none items-center justify-between py-0.5 [&::-webkit-details-marker]:hidden">
+                      <span className="flex items-center gap-1 text-sm font-medium">
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground transition-transform group-open:rotate-90" />
+                        Text size
+                      </span>
                       <span className={cn(
                         'text-sm tabular-nums',
                         scale !== 100 ? 'text-primary font-medium' : 'text-muted-foreground'
                       )}>
                         {scale}%
                       </span>
-                    </div>
+                    </summary>
+                  <div className="space-y-1.5 pt-2">
                     <div className="flex items-center gap-2">
                       <span className="text-xs text-muted-foreground w-6">A</span>
                       <div className="flex-1 relative">
@@ -171,6 +183,7 @@ export function DisplaysSection() {
                       </>
                     )}
                   </div>
+                  </details>
                 </CardContent>
               </Card>
             );


### PR DESCRIPTION
Reading a dashboard from right across a room is a real situation but an
uncommon one, and the control for it was being paid for by everyone else: an
open slider, in a section sitting fifth from the top of Settings, for a
setting most people never touch.

Three changes, none of them to behaviour.

**Renamed from "Displays" to "Text Size".** The section only ever contained
this one control, so the old name promised a good deal more than it held.

**Moved to second from the bottom** of the settings list, below Activity Log.

**Collapsed behind a disclosure**, with the current value on the summary line
so it can be read without expanding.

It stays expanded when the value is not 100%. A display someone has already
tuned should not have that hidden from them, or the setting becomes something
you can change once and then never find again.

The description now says what the control actually does — scales the whole
board at once, as distinct from the per-widget text size in the layout editor
— rather than leading with viewing distance, which is not a core Prism
scenario.

No stored value moves. `layouts.font_scale`, the API and the 75-150 range are
untouched, so nobody's display changes.

## Verification

Settings sits behind a parent PIN, so this is **not** driven through the UI —
it is verified by build, lint and type-check only, and wants a human look.

Worth recording: the first build failed on an unescaped apostrophe in the new
copy (`react/no-unescaped-entities`). Neither `tsc --noEmit` nor jest catches
that, and the deploy script stops before copying when the build fails, so the
container silently kept serving the previous bundle. Checked the container's
build timestamp against the local one to catch it.
