### PR TITLE
fix(nav): keep navigation inside the dashboard you are looking at

### DIFF
--- a/src/app/d/[slug]/travel/page.tsx
+++ b/src/app/d/[slug]/travel/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/app/travel/page';

--- a/src/app/d/[slug]/weekend/page.tsx
+++ b/src/app/d/[slug]/weekend/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/app/weekend/page';

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { scopedHref, isNavActive } from '@/lib/utils/dashboardScope';
 import { useTranslations } from 'next-intl';
 import {
   ShoppingCart,
@@ -105,11 +106,11 @@ export function MobileNav({ user, onLogin, onLogout, uiHidden }: MobileNavProps)
           <div className="grid grid-cols-3 gap-1 p-2">
             {visibleSecondary.map((item) => {
               const Icon = item.icon;
-              const isActive = pathname === item.href;
+              const isActive = isNavActive(item.href, pathname);
               return (
                 <Link
                   key={item.href}
-                  href={item.href}
+                  href={scopedHref(item.href, pathname)}
                   onClick={() => setShowMore(false)}
                   className={cn(
                     'flex flex-col items-center gap-1 py-3 px-2 rounded-lg transition-colors',
@@ -201,11 +202,11 @@ export function MobileNav({ user, onLogin, onLogout, uiHidden }: MobileNavProps)
         <div className="flex items-center justify-around h-16">
           {visiblePrimary.map((item) => {
             const Icon = item.icon;
-            const isActive = pathname === item.href;
+            const isActive = isNavActive(item.href, pathname);
             return (
               <Link
                 key={item.href}
-                href={item.href}
+                href={scopedHref(item.href, pathname)}
                 className={cn(
                   'flex flex-col items-center gap-0.5 py-2 px-3 min-w-[64px] transition-colors',
                   isActive

--- a/src/components/layout/PortraitNav.tsx
+++ b/src/components/layout/PortraitNav.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { scopedHref, isNavActive } from '@/lib/utils/dashboardScope';
 import { User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
@@ -36,10 +37,7 @@ export function PortraitNav({ user, onLogin, onLogout, uiHidden }: PortraitNavPr
   const navItems = filterNavItems(ALL_NAV_ITEMS);
   const t = useTranslations('common');
 
-  const isActive = (href: string) => {
-    if (href === '/') return pathname === '/';
-    return pathname.startsWith(href);
-  };
+  const isActive = (href: string) => isNavActive(href, pathname);
 
   return (
     <nav className={cn(
@@ -54,7 +52,7 @@ export function PortraitNav({ user, onLogin, onLogout, uiHidden }: PortraitNavPr
           return (
             <Link
               key={item.href}
-              href={item.href}
+              href={scopedHref(item.href, pathname)}
               className={cn(
                 'flex flex-col items-center gap-1 py-2 px-4 min-w-[72px] shrink-0 transition-colors',
                 active ? 'text-primary' : 'text-muted-foreground hover:text-foreground'

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -27,6 +27,7 @@ import * as React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { scopedHref, isNavActive } from '@/lib/utils/dashboardScope';
 import { HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { PrismIcon } from '@/components/ui/PrismIcon';
@@ -104,12 +105,7 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
   }, [pathname]);
 
   // Check if a nav item is active
-  const isActive = (href: string) => {
-    if (href === '/') {
-      return pathname === '/';
-    }
-    return pathname.startsWith(href);
-  };
+  const isActive = (href: string) => isNavActive(href, pathname);
 
   // Toggle drawer on tap in blank area — skip if clicking a link or button
   const handleAsideClick = (e: React.MouseEvent) => {
@@ -136,7 +132,7 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
       >
         {/* HEADER WITH LOGO */}
         <div className={cn('flex items-center h-12 [@media(pointer:coarse)]:h-16 px-2', expanded ? 'justify-start' : 'justify-center')}>
-          <Link href="/" className="flex items-center gap-2" aria-label="Prism home">
+          <Link href={scopedHref('/', pathname)} className="flex items-center gap-2" aria-label="Prism home">
             <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 overflow-hidden">
               <PrismIcon size={24} />
             </div>
@@ -154,7 +150,7 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
               return (
                 <li key={item.href}>
                   <Link
-                    href={item.href}
+                    href={scopedHref(item.href, pathname)}
                     aria-label={t(item.i18nKey)}
                     className={cn(
                       'flex items-center gap-3 px-3 py-1.5 [@media(pointer:coarse)]:py-2.5 rounded-lg',

--- a/src/lib/utils/__tests__/dashboardScope.test.ts
+++ b/src/lib/utils/__tests__/dashboardScope.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Navigation has to stay inside the dashboard you are looking at.
+ *
+ * A dashboard carries its own font scale and its subpages honour it, but only
+ * while the URL says which dashboard you are in. The navigation linked to
+ * `/chores` rather than `/d/kitchen/chores`, so one tap left the dashboard and
+ * the display dropped back to 100% — reported as scaling that "doesn't stay
+ * when navigating between pages".
+ */
+import { scopedHref, isNavActive, dashboardSlug, SCOPED_ROUTES } from '../dashboardScope';
+
+describe('dashboardSlug', () => {
+  it.each([
+    ['/d/kitchen', 'kitchen'],
+    ['/d/kitchen/chores', 'kitchen'],
+    ['/d/scale150/calendar', 'scale150'],
+    ['/chores', null],
+    ['/', null],
+    ['', null],
+  ])('%s -> %s', (path, slug) => {
+    expect(dashboardSlug(path)).toBe(slug);
+  });
+});
+
+describe('scopedHref', () => {
+  it('keeps a destination inside the dashboard you are in', () => {
+    expect(scopedHref('/chores', '/d/kitchen')).toBe('/d/kitchen/chores');
+    expect(scopedHref('/chores', '/d/kitchen/calendar')).toBe('/d/kitchen/chores');
+  });
+
+  it('sends the home link back to the dashboard, not to the default one', () => {
+    expect(scopedHref('/', '/d/kitchen/chores')).toBe('/d/kitchen');
+  });
+
+  it('leaves things alone outside a dashboard', () => {
+    expect(scopedHref('/chores', '/calendar')).toBe('/chores');
+    expect(scopedHref('/', '/calendar')).toBe('/');
+  });
+
+  it('does not invent a scoped route that does not exist', () => {
+    // Settings deliberately has no scoped twin: it is where the scale is
+    // changed, and a settings page at 150% is the one place being too large
+    // actively gets in the way.
+    expect(scopedHref('/settings', '/d/kitchen')).toBe('/settings');
+    expect(SCOPED_ROUTES).not.toContain('/settings');
+  });
+
+  it('covers every destination the navigation offers except settings', () => {
+    for (const href of ['/calendar', '/tasks', '/chores', '/goals', '/shopping',
+      '/meals', '/recipes', '/messages', '/photos', '/wishes', '/babysitter',
+      '/travel', '/weekend']) {
+      expect(scopedHref(href, '/d/kitchen')).toBe(`/d/kitchen${href}`);
+    }
+  });
+});
+
+describe('isNavActive', () => {
+  it('highlights the open page inside a dashboard', () => {
+    expect(isNavActive('/chores', '/d/kitchen/chores')).toBe(true);
+    expect(isNavActive('/calendar', '/d/kitchen/chores')).toBe(false);
+  });
+
+  it('highlights home only on the dashboard itself', () => {
+    expect(isNavActive('/', '/d/kitchen')).toBe(true);
+    expect(isNavActive('/', '/d/kitchen/chores')).toBe(false);
+  });
+
+  it('still works outside a dashboard', () => {
+    expect(isNavActive('/chores', '/chores')).toBe(true);
+    expect(isNavActive('/', '/')).toBe(true);
+    expect(isNavActive('/', '/chores')).toBe(false);
+  });
+
+  it('does not match a different page that starts with the same name', () => {
+    expect(isNavActive('/meals', '/mealsomething')).toBe(false);
+  });
+});

--- a/src/lib/utils/dashboardScope.ts
+++ b/src/lib/utils/dashboardScope.ts
@@ -1,0 +1,67 @@
+/**
+ * Keeping navigation inside the dashboard you are looking at.
+ *
+ * A dashboard can carry its own font scale, and its subpages honour it — but
+ * only while the URL says which dashboard you are in. The navigation linked to
+ * `/chores` rather than `/d/kitchen/chores`, so one tap on the sidebar left the
+ * dashboard's scope and the display dropped back to 100%. Reported as scaling
+ * that "doesn't stay when navigating between pages", which is exactly what it
+ * looked like from the outside.
+ *
+ * Not every destination has a scoped twin, and Settings deliberately does not:
+ * it is where the scale is changed, and a settings page rendered at 150% is the
+ * one place that being too large is actively unhelpful.
+ */
+
+/** Destinations that exist under `/d/[slug]` as well as at the top level. */
+export const SCOPED_ROUTES = [
+  '/calendar',
+  '/tasks',
+  '/chores',
+  '/goals',
+  '/shopping',
+  '/meals',
+  '/recipes',
+  '/messages',
+  '/photos',
+  '/wishes',
+  '/babysitter',
+  '/travel',
+  '/weekend',
+] as const;
+
+/** The dashboard slug the given path is inside, if any. */
+export function dashboardSlug(pathname: string | null | undefined): string | null {
+  if (!pathname) return null;
+  const m = /^\/d\/([^/]+)/.exec(pathname);
+  return m ? m[1]! : null;
+}
+
+/**
+ * Rewrite a top-level href to stay inside the current dashboard.
+ *
+ * Returns the href unchanged when there is no dashboard to stay inside, or when
+ * the destination has no scoped route to go to.
+ */
+export function scopedHref(href: string, pathname: string | null | undefined): string {
+  const slug = dashboardSlug(pathname);
+  if (!slug) return href;
+  if (href === '/') return `/d/${slug}`;
+  if (!(SCOPED_ROUTES as readonly string[]).includes(href)) return href;
+  return `/d/${slug}${href}`;
+}
+
+/**
+ * Whether a nav destination is the page currently open.
+ *
+ * Compared against the scoped href, not the bare one: inside a dashboard the
+ * path is `/d/kitchen/chores`, which does not begin with `/chores`, so matching
+ * on the raw href left every item unhighlighted the moment you were in a
+ * dashboard.
+ */
+export function isNavActive(href: string, pathname: string | null | undefined): boolean {
+  const path = pathname ?? '';
+  const target = scopedHref(href, path);
+  if (href === '/') return path === target;
+  return path === target || path.startsWith(`${target}/`);
+}


### PR DESCRIPTION
Fixes #365.

The scale was applying correctly all along — `/d/scale150/chores` renders at
150%. What went wrong is that the sidebar linked to `/chores`, so following it
left the dashboard entirely and landed on the unscoped page. From the outside
that looks like the setting not sticking.

All three navigations now keep their destinations in scope, and the two that had
no scoped route — travel and weekend — have one. Settings deliberately does not:
it is where the scale is changed, and a settings page at 150% is the one place
being too large gets in the way.

The active-item highlight had to move with it, since it matched on the bare href
and `/d/kitchen/chores` does not begin with `/chores`.

Verified against a running instance with a dashboard at 150%: the sidebar link
reads `/d/<slug>/chores`, the zoom stays at 1.5 after following it, and the open
page is the one highlighted.
