### PR TITLE
chore(release): 1.25.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+## [1.25.0] – 2026-09-07
+
 ### Added
 - **A theme can now choose a typeface and how tightly things pack.** Colour and three numbers were the whole vocabulary, and colour alone makes themes read as tints of each other. A theme can now name a typeface by role — sans, serif, rounded or mono — which is the largest identity lever left after density: a rounded geometric and a newspaper serif read as different products in a way no palette swap manages. It can also pick from a small set of display modes: whether calendar events pack *comfortably* or *compact*, and whether panels read as raised cards or flat regions of the page. A theme picks a name from a list; what the name means is decided in Prism, so themes stay pure data. Every one of these is optional, and a theme that sets none of them looks exactly as it did.
 - **A new built-in: Notice Board.** Near-white, flat and packed tight, with a rounded face and no borders at all. It is built for the job a shared wall calendar actually does — the events supply the colour, one hue per person, so everything around them gets out of the way. Compact events fit a family's whole week into a month cell. It is also the worked example of the new controls, for anyone building a theme of their own.

--- a/ha-app/config.yaml
+++ b/ha-app/config.yaml
@@ -1,5 +1,5 @@
 name: Prism
-version: "1.24.0"
+version: "1.25.0"
 slug: prism
 description: Self-hosted family dashboard — calendars, tasks, photos, and more.
 url: https://github.com/sandydargoport/prism

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Prism - Your family's digital home. An open-source family dashboard for calendars, tasks, chores, and more.",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Cuts 1.25.0. Bumps `package.json`, `ha-app/config.yaml` and the changelog,
moving the four `## Unreleased` entries under a dated 1.25.0 heading.

Contents: theme typeface and display modes, the Notice Board built-in, the
community gallery accepting and installing themes, and the German calendar.

`check-version-sync.sh` passes on all three files.
