### PR TITLE
chore(release): 1.23.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.23.0] – 2026-09-05
+
 ### Added
 - **The screensaver can bring its widgets in and out, four different ways.** It has always drawn every widget in its layout, all the time: busy to look at, and the worst case for a panel, since nothing on screen ever moves. It can now show about two thirds of them and rotate which ones — *Settings → Appearance → Screensaver → Widget transition effect*. **Fade** is opacity, eased at both ends. **Smoke** dissolves the widget's own pixels through a turbulence mask. **Fill and drain** runs a waterline across it, with one widget draining as another fills — the water leaving one is exactly the water arriving in the other, and the pair is chosen from opposite sides of the board so it reads as a transfer. **Fireworks** takes the widget apart into its own pixels: it is sampled pixel by pixel and each fragment carries that pixel's colour, so at the instant it comes apart you are looking at the widget itself. Off by default; no display changes character on an update without being asked.
 - **Widgets can drift, to spare the panel.** Slow, out-of-step movement — *Breathe*, *Ripple* or *Figure eight* — over periods of twenty seconds to a minute and a half. Rotating which widgets are shown helps with burn-in; moving the ones that are showing helps more, because it shifts the edges rather than what is inside them. Breathe and Figure eight are meant to go unnoticed. Ripple is meant to be just noticeable.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.22.0"
+version: "1.23.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Version bump only: package.json, ha-app/config.yaml, and the CHANGELOG heading.

Moves the Unreleased section under `## [1.23.0]`. No code changes.
