### PR TITLE
fix(auth): give each member a distinct key on the pre-auth PIN pads

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **The unlock screen no longer shows the same person twice.** Choosing who you are when leaving Away mode, leaving Babysitter mode, or opening Settings could draw one parent's picture next to another parent's name, so it looked as though somebody appeared twice and somebody else was missing. Signing in still worked; only the pictures were shuffled. Present since 1.10.0 and easy to miss on a household with one parent.
+
 ## [1.22.0] – 2026-09-03
 
 ### Added

--- a/src/app/settings/SettingsPinGate.tsx
+++ b/src/app/settings/SettingsPinGate.tsx
@@ -333,7 +333,12 @@ function SettingsPinPrompt({
               <div className="grid grid-cols-2 gap-1.5">
                 {parents.map((parent) => (
                   <button
-                    key={parent.id}
+                    // `id` is deliberately blank in the unauthenticated /api/family
+                    // response — `loginIndex` is the login token there. Keying on the
+                    // blank id gave every parent the SAME key, so React reused DOM
+                    // nodes between them and the list rendered one member's avatar
+                    // against another's name. Matches QuickPinModal, which had it right.
+                    key={parent.id || parent.loginIndex}
                     onClick={() => setSelectedParent(parent)}
                     className={cn(
                       'flex flex-col items-center p-1.5 rounded-xl',

--- a/src/components/auth/__tests__/pinPadMemberKeys.test.ts
+++ b/src/components/auth/__tests__/pinPadMemberKeys.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Structural guard: PIN pads must not key their member list on `id` alone.
+ *
+ * `/api/family` returns two different shapes. Authenticated callers get real
+ * UUIDs; unauthenticated ones get a display-only shape where `id` is
+ * deliberately always the empty string and `loginIndex` is the login token
+ * instead, so a PIN pad can draw the family without leaking user IDs to anyone
+ * who can reach the endpoint.
+ *
+ * Every pad renders that public shape, which means keying a list on `id` gives
+ * every member the SAME key. React then reuses DOM nodes between them and the
+ * list renders one member's avatar against another's name. It looks like
+ * duplicated people rather than a keying fault, which is why it survived in
+ * three separate components at once — away mode, babysitter mode, and the
+ * settings gate — while the original in QuickPinModal was correct all along.
+ *
+ * A behavioural test per component would not have caught the third copy, let
+ * alone a fourth. This reads the source instead.
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+const SRC = join(process.cwd(), 'src');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry !== '__tests__' && entry !== 'node_modules') walk(full, out);
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** A component renders the pre-auth family list if it reads `loginIndex`. */
+function usesPublicFamilyShape(text: string): boolean {
+  return /loginIndex/.test(text);
+}
+
+/** `key={x.id}` with no fallback — the defect. */
+const BARE_ID_KEY = /key=\{\s*(\w+)\.id\s*\}/g;
+
+describe('PIN pad member list keys', () => {
+  const files = walk(SRC).map((f) => ({
+    file: relative(process.cwd(), f),
+    text: readFileSync(f, 'utf8'),
+  }));
+
+  it('finds the components that render the pre-auth family list', () => {
+    // Guards the guard: if this drops to zero the check below passes vacuously.
+    expect(files.filter((f) => usesPublicFamilyShape(f.text)).length).toBeGreaterThan(0);
+  });
+
+  it('never keys a member list on `id` alone where ids can be blank', () => {
+    const offenders: string[] = [];
+    for (const { file, text } of files) {
+      if (!usesPublicFamilyShape(text)) continue;
+      for (const m of text.matchAll(BARE_ID_KEY)) {
+        offenders.push(`${file}: key={${m[1]}.id}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/components/away-mode/ExitAwayModeModal.tsx
+++ b/src/components/away-mode/ExitAwayModeModal.tsx
@@ -183,7 +183,12 @@ export function ExitAwayModeModal({
               <div className="grid grid-cols-2 gap-3">
                 {parents.map((parent) => (
                   <button
-                    key={parent.id}
+                    // `id` is deliberately blank in the unauthenticated /api/family
+                    // response — `loginIndex` is the login token there. Keying on the
+                    // blank id gave every parent the SAME key, so React reused DOM
+                    // nodes between them and the list rendered one member's avatar
+                    // against another's name. Matches QuickPinModal, which had it right.
+                    key={parent.id || parent.loginIndex}
                     onClick={() => setSelectedParent(parent)}
                     className={cn(
                       'flex flex-col items-center p-3 rounded-xl',

--- a/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
+++ b/src/components/babysitter-mode/ExitBabysitterModeModal.tsx
@@ -183,7 +183,12 @@ export function ExitBabysitterModeModal({
               <div className="grid grid-cols-2 gap-3">
                 {parents.map((parent) => (
                   <button
-                    key={parent.id}
+                    // `id` is deliberately blank in the unauthenticated /api/family
+                    // response — `loginIndex` is the login token there. Keying on the
+                    // blank id gave every parent the SAME key, so React reused DOM
+                    // nodes between them and the list rendered one member's avatar
+                    // against another's name. Matches QuickPinModal, which had it right.
+                    key={parent.id || parent.loginIndex}
                     onClick={() => setSelectedParent(parent)}
                     className={cn(
                       'flex flex-col items-center p-3 rounded-xl',


### PR DESCRIPTION
Reported from a wall display: leaving Away mode showed one parent twice, with
the list looking jumbled.

## Cause

`/api/family` returns two shapes. Authenticated callers get real UUIDs;
unauthenticated ones get a display-only shape where `id` is **deliberately
always the empty string** and `loginIndex` is the login token instead, so a PIN
pad can draw the family without leaking user IDs to anyone who can reach the
endpoint. That part is working as designed.

Three components render that public shape and keyed their list on `id` alone,
which gives every member the *same* key. React then reuses DOM nodes between
them, so the list draws one member's avatar against another's name:

- `src/components/away-mode/ExitAwayModeModal.tsx`
- `src/components/babysitter-mode/ExitBabysitterModeModal.tsx`
- `src/app/settings/SettingsPinGate.tsx`

It presents as a person appearing twice rather than as a keying fault, which is
presumably how it survived in three places at once. `QuickPinModal` had it
right all along with `key={member.id || member.loginIndex}`; the three above
now match it.

**Sign-in was never affected.** All four already fall back to `memberIndex`
when the id is blank — only the pictures were shuffled.

Present since c0adc750 (2026-04-09), first released in **v1.10.0**, so this has
been there about five months. Easy to miss on a household with a single parent,
since one member cannot collide with anyone.

The babysitter pad had the identical bug and was untested when this was
reported — worth trying that one too.

## The guard

A structural test rather than one per component: this was a single mistake
copied three times, so a behavioural test would not have caught the third, let
alone a fourth. It reads the source, flags any `key={x.id}` in a file that also
reads `loginIndex`, and asserts it found some such files first so it cannot
pass vacuously.

Confirmed it fails — and names the offending file — when the fix is reverted.

## Verification

Driven on the deployed away-mode pad with the mode endpoint stubbed, so no real
display state was touched: two parents, two distinct names, two distinct
avatars.

Worth noting three earlier attempts at that check reported a false failure,
each from the harness rather than the code — a button selector that swept the
whole page, then a missing `[role="dialog"]`, then a scope that caught 8
buttons instead of 2. The modal is `div.bg-card.rounded-2xl`, for anyone
writing a test against it later.
