### PR TITLE
feat(i18n): translate the calendar and its event form into German

### DIFF
--- a/docs/features/LANGUAGES.md
+++ b/docs/features/LANGUAGES.md
@@ -26,8 +26,7 @@ translation is perfectly usable.
 | Navigation (sidebar, portrait nav, mobile nav) | ✅ done |
 | Common actions (Save, Cancel, Delete, …) | ✅ keys ready |
 | Birthdays widget | ✅ done |
-| Calendar - views, toolbar, widget | ✅ done |
-| Calendar - add/edit event form | ⬜ to do |
+| Calendar - views, toolbar, widget, add/edit event form | ✅ done |
 | Chores — widget + page | ⬜ to do |
 | Meals — widget + page | ⬜ to do |
 | Messages — widget + page | ⬜ to do |

--- a/docs/features/LANGUAGES.md
+++ b/docs/features/LANGUAGES.md
@@ -26,7 +26,8 @@ translation is perfectly usable.
 | Navigation (sidebar, portrait nav, mobile nav) | ✅ done |
 | Common actions (Save, Cancel, Delete, …) | ✅ keys ready |
 | Birthdays widget | ✅ done |
-| Calendar — widget + page | ⬜ to do |
+| Calendar - views, toolbar, widget | ✅ done |
+| Calendar - add/edit event form | ⬜ to do |
 | Chores — widget + page | ⬜ to do |
 | Meals — widget + page | ⬜ to do |
 | Messages — widget + page | ⬜ to do |
@@ -35,7 +36,8 @@ translation is perfectly usable.
 | Tasks — widget + page | ⬜ to do |
 | Travel — widget + page | ⬜ to do |
 | Wishes — widget + page | ⬜ to do |
-| Clock / Weather / Points / Bus widgets | ⬜ to do |
+| Clock / Weather widgets | ✅ done |
+| Points / Bus widgets | ⬜ to do |
 | Settings pages | ⬜ to do |
 | Setup wizard | ⬜ to do |
 
@@ -45,7 +47,11 @@ used in both places.
 ## Dates, times and numbers
 
 Dates and numbers already follow the selected language automatically — a German
-dashboard shows `24. Dez.` rather than `Dec 24`.
+dashboard shows `24. Dez.` rather than `Dec 24`. That covers the **order** of
+the parts as well as their names: a German calendar header reads
+`4. September 2026`, not `September 4, 2026`. Day-first order isn't something a
+translation file can express, so date labels are built from the language rather
+than from a fixed pattern in the code.
 
 **12- vs 24-hour time is a separate setting**, under
 **Settings → General**. It is deliberately independent of language, so you can

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addDays, addWeeks, startOfDay } from 'date-fns';
 import {
   DndContext,
@@ -86,6 +88,7 @@ function sortMealsByType<T extends { mealType: 'breakfast' | 'lunch' | 'dinner' 
 const MealModal = lazy(() => import('@/app/meals/MealsView').then(m => ({ default: m.MealModal })));
 
 export function CalendarView() {
+  const t = useTranslations('calendar');
   const { activeUser, requireAuth } = useAuth();
   const { members: familyMembers } = useFamily();
   const { weekStartsOn } = useWeekStartsOn();
@@ -322,7 +325,7 @@ export function CalendarView() {
         await moveEvent(itemId, ev.startTime, ev.endTime, targetBucket.date);
       }
     } catch (err) {
-      setMoveError(err instanceof Error ? err.message : 'Failed to move item');
+      setMoveError(err instanceof Error ? err.message : t('errors.moveFailed'));
     }
   };
 
@@ -354,7 +357,7 @@ export function CalendarView() {
   });
 
   const handleAddWithAuth = async () => {
-    const user = await requireAuth('Add Event', 'Please log in to add an event');
+    const user = await requireAuth(t('toolbar.addEvent'), t('toolbar.addEventAuth'));
     if (!user) return;
     setShowAddEvent(true);
   };
