### PR TITLE
fix(photos): give synced photos an orientation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **Photos from a synced source now filter by orientation.** Orientation was worked out only for photos uploaded by hand, so anything arriving from OneDrive or Immich was stored without one and the landscape/portrait filter on the Photos page returned nothing for it. That is the filter that keeps phone-shaped photos off a landscape display, and every photo joins the wallpaper rotation by default whatever its shape, so on a synced library there was no practical way to exclude them short of paging through the lot. Existing photos are fixed in place on update, using the dimensions already recorded, so nothing re-syncs and no photos are downloaded again.
+
 ## [1.25.0] – 2026-09-07
 
 ### Added

--- a/drizzle/0026_photo_orientation_backfill.sql
+++ b/drizzle/0026_photo_orientation_backfill.sql
@@ -1,0 +1,28 @@
+-- 0026_photo_orientation_backfill.sql
+--
+-- Give synced photos the orientation they should always have had.
+--
+-- `photos.orientation` drives the Photos page filter, and it was computed only
+-- in the manual upload path. Neither the OneDrive nor the Immich sync set it,
+-- so every synced photo landed with orientation NULL. The filter compares with
+-- equality, so it silently matched nothing for those rows: on an instance whose
+-- photos all arrive by sync, filtering by landscape or portrait returned an
+-- empty page and there was no way to keep phone-shaped portraits out of a
+-- landscape wallpaper rotation.
+--
+-- The sync paths now set orientation on insert. This backfills what is already
+-- in the table. Width and height were always recorded, so this is pure
+-- arithmetic on data we hold: no re-sync, no provider calls, no file reads.
+--
+-- Rows with a missing dimension keep NULL, which is the honest value for
+-- "unknown" and is what the helper returns for them too.
+
+UPDATE photos
+SET orientation = CASE
+  WHEN width > height THEN 'landscape'
+  WHEN height > width THEN 'portrait'
+  ELSE 'square'
+END
+WHERE orientation IS NULL
+  AND width IS NOT NULL
+  AND height IS NOT NULL;

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -23,6 +23,7 @@ import { getCached } from '@/lib/cache/redis';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
 import { rateLimitGuard } from '@/lib/cache/rateLimit';
 import { logError } from '@/lib/utils/logError';
