### PR TITLE
docs: retire the roadmap voting model

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,15 +1,15 @@
 name: Feature request
 description: Suggest something Prism should do
 title: "feat: "
-labels: ["enhancement", "roadmap"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the idea! Feature requests are filed as **roadmap items** — community 👍 / 👎 reactions on the issue signal priority.
+        Thanks for the idea! Feature requests get a `P1`, `P2` or `P3` label once they're triaged, which is how the queue is ordered.
 
-        See the current roadmap, sorted by votes:
-        https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap+sort%3Areactions-%2B1-desc
+        See what's queued next:
+        https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3AP1
 
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 3. Run the quality checks (see below)
 4. Submit a pull request
 
-**Not sure what to work on?** The public roadmap is the [Prism Roadmap project](https://github.com/users/sandydargoport/projects/3) (vote with an emoji reaction). Internal planning, the untracked backlog, and the engineering-reference docs are all indexed in [`docs/planning.md`](docs/planning.md).
+**Not sure what to work on?** Open issues are ranked with `P1`, `P2` and `P3` labels: [P1 is what's next](https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3AP1). Internal planning, the untracked backlog, and the engineering-reference docs are all indexed in [`docs/planning.md`](docs/planning.md).
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -76,18 +76,9 @@ If something is missing or broken, open an issue or submit a PR.
 - Star the repo
 - Report issues you encounter
 - Suggest features that would help your family
-- **Vote on the roadmap** (see below)
 - Submit PRs for improvements
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
-
-### Vote on what gets built next
-
-The public roadmap lives in the [**Prism Roadmap** Project](https://github.com/users/sandydargoport/projects/3). Each item is an issue tagged `roadmap`. React with any emoji — 👍, ❤️, 🚀, 🎉 — to signal you want it built. The priority order on the [vote-rank list](https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap+sort%3Areactions-desc) sums all reactions, so it doesn't matter which one you pick.
-
-**How to react on an issue:** open the issue, look at the bottom-right of the issue body for the small 😊 icon, click it, pick any reaction. Reactions on the issue body count toward the sort; reactions on comments do not.
-
-Your reactions shape what ships next.
 
 ## License
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -1,6 +1,6 @@
 # Planning &amp; project status
 
-A single map of where Prism's planning lives. The roadmap itself is public and community-voted on GitHub — this page **indexes** the internal planning/reference docs and **gathers the backlog** that isn't yet tracked as an issue, so nothing gets lost.
+A single map of where Prism's planning lives. The roadmap itself is public on GitHub, as ranked issues; this page **indexes** the internal planning/reference docs and **gathers the backlog** that isn't yet tracked as an issue, so nothing gets lost.
 
 _Last reviewed: 2026-07-27, after the recipe/meal **sync framework** shipped ([#58](https://github.com/sandydargoport/prism/issues/58))._
 
@@ -21,7 +21,9 @@ Deliberately **deprioritized:** real RRULE recurrence builder ([#59](https://git
 
 ## Roadmap (live, on GitHub)
 
-The authoritative roadmap is the **[Prism Roadmap project](https://github.com/users/sandydargoport/projects/3)** — every item is a [`roadmap`-labeled issue](https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap+sort%3Areactions-desc), ranked by 👍/❤️/🚀 reaction count. React on an issue to vote for it.
+The authoritative roadmap is the open issues, ranked by label: **[P1](https://github.com/sandydargoport/prism/issues?q=is%3Aissue+is%3Aopen+label%3AP1)** is what gets built next, then `P2`, then `P3` for the unscheduled backlog. `bash scripts/next.sh` prints the whole queue, and anything open without one of those labels is listed as unranked rather than dropping out of sight.
+
+The ranking lives on the issues themselves on purpose. A separate board is a second copy of the truth, and it goes stale silently.
 
 This page **deliberately does not mirror the full list** (a copy would drift). The themed snapshot below is just orientation — GitHub is the source of truth.
 


### PR DESCRIPTION
The Prism Roadmap project board has been deleted and the `roadmap` label
removed, so every reference to them was either a dead link or an instruction to
use a mechanism that no longer exists. Open issues are ranked with `P1`, `P2`
and `P3` labels instead, and `scripts/next.sh` prints that queue.

- **README:** drops the "Vote on what gets built next" section and its bullet
- **CONTRIBUTING:** the "not sure what to work on?" pointer now goes to the P1
  queue instead of the deleted board
- **docs/planning.md:** describes the label ranking, and why the ranking lives
  on the issues rather than on a separate board
- **Feature request template:** stops applying the `roadmap` label, and points
  at the P1 queue rather than a reaction-sorted list

Historical changelog entries that mention the old model are left alone, since
they are accurate as history.