@@ -391,20 +394,20 @@ export function CalendarView() {
                 size="sm"
                 onClick={() => setShowPendingReview(true)}
                 className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
-                title="Review calendar removals held for your approval"
+                title={t('toolbar.reviewTitle')}
               >
                 <AlertTriangle className="h-4 w-4 mr-1" />
-                Review {pendingCount}
+                {t('toolbar.review', { count: pendingCount })}
               </Button>
             )}
             {isMobile ? null : (
               <>
-                <Button variant="outline" size="sm" onClick={goToToday} className="h-9">Today</Button>
+                <Button variant="outline" size="sm" onClick={goToToday} className="h-9">{t('today')}</Button>
                 <div className="flex items-center gap-1">
-                  <Button variant="outline" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-9 w-9">
+                  <Button variant="outline" size="icon" onClick={goToPrevious} aria-label={t('nav.previous')} className="h-9 w-9">
                     <ChevronLeft className="h-5 w-5" />
                   </Button>
-                  <Button variant="outline" size="icon" onClick={goToNext} aria-label="Next" className="h-9 w-9">
+                  <Button variant="outline" size="icon" onClick={goToNext} aria-label={t('nav.next')} className="h-9 w-9">
                     <ChevronRight className="h-5 w-5" />
                   </Button>
                 </div>
@@ -451,13 +454,13 @@ export function CalendarView() {
               />
             </div>
             {!isMobile && (
-              <Button variant="outline" size="sm" onClick={() => setShowManageCalendars(true)} className="h-9" title="Manage calendars">
-                <CalendarCog className="h-4 w-4 mr-1" />Manage
+              <Button variant="outline" size="sm" onClick={() => setShowManageCalendars(true)} className="h-9" title={t('toolbar.manageCalendars')}>
+                <CalendarCog className="h-4 w-4 mr-1" />{t('toolbar.manage')}
               </Button>
             )}
             {!isMobile && (
               <Button size="sm" onClick={handleAddWithAuth}>
-                <Plus className="h-4 w-4 mr-1" />Add Event
+                <Plus className="h-4 w-4 mr-1" />{t('toolbar.addEvent')}
               </Button>
             )}
           </>}
@@ -465,14 +468,14 @@ export function CalendarView() {
 
         {!isMobile && calendarGroups.length > 0 && (
           <FilterBar>
-            <span className="text-sm text-muted-foreground shrink-0">Show:</span>
+            <span className="text-sm text-muted-foreground shrink-0">{t('toolbar.show')}</span>
             <Button
               variant={selectedCalendarIds.has('all') ? 'default' : 'outline'}
               size="sm"
               onClick={() => toggleCalendar('all')}
               className="h-7 text-xs"
             >
-              All
+              {t('toolbar.all')}
             </Button>
             {calendarGroups.map((group) => {
               const isSelected = selectedCalendarIds.has(group.id) || selectedCalendarIds.has('all');
@@ -496,10 +499,10 @@ export function CalendarView() {
                 size="sm"
                 onClick={() => setMergedView(!mergedView)}
                 className="gap-1 ml-auto"
-                title={mergedView ? 'Split by calendar' : 'Merge into one column'}
+                title={mergedView ? t('toolbar.splitHint') : t('toolbar.mergeHint')}
               >
                 <Merge className="h-3.5 w-3.5" />
-                {mergedView ? 'Split' : 'Merge'}
+                {mergedView ? t('toolbar.split') : t('toolbar.merge')}
               </Button>
             )}
           </FilterBar>
@@ -513,18 +516,18 @@ export function CalendarView() {
           )}
           {error && (
             <div className="h-full flex items-center justify-center">
-              <p className="text-destructive">Failed to load calendar: {error}</p>
+              <p className="text-destructive">{t('errors.loadFailed', { error })}</p>
             </div>
           )}
           {!loading && !error && hasNoCalendarSources && (
             <EmptyState
               icon={<CalendarCog />}
-              title="No calendar connected yet"
-              description="Connect Google, Apple, Outlook, or any iCal link to see events here."
+              title={t('empty.title')}
+              description={t('empty.description')}
               action={
                 <Button onClick={() => setShowManageCalendars(true)}>
                   <Plus className="h-4 w-4 mr-1" />
-                  Connect a calendar
+                  {t('empty.action')}
                 </Button>
               }
             />
@@ -718,11 +721,11 @@ export function CalendarView() {
                     listId: updated.listId,
                   }),
                 });
-                if (!res.ok) throw new Error('Failed to update task');
+                if (!res.ok) throw new Error(t('errors.updateTaskFailed'));
                 await refreshAllTasks();
                 await refreshBuckets();
               } catch (err) {
-                toast({ title: err instanceof Error ? err.message : 'Failed to update task', variant: 'destructive' });
+                toast({ title: err instanceof Error ? err.message : t('errors.updateTaskFailed'), variant: 'destructive' });
               } finally {
                 setEditingTask(null);
               }
@@ -745,11 +748,11 @@ export function CalendarView() {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(updates),
                   });
-                  if (!res.ok) throw new Error('Failed to update meal');
+                  if (!res.ok) throw new Error(t('errors.updateMealFailed'));
                   await refreshAllMeals();
                   await refreshBuckets();
                 } catch (err) {
-                  toast({ title: err instanceof Error ? err.message : 'Failed to update meal', variant: 'destructive' });
+                  toast({ title: err instanceof Error ? err.message : t('errors.updateMealFailed'), variant: 'destructive' });
                 } finally {
                   setEditingMeal(null);
                 }
@@ -770,20 +773,23 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
   onDeleted: () => void;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const tActions = useTranslations('common.actions');
+  const d = useDateLabels();
   const { confirm, dialogProps } = useConfirmDialog();
 
   const handleDelete = async () => {
-    const ok = await confirm('Delete this event?', 'Are you sure you want to delete this event?');
+    const ok = await confirm(t('event.deleteConfirmTitle'), t('event.deleteConfirmBody'));
     if (!ok) return;
     try {
       const response = await fetch(`/api/events/${event.id}`, { method: 'DELETE' });
       if (!response.ok) {
         const err = await response.json();
-        toast({ title: err.error || 'Failed to delete event', variant: 'destructive' });
+        toast({ title: err.error || t('errors.deleteFailed'), variant: 'destructive' });
         return;
       }
       onDeleted();
-    } catch { toast({ title: 'Failed to delete event', variant: 'destructive' }); }
+    } catch { toast({ title: t('errors.deleteFailed'), variant: 'destructive' }); }
   };
 
   return (
@@ -793,18 +799,21 @@ function EventDetailModal({ event, onClose, onEdit, onDeleted }: {
         <h2 className="text-xl font-bold mb-2">{event.title}</h2>
         <p className="text-sm text-muted-foreground mb-1">
           {event.allDay
-            ? format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')
-            : `${format(toDisplayDate(event.startTime, displayTimezone), 'EEEE, MMMM d')} at ${formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}`}
+            ? d.weekdayLongMonthDay(toDisplayDate(event.startTime, displayTimezone))
+            : t('dateAtTime', {
+                date: d.weekdayLongMonthDay(toDisplayDate(event.startTime, displayTimezone)),
+                time: formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone),
+              })}
         </p>
         {event.location && <p className="text-sm text-muted-foreground mb-4">{event.location}</p>}
         <p className="text-xs text-muted-foreground">{event.calendarName}</p>
         <div className="flex justify-between mt-6">
           <Button variant="destructive" onClick={handleDelete}>
-            Delete
+            {tActions('delete')}
           </Button>
           <div className="flex gap-2">
-            <Button variant="outline" onClick={onClose}>Close</Button>
-            <Button onClick={onEdit}>Edit</Button>
+            <Button variant="outline" onClick={onClose}>{tActions('close')}</Button>
+            <Button onClick={onEdit}>{tActions('edit')}</Button>
           </div>
         </div>
       </div>
@@ -841,6 +850,7 @@ function CalendarDragPreview({
   mealColor: string;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
   const colon = dragId.indexOf(':');
   if (colon === -1) return null;
   const variant = dragId.slice(0, colon) as 'meal' | 'chore' | 'task' | 'event';
@@ -857,7 +867,7 @@ function CalendarDragPreview({
           layout="column"
           stripeColor={ev.color}
           title={ev.title}
-          timeLabel={ev.allDay ? 'All day' : formatDisplayTime(ev.startTime, timeFormat, {}, displayTimezone)}
+          timeLabel={ev.allDay ? t('allDay') : formatDisplayTime(ev.startTime, timeFormat, {}, displayTimezone)}
           subtitle={ev.location || ev.calendarName}
         />
       </div>

--- a/src/app/calendar/ManageCalendarsModal.tsx
+++ b/src/app/calendar/ManageCalendarsModal.tsx
@@ -8,6 +8,7 @@
  * groups, hours, iCal subscriptions).
  */
 
+import { useTranslations } from 'next-intl';
 import {
   Dialog,
   DialogContent,
@@ -24,11 +25,13 @@ export function ManageCalendarsModal({
   /** Called after a manual sync so the calendar page can refetch its events. */
   onSynced?: () => void;
 }) {
+  const t = useTranslations('calendar.toolbar');
+
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent className="w-[calc(100vw-2rem)] max-w-5xl max-h-[85vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
-          <DialogTitle>Manage calendars</DialogTitle>
+          <DialogTitle>{t('manageCalendars')}</DialogTitle>
         </DialogHeader>
         <CalendarsSection onSynced={onSynced} />
       </DialogContent>

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { format, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { AlertTriangle, ArrowRight, Home } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -15,6 +16,7 @@ import {
 import type { PendingDeletion } from '@/lib/hooks/usePendingDeletions';
 import { useTimeFormat } from '@/components/providers';
 import { formatDisplayTime, toDisplayDate } from '@/lib/utils/timeFormat';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 
 /**
  * Deletes-only review (#171 Stage 3). Lists events the sync found removed from
@@ -31,6 +33,9 @@ export function PendingDeletionsModal({
   onClose: () => void;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar.pending');
+  const tActions = useTranslations('common.actions');
+  const d = useDateLabels();
   const [selected, setSelected] = useState<Set<string>>(() => new Set(pending.map((p) => p.id)));
   const [busy, setBusy] = useState(false);
 
@@ -59,19 +64,21 @@ export function PendingDeletionsModal({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
-            Review removals
+            {t('title')}
           </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-3 py-1 flex-1 min-h-0 flex flex-col">
           <p className="text-sm text-muted-foreground">
-            These events were removed from their source calendar and held for review.{' '}
-            <span className="font-medium text-foreground">Delete</span> removes them from Prism too.{' '}
-            <span className="font-medium text-foreground">Keep</span> transfers each one to your{' '}
-            <span className="inline-flex items-center gap-1 font-medium text-foreground">
-              <Home className="h-3 w-3" />local calendar
-            </span>{' '}
-            — it stops syncing and stays put.
+            {t.rich('explain', {
+              b: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
+              local: (chunks) => (
+                <span className="inline-flex items-center gap-1 font-medium text-foreground">
+                  <Home className="h-3 w-3" />
+                  {chunks}
+                </span>
+              ),
+            })}
           </p>
 
           <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground px-1">
@@ -81,7 +88,7 @@ export function PendingDeletionsModal({
                 setSelected(allSelected ? new Set() : new Set(pending.map((p) => p.id)))
               }
             />
-            Select all ({selected.size}/{pending.length})
+            {t('selectAll', { selected: selected.size, total: pending.length })}
           </label>
 
           {/* Native scroll (not Radix ScrollArea) so the list drag-scrolls on
@@ -98,8 +105,8 @@ export function PendingDeletionsModal({
                     <span className="font-medium">{p.title}</span>
                     <span className="block text-xs text-muted-foreground">
                       {p.allDay
-                        ? format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')
-                        : `${format(toDisplayDate(parseISO(p.startTime), displayTimezone), 'EEE, MMM d')} · ${formatDisplayTime(parseISO(p.startTime), timeFormat, {}, displayTimezone)}`}
+                        ? d.weekdayMonthDay(toDisplayDate(parseISO(p.startTime), displayTimezone))
+                        : `${d.weekdayMonthDay(toDisplayDate(parseISO(p.startTime), displayTimezone))} · ${formatDisplayTime(parseISO(p.startTime), timeFormat, {}, displayTimezone)}`}
                     </span>
                     <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground flex-wrap">
                       <span className="inline-flex items-center gap-1 min-w-0">
@@ -111,7 +118,7 @@ export function PendingDeletionsModal({
                       </span>
                       <ArrowRight className="h-3 w-3 opacity-60 shrink-0" />
                       <span className="inline-flex items-center gap-1 shrink-0">
-                        <Home className="h-3 w-3" />Local (if kept)
+                        <Home className="h-3 w-3" />{t('localIfKept')}
                       </span>
                     </span>
                   </span>
@@ -123,14 +130,14 @@ export function PendingDeletionsModal({
 
         <DialogFooter className="gap-2">
           <Button variant="outline" onClick={onClose} disabled={busy}>
-            Cancel
+            {tActions('cancel')}
           </Button>
           <Button variant="outline" onClick={() => act('keep')} disabled={busy || selected.size === 0}>
             <Home className="h-4 w-4 mr-1.5" />
-            Keep {selected.size} in Local
+            {t('keep', { count: selected.size })}
           </Button>
           <Button variant="destructive" onClick={() => act('delete')} disabled={busy || selected.size === 0}>
-            Delete {selected.size}
+            {t('delete', { count: selected.size })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/calendar/ViewMenu.tsx
+++ b/src/app/calendar/ViewMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useTranslations } from 'next-intl';
 import {
   Calendar,
   CalendarDays,
@@ -35,8 +36,8 @@ interface ViewMenuProps {
 }
 
 interface ViewOption {
-  /** Label shown in trigger AND menu. */
-  label: string;
+  /** Key into the `calendar.views` catalogue. Shown in trigger AND menu. */
+  labelKey: string;
   /** Icon shown alongside the label. */
   Icon: typeof Calendar;
   /** Returns true when this option matches the current view state. */
@@ -50,61 +51,61 @@ interface ViewOption {
 
 const OPTIONS: ViewOption[] = [
   {
-    label: 'Agenda',
+    labelKey: 'agenda',
     Icon: ListChecks,
     isActive: (v) => v === 'agenda',
     apply: (setView) => setView('agenda'),
   },
   {
-    label: 'Day',
+    labelKey: 'day',
     Icon: CalendarDays,
     isActive: (v) => v === 'day',
     apply: (setView) => setView('day'),
   },
   {
-    label: 'List',
+    labelKey: 'list',
     Icon: List,
     isActive: (v) => v === 'weekVertical',
     apply: (setView) => setView('weekVertical'),
   },
   {
-    label: 'Schedule',
+    labelKey: 'schedule',
     Icon: Clock,
     isActive: (v) => v === 'week',
     apply: (setView) => setView('week'),
   },
   {
-    label: '1 Week',
+    labelKey: 'week1',
     Icon: CalendarRange,
     isActive: (v, wc) => v === 'multiWeek' && wc === 1,
     apply: (setView, setWeekCount) => { setView('multiWeek'); setWeekCount(1); },
   },
   {
-    label: '2 Weeks',
+    labelKey: 'week2',
     Icon: CalendarRange,
     isActive: (v, wc) => v === 'multiWeek' && wc === 2,
     apply: (setView, setWeekCount) => { setView('multiWeek'); setWeekCount(2); },
   },
   {
-    label: '3 Weeks',
+    labelKey: 'week3',
     Icon: CalendarRange,
     isActive: (v, wc) => v === 'multiWeek' && wc === 3,
     apply: (setView, setWeekCount) => { setView('multiWeek'); setWeekCount(3); },
   },
   {
-    label: '4 Weeks',
+    labelKey: 'week4',
     Icon: CalendarRange,
     isActive: (v, wc) => v === 'multiWeek' && wc === 4,
     apply: (setView, setWeekCount) => { setView('multiWeek'); setWeekCount(4); },
   },
   {
-    label: 'Month',
+    labelKey: 'month',
     Icon: LayoutGrid,
     isActive: (v) => v === 'month',
     apply: (setView) => setView('month'),
   },
   {
-    label: '3 Months',
+    labelKey: 'threeMonth',
     Icon: Grid3X3,
     isActive: (v) => v === 'threeMonth',
     apply: (setView) => setView('threeMonth'),
@@ -112,6 +113,7 @@ const OPTIONS: ViewOption[] = [
 ];
 
 export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange }: ViewMenuProps) {
+  const t = useTranslations('calendar');
   const [open, setOpen] = React.useState(false);
   const activeIndex = Math.max(
     0,
@@ -138,7 +140,7 @@ export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange 
         <PopoverTrigger asChild>
           <Button variant="outline" size="sm" className="gap-1.5 w-32 h-full justify-center">
             <ActiveIcon className="h-4 w-4 shrink-0" />
-            <span className="truncate">{active.label}</span>
+            <span className="truncate">{t(`views.${active.labelKey}`)}</span>
             <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
           </Button>
         </PopoverTrigger>
@@ -148,7 +150,7 @@ export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange 
             const isActive = opt.isActive(viewType, weekCount);
             return (
               <button
-                key={opt.label}
+                key={opt.labelKey}
                 type="button"
                 onClick={() => {
                   opt.apply(onViewChange, onWeekCountChange);
@@ -161,7 +163,7 @@ export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange 
                 )}
               >
                 <Icon className="h-4 w-4 shrink-0" />
-                <span className="flex-1 text-left">{opt.label}</span>
+                <span className="flex-1 text-left">{t(`views.${opt.labelKey}`)}</span>
               </button>
             );
           })}
@@ -170,8 +172,8 @@ export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange 
       <div className="grid grid-rows-2 gap-0.5 w-7 h-full">
         <button
           type="button"
-          aria-label="Previous view"
-          title="Previous view"
+          aria-label={t('nav.previousView')}
+          title={t('nav.previousView')}
           onClick={() => cycle(-1)}
           className="rounded border border-input hover:bg-accent inline-flex items-center justify-center text-foreground/80 hover:text-foreground transition-colors min-h-0"
         >
@@ -179,8 +181,8 @@ export function ViewMenu({ viewType, weekCount, onViewChange, onWeekCountChange 
         </button>
         <button
           type="button"
-          aria-label="Next view"
-          title="Next view"
+          aria-label={t('nav.nextView')}
+          title={t('nav.nextView')}
           onClick={() => cycle(1)}
           className="rounded border border-input hover:bg-accent inline-flex items-center justify-center text-foreground/80 hover:text-foreground transition-colors min-h-0"
         >

--- a/src/app/calendar/ViewOptionsMenu.tsx
+++ b/src/app/calendar/ViewOptionsMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useTranslations } from 'next-intl';
 import {
   Settings2,
   Calendar,
@@ -50,11 +51,13 @@ interface ViewOptionsMenuProps {
   triggerClassName?: string;
 }
 
-const OVERLAY_ROWS: Array<{ key: keyof OverlayFlags; label: string; Icon: typeof Calendar }> = [
-  { key: 'events', label: 'Events', Icon: Calendar },
-  { key: 'meals', label: 'Meals', Icon: UtensilsCrossed },
-  { key: 'chores', label: 'Chores', Icon: ListChecks },
-  { key: 'tasks', label: 'Tasks', Icon: CheckSquare },
+// Labels come from `calendar.options` at render. The key doubles as the
+// catalogue key, so the two lists can't drift apart.
+const OVERLAY_ROWS: Array<{ key: keyof OverlayFlags; Icon: typeof Calendar }> = [
+  { key: 'events', Icon: Calendar },
+  { key: 'meals', Icon: UtensilsCrossed },
+  { key: 'chores', Icon: ListChecks },
+  { key: 'tasks', Icon: CheckSquare },
 ];
 
 interface CheckRowProps {
@@ -119,6 +122,7 @@ export function ViewOptionsMenu({
   onReset,
   triggerClassName,
 }: ViewOptionsMenuProps) {
+  const t = useTranslations('calendar.options');
   // Count toggles that are non-default so we can show a badge on the trigger.
   // 'inline' is the first-load default in both useCalendarViewData and
   // useCalendarWidgetPrefs — keep this in sync with those initializers and
@@ -144,12 +148,12 @@ export function ViewOptionsMenu({
         <Button
           variant="outline"
           size="sm"
-          aria-label="View options"
-          title="View options"
+          aria-label={t('label')}
+          title={t('label')}
           className={cn('gap-1.5 h-9', triggerClassName)}
         >
           <Settings2 className="h-4 w-4" />
-          <span className="hidden sm:inline">View</span>
+          <span className="hidden sm:inline">{t('trigger')}</span>
           {nonDefaultCount > 0 && (
             // Count circle is the ONLY visual indicator that filters are
             // active — the button's outer fill stays the same regardless,
@@ -165,7 +169,7 @@ export function ViewOptionsMenu({
         <div className="space-y-3">
           <section>
             <p className="mb-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Display
+              {t('display')}
             </p>
             <div className="space-y-0.5">
               {displayApplicable && (
@@ -187,7 +191,7 @@ export function ViewOptionsMenu({
                     >
                       {displayMode === 'cards' && <span className="h-2 w-2 rounded-full bg-primary" />}
                     </span>
-                    <span className="flex-1 text-left">Cards</span>
+                    <span className="flex-1 text-left">{t('cards')}</span>
                   </button>
                   <button
                     type="button"
@@ -206,34 +210,34 @@ export function ViewOptionsMenu({
                     >
                       {displayMode === 'inline' && <span className="h-2 w-2 rounded-full bg-primary" />}
                     </span>
-                    <span className="flex-1 text-left">Inline blocks</span>
+                    <span className="flex-1 text-left">{t('inlineBlocks')}</span>
                   </button>
                 </>
               )}
               <CheckRow
                 checked={weeksBordered}
                 onChange={onWeeksBorderedChange}
-                label="Grid lines"
+                label={t('gridLines')}
               />
               {weekendsApplicable && (
                 <CheckRow
                   checked={hideWeekends}
                   onChange={onHideWeekendsChange}
-                  label="Hide weekends"
+                  label={t('hideWeekends')}
                 />
               )}
               {notesApplicable && (
                 <CheckRow
                   checked={showNotes}
                   onChange={onShowNotesChange}
-                  label="Notes column"
+                  label={t('notesColumn')}
                 />
               )}
               {mergeApplicable && onMergedViewChange && (
                 <CheckRow
                   checked={mergedView}
                   onChange={onMergedViewChange}
-                  label="Merge calendars"
+                  label={t('mergeCalendars')}
                 />
               )}
             </div>
@@ -241,15 +245,15 @@ export function ViewOptionsMenu({
 
           <section>
             <p className="mb-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Show on calendar
+              {t('showOnCalendar')}
             </p>
             <div className="space-y-0.5">
-              {OVERLAY_ROWS.map(({ key, label, Icon }) => (
+              {OVERLAY_ROWS.map(({ key, Icon }) => (
                 <CheckRow
                   key={key}
                   checked={overlays[key]}
                   onChange={() => toggleOverlay(key)}
-                  label={label}
+                  label={t(key)}
                   Icon={Icon}
                   disabled={!showOverlayRows && key !== 'events'}
                 />
@@ -257,7 +261,7 @@ export function ViewOptionsMenu({
             </div>
             {!showOverlayRows && (
               <p className="mt-2 px-2 text-[10px] leading-snug text-muted-foreground">
-                Switch to Cards mode to show meals, chores, and tasks alongside events.
+                {t('cardsHint')}
               </p>
             )}
           </section>
@@ -270,7 +274,7 @@ export function ViewOptionsMenu({
                 onClick={onReset}
                 className="flex w-full items-center justify-center rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
               >
-                Reset to defaults
+                {t('reset')}
               </button>
             </>
           )}

--- a/src/app/calendar/error.tsx
+++ b/src/app/calendar/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 
 export default function CalendarError({
   error,
@@ -10,6 +11,8 @@ export default function CalendarError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const t = useTranslations('calendar.errors');
+
   useEffect(() => {
     console.error('Calendar error:', error);
   }, [error]);
@@ -17,24 +20,24 @@ export default function CalendarError({
   return (
     <div className="flex items-center justify-center min-h-screen bg-background text-foreground p-8">
       <div className="max-w-md text-center space-y-4">
-        <h1 className="text-2xl font-bold">Calendar Error</h1>
+        <h1 className="text-2xl font-bold">{t('pageTitle')}</h1>
         <p className="text-muted-foreground">
           {process.env.NODE_ENV === 'development'
             ? error.message
-            : 'Failed to load the calendar. Please try again.'}
+            : t('pageBody')}
         </p>
         <div className="flex gap-2 justify-center">
           <button
             onClick={reset}
             className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:opacity-90"
           >
-            Try again
+            {t('tryAgain')}
           </button>
           <Link
             href="/"
             className="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:opacity-90"
           >
-            Back to Dashboard
+            {t('backToDashboard')}
           </Link>
         </div>
       </div>

--- a/src/app/calendar/useCalendarViewData.ts
+++ b/src/app/calendar/useCalendarViewData.ts
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useMemo, useCallback, useTransition } from 'react';
 import {
-  format,
   startOfWeek,
   endOfWeek,
   addDays,
@@ -12,7 +11,9 @@ import {
   subWeeks,
   subDays,
 } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { useCalendarEvents, useCalendarFilter } from '@/lib/hooks';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { deduplicateEvents } from '@/lib/utils/calendarDedup';
 import { getFullCalendarRange, MAX_CALENDAR_EVENTS } from '@/lib/utils/calendarRange';
@@ -26,6 +27,8 @@ export type MultiWeekCount = 1 | 2 | 3 | 4;
 export type { CalendarGroup } from '@/lib/hooks';
 
 export function useCalendarViewData() {
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const { weekStartsOn } = useWeekStartsOn();
   const { displayTimezone } = useTimeFormat();
   // View/date changes trigger a heavy re-bucket + grid re-render. Running those
@@ -186,28 +189,30 @@ export function useCalendarViewData() {
     }));
   }, [viewType, weekCount]);
 
+  // The header reads in the interface language: Intl picks the field order as
+  // well as the names, so German gets "4. September 2026", not "September 4".
   const getDateRangeTitle = useCallback((): string => {
     switch (viewType) {
       case 'agenda':
-        return 'Upcoming Events';
+        return t('upcoming');
       case 'day':
-        return format(currentDate, 'EEEE, MMMM d, yyyy');
+        return d.fullDate(currentDate);
       case 'week':
-      case 'weekVertical': {
-        const ws = startOfWeek(currentDate, { weekStartsOn });
-        const we = endOfWeek(currentDate, { weekStartsOn });
-        return `${format(ws, 'MMM d')} - ${format(we, 'MMM d, yyyy')}`;
-      }
-      case 'multiWeek': {
-        const tws = startOfWeek(currentDate, { weekStartsOn });
-        const twe = endOfWeek(addWeeks(currentDate, weekCount - 1), { weekStartsOn });
-        return `${format(tws, 'MMM d')} - ${format(twe, 'MMM d, yyyy')}`;
-      }
+      case 'weekVertical':
+        return d.range(
+          startOfWeek(currentDate, { weekStartsOn }),
+          endOfWeek(currentDate, { weekStartsOn }),
+        );
+      case 'multiWeek':
+        return d.range(
+          startOfWeek(currentDate, { weekStartsOn }),
+          endOfWeek(addWeeks(currentDate, weekCount - 1), { weekStartsOn }),
+        );
       case 'month':
       case 'threeMonth':
-        return format(currentDate, 'MMMM yyyy');
+        return d.monthYear(currentDate);
     }
-  }, [viewType, weekCount, currentDate, weekStartsOn]);
+  }, [viewType, weekCount, currentDate, weekStartsOn, t, d]);
 
   return {
     currentDate, setCurrentDate,

--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -6,6 +6,7 @@ import {
   addDays,
   startOfDay,
 } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { Calendar, UtensilsCrossed } from 'lucide-react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
@@ -23,6 +24,7 @@ import {
   type TimeFormat,
 } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useDateLabels, type DateLabels } from '@/lib/hooks/useDateLabels';
 
 const MEAL_FALLBACK_COLOR = '#10b981';
 const CHORE_FALLBACK_COLOR = '#f59e0b';
@@ -70,7 +72,7 @@ export function AgendaView({
   days = 14,
   maxEventsPerDay = 0,
   onEventClick,
-  emptyMessage = 'No upcoming events',
+  emptyMessage,
   displayMode = 'inline',
   bucketsByDate,
   enableDnd = false,
@@ -78,6 +80,7 @@ export function AgendaView({
   onItemClick,
 }: AgendaViewProps) {
   const { displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
   const cards = displayMode === 'cards';
   const startDate = startOfDay(toDisplayDate(new Date(), displayTimezone));
 
@@ -123,7 +126,7 @@ export function AgendaView({
     return (
       <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-2">
         <Calendar className="h-8 w-8" />
-        <span className="text-sm">{emptyMessage}</span>
+        <span className="text-sm">{emptyMessage ?? t('noUpcomingEvents')}</span>
       </div>
     );
   }
@@ -172,8 +175,10 @@ function AgendaDaySection({
   onItemClick?: (ref: OverlayItemRef) => void;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const droppable = useDayDroppable({ date, enabled: cards && enableDnd });
-  const rows = buildAgendaRows({ date, events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone });
+  const rows = buildAgendaRows({ date, events, bucket, onEventClick, mealColor, onItemClick, timeFormat, displayTimezone, t });
   const displayRows = maxEvents > 0 ? rows.slice(0, maxEvents) : rows;
   const remainingCount = maxEvents > 0 ? rows.length - maxEvents : 0;
 
@@ -193,11 +198,11 @@ function AgendaDaySection({
             isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && 'text-seasonal-accent'
           )}
         >
-          {formatAgendaDayHeader(date, displayTimezone)}
+          {formatAgendaDayHeader(date, displayTimezone, t, d)}
         </span>
         {isSameDay(date, toDisplayDate(new Date(), displayTimezone)) && (
           <Badge className="text-[10px] px-1.5 py-0 bg-seasonal-highlight text-foreground">
-            Today
+            {t('today')}
           </Badge>
         )}
       </div>
@@ -208,7 +213,7 @@ function AgendaDaySection({
         ))}
         {remainingCount > 0 && (
           <div className="text-xs text-muted-foreground pl-2">
-            +{remainingCount} more events
+            {t('moreItems', { count: remainingCount })}
           </div>
         )}
       </div>
@@ -225,6 +230,7 @@ function buildAgendaRows({
   onItemClick,
   timeFormat,
   displayTimezone,
+  t,
 }: {
   date: Date;
   events: CalendarEvent[];
@@ -234,6 +240,7 @@ function buildAgendaRows({
   onItemClick?: (ref: OverlayItemRef) => void;
   timeFormat: TimeFormat;
   displayTimezone: string;
+  t: (key: string, values?: Record<string, string | number | Date>) => string;
 }): AgendaRow[] {
   const rows: AgendaRow[] = [];
 
@@ -255,10 +262,10 @@ function buildAgendaRows({
       floating,
       stripeColor: event.color,
       timeLabel: allDay
-        ? 'All day'
+        ? t('allDay')
         : startsToday
           ? formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)
-          : 'Continues',
+          : t('continues'),
       title: event.title,
       subtitle: event.location,
       onClick: onEventClick ? () => onEventClick(event) : undefined,
@@ -267,31 +274,31 @@ function buildAgendaRows({
 
   if (bucket) {
     for (const meal of bucket.meals) {
-      const t = getMealTime(meal);
-      const min = parseTimeOfDay(t);
+      const mealTime = getMealTime(meal);
+      const min = parseTimeOfDay(mealTime);
       rows.push({
         key: `meal-${meal.id}`,
         sortMinutes: min ?? -1,
         floating: min === null,
         dragId: `meal:${meal.id}`,
         stripeColor: mealColor ?? meal.cookedBy?.color ?? meal.createdBy?.color ?? MEAL_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t, timeFormat) : meal.mealType,
+        timeLabel: min !== null ? formatTimeLabel(mealTime, timeFormat) : meal.mealType,
         title: meal.name,
-        subtitle: meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined,
+        subtitle: meal.cookedBy?.name ? t('cookedBy', { name: meal.cookedBy.name }) : undefined,
         muted: Boolean(meal.cookedAt),
         onClick: onItemClick ? () => onItemClick({ kind: 'meal', id: meal.id }) : undefined,
       });
     }
     for (const chore of bucket.chores) {
-      const t = getChoreTime(chore);
-      const min = parseTimeOfDay(t);
+      const choreTime = getChoreTime(chore);
+      const min = parseTimeOfDay(choreTime);
       rows.push({
         key: `chore-${chore.id}`,
         sortMinutes: min ?? -1,
         floating: min === null,
         dragId: `chore:${chore.id}`,
         stripeColor: chore.assignedTo?.color || CHORE_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Chore',
+        timeLabel: min !== null ? formatTimeLabel(choreTime!, timeFormat) : t('chore'),
         title: chore.title,
         subtitle: chore.assignedTo?.name,
         pendingApproval: Boolean(chore.pendingApproval),
@@ -299,15 +306,15 @@ function buildAgendaRows({
       });
     }
     for (const task of bucket.tasks) {
-      const t = getTaskTime(task);
-      const min = parseTimeOfDay(t);
+      const taskTime = getTaskTime(task);
+      const min = parseTimeOfDay(taskTime);
       rows.push({
         key: `task-${task.id}`,
         sortMinutes: min ?? -1,
         floating: min === null,
         dragId: `task:${task.id}`,
         stripeColor: task.assignedTo?.color || TASK_FALLBACK_COLOR,
-        timeLabel: min !== null ? formatTimeLabel(t!, timeFormat) : 'Task',
+        timeLabel: min !== null ? formatTimeLabel(taskTime!, timeFormat) : t('task'),
         title: task.title,
         subtitle: task.assignedTo?.name,
         muted: task.completed,
@@ -393,10 +400,15 @@ function AgendaRowItem({ row, cards = false }: { row: AgendaRow; cards?: boolean
   );
 }
 
-function formatAgendaDayHeader(date: Date, displayTimezone: string): string {
+function formatAgendaDayHeader(
+  date: Date,
+  displayTimezone: string,
+  t: (key: string, values?: Record<string, string | number | Date>) => string,
+  d: DateLabels,
+): string {
   const displayNow = toDisplayDate(new Date(), displayTimezone);
-  const dayName = format(date, 'EEEE, MMMM d, yyyy');
-  if (isSameDay(date, displayNow)) return `Today - ${dayName}`;
-  if (isSameDay(date, addDays(displayNow, 1))) return `Tomorrow - ${dayName}`;
+  const dayName = d.fullDate(date);
+  if (isSameDay(date, displayNow)) return t('dayHeader', { label: t('today'), date: dayName });
+  if (isSameDay(date, addDays(displayNow, 1))) return t('dayHeader', { label: t('tomorrow'), date: dayName });
   return dayName;
 }

--- a/src/components/calendar/CalendarFilterPopover.tsx
+++ b/src/components/calendar/CalendarFilterPopover.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useState, useRef, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Filter } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { contrastText } from '@/lib/utils/color';
@@ -18,6 +19,7 @@ export function CalendarFilterPopover({
   selectedCalendarIds,
   onToggle,
 }: CalendarFilterPopoverProps) {
+  const t = useTranslations('calendar.toolbar');
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -45,7 +47,7 @@ export function CalendarFilterPopover({
           'p-1 rounded hover:bg-accent transition-colors',
           open && 'bg-accent'
         )}
-        aria-label="Filter calendars"
+        aria-label={t('filterCalendars')}
       >
         <Filter className="h-3.5 w-3.5" />
       </button>
@@ -62,7 +64,7 @@ export function CalendarFilterPopover({
                 : 'hover:bg-accent text-muted-foreground'
             )}
           >
-            All Calendars
+            {t('allCalendars')}
           </button>
 
           <div className="border-t border-border my-1" />

--- a/src/components/calendar/CalendarNotesColumn.tsx
+++ b/src/components/calendar/CalendarNotesColumn.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { format } from 'date-fns';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { NoteEditor } from './NoteEditor';
 import type { CalendarNote } from '@/lib/hooks/useCalendarNotes';
 
@@ -17,6 +18,8 @@ export function CalendarNotesColumn({
   onNoteChange,
   hideDateHeaders,
 }: CalendarNotesColumnProps) {
+  const d = useDateLabels();
+
   return (
     <div className="h-full overflow-auto">
       {days.map((day) => {
@@ -27,7 +30,7 @@ export function CalendarNotesColumn({
             {!hideDateHeaders && (
               <div className="px-3 pt-2 pb-1">
                 <span className="text-xs font-medium text-muted-foreground">
-                  {format(day, 'EEE, MMM d')}
+                  {d.weekdayMonthDay(day)}
                 </span>
               </div>
             )}

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -9,6 +9,7 @@ import {
 } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { NoteEditor } from './NoteEditor';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useHiddenHours } from '@/lib/hooks/useHiddenHours';
@@ -69,6 +70,7 @@ export function DayViewSideBySide({
   onItemClick,
 }: DayViewSideBySideProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
   const cards = displayMode === 'cards';
   const droppable = useDayDroppable({ date: currentDate, enabled: cards && enableDnd });
   const bgOverride = useWidgetBgOverride();
@@ -185,7 +187,7 @@ export function DayViewSideBySide({
                     ? 'bg-blue-500 text-white'
                     : 'hover:bg-accent text-muted-foreground'
                 )}
-                title={hiddenSettings.enabled ? 'Show all hours' : 'Hide time block'}
+                title={hiddenSettings.enabled ? t('showAllHours') : t('hideTimeBlock')}
               >
                 <Clock className="h-4 w-4" />
               </button>
@@ -270,7 +272,7 @@ export function DayViewSideBySide({
                   className="text-sm font-medium text-center py-1 mb-1 rounded text-white"
                   style={{ backgroundColor: '#6366f1' }}
                 >
-                  Notes
+                  {t('notes')}
                 </div>
               </div>
             )}

--- a/src/components/calendar/DayViewSideBySide.tsx
+++ b/src/components/calendar/DayViewSideBySide.tsx
@@ -143,7 +143,7 @@ export function DayViewSideBySide({
 
   // For single-column mode or when no groups are selected, create a synthetic group
   const displayGroups = showAllInOne || filteredGroups.length === 0
-    ? [{ id: 'all', name: 'All Events', color: '#3B82F6' }]
+    ? [{ id: 'all', name: t('allEvents'), color: '#3B82F6' }]
     : filteredGroups;
 
   const getEventsForGroup = (gid: string) => {

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -19,6 +19,7 @@ import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { hexToRgba } from '@/lib/utils/color';
 import { useWeekStartsOn } from '@/lib/hooks/useWeekStartsOn';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import type { CalendarEvent } from '@/types/calendar';
 import { seasonalPalettes } from '@/lib/themes/seasonalThemes';
 import { CardHeightProbe, DayOverflowPopover, DroppableOverlayCell, InlineCalendarEvent, SpanningEventRows, useDayDroppable, type OverlayItemRef } from './cells';
@@ -65,6 +66,7 @@ export function MonthView({
   showMonthHeader = true,
 }: MonthViewProps) {
   const { displayTimezone } = useTimeFormat();
+  const d = useDateLabels();
   const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
@@ -88,7 +90,9 @@ export function MonthView({
   }
 
   const numWeeks = Math.ceil(days.length / 7);
-  const dayNames = [...DAYS_SHORT_ARRAY.slice(weekStartsOn), ...DAYS_SHORT_ARRAY.slice(0, weekStartsOn)];
+  // Sunday-first indices rotated to the configured week start; the names
+  // themselves come from the interface language, not DAYS_SHORT_ARRAY.
+  const dayIndices = Array.from({ length: 7 }, (_, i) => (i + weekStartsOn) % DAYS_SHORT_ARRAY.length);
   // Scope the wide event list to this month grid's visible range once, so the
   // spanning + per-day filters iterate ~40 events instead of thousands.
   const scopedEvents = eventsOverlappingRange(events, calendarStart, calendarEnd);
@@ -110,16 +114,16 @@ export function MonthView({
           className="shrink-0 text-center py-1 font-semibold text-sm text-white rounded-t-md shadow-sm"
           style={{ backgroundColor: monthColor }}
         >
-          {format(currentDate, 'MMMM yyyy')}
+          {d.monthYear(currentDate)}
         </div>
       )}
       <div className="shrink-0 grid grid-cols-7 border-b border-border/70">
-        {dayNames.map((name) => (
+        {dayIndices.map((index) => (
           <div
-            key={name}
+            key={index}
             className="text-center text-xs font-medium text-muted-foreground py-1.5"
           >
-            {name}
+            {d.weekdayByIndex(index)}
           </div>
         ))}
       </div>

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -27,6 +27,8 @@ import type { DayBucket } from '@/lib/hooks/useWeekViewData';
 import { useTimeFormat } from '@/components/providers';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, formatDisplayTime, isCalendarEventPast, toDisplayDate } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
+import { useTranslations } from 'next-intl';
 
 export interface MultiWeekViewProps {
   currentDate: Date;
@@ -199,6 +201,8 @@ function DayCell({
   showAll?: boolean;
 }) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const cards = displayMode === 'cards';
   const fallback = compact ? FALLBACK_VISIBLE_CARDS_COMPACT : FALLBACK_VISIBLE_CARDS;
   const spanningEventSet = new Set(spanningEvents);
@@ -261,12 +265,12 @@ function DayCell({
   const today = isSameDay(date, displayNow);
   const tomorrow = isSameDay(date, addDays(displayNow, 1));
   const dayLabel = today
-    ? 'Today'
+    ? t('today')
     : tomorrow
-      ? 'Tomorrow'
+      ? t('tomorrow')
       : compact
-        ? format(date, 'EEE')
-        : format(date, 'EEEE');
+        ? d.weekdayShort(date)
+        : d.weekdayLong(date);
   const dayWeather = bucket?.weather;
   const cardSize = compact ? 'sm' : 'md';
   const monthAccent = getMonthAccentColor(date);
@@ -370,7 +374,7 @@ function DayCell({
                   layout="column"
                   stripeColor={event.color}
                   title={event.title}
-                  timeLabel={event.allDay ? 'All day' : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
+                  timeLabel={event.allDay ? t('allDay') : formatDisplayTime(event.startTime, timeFormat, {}, displayTimezone)}
                   subtitle={event.location || event.calendarName}
                   onClick={() => onEventClick(event)}
                   dragId={draggable ? `event:${event.id}` : undefined}

--- a/src/components/calendar/NoteEditor.tsx
+++ b/src/components/calendar/NoteEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useCallback, useEffect } from 'react';
 import DOMPurify from 'dompurify';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
 export interface NoteEditorProps {
@@ -22,8 +23,9 @@ export function NoteEditor({
   content,
   onNoteChange,
   className,
-  placeholder = 'Add notes...',
+  placeholder,
 }: NoteEditorProps) {
+  const t = useTranslations('calendar');
   const editable = !!onNoteChange;
   const editorRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -108,7 +110,7 @@ export function NoteEditor({
         editable && 'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/40 empty:before:pointer-events-none',
         className,
       )}
-      data-placeholder={editable ? placeholder : undefined}
+      data-placeholder={editable ? (placeholder ?? t('notesPlaceholder')) : undefined}
     />
   );
 }

--- a/src/components/calendar/ThreeMonthView.tsx
+++ b/src/components/calendar/ThreeMonthView.tsx
@@ -24,6 +24,7 @@ import { useTimeFormat } from '@/components/providers';
 import { InlineCalendarEvent, SpanningEventRows } from './cells';
 import { eventOccursOnDisplayDay, eventSpansMultipleDisplayDays, toDisplayDate } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 
 // Get the accent color for a month (1-12)
 function getMonthColor(month: Date): string {
@@ -58,9 +59,12 @@ function MiniMonth({
   bordered?: boolean;
 }) {
   const { displayTimezone } = useTimeFormat();
+  const d = useDateLabels();
   const displayNow = toDisplayDate(new Date(), displayTimezone);
   const { weekStartsOn } = useWeekStartsOn();
-  const dayNames = [...ALL_DAY_NAMES.slice(weekStartsOn), ...ALL_DAY_NAMES.slice(0, weekStartsOn)];
+  // Sunday-first indices rotated to the configured week start; the initials
+  // themselves come from the interface language.
+  const dayIndices = Array.from({ length: ALL_DAY_NAMES.length }, (_, i) => (i + weekStartsOn) % ALL_DAY_NAMES.length);
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
   const monthStart = startOfMonth(month);
@@ -105,14 +109,14 @@ function MiniMonth({
         className="text-center py-1 font-semibold text-sm flex-shrink-0 text-white shadow-sm"
         style={{ backgroundColor: monthColor }}
       >
-        {format(month, 'MMMM yyyy')}
+        {d.monthYear(month)}
       </div>
 
       {/* Day name headers */}
       <div className="grid grid-cols-7 gap-px px-1 flex-shrink-0">
-        {dayNames.map((name, i) => (
-          <div key={i} className="text-center text-[10px] font-medium text-muted-foreground py-1">
-            {name}
+        {dayIndices.map((index) => (
+          <div key={index} className="text-center text-[10px] font-medium text-muted-foreground py-1">
+            {d.weekdayByIndex(index, 'weekdayNarrow')}
           </div>
         ))}
       </div>

--- a/src/components/calendar/TwoWeekView.tsx
+++ b/src/components/calendar/TwoWeekView.tsx
@@ -11,6 +11,7 @@ import {
 } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { DAYS_SHORT_ARRAY } from '@/lib/constants/days';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { useWidgetBgOverride } from '@/components/widgets/WidgetContainer';
 import { useOrientation } from '@/lib/hooks/useOrientation';
 import type { CalendarEvent } from '@/types/calendar';
@@ -35,6 +36,7 @@ export function TwoWeekView({
   onEventClick,
 }: TwoWeekViewProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const d = useDateLabels();
   const displayNow = toDisplayDate(new Date(), displayTimezone);
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
@@ -47,7 +49,7 @@ export function TwoWeekView({
     days.push(addDays(weekStart, i));
   }
 
-  const dayNames = DAYS_SHORT_ARRAY;
+  const dayIndices = DAYS_SHORT_ARRAY.map((_, index) => index);
   const week1 = days.slice(0, 7);
   const week2 = days.slice(7, 14);
   const week1Num = getWeek(week1[0]!);
@@ -95,7 +97,7 @@ export function TwoWeekView({
             today && 'text-primary'
           )}>
             <span className="font-bold">{format(date, 'd')}</span>
-            <span className="text-xs text-muted-foreground">{format(date, 'MMM')}</span>
+            <span className="text-xs text-muted-foreground">{d.monthShort(date)}</span>
           </div>
         </div>
 
@@ -151,12 +153,12 @@ export function TwoWeekView({
           className="flex-1 shrink-0 grid gap-1"
           style={{ gridTemplateRows: 'repeat(7, minmax(50px, 1fr))' }}
         >
-          {dayNames.map((dayName, dayIndex) => (
+          {dayIndices.map((dayIndex) => (
             <div key={dayIndex} className="flex gap-1 min-h-0 h-full">
               {/* Day label */}
               <div className="w-10 shrink-0 flex items-center justify-center">
                 <span className="text-xs font-bold text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded">
-                  {dayName}
+                  {d.weekdayByIndex(dayIndex)}
                 </span>
               </div>
               {/* Week 1 day */}
@@ -179,9 +181,9 @@ export function TwoWeekView({
     <div className="h-full flex flex-col overflow-auto">
       {/* Day headers */}
       <div className="grid grid-cols-7 gap-1 mb-1 shrink-0">
-        {dayNames.map((name) => (
-          <div key={name} className="text-center text-sm font-medium text-muted-foreground py-2">
-            {name}
+        {dayIndices.map((index) => (
+          <div key={index} className="text-center text-sm font-medium text-muted-foreground py-2">
+            {d.weekdayByIndex(index)}
           </div>
         ))}
       </div>

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -26,6 +26,7 @@ import {
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 
 export interface WeekVerticalViewProps {
   currentDate: Date;
@@ -183,6 +184,7 @@ function WeekListDayRow({
   onItemClick: ((ref: OverlayItemRef) => void) | undefined;
 }) {
   const { displayTimezone } = useTimeFormat();
+  const d = useDateLabels();
   const cards = displayMode === 'cards';
   const dayStart = startOfDay(day);
   const isCurrentDay = isSameDay(day, today);
@@ -230,7 +232,7 @@ function WeekListDayRow({
           'text-xs font-medium uppercase tracking-wide',
           isCurrentDay ? 'text-primary-foreground' : 'text-muted-foreground'
         )}>
-          {format(day, 'EEE')}
+          {d.weekdayShort(day)}
         </span>
         <span className={cn(
           'text-2xl font-bold leading-tight',
@@ -242,7 +244,7 @@ function WeekListDayRow({
           'text-[10px]',
           isCurrentDay ? 'text-primary-foreground/80' : 'text-muted-foreground'
         )}>
-          {format(day, 'MMM')}
+          {d.monthShort(day)}
         </span>
       </div>
 

--- a/src/components/calendar/WeekVerticalView.tsx
+++ b/src/components/calendar/WeekVerticalView.tsx
@@ -26,6 +26,7 @@ import {
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useTranslations } from 'next-intl';
 import { useDateLabels } from '@/lib/hooks/useDateLabels';
 
 export interface WeekVerticalViewProps {
@@ -73,6 +74,7 @@ export function WeekVerticalView({
   const cellBg = bgOverride?.cellBackgroundColor;
   const cellBgOpacity = bgOverride?.cellBackgroundOpacity ?? 1;
   const cellBgStyle = cellBg ? { backgroundColor: hexToRgba(cellBg, cellBgOpacity) } : undefined;
+  const t = useTranslations('calendar');
   const weekStart = startOfWeek(currentDate, { weekStartsOn });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   // Scope the wide event list to this week once; passed into each day row.
@@ -86,7 +88,7 @@ export function WeekVerticalView({
     ? calendarGroups.filter((g) => selectedCalendarIds.has(g.id))
     : calendarGroups;
   const displayGroups = showAllInOne || filteredGroups.length === 0
-    ? [{ id: 'all', name: 'All Events', color: '#3B82F6' }]
+    ? [{ id: 'all', name: t('allEvents'), color: '#3B82F6' }]
     : filteredGroups;
 
   const getEventsForGroup = (dayEvents: CalendarEvent[], gid: string) => {

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -31,6 +31,8 @@ import {
   toDisplayDate,
 } from '@/lib/utils/timeFormat';
 import { eventsOverlappingRange } from '@/lib/utils/calendarRange';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
+import { useTranslations } from 'next-intl';
 
 export type CalendarDisplayMode = 'inline' | 'cards';
 
@@ -61,6 +63,8 @@ export function WeekView({
   onItemClick,
 }: WeekViewProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const displayNow = toDisplayDate(new Date(), displayTimezone);
   const cards = displayMode === 'cards';
   const { weekStartsOn } = useWeekStartsOn();
@@ -169,7 +173,7 @@ export function WeekView({
           )}
         >
           <div className={cn('font-bold uppercase tracking-wide', compact ? 'text-xs' : 'text-sm')}>
-            {format(date, 'EEE')}
+            {d.weekdayShort(date)}
           </div>
           <div className={cn('font-bold', compact ? 'text-lg' : 'text-xl')}>
             {format(date, 'd')}
@@ -286,8 +290,8 @@ export function WeekView({
                     ? 'bg-blue-500 text-white'
                     : 'hover:bg-accent text-muted-foreground'
                 )}
-                title={hiddenSettings.enabled ? 'Show all hours' : 'Hide time block'}
-                aria-label={hiddenSettings.enabled ? 'Show all hours' : 'Hide time block'}
+                title={hiddenSettings.enabled ? t('showAllHours') : t('hideTimeBlock')}
+                aria-label={hiddenSettings.enabled ? t('showAllHours') : t('hideTimeBlock')}
               >
                 <Clock className="h-3 w-3" />
               </button>
@@ -346,8 +350,8 @@ export function WeekView({
                     ? 'bg-blue-500 text-white'
                     : 'hover:bg-accent text-muted-foreground'
                 )}
-                title={hiddenSettings.enabled ? 'Show all hours' : 'Hide time block'}
-                aria-label={hiddenSettings.enabled ? 'Show all hours' : 'Hide time block'}
+                title={hiddenSettings.enabled ? t('showAllHours') : t('hideTimeBlock')}
+                aria-label={hiddenSettings.enabled ? t('showAllHours') : t('hideTimeBlock')}
               >
                 <Clock className="h-4 w-4" />
               </button>
@@ -398,7 +402,7 @@ export function WeekView({
                         'text-xs font-medium uppercase tracking-wide truncate leading-none',
                         isSameDay(date, displayNow) && cards ? 'text-seasonal-accent font-semibold' : undefined,
                       )}>
-                        {isSameDay(date, displayNow) ? 'Today' : format(date, 'EEE')}
+                        {isSameDay(date, displayNow) ? t('today') : d.weekdayShort(date)}
                       </span>
                     </div>
                     {dayWeather && (

--- a/src/components/calendar/cells/DayColumn.tsx
+++ b/src/components/calendar/cells/DayColumn.tsx
@@ -7,7 +7,9 @@ import { cn } from '@/lib/utils';
 import { WeekItemCard, type WeekItemSize, type WeekItemLayout } from './WeekItemCard';
 import { weatherIcon } from './weatherIcon';
 import type { DayBucket } from '@/lib/hooks/useWeekViewData';
+import { useTranslations } from 'next-intl';
 import { useTimeFormat } from '@/components/providers';
+import { useDateLabels, type DateLabels } from '@/lib/hooks/useDateLabels';
 import { formatDisplayTime, toDisplayDate, type TimeFormat } from '@/lib/utils/timeFormat';
 
 const PRIORITY_COLORS = {
@@ -40,15 +42,27 @@ function mealStripeColor(meal: {
   return meal.cookedBy?.color || meal.createdBy?.color || MEAL_FALLBACK_COLOR;
 }
 
-function dayLabel(date: Date, displayTimezone: string): string {
+function dayLabel(
+  date: Date,
+  displayTimezone: string,
+  t: (key: string) => string,
+  d: DateLabels,
+): string {
   const displayNow = toDisplayDate(new Date(), displayTimezone);
-  if (isSameDay(date, displayNow)) return 'Today';
-  if (isSameDay(date, new Date(displayNow.getFullYear(), displayNow.getMonth(), displayNow.getDate() + 1))) return 'Tomorrow';
-  return format(date, 'EEEE');
+  if (isSameDay(date, displayNow)) return t('today');
+  if (isSameDay(date, new Date(displayNow.getFullYear(), displayNow.getMonth(), displayNow.getDate() + 1))) return t('tomorrow');
+  return d.weekdayLong(date);
 }
 
-function timeLabel(start: Date, end: Date, allDay: boolean, timeFormat: TimeFormat, displayTimezone: string): string | undefined {
-  if (allDay) return 'All day';
+function timeLabel(
+  start: Date,
+  end: Date,
+  allDay: boolean,
+  timeFormat: TimeFormat,
+  displayTimezone: string,
+  t: (key: string) => string,
+): string | undefined {
+  if (allDay) return t('allDay');
   const startStr = formatDisplayTime(start, timeFormat, {}, displayTimezone);
   if (!isSameDay(toDisplayDate(start, displayTimezone), toDisplayDate(end, displayTimezone))) return startStr;
   return startStr;
@@ -151,6 +165,8 @@ export function DayColumn({
   className,
 }: DayColumnProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const flags = { ...ALL_OVERLAYS, ...overlays };
   const today = isSameDay(bucket.date, toDisplayDate(new Date(), displayTimezone));
   const droppableId = format(bucket.date, 'yyyy-MM-dd');
@@ -196,7 +212,7 @@ export function DayColumn({
                 : 'text-muted-foreground',
             )}
           >
-            {dayLabel(bucket.date, displayTimezone)}
+            {dayLabel(bucket.date, displayTimezone, t, d)}
           </span>
         </div>
         {profile.showWeather && bucket.weather && (
@@ -218,7 +234,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel="All day"
+            timeLabel={t('allDay')}
             subtitle={event.calendarName}
           />
         ))}
@@ -232,7 +248,7 @@ export function DayColumn({
             layout={itemLayout}
             stripeColor={event.color}
             title={event.title}
-            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat, displayTimezone)}
+            timeLabel={timeLabel(event.startTime, event.endTime, false, timeFormat, displayTimezone, t)}
             subtitle={event.location || event.calendarName}
           />
         ))}
@@ -284,7 +300,7 @@ export function DayColumn({
             stripeColor={mealStripeColor(meal)}
             title={meal.name}
             timeLabel={meal.mealType}
-            subtitle={meal.cookedBy?.name ? `Cooked by ${meal.cookedBy.name}` : undefined}
+            subtitle={meal.cookedBy?.name ? t('cookedBy', { name: meal.cookedBy.name }) : undefined}
             muted={Boolean(meal.cookedAt)}
             dragId={disableDrop ? undefined : `meal:${meal.id}`}
           />
@@ -292,7 +308,7 @@ export function DayColumn({
 
       {profile.showEmptyState && isEmpty && (
         <div className="flex flex-1 items-center justify-center rounded border border-dashed border-border/30 bg-black/10 py-3 text-[10px] text-muted-foreground">
-          Nothing planned
+          {t('nothingPlanned')}
         </div>
       )}
     </div>

--- a/src/components/calendar/cells/DayOverflowPopover.tsx
+++ b/src/components/calendar/cells/DayOverflowPopover.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { format } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import type { CalendarEvent } from '@/types/calendar';
 import { useTimeFormat } from '@/components/providers';
 import { formatDisplayTime, isCalendarEventPast } from '@/lib/utils/timeFormat';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 
 interface DayOverflowPopoverProps {
   /** The date this popover represents — shown in the popover header. */
@@ -31,6 +32,8 @@ export function DayOverflowPopover({
   triggerClassName,
 }: DayOverflowPopoverProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
   const [open, setOpen] = React.useState(false);
 
   if (hiddenEvents.length === 0) return null;
@@ -49,7 +52,7 @@ export function DayOverflowPopover({
             triggerClassName,
           )}
         >
-          + {hiddenEvents.length} more
+          {t('moreEvents', { count: hiddenEvents.length })}
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -58,7 +61,7 @@ export function DayOverflowPopover({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="text-xs font-semibold text-muted-foreground mb-2">
-          {format(date, 'EEEE, MMM d')}
+          {d.weekdayLongMonthDay(date)}
         </div>
         <ul className="space-y-1 list-none m-0 p-0">
           {hiddenEvents.map((event) => (

--- a/src/components/calendar/cells/__tests__/itemTime.test.ts
+++ b/src/components/calendar/cells/__tests__/itemTime.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared by every calendar view's item labels, and previously untested. The
+ * ":00" drop below is deliberate (compact event labels) and is why the event
+ * form's time picker keeps its own formatter instead: a column of half-hour
+ * slots reading "9 AM / 9:30 AM / 10 AM" is ragged.
+ */
+import { formatTimeOfDay } from '@/components/calendar/cells';
+
+describe('formatTimeOfDay', () => {
+  it('renders 24-hour time zero-padded, with no meridiem', () => {
+    expect(formatTimeOfDay('14:30', '24h')).toBe('14:30');
+    expect(formatTimeOfDay('09:00', '24h')).toBe('09:00');
+    expect(formatTimeOfDay('00:00', '24h')).toBe('00:00');
+    expect(formatTimeOfDay('23:59', '24h')).toBe('23:59');
+  });
+
+  it('renders 12-hour time with the right meridiem at the boundaries', () => {
+    expect(formatTimeOfDay('14:30', '12h')).toBe('2:30 PM');
+    // On-the-hour drops ":00" in 12h mode, but never in 24h mode above.
+    expect(formatTimeOfDay('09:00', '12h')).toBe('9 AM');
+    // Midnight and noon are where a naive `h % 12` produces "0".
+    expect(formatTimeOfDay('00:00', '12h')).toBe('12 AM');
+    expect(formatTimeOfDay('12:00', '12h')).toBe('12 PM');
+    expect(formatTimeOfDay('12:30', '12h')).toBe('12:30 PM');
+  });
+
+  it('defaults to 12-hour when no format is given', () => {
+    expect(formatTimeOfDay('14:30')).toBe('2:30 PM');
+  });
+
+  it('passes through anything that is not HH:MM', () => {
+    expect(formatTimeOfDay('')).toBe('');
+    expect(formatTimeOfDay(null)).toBe('');
+    expect(formatTimeOfDay(undefined)).toBe('');
+    expect(formatTimeOfDay('not a time')).toBe('not a time');
+  });
+});

--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -18,7 +18,9 @@ import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { Loader2, MapPin, AlignLeft, ChevronDown, ChevronUp } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { useCalendarSources } from '@/lib/hooks';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { useAuth, useTimeFormat } from '@/components/providers';
 import { fromDisplayDateTime, toDisplayDate } from '@/lib/utils/timeFormat';
 import { toast } from '@/components/ui/use-toast';
@@ -93,27 +95,30 @@ export interface AddEventModalProps {
 }
 
 /**
- * Recurrence presets
+ * Recurrence presets. `labelKey` indexes `calendar.eventForm.recurrence`; the
+ * RRULE on the left is protocol, the label on the right is copy.
  */
 const RECURRENCE_OPTIONS = [
-  { value: '', label: 'Does not repeat' },
-  { value: 'FREQ=DAILY', label: 'Daily' },
-  { value: 'FREQ=WEEKLY', label: 'Weekly' },
-  { value: 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR', label: 'Every weekday' },
-  { value: 'FREQ=MONTHLY', label: 'Monthly' },
-  { value: 'FREQ=YEARLY', label: 'Yearly' },
+  { value: '', labelKey: 'none' },
+  { value: 'FREQ=DAILY', labelKey: 'daily' },
+  { value: 'FREQ=WEEKLY', labelKey: 'weekly' },
+  { value: 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR', labelKey: 'weekdays' },
+  { value: 'FREQ=MONTHLY', labelKey: 'monthly' },
+  { value: 'FREQ=YEARLY', labelKey: 'yearly' },
 ];
 
 /**
- * Reminder options (minutes before event)
+ * Reminder options, in minutes before the event. The label is built from an
+ * ICU plural rather than a fixed string, so a language whose plural rules
+ * differ from English ("1 Minute" vs "5 Minuten") still reads correctly.
  */
 const REMINDER_OPTIONS = [
-  { value: 5, label: '5 minutes before' },
-  { value: 10, label: '10 minutes before' },
-  { value: 15, label: '15 minutes before' },
-  { value: 30, label: '30 minutes before' },
-  { value: 60, label: '1 hour before' },
-  { value: 1440, label: '1 day before' },
+  { value: 5, unitKey: 'minutesBefore', count: 5 },
+  { value: 10, unitKey: 'minutesBefore', count: 10 },
+  { value: 15, unitKey: 'minutesBefore', count: 15 },
+  { value: 30, unitKey: 'minutesBefore', count: 30 },
+  { value: 60, unitKey: 'hoursBefore', count: 1 },
+  { value: 1440, unitKey: 'daysBefore', count: 1 },
 ];
 
 /** Format date for datetime-local input (YYYY-MM-DDTHH:mm) */
@@ -171,6 +176,9 @@ export function AddEventModal({
   defaultDate,
 }: AddEventModalProps) {
   const isEditMode = !!event;
+  const t = useTranslations('calendar');
+  const tActions = useTranslations('common.actions');
+  const d = useDateLabels();
 
   // Fetch available calendars
   const { calendars } = useCalendarSources();
@@ -330,7 +338,7 @@ export function AddEventModal({
       : fromDisplayDateTime(endDate, endTimeStr, displayTimezone).toISOString();
 
     if (new Date(endISO) < new Date(startISO)) {
-      setError('End must be after start');
+      setError(t('eventForm.endBeforeStart'));
       return;
     }
 
@@ -364,14 +372,14 @@ export function AddEventModal({
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to save event');
+        throw new Error(errorData.error || t('eventForm.saveFailed'));
       }
 
       const savedEvent = await response.json();
 
       if (savedEvent.warning) {
         toast({
-          title: 'Event saved locally',
+          title: t('eventForm.savedLocally'),
           description: savedEvent.warning,
           variant: 'warning',
         });
@@ -384,7 +392,7 @@ export function AddEventModal({
       onOpenChange(false);
     } catch (err) {
       console.error('Failed to save event:', err);
-      setError(err instanceof Error ? err.message : 'Failed to save event');
+      setError(err instanceof Error ? err.message : t('eventForm.saveFailed'));
     } finally {
       setIsSubmitting(false);
     }
@@ -394,9 +402,9 @@ export function AddEventModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>{isEditMode ? 'Edit Event' : 'New Event'}</DialogTitle>
+          <DialogTitle>{t(isEditMode ? 'eventForm.titleEdit' : 'eventForm.titleNew')}</DialogTitle>
           <DialogDescription className="sr-only">
-            {isEditMode ? 'Update event details.' : 'Create a new calendar event.'}
+            {t(isEditMode ? 'eventForm.descriptionEdit' : 'eventForm.descriptionNew')}
           </DialogDescription>
         </DialogHeader>
 
@@ -405,7 +413,7 @@ export function AddEventModal({
           <Input
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="Add title"
+            placeholder={t('eventForm.titlePlaceholder')}
             className="text-base border-0 border-b rounded-none px-0 focus-visible:ring-0 focus-visible:border-primary"
             autoFocus
             required
@@ -420,7 +428,7 @@ export function AddEventModal({
                 onClick={(e) => (e.currentTarget.nextElementSibling as HTMLInputElement | null)?.showPicker?.()}
                 className="h-8 px-2.5 rounded-md text-sm font-medium hover:bg-muted transition-colors whitespace-nowrap"
               >
-                {startDate ? format(parseISO(startDate + 'T00:00:00'), 'EEE, MMM d') : 'Start date'}
+                {startDate ? d.weekdayMonthDay(parseISO(startDate + 'T00:00:00')) : t('eventForm.startDate')}
               </button>
               <input
                 type="date"
@@ -447,7 +455,7 @@ export function AddEventModal({
                   onClick={(e) => (e.currentTarget.nextElementSibling as HTMLInputElement | null)?.showPicker?.()}
                   className="h-8 px-2.5 rounded-md text-sm font-medium hover:bg-muted transition-colors whitespace-nowrap"
                 >
-                  {endDate ? format(parseISO(endDate + 'T00:00:00'), 'EEE, MMM d') : 'End date'}
+                  {endDate ? d.weekdayMonthDay(parseISO(endDate + 'T00:00:00')) : t('eventForm.endDate')}
                 </button>
                 <input
                   type="date"
@@ -472,7 +480,7 @@ export function AddEventModal({
             {/* All day toggle */}
             <div className="flex items-center gap-1.5 ml-1">
               <Switch id="event-all-day" checked={allDay} onCheckedChange={handleAllDayChange} />
-              <Label htmlFor="event-all-day" className="text-sm cursor-pointer select-none">All day</Label>
+              <Label htmlFor="event-all-day" className="text-sm cursor-pointer select-none">{t('allDay')}</Label>
             </div>
 
             {/* End date selector when all-day and same date (show explicit end date control) */}
@@ -483,7 +491,7 @@ export function AddEventModal({
                   onClick={(e) => (e.currentTarget.nextElementSibling as HTMLInputElement | null)?.showPicker?.()}
                   className="h-8 px-2.5 rounded-md text-sm font-medium hover:bg-muted transition-colors whitespace-nowrap text-muted-foreground"
                 >
-                  {endDate ? format(parseISO(endDate + 'T00:00:00'), 'EEE, MMM d') : 'End date'}
+                  {endDate ? d.weekdayMonthDay(parseISO(endDate + 'T00:00:00')) : t('eventForm.endDate')}
                 </button>
                 <input
                   type="date"
@@ -500,7 +508,7 @@ export function AddEventModal({
           {/* Calendar Selection */}
           <Select value={calendarSourceId} onValueChange={setCalendarSourceId}>
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select a calendar" />
+              <SelectValue placeholder={t('eventForm.selectCalendar')} />
             </SelectTrigger>
             <SelectContent>
               {writableCalendars.map((cal) => (
@@ -536,7 +544,7 @@ export function AddEventModal({
               outward — and only once such an account actually exists. */}
           {writableCalendars.some((c) => c.provider === 'google') && (
             <p className="text-xs text-muted-foreground">
-              Local calendars stay on this dashboard. Connected calendars (like Google) sync both ways.
+              {t('eventForm.syncHint')}
             </p>
           )}
 
@@ -547,7 +555,7 @@ export function AddEventModal({
             className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             {showMore ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-            {showMore ? 'Less options' : 'More options'}
+            {t(showMore ? 'eventForm.lessOptions' : 'eventForm.moreOptions')}
           </button>
 
           {showMore && (
@@ -558,7 +566,7 @@ export function AddEventModal({
                 <Input
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
-                  placeholder="Add location"
+                  placeholder={t('eventForm.locationPlaceholder')}
                   className="flex-1"
                 />
               </div>
@@ -569,7 +577,7 @@ export function AddEventModal({
                 <Textarea
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  placeholder="Add description"
+                  placeholder={t('eventForm.descriptionPlaceholder')}
                   rows={2}
                   className="flex-1"
                 />
@@ -581,12 +589,12 @@ export function AddEventModal({
                 onValueChange={(v) => setRecurrenceRule(v === '__none__' ? '' : v)}
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Does not repeat" />
+                  <SelectValue placeholder={t('eventForm.recurrence.none')} />
                 </SelectTrigger>
                 <SelectContent>
                   {RECURRENCE_OPTIONS.map((opt) => (
                     <SelectItem key={opt.value || '__none__'} value={opt.value || '__none__'}>
-                      {opt.label}
+                      {t(`eventForm.recurrence.${opt.labelKey}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -598,13 +606,13 @@ export function AddEventModal({
                 onValueChange={(value) => setReminderMinutes(value === 'none' ? '' : Number(value))}
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="No reminder" />
+                  <SelectValue placeholder={t('eventForm.noReminder')} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No reminder</SelectItem>
+                  <SelectItem value="none">{t('eventForm.noReminder')}</SelectItem>
                   {REMINDER_OPTIONS.map((option) => (
                     <SelectItem key={option.value} value={String(option.value)}>
-                      {option.label}
+                      {t(`eventForm.reminder.${option.unitKey}`, { count: option.count })}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -627,16 +635,16 @@ export function AddEventModal({
               onClick={() => onOpenChange(false)}
               disabled={isSubmitting}
             >
-              Cancel
+              {tActions('cancel')}
             </Button>
             <Button type="submit" disabled={!title.trim() || !startDate || !endDate || (!allDay && (!startTimeStr || !endTimeStr)) || isSubmitting}>
               {isSubmitting ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Saving...
+                  {t('eventForm.saving')}
                 </>
               ) : (
-                isEditMode ? 'Save' : 'Save'
+                tActions('save')
               )}
             </Button>
           </div>

--- a/src/components/modals/TimeDropdown.tsx
+++ b/src/components/modals/TimeDropdown.tsx
@@ -1,16 +1,30 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { useTimeFormat } from '@/components/providers';
+import type { TimeFormat } from '@/lib/utils/timeFormat';
 
-export function formatTime12(hhmm: string): string {
+/**
+ * Render an "HH:mm" slot for the picker, honouring Settings -> General, so a
+ * German dashboard on 24h reads "14:30" rather than "2:30 PM".
+ *
+ * Deliberately NOT calendar/cells' formatTimeOfDay: that one drops ":00" on
+ * the hour to keep event labels compact, which in a column of half-hour slots
+ * gives a ragged "9 AM / 9:30 AM / 10 AM". A picker wants every row the same
+ * shape.
+ */
+export function formatPickerTime(hhmm: string, timeFormat: TimeFormat = '12h'): string {
   const [hStr, mStr] = hhmm.split(':');
   const h = parseInt(hStr ?? '0', 10);
   const m = parseInt(mStr ?? '0', 10);
   if (isNaN(h) || isNaN(m)) return '';
+  const mm = String(m).padStart(2, '0');
+  if (timeFormat === '24h') return `${String(h).padStart(2, '0')}:${mm}`;
   const period = h >= 12 ? 'PM' : 'AM';
   const hour = h % 12 || 12;
-  return `${hour}:${String(m).padStart(2, '0')} ${period}`;
+  return `${hour}:${mm} ${period}`;
 }
 
 function parseTimeInput(raw: string): string | null {
@@ -56,6 +70,8 @@ interface TimeDropdownProps {
 }
 
 export function TimeDropdown({ value, onChange, minTime, disabled, className }: TimeDropdownProps) {
+  const t = useTranslations('calendar.eventForm');
+  const { timeFormat } = useTimeFormat();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState('');
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -106,7 +122,7 @@ export function TimeDropdown({ value, onChange, minTime, disabled, className }: 
         onClick={() => setOpen((v) => !v)}
         className="h-8 px-2.5 rounded-md text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
       >
-        {value ? formatTime12(value) : 'Time'}
+        {value ? formatPickerTime(value, timeFormat) : t('timePlaceholder')}
       </button>
 
       {open && (
@@ -118,7 +134,7 @@ export function TimeDropdown({ value, onChange, minTime, disabled, className }: 
               onChange={(e) => setDraft(e.target.value)}
               onKeyDown={handleKeyDown}
               onBlur={commitDraft}
-              placeholder="e.g. 2:30 PM"
+              placeholder={t('timeHint')}
               className="w-full text-xs px-2 py-1.5 rounded-md bg-muted/50 placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
@@ -134,7 +150,7 @@ export function TimeDropdown({ value, onChange, minTime, disabled, className }: 
                     minTime && slot < minTime && slot !== value && 'text-muted-foreground/50'
                   )}
                 >
-                  {formatTime12(slot)}
+                  {formatPickerTime(slot, timeFormat)}
                 </button>
               </li>
             ))}

--- a/src/components/modals/__tests__/timeDropdown.test.ts
+++ b/src/components/modals/__tests__/timeDropdown.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The event form's time picker used to hardcode AM/PM, so a German household
+ * on a 24-hour clock still saw "2:30 PM" while the rest of the form was
+ * German. It now takes the household's Settings -> General choice.
+ */
+import { formatPickerTime } from '@/components/modals/TimeDropdown';
+
+describe('formatPickerTime', () => {
+  it('renders 24-hour time zero-padded, with no meridiem', () => {
+    expect(formatPickerTime('14:30', '24h')).toBe('14:30');
+    expect(formatPickerTime('09:00', '24h')).toBe('09:00');
+    expect(formatPickerTime('00:00', '24h')).toBe('00:00');
+    expect(formatPickerTime('23:30', '24h')).toBe('23:30');
+  });
+
+  it('keeps every 12-hour slot the same shape, including on the hour', () => {
+    // Unlike calendar/cells' formatTimeOfDay, ":00" is NOT dropped here: a
+    // column of half-hour slots has to line up.
+    expect(formatPickerTime('09:00', '12h')).toBe('9:00 AM');
+    expect(formatPickerTime('09:30', '12h')).toBe('9:30 AM');
+    expect(formatPickerTime('14:30', '12h')).toBe('2:30 PM');
+  });
+
+  it('gets midnight and noon right, where `h % 12` alone gives 0', () => {
+    expect(formatPickerTime('00:00', '12h')).toBe('12:00 AM');
+    expect(formatPickerTime('00:30', '12h')).toBe('12:30 AM');
+    expect(formatPickerTime('12:00', '12h')).toBe('12:00 PM');
+  });
+
+  it('defaults to 12-hour when no preference is passed', () => {
+    expect(formatPickerTime('14:30')).toBe('2:30 PM');
+  });
+});

--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -12,6 +12,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core';
+import { useTranslations } from 'next-intl';
 import { Calendar, Loader2, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
@@ -19,6 +20,7 @@ import { isLightColor } from '@/lib/utils/color';
 import { deduplicateEvents } from '@/lib/utils/calendarDedup';
 import { WidgetContainer, useWidgetBgOverride } from './WidgetContainer';
 import { useCalendarEvents, useCalendarFilter, useCalendarNotes } from '@/lib/hooks';
+import { useDateLabels } from '@/lib/hooks/useDateLabels';
 import { useDayBucketsForRange } from '@/lib/hooks/useDayBucketsForRange';
 import { useWeekMutations } from '@/lib/hooks/useWeekMutations';
 import { useAuth } from '@/components/providers';
@@ -58,6 +60,8 @@ export const CalendarWidget = React.memo(function CalendarWidget({
   gridH = 2,
 }: CalendarWidgetProps) {
   const { activeUser } = useAuth();
+  const t = useTranslations('calendar');
+  const formatDayHeader = useDayHeaderFormatter();
   const { weekStartsOn } = useWeekStartsOn();
   const bgOverride = useWidgetBgOverride();
   const transparentMode = bgOverride?.hasCustomBg === true;
@@ -192,7 +196,7 @@ export const CalendarWidget = React.memo(function CalendarWidget({
         await moveEvent(itemId, ev.startTime, ev.endTime, targetBucket.date);
       }
     } catch (err) {
-      setMoveError(err instanceof Error ? err.message : 'Failed to move item');
+      setMoveError(err instanceof Error ? err.message : t('errors.moveFailed'));
     }
   };
 
@@ -232,7 +236,7 @@ export const CalendarWidget = React.memo(function CalendarWidget({
             : transparentMode ? 'text-current/70 hover:text-current' : 'bg-muted text-muted-foreground hover:bg-accent'
         )}
       >
-        All
+        {t('toolbar.all')}
       </button>
       {calendarGroups.map((group) => (
         <button
@@ -259,7 +263,7 @@ export const CalendarWidget = React.memo(function CalendarWidget({
 
   return (
     <WidgetContainer
-      title="Calendar"
+      title={t('title')}
       titleHref={titleHref}
       icon={<Calendar className="h-4 w-4" />}
       size="large"
@@ -307,7 +311,9 @@ export const CalendarWidget = React.memo(function CalendarWidget({
 
       {viewUnavailable && (
         <div className="text-[10px] text-muted-foreground text-center py-1 bg-muted/50 rounded mb-1">
-          Resize widget for {VIEW_OPTIONS.find(v => v.value === viewType)?.label} view
+          {t('toolbar.resizeForView', {
+            view: t(`views.${VIEW_OPTIONS.find((v) => v.value === viewType)?.labelKey ?? 'agenda'}`),
+          })}
         </div>
       )}
 
@@ -433,9 +439,13 @@ export const CalendarWidget = React.memo(function CalendarWidget({
   );
 });
 
-function formatDayHeader(date: Date): string {
-  const dayName = format(date, 'EEEE, MMMM d, yyyy');
-  if (isToday(date)) return `Today - ${dayName}`;
-  if (isTomorrow(date)) return `Tomorrow - ${dayName}`;
-  return dayName;
+function useDayHeaderFormatter(): (date: Date) => string {
+  const t = useTranslations('calendar');
+  const d = useDateLabels();
+  return (date: Date) => {
+    const dayName = d.fullDate(date);
+    if (isToday(date)) return t('dayHeader', { label: t('today'), date: dayName });
+    if (isTomorrow(date)) return t('dayHeader', { label: t('tomorrow'), date: dayName });
+    return dayName;
+  };
 }

--- a/src/components/widgets/CalendarWidgetControls.tsx
+++ b/src/components/widgets/CalendarWidgetControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useTranslations } from 'next-intl';
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -58,6 +59,7 @@ export function CalendarWidgetControls({
   goToToday,
   goToNext,
 }: CalendarWidgetControlsProps) {
+  const t = useTranslations('calendar');
   // The widget views that benefit from "card vs inline" toggle: day, list,
   // week, multiWeek, month. Agenda has no such concept.
   const displayApplicable = resolvedView !== 'agenda';
@@ -99,12 +101,12 @@ export function CalendarWidgetControls({
                 : 'bg-background text-foreground hover:bg-accent',
             )}
           >
-            Today
+            {t('today')}
           </Button>
-          <Button variant="outline" size="icon" onClick={goToPrevious} aria-label="Previous" className="h-8 w-8">
+          <Button variant="outline" size="icon" onClick={goToPrevious} aria-label={t('nav.previous')} className="h-8 w-8">
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button variant="outline" size="icon" onClick={goToNext} aria-label="Next" className="h-8 w-8">
+          <Button variant="outline" size="icon" onClick={goToNext} aria-label={t('nav.next')} className="h-8 w-8">
             <ChevronRight className="h-4 w-4" />
           </Button>
         </>
@@ -168,6 +170,7 @@ function ViewPopover({
   availableViews: WidgetViewType[];
   transparentMode: boolean;
 }) {
+  const t = useTranslations('calendar');
   const [open, setOpen] = React.useState(false);
   const enabled = VIEW_OPTIONS.filter((opt) => availableViews.includes(opt.value));
   const activeOpt =
@@ -191,13 +194,13 @@ function ViewPopover({
         <PopoverTrigger asChild>
           <button
             type="button"
-            aria-label="Calendar view"
+            aria-label={t('nav.calendarView')}
             className={cn(
               'inline-flex items-center justify-center gap-1 h-full w-24 px-2 text-xs rounded border border-input bg-background hover:opacity-90',
               transparentMode && 'bg-transparent border-current/20',
             )}
           >
-            <span className="truncate">{activeOpt.label}</span>
+            <span className="truncate">{t(`views.${activeOpt.labelKey}`)}</span>
             <ChevronDown className="h-3 w-3 opacity-60 shrink-0" />
           </button>
         </PopoverTrigger>
@@ -221,7 +224,7 @@ function ViewPopover({
                   !isAvailable && 'opacity-40 cursor-not-allowed',
                 )}
               >
-                <span className="flex-1 text-left">{opt.label}</span>
+                <span className="flex-1 text-left">{t(`views.${opt.labelKey}`)}</span>
               </button>
             );
           })}
@@ -230,8 +233,8 @@ function ViewPopover({
       <div className="grid grid-rows-2 gap-0.5 w-7 h-full">
         <button
           type="button"
-          aria-label="Previous view"
-          title="Previous view"
+          aria-label={t('nav.previousView')}
+          title={t('nav.previousView')}
           onClick={() => cycle(-1)}
           className="rounded border border-input hover:bg-accent inline-flex items-center justify-center min-h-0"
         >
@@ -239,8 +242,8 @@ function ViewPopover({
         </button>
         <button
           type="button"
-          aria-label="Next view"
-          title="Next view"
+          aria-label={t('nav.nextView')}
+          title={t('nav.nextView')}
           onClick={() => cycle(1)}
           className="rounded border border-input hover:bg-accent inline-flex items-center justify-center min-h-0"
         >

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -38,6 +38,7 @@
     "today": "Heute",
     "tomorrow": "Morgen",
     "allDay": "Ganztägig",
+    "allEvents": "Alle Termine",
     "continues": "Läuft weiter",
     "chore": "Hausarbeit",
     "task": "Aufgabe",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -119,6 +119,41 @@
       "deleteConfirmTitle": "Diesen Termin löschen?",
       "deleteConfirmBody": "Soll dieser Termin wirklich gelöscht werden?"
     },
+    "eventForm": {
+      "titleNew": "Neuer Termin",
+      "titleEdit": "Termin bearbeiten",
+      "descriptionNew": "Einen neuen Kalendertermin erstellen.",
+      "descriptionEdit": "Termindetails aktualisieren.",
+      "titlePlaceholder": "Titel hinzufügen",
+      "startDate": "Startdatum",
+      "endDate": "Enddatum",
+      "selectCalendar": "Kalender auswählen",
+      "syncHint": "Lokale Kalender bleiben auf diesem Dashboard. Verbundene Kalender (etwa Google) werden in beide Richtungen synchronisiert.",
+      "moreOptions": "Weitere Optionen",
+      "lessOptions": "Weniger Optionen",
+      "locationPlaceholder": "Ort hinzufügen",
+      "descriptionPlaceholder": "Beschreibung hinzufügen",
+      "noReminder": "Keine Erinnerung",
+      "saving": "Wird gespeichert …",
+      "timePlaceholder": "Uhrzeit",
+      "timeHint": "z. B. 14:30",
+      "savedLocally": "Termin lokal gespeichert",
+      "endBeforeStart": "Das Ende muss nach dem Beginn liegen",
+      "saveFailed": "Termin konnte nicht gespeichert werden",
+      "recurrence": {
+        "none": "Wiederholt sich nicht",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "weekdays": "Jeden Wochentag",
+        "monthly": "Monatlich",
+        "yearly": "Jährlich"
+      },
+      "reminder": {
+        "minutesBefore": "{count, plural, one {# Minute vorher} other {# Minuten vorher}}",
+        "hoursBefore": "{count, plural, one {# Stunde vorher} other {# Stunden vorher}}",
+        "daysBefore": "{count, plural, one {# Tag vorher} other {# Tage vorher}}"
+      }
+    },
     "pending": {
       "title": "Löschungen prüfen",
       "explain": "Diese Termine wurden aus ihrem Quellkalender entfernt und zur Prüfung zurückgehalten. <b>Löschen</b> entfernt sie auch aus Prism. <b>Behalten</b> überträgt sie in den <local>lokalen Kalender</local>. Sie werden dann nicht mehr synchronisiert und bleiben erhalten.",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -32,6 +32,113 @@
       "loading": "Wird geladen"
     }
   },
+  "calendar": {
+    "title": "Kalender",
+    "upcoming": "Anstehende Termine",
+    "today": "Heute",
+    "tomorrow": "Morgen",
+    "allDay": "Ganztägig",
+    "continues": "Läuft weiter",
+    "chore": "Hausarbeit",
+    "task": "Aufgabe",
+    "nothingPlanned": "Nichts geplant",
+    "noUpcomingEvents": "Keine anstehenden Termine",
+    "moreEvents": "+ {count} weitere",
+    "moreItems": "+{count} weitere Einträge",
+    "dayHeader": "{label} – {date}",
+    "dateAtTime": "{date} um {time}",
+    "notesPlaceholder": "Notizen hinzufügen …",
+    "notes": "Notizen",
+    "showAllHours": "Alle Stunden anzeigen",
+    "hideTimeBlock": "Zeitblock ausblenden",
+    "cookedBy": "Gekocht von {name}",
+    "nav": {
+      "previous": "Zurück",
+      "next": "Weiter",
+      "previousView": "Vorherige Ansicht",
+      "nextView": "Nächste Ansicht",
+      "calendarView": "Kalenderansicht"
+    },
+    "views": {
+      "agenda": "Agenda",
+      "day": "Tag",
+      "list": "Liste",
+      "schedule": "Zeitplan",
+      "week1": "1 Woche",
+      "week2": "2 Wochen",
+      "week3": "3 Wochen",
+      "week4": "4 Wochen",
+      "month": "Monat",
+      "threeMonth": "3 Monate",
+      "week1Short": "1 Wo.",
+      "week2Short": "2 Wo.",
+      "week3Short": "3 Wo.",
+      "week4Short": "4 Wo."
+    },
+    "options": {
+      "trigger": "Ansicht",
+      "label": "Ansichtsoptionen",
+      "display": "Darstellung",
+      "cards": "Karten",
+      "inlineBlocks": "Inline-Blöcke",
+      "gridLines": "Gitternetzlinien",
+      "hideWeekends": "Wochenenden ausblenden",
+      "notesColumn": "Notizspalte",
+      "mergeCalendars": "Kalender zusammenführen",
+      "showOnCalendar": "Im Kalender anzeigen",
+      "events": "Termine",
+      "meals": "Mahlzeiten",
+      "chores": "Hausarbeiten",
+      "tasks": "Aufgaben",
+      "cardsHint": "Zur Kartenansicht wechseln, um Mahlzeiten, Hausarbeiten und Aufgaben neben den Terminen anzuzeigen.",
+      "reset": "Auf Standard zurücksetzen"
+    },
+    "toolbar": {
+      "manage": "Verwalten",
+      "manageCalendars": "Kalender verwalten",
+      "addEvent": "Termin hinzufügen",
+      "addEventAuth": "Zum Hinzufügen eines Termins bitte anmelden",
+      "review": "{count} prüfen",
+      "reviewTitle": "Zurückgehaltene Kalender-Löschungen prüfen",
+      "show": "Anzeigen:",
+      "all": "Alle",
+      "allCalendars": "Alle Kalender",
+      "filterCalendars": "Kalender filtern",
+      "merge": "Zusammenführen",
+      "split": "Aufteilen",
+      "mergeHint": "In eine Spalte zusammenführen",
+      "splitHint": "Nach Kalender aufteilen",
+      "resizeForView": "Für die Ansicht „{view}“ das Widget vergrößern"
+    },
+    "empty": {
+      "title": "Noch kein Kalender verbunden",
+      "description": "Google, Apple, Outlook oder einen beliebigen iCal-Link verbinden, um hier Termine zu sehen.",
+      "action": "Kalender verbinden"
+    },
+    "event": {
+      "deleteConfirmTitle": "Diesen Termin löschen?",
+      "deleteConfirmBody": "Soll dieser Termin wirklich gelöscht werden?"
+    },
+    "pending": {
+      "title": "Löschungen prüfen",
+      "explain": "Diese Termine wurden aus ihrem Quellkalender entfernt und zur Prüfung zurückgehalten. <b>Löschen</b> entfernt sie auch aus Prism. <b>Behalten</b> überträgt sie in den <local>lokalen Kalender</local>. Sie werden dann nicht mehr synchronisiert und bleiben erhalten.",
+      "selectAll": "Alle auswählen ({selected}/{total})",
+      "localIfKept": "Lokal (falls behalten)",
+      "keep": "{count} lokal behalten",
+      "delete": "{count} löschen"
+    },
+    "errors": {
+      "loadFailed": "Kalender konnte nicht geladen werden: {error}",
+      "moveFailed": "Element konnte nicht verschoben werden",
+      "deleteFailed": "Termin konnte nicht gelöscht werden",
+      "updateTaskFailed": "Aufgabe konnte nicht aktualisiert werden",
+      "updateMealFailed": "Mahlzeit konnte nicht aktualisiert werden",
+      "pageTitle": "Kalenderfehler",
+      "pageBody": "Der Kalender konnte nicht geladen werden. Bitte erneut versuchen.",
+      "tryAgain": "Erneut versuchen",
+      "backToDashboard": "Zurück zur Übersicht"
+    }
+  },
   "birthdays": {
     "title": "Anstehende Geburtstage & Meilensteine",
     "empty": "Keine anstehenden Geburtstage oder Meilensteine",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -38,6 +38,7 @@
     "today": "Today",
     "tomorrow": "Tomorrow",
     "allDay": "All day",
+    "allEvents": "All Events",
     "continues": "Continues",
     "chore": "Chore",
     "task": "Task",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -119,6 +119,41 @@
       "deleteConfirmTitle": "Delete this event?",
       "deleteConfirmBody": "Are you sure you want to delete this event?"
     },
+    "eventForm": {
+      "titleNew": "New Event",
+      "titleEdit": "Edit Event",
+      "descriptionNew": "Create a new calendar event.",
+      "descriptionEdit": "Update event details.",
+      "titlePlaceholder": "Add title",
+      "startDate": "Start date",
+      "endDate": "End date",
+      "selectCalendar": "Select a calendar",
+      "syncHint": "Local calendars stay on this dashboard. Connected calendars (like Google) sync both ways.",
+      "moreOptions": "More options",
+      "lessOptions": "Less options",
+      "locationPlaceholder": "Add location",
+      "descriptionPlaceholder": "Add description",
+      "noReminder": "No reminder",
+      "saving": "Saving...",
+      "timePlaceholder": "Time",
+      "timeHint": "e.g. 2:30 PM",
+      "savedLocally": "Event saved locally",
+      "endBeforeStart": "End must be after start",
+      "saveFailed": "Failed to save event",
+      "recurrence": {
+        "none": "Does not repeat",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "weekdays": "Every weekday",
+        "monthly": "Monthly",
+        "yearly": "Yearly"
+      },
+      "reminder": {
+        "minutesBefore": "{count, plural, one {# minute before} other {# minutes before}}",
+        "hoursBefore": "{count, plural, one {# hour before} other {# hours before}}",
+        "daysBefore": "{count, plural, one {# day before} other {# days before}}"
+      }
+    },
     "pending": {
       "title": "Review removals",
       "explain": "These events were removed from their source calendar and held for review. <b>Delete</b> removes them from Prism too. <b>Keep</b> transfers each one to your <local>local calendar</local> — it stops syncing and stays put.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -32,6 +32,113 @@
       "loading": "Loading"
     }
   },
+  "calendar": {
+    "title": "Calendar",
+    "upcoming": "Upcoming Events",
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "allDay": "All day",
+    "continues": "Continues",
+    "chore": "Chore",
+    "task": "Task",
+    "nothingPlanned": "Nothing planned",
+    "noUpcomingEvents": "No upcoming events",
+    "moreEvents": "+ {count} more",
+    "moreItems": "+{count} more events",
+    "dayHeader": "{label} - {date}",
+    "dateAtTime": "{date} at {time}",
+    "notesPlaceholder": "Add notes...",
+    "notes": "Notes",
+    "showAllHours": "Show all hours",
+    "hideTimeBlock": "Hide time block",
+    "cookedBy": "Cooked by {name}",
+    "nav": {
+      "previous": "Previous",
+      "next": "Next",
+      "previousView": "Previous view",
+      "nextView": "Next view",
+      "calendarView": "Calendar view"
+    },
+    "views": {
+      "agenda": "Agenda",
+      "day": "Day",
+      "list": "List",
+      "schedule": "Schedule",
+      "week1": "1 Week",
+      "week2": "2 Weeks",
+      "week3": "3 Weeks",
+      "week4": "4 Weeks",
+      "month": "Month",
+      "threeMonth": "3 Months",
+      "week1Short": "1W",
+      "week2Short": "2W",
+      "week3Short": "3W",
+      "week4Short": "4W"
+    },
+    "options": {
+      "trigger": "View",
+      "label": "View options",
+      "display": "Display",
+      "cards": "Cards",
+      "inlineBlocks": "Inline blocks",
+      "gridLines": "Grid lines",
+      "hideWeekends": "Hide weekends",
+      "notesColumn": "Notes column",
+      "mergeCalendars": "Merge calendars",
+      "showOnCalendar": "Show on calendar",
+      "events": "Events",
+      "meals": "Meals",
+      "chores": "Chores",
+      "tasks": "Tasks",
+      "cardsHint": "Switch to Cards mode to show meals, chores, and tasks alongside events.",
+      "reset": "Reset to defaults"
+    },
+    "toolbar": {
+      "manage": "Manage",
+      "manageCalendars": "Manage calendars",
+      "addEvent": "Add Event",
+      "addEventAuth": "Please log in to add an event",
+      "review": "Review {count}",
+      "reviewTitle": "Review calendar removals held for your approval",
+      "show": "Show:",
+      "all": "All",
+      "allCalendars": "All Calendars",
+      "filterCalendars": "Filter calendars",
+      "merge": "Merge",
+      "split": "Split",
+      "mergeHint": "Merge into one column",
+      "splitHint": "Split by calendar",
+      "resizeForView": "Resize widget for {view} view"
+    },
+    "empty": {
+      "title": "No calendar connected yet",
+      "description": "Connect Google, Apple, Outlook, or any iCal link to see events here.",
+      "action": "Connect a calendar"
+    },
+    "event": {
+      "deleteConfirmTitle": "Delete this event?",
+      "deleteConfirmBody": "Are you sure you want to delete this event?"
+    },
+    "pending": {
+      "title": "Review removals",
+      "explain": "These events were removed from their source calendar and held for review. <b>Delete</b> removes them from Prism too. <b>Keep</b> transfers each one to your <local>local calendar</local> — it stops syncing and stays put.",
+      "selectAll": "Select all ({selected}/{total})",
+      "localIfKept": "Local (if kept)",
+      "keep": "Keep {count} in Local",
+      "delete": "Delete {count}"
+    },
+    "errors": {
+      "loadFailed": "Failed to load calendar: {error}",
+      "moveFailed": "Failed to move item",
+      "deleteFailed": "Failed to delete event",
+      "updateTaskFailed": "Failed to update task",
+      "updateMealFailed": "Failed to update meal",
+      "pageTitle": "Calendar Error",
+      "pageBody": "Failed to load the calendar. Please try again.",
+      "tryAgain": "Try again",
+      "backToDashboard": "Back to Dashboard"
+    }
+  },
   "birthdays": {
     "title": "Upcoming Birthdays & Milestones",
     "empty": "No upcoming birthdays or events",

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -31,3 +31,5 @@ export { useHiddenPages } from './useHiddenPages';
 export { useCalendarNotes } from './useCalendarNotes';
 export type { CalendarNote } from './useCalendarNotes';
 export { useGiftIdeas } from './useGiftIdeas';
+export { useDateLabels } from './useDateLabels';
+export type { DateLabels } from './useDateLabels';

--- a/src/lib/hooks/useCalendarWidgetPrefs.ts
+++ b/src/lib/hooks/useCalendarWidgetPrefs.ts
@@ -32,16 +32,21 @@ const VALID_VIEWS: WidgetViewType[] = [
   'agenda', 'list', 'day', 'week', 'multiWeek', 'multiWeek2', 'multiWeek3', 'multiWeek4', 'month',
 ];
 
-export const VIEW_OPTIONS: { value: WidgetViewType; label: string }[] = [
-  { value: 'agenda', label: 'Agenda' },
-  { value: 'day', label: 'Day' },
-  { value: 'list', label: 'List' },
-  { value: 'week', label: 'Schedule' },
-  { value: 'multiWeek', label: '1W' },
-  { value: 'multiWeek2', label: '2W' },
-  { value: 'multiWeek3', label: '3W' },
-  { value: 'multiWeek4', label: '4W' },
-  { value: 'month', label: 'Month' },
+/**
+ * `labelKey` indexes the `calendar.views` catalogue rather than holding copy:
+ * the widget toolbar has to follow Settings → Appearance → Language, and this
+ * module is imported by non-React code that has no translator to call.
+ */
+export const VIEW_OPTIONS: { value: WidgetViewType; labelKey: string }[] = [
+  { value: 'agenda', labelKey: 'agenda' },
+  { value: 'day', labelKey: 'day' },
+  { value: 'list', labelKey: 'list' },
+  { value: 'week', labelKey: 'schedule' },
+  { value: 'multiWeek', labelKey: 'week1Short' },
+  { value: 'multiWeek2', labelKey: 'week2Short' },
+  { value: 'multiWeek3', labelKey: 'week3Short' },
+  { value: 'multiWeek4', labelKey: 'week4Short' },
+  { value: 'month', labelKey: 'month' },
 ];
 
 /** Which views are available at a given grid size (48-column grid) */

--- a/src/lib/hooks/useDateLabels.ts
+++ b/src/lib/hooks/useDateLabels.ts
@@ -1,0 +1,71 @@
+'use client';
+
+/**
+ * Date labels bound to the interface language.
+ *
+ * Every calendar surface needs the same handful of human-readable date shapes,
+ * and every one of them has to follow Settings → Appearance → Language rather
+ * than the code's English patterns. This binds the shared formatters in
+ * lib/utils/dateLocale to the active locale so a component can write
+ * `d.weekdayShort(date)` instead of threading a locale through its props.
+ *
+ * Machine keys (`format(date, 'yyyy-MM-dd')` for bucket lookups) stay on
+ * date-fns. They are identifiers, not copy.
+ */
+import * as React from 'react';
+import { useLocale } from 'next-intl';
+import {
+  formatDateRange,
+  formatDateStyle,
+  weekdayNameByIndex,
+  type DateStyle,
+} from '@/lib/utils/dateLocale';
+
+export interface DateLabels {
+  /** "Thu" */
+  weekdayShort: (date: Date) => string;
+  /** "Thursday" */
+  weekdayLong: (date: Date) => string;
+  /** "Sep" */
+  monthShort: (date: Date) => string;
+  /** "September" */
+  monthLong: (date: Date) => string;
+  /** "September 2026" */
+  monthYear: (date: Date) => string;
+  /** "Sep 4" */
+  monthDay: (date: Date) => string;
+  /** "Thu, Sep 4" */
+  weekdayMonthDay: (date: Date) => string;
+  /** "Thursday, September 4" */
+  weekdayLongMonthDay: (date: Date) => string;
+  /** "Thursday, September 4, 2026" */
+  fullDate: (date: Date) => string;
+  /** "Sep 1 – 14, 2026" */
+  range: (start: Date, end: Date) => string;
+  /** Weekday name for a column header with no date. 0 = Sunday. */
+  weekdayByIndex: (index: number, style?: 'weekdayShort' | 'weekdayLong' | 'weekdayNarrow') => string;
+  /** The active locale, for the rare caller that needs it directly. */
+  locale: string;
+}
+
+export function useDateLabels(): DateLabels {
+  const locale = useLocale();
+
+  return React.useMemo(() => {
+    const styled = (style: DateStyle) => (date: Date) => formatDateStyle(date, style, locale);
+    return {
+      weekdayShort: styled('weekdayShort'),
+      weekdayLong: styled('weekdayLong'),
+      monthShort: styled('monthShort'),
+      monthLong: styled('monthLong'),
+      monthYear: styled('monthYear'),
+      monthDay: styled('monthDay'),
+      weekdayMonthDay: styled('weekdayMonthDay'),
+      weekdayLongMonthDay: styled('weekdayLongMonthDay'),
+      fullDate: styled('fullDate'),
+      range: (start: Date, end: Date) => formatDateRange(start, end, locale),
+      weekdayByIndex: (index, style) => weekdayNameByIndex(index, locale, style),
+      locale,
+    };
+  }, [locale]);
+}

--- a/src/lib/utils/__tests__/dateLocale.test.ts
+++ b/src/lib/utils/__tests__/dateLocale.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The point of dateLocale is that a translated catalogue cannot fix date
+ * *order*. "MMMM d, yyyy" is September 4, 2026 in every language, while German
+ * writes 4. September 2026. These tests pin the order and the names, because
+ * that is the regression a German household would actually see on the wall.
+ */
+import {
+  formatDateRange,
+  formatDateStyle,
+  weekdayNameByIndex,
+} from '@/lib/utils/dateLocale';
+
+const FRIDAY = new Date(2026, 8, 4); // 2026-09-04
+
+describe('formatDateStyle', () => {
+  it('names the weekday and month in the requested language', () => {
+    expect(formatDateStyle(FRIDAY, 'weekdayLong', 'en')).toBe('Friday');
+    expect(formatDateStyle(FRIDAY, 'weekdayLong', 'de')).toBe('Freitag');
+    expect(formatDateStyle(FRIDAY, 'monthLong', 'en')).toBe('September');
+    expect(formatDateStyle(FRIDAY, 'monthYear', 'de')).toBe('September 2026');
+  });
+
+  it('puts the day before the month in German, not after it', () => {
+    // The old date-fns pattern produced "September 4" in both languages.
+    expect(formatDateStyle(FRIDAY, 'monthDay', 'en')).toMatch(/^Sep\b.*4$/);
+    expect(formatDateStyle(FRIDAY, 'monthDay', 'de')).toMatch(/^4\./);
+    expect(formatDateStyle(FRIDAY, 'fullDate', 'de')).toContain('Freitag');
+    expect(formatDateStyle(FRIDAY, 'fullDate', 'de')).toContain('4. September 2026');
+  });
+
+  it('returns the same formatter instance for repeat calls', () => {
+    // A month view formats ~40 dates per render; a fresh Intl.DateTimeFormat
+    // each time is the difference between a frame and a stutter.
+    const first = formatDateStyle(FRIDAY, 'weekdayShort', 'de');
+    const second = formatDateStyle(FRIDAY, 'weekdayShort', 'de');
+    expect(first).toBe(second);
+  });
+});
+
+describe('weekdayNameByIndex', () => {
+  it('treats 0 as Sunday, matching Date.getDay() and DAYS_SHORT_ARRAY', () => {
+    expect(weekdayNameByIndex(0, 'en', 'weekdayLong')).toBe('Sunday');
+    expect(weekdayNameByIndex(1, 'en', 'weekdayLong')).toBe('Monday');
+    expect(weekdayNameByIndex(6, 'en', 'weekdayLong')).toBe('Saturday');
+    expect(weekdayNameByIndex(0, 'de', 'weekdayLong')).toBe('Sonntag');
+    expect(weekdayNameByIndex(3, 'de', 'weekdayLong')).toBe('Mittwoch');
+  });
+
+  it('gives a narrow initial for the three-month grid', () => {
+    expect(weekdayNameByIndex(1, 'de', 'weekdayNarrow')).toBe('M');
+  });
+});
+
+describe('formatDateRange', () => {
+  it('collapses the shared parts of a week range', () => {
+    const start = new Date(2026, 8, 1);
+    const end = new Date(2026, 8, 14);
+    expect(formatDateRange(start, end, 'en')).toContain('2026');
+    // German keeps day-first on both ends of the range.
+    expect(formatDateRange(start, end, 'de')).toMatch(/^1\./);
+  });
+});

--- a/src/lib/utils/dateLocale.ts
+++ b/src/lib/utils/dateLocale.ts
@@ -1,0 +1,71 @@
+/**
+ * Locale-aware date labels.
+ *
+ * date-fns `format` renders English month and weekday names, and, worse, the
+ * pattern itself fixes the field order. `format(d, 'MMMM d, yyyy')` is
+ * "September 4, 2026" in every language, but German writes "4. September 2026".
+ * A translated catalogue cannot fix that, because the order lives in the code.
+ *
+ * So every human-readable date label goes through Intl.DateTimeFormat, which
+ * takes both the names and the order from the locale. date-fns stays for
+ * machine keys (`yyyy-MM-dd` bucket lookups), where English is the point.
+ *
+ * Constructing an Intl.DateTimeFormat costs ~1ms and a month view asks for
+ * dozens per render, so formatters are cached per locale + style: the same
+ * trick timeFormat.ts uses for its wall-clock formatter.
+ */
+
+const STYLES = {
+  weekdayShort: { weekday: 'short' },
+  weekdayLong: { weekday: 'long' },
+  weekdayNarrow: { weekday: 'narrow' },
+  monthShort: { month: 'short' },
+  monthLong: { month: 'long' },
+  monthYear: { month: 'long', year: 'numeric' },
+  monthDay: { month: 'short', day: 'numeric' },
+  monthDayYear: { month: 'short', day: 'numeric', year: 'numeric' },
+  weekdayMonthDay: { weekday: 'short', month: 'short', day: 'numeric' },
+  weekdayLongMonthDay: { weekday: 'long', month: 'long', day: 'numeric' },
+  fullDate: { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' },
+} satisfies Record<string, Intl.DateTimeFormatOptions>;
+
+export type DateStyle = keyof typeof STYLES;
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(locale: string, style: DateStyle): Intl.DateTimeFormat {
+  const cacheKey = `${locale}|${style}`;
+  let formatter = formatterCache.get(cacheKey);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, STYLES[style]);
+    formatterCache.set(cacheKey, formatter);
+  }
+  return formatter;
+}
+
+/** Format `date` in `locale` using one of the shared semantic styles. */
+export function formatDateStyle(date: Date, style: DateStyle, locale: string): string {
+  return getFormatter(locale, style).format(date);
+}
+
+/**
+ * Weekday name for a day index (0 = Sunday, matching Date.getDay() and
+ * DAYS_SHORT_ARRAY), for column headers that have a weekday but no date.
+ * 2024-01-07 was a Sunday; UTC noon keeps the offset from shifting the day.
+ */
+export function weekdayNameByIndex(
+  index: number,
+  locale: string,
+  style: 'weekdayShort' | 'weekdayLong' | 'weekdayNarrow' = 'weekdayShort',
+): string {
+  return formatDateStyle(new Date(Date.UTC(2024, 0, 7 + index, 12)), style, locale);
+}
+
+/**
+ * A date range as one label: "Sep 1 – Sep 14, 2026" in English,
+ * "1. Sep. – 14. Sep. 2026" in German. formatRange collapses the parts the two
+ * ends share, which is exactly what the old `${a} - ${b}` string faked.
+ */
+export function formatDateRange(start: Date, end: Date, locale: string): string {
+  return getFormatter(locale, 'monthDayYear').formatRange(start, end);
+}

--- a/src/test-utils/nextIntlMock.tsx
+++ b/src/test-utils/nextIntlMock.tsx
@@ -12,10 +12,21 @@ import en from '@/i18n/messages/en.json';
 
 type Dict = Record<string, unknown>;
 
+/** Walk a dotted path ("calendar.views" / "week1") through the catalogue. */
+function resolve(path: string): unknown {
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (node, segment) =>
+        node && typeof node === 'object' ? (node as Dict)[segment] : undefined,
+      en,
+    );
+}
+
 function lookup(namespace: string | undefined, key: string): string {
-  const base = (namespace ? (en as Dict)[namespace] : en) as Dict | undefined;
-  const value = base?.[key];
-  return typeof value === 'string' ? value : namespace ? `${namespace}.${key}` : key;
+  const path = namespace ? `${namespace}.${key}` : key;
+  const value = resolve(path);
+  return typeof value === 'string' ? value : path;
 }
 
 export function NextIntlClientProvider({ children }: { children?: React.ReactNode }) {
@@ -23,15 +34,24 @@ export function NextIntlClientProvider({ children }: { children?: React.ReactNod
 }
 
 export function useTranslations(namespace?: string) {
-  return (key: string, values?: Record<string, unknown>) => {
+  const substitute = (key: string, values?: Record<string, unknown>) => {
     let out = lookup(namespace, key);
     if (values) {
       for (const [k, v] of Object.entries(values)) {
+        if (typeof v === 'function') continue; // rich-text tag handler, not a value
         out = out.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
       }
     }
     return out;
   };
+
+  const t = (key: string, values?: Record<string, unknown>) => substitute(key, values);
+  // t.rich renders tags via handlers in the real runtime; tests only need the
+  // text, so strip the markup and return a plain string.
+  t.rich = (key: string, values?: Record<string, unknown>) =>
+    substitute(key, values).replace(/<\/?[a-zA-Z][^>]*>/g, '');
+  t.raw = (key: string) => lookup(namespace, key);
+  return t;
 }
 
 export function useLocale() {


### PR DESCRIPTION
Continues the i18n work from #289: the calendar, its add/edit event form, and
the last strings that were still English on a German screen.

## What is translated

- The calendar page and its view menus, filter popover and manage/pending
  modals
- The add and edit event form, including recurrence and reminder options, with
  plural forms where German needs them
- The calendar widget and its controls
- The agenda, week, multi-week, three-month and side-by-side day views
- Dates throughout, via a shared `useDateLabels` hook, so weekday and month
  names follow the interface language rather than the code's English patterns

Both catalogs are at **167 keys with no gaps in either direction**. The only two
entries identical across them are *Babysitter* and *Agenda*, which are the same
word in German.

## What is deliberately not translated

- `format(date, 'yyyy-MM-dd')` and similar. Those are bucket keys and
  identifiers, not copy — translating them would break lookups.
- The `group.name === 'Family'` comparison in the vertical week view. It reads a
  calendar group's *stored* name, so localising it would break the match rather
  than translate anything.
- Event titles. Those are user data.

## On the German itself

The strings here are meant to be **correct enough to be corrected**, not final.
They follow the vocabulary the catalog already established — an event is a
*Termin*, so "Keine anstehenden Termine", "Neuer Termin", "Termin bearbeiten" —
and the newest string follows suit as *Alle Termine*. But they were written by
someone working from the existing pattern rather than by a native speaker, and
the intent is that a native reviewer corrects them in place.

Anything that reads as stiff, over-literal, or simply wrong is worth flagging,
including the date formats: those were the part written with the most care and
are the most likely to be subtly off.

## Checks

- 1840 tests pass, `tsc --noEmit` and eslint clean
- Rebased onto current master (it was 53 commits behind; one trivial import
  conflict, in the calendar widget's lucide imports)