+import { orientationFromDimensions } from '@/lib/utils/photoOrientation';
 
 export async function GET(request: NextRequest) {
   const auth = await getDisplayAuth();
@@ -180,13 +181,7 @@ export async function POST(request: NextRequest) {
     const result = await savePhoto(buffer, filename);
     const gps = await extractGps(buffer);
 
-    // Auto-detect orientation from dimensions
-    let orientation: 'landscape' | 'portrait' | 'square' | undefined;
-    if (result.width && result.height) {
-      if (result.width > result.height) orientation = 'landscape';
-      else if (result.height > result.width) orientation = 'portrait';
-      else orientation = 'square';
-    }
+    const orientation = orientationFromDimensions(result.width, result.height);
 
     const [photo] = await db
       .insert(photos)

--- a/src/lib/services/__tests__/photo-sync.test.ts
+++ b/src/lib/services/__tests__/photo-sync.test.ts
@@ -134,6 +134,41 @@ describe('syncOneDriveSource', () => {
     expect(mockInsertValues).toHaveBeenCalledTimes(1);
   });
 
+  it('records orientation on a downloaded photo, so the Photos filter can match it', async () => {
+    mockListPhotos.mockResolvedValue([
+      { id: 'remote-1', name: 'tall.jpg', file: { mimeType: 'image/jpeg' } },
+    ]);
+    mockSelectFrom.mockResolvedValue([]);
+    mockDownloadPhoto.mockResolvedValue(Buffer.from('image-data'));
+    mockSavePhoto.mockResolvedValue({ width: 3024, height: 4032, sizeBytes: 5000, thumbnailPath: 'thumb_tall.jpg' });
+
+    await syncOneDriveSource('source-1');
+
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ orientation: 'portrait' }),
+    );
+  });
+
+  it('records orientation on a metadata-only photo too', async () => {
+    mockListPhotos.mockResolvedValue([
+      {
+        id: 'remote-1',
+        name: 'wide.jpg',
+        file: { mimeType: 'image/jpeg' },
+        image: { width: 4032, height: 3024 },
+        location: { latitude: 51.5, longitude: -0.12 },
+      },
+    ]);
+    mockSelectFrom.mockResolvedValue([]);
+
+    await syncOneDriveSource('source-1');
+
+    expect(mockDownloadPhoto).not.toHaveBeenCalled();
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ orientation: 'landscape' }),
+    );
+  });
+
   it('skips photos already in the database', async () => {
     mockListPhotos.mockResolvedValue([
       { id: 'remote-1', name: 'photo1.jpg', file: { mimeType: 'image/jpeg' } },

--- a/src/lib/services/photo-sync.ts
+++ b/src/lib/services/photo-sync.ts
@@ -12,6 +12,7 @@ import { clearPhotoCache } from './photo-cache';
 import { promises as fs } from 'fs';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import exifr from 'exifr';
+import { orientationFromDimensions } from '@/lib/utils/photoOrientation';
 
 async function extractGps(buffer: Buffer): Promise<{ latitude: string; longitude: string } | null> {
   try {
@@ -146,6 +147,7 @@ export async function syncOneDriveSource(sourceId: string) {
           longitude: facetLng.toString(),
           isExternal: true,
           usage: '',
+          orientation: orientationFromDimensions(mdWidth, mdHeight),
           dedupeKey: computeDedupeKey(takenAt, mdWidth, mdHeight),
         });
       } else {
@@ -169,6 +171,7 @@ export async function syncOneDriveSource(sourceId: string) {
           latitude: gps?.latitude ?? null,
           longitude: gps?.longitude ?? null,
           isExternal: false,
+          orientation: orientationFromDimensions(result.width, result.height),
           dedupeKey: computeDedupeKey(takenAt, result.width, result.height),
         });
       }
@@ -330,6 +333,7 @@ export async function syncImmichSource(sourceId: string) {
       longitude: asset.longitude != null ? asset.longitude.toString() : null,
       isExternal: true,
       usage: 'wallpaper,gallery,screensaver',
+      orientation: orientationFromDimensions(asset.width, asset.height),
       dedupeKey: computeDedupeKey(takenAt, asset.width, asset.height),
     });
   }

--- a/src/lib/utils/__tests__/photoOrientation.test.ts
+++ b/src/lib/utils/__tests__/photoOrientation.test.ts
@@ -1,0 +1,25 @@
+import { orientationFromDimensions } from '../photoOrientation';
+
+describe('orientationFromDimensions', () => {
+  it('calls a wider-than-tall photo landscape', () => {
+    expect(orientationFromDimensions(4032, 3024)).toBe('landscape');
+  });
+
+  it('calls a taller-than-wide photo portrait', () => {
+    expect(orientationFromDimensions(3024, 4032)).toBe('portrait');
+  });
+
+  it('calls equal dimensions square', () => {
+    expect(orientationFromDimensions(1080, 1080)).toBe('square');
+  });
+
+  it('returns null when a dimension is missing, rather than guessing square', () => {
+    expect(orientationFromDimensions(null, 3024)).toBeNull();
+    expect(orientationFromDimensions(4032, null)).toBeNull();
+    expect(orientationFromDimensions(undefined, undefined)).toBeNull();
+  });
+
+  it('treats zero as a real dimension, not as missing', () => {
+    expect(orientationFromDimensions(0, 100)).toBe('portrait');
+  });
+});

--- a/src/lib/utils/photoOrientation.ts
+++ b/src/lib/utils/photoOrientation.ts
@@ -1,0 +1,20 @@
+/**
+ * Orientation for a photo, derived from its pixel dimensions.
+ *
+ * `photos.orientation` drives the Photos page filter and lets a landscape wall
+ * display avoid a library that is mostly phone-shaped portraits. It was
+ * previously computed only on manual upload, so every synced photo landed with
+ * a NULL orientation and the filter silently matched nothing for them.
+ *
+ * Returns null when either dimension is missing, which is the honest answer:
+ * a NULL means "unknown", not "square".
+ */
+export function orientationFromDimensions(
+  width: number | null | undefined,
+  height: number | null | undefined,
+): 'landscape' | 'portrait' | 'square' | null {
+  if (width == null || height == null) return null;
+  if (width > height) return 'landscape';
+  if (height > width) return 'portrait';
+  return 'square';
+}


### PR DESCRIPTION
Closes #383.

Orientation was computed only in the manual upload path, so every photo
arriving from OneDrive or Immich was stored with `orientation` NULL. The Photos
page filter compares with equality, so it matched nothing for those rows: on a
library built by sync, filtering landscape or portrait returned an empty page.

That is also the filter that keeps phone-shaped photos off a landscape wall
display, since photos default to `usage = 'wallpaper,gallery,screensaver'` and
join the rotation whatever their shape.

## What changed

- `orientationFromDimensions()` in `src/lib/utils/photoOrientation.ts`, used by
  the three sync insert sites and by the upload path, so they cannot drift.
  Returns null for a missing dimension rather than guessing square.
- Migration `0026_photo_orientation_backfill.sql` fills existing rows from the
  width and height already stored. No re-sync, no provider calls, no file
  reads.

## Checks

- `tsc --noEmit` and eslint clean; 28 tests pass in the two touched suites,
  including new cases for both OneDrive insert branches
- The backfill was dry-run inside a transaction against a real synced library
  and rolled back: it filled every row, splitting into landscape and portrait
  exactly as the stored dimensions predicted

## Deploying

This one carries a migration, so a local deploy needs the SQL file copied into
the container alongside the build, not just the build.
