### PR TITLE
feat(themes): let a theme set the status colours

### DIFF
--- a/community/themes/README.md
+++ b/community/themes/README.md
@@ -4,6 +4,12 @@ A theme is a set of colours. Nineteen values for light mode, nineteen for dark,
 a name and a short description. No CSS, no fonts, no images — a theme cannot
 contain anything but colour values, deliberately.
 
+Four more are optional: `success`, `success-foreground`, `warning` and
+`warning-foreground`, the colours behind "this worked" and "this needs
+attention". Leave them out and Prism's own values apply, so a theme written
+before they existed is still complete and still correct. Set them and they are
+checked for contrast like every other pair.
+
 ## Installing one
 
 *Settings → Appearance → Palette → Browse* lists everything in this directory,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Prism are documented in this file.
 
 ## Unreleased
 
+### Added
+- **Themes now control the status colours too.** Success, warning and error states were written as literal greens, ambers and reds in the markup, so a theme could not reach them: install a dark, muted palette and the "saved" ticks and "needs attention" banners stayed the same bright factory colours. Around 400 of those hardcoded colours across 66 files now read theme values instead. Two new colours, `success` and `warning`, join the palette a theme may set, alongside the error colour that already existed. Both are **optional**: a theme that says nothing about them keeps Prism's defaults, so every existing theme, including any installed from the gallery, looks exactly as it did. A theme that does set them is contrast-checked on them like any other pair. The per-widget icon colours on the dashboard are deliberately untouched, because those are a set of distinct hues doing a job that one shared colour cannot do.
+
 ### Fixed
 - **Photos from a synced source now filter by orientation.** Orientation was worked out only for photos uploaded by hand, so anything arriving from OneDrive or Immich was stored without one and the landscape/portrait filter on the Photos page returned nothing for it. That is the filter that keeps phone-shaped photos off a landscape display, and every photo joins the wallpaper rotation by default whatever its shape, so on a synced library there was no practical way to exclude them short of paging through the lot. Existing photos are fixed in place on update, using the dimensions already recorded, so nothing re-syncs and no photos are downloaded again.
 

--- a/src/app/calendar/CalendarView.tsx
+++ b/src/app/calendar/CalendarView.tsx
@@ -381,7 +381,7 @@ export function CalendarView() {
                 variant="outline"
                 size="sm"
                 onClick={() => setShowManageCalendars(true)}
-                className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                className="h-9 border-warning/50 text-warning hover:bg-warning/10"
                 title={`${stalledProvider ? `${stalledProvider} calendar sync` : 'Calendar sync'} has stopped — reconnect to resume`}
               >
                 <AlertTriangle className="h-4 w-4 mr-1" />
@@ -393,7 +393,7 @@ export function CalendarView() {
                 variant="outline"
                 size="sm"
                 onClick={() => setShowPendingReview(true)}
-                className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                className="h-9 border-warning/50 text-warning hover:bg-warning/10"
                 title={t('toolbar.reviewTitle')}
               >
                 <AlertTriangle className="h-4 w-4 mr-1" />

--- a/src/app/calendar/PendingDeletionsModal.tsx
+++ b/src/app/calendar/PendingDeletionsModal.tsx
@@ -63,7 +63,7 @@ export function PendingDeletionsModal({
       <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <AlertTriangle className="h-5 w-5 text-warning" />
             {t('title')}
           </DialogTitle>
         </DialogHeader>

--- a/src/app/chores/ChoreCompletionsList.tsx
+++ b/src/app/chores/ChoreCompletionsList.tsx
@@ -50,7 +50,7 @@ export function ChoreCompletionsList({
                 'flex items-center gap-3 p-3 rounded-lg border bg-card/85 backdrop-blur-sm',
                 c.approvedBy
                   ? 'border-border'
-                  : 'border-amber-500/30 bg-amber-50/50 dark:bg-amber-950/30'
+                  : 'border-warning/30 bg-warning/10'
               )}
             >
               <span className="text-lg shrink-0">{getCategoryEmoji(c.choreCategory)}</span>
@@ -63,11 +63,11 @@ export function ChoreCompletionsList({
                     </Badge>
                   )}
                   {c.approvedBy ? (
-                    <Badge variant="outline" className="text-xs text-green-600 border-green-500/30">
+                    <Badge variant="outline" className="text-xs text-success border-success/30">
                       <ShieldCheck className="h-3 w-3 mr-0.5" />Approved
                     </Badge>
                   ) : (
-                    <Badge variant="default" className="text-xs bg-amber-500 hover:bg-amber-500">
+                    <Badge variant="default" className="text-xs bg-warning hover:bg-warning">
                       Pending Approval
                     </Badge>
                   )}
@@ -84,7 +84,7 @@ export function ChoreCompletionsList({
                   </div>
                   {c.approvedBy && (
                     <div className="flex items-center gap-1">
-                      <ShieldCheck className="h-3 w-3 text-green-500" />
+                      <ShieldCheck className="h-3 w-3 text-success" />
                       <span>{c.approvedBy.name}</span>
                     </div>
                   )}

--- a/src/app/chores/ChoreGroupCard.tsx
+++ b/src/app/chores/ChoreGroupCard.tsx
@@ -58,11 +58,11 @@ export function ChoreGroupCard({
       className={cn(
         'p-2 rounded-md border cursor-pointer hover:bg-muted/50 transition-colors group',
         isPendingApproval
-          ? 'bg-amber-50/80 dark:bg-amber-950/30 border-amber-500/50'
+          ? 'bg-warning/10 border-warning/50'
           : isCompletedToday
-          ? 'opacity-60 bg-green-50/50 dark:bg-green-950/20 border-green-500/30'
+          ? 'opacity-60 bg-success/10 border-success/30'
           : isOverdue
-          ? 'border-red-500/50 bg-red-50/50 dark:bg-red-950/20'
+          ? 'border-destructive/50 bg-destructive/10'
           : 'border-border'
       )}
       onClick={async () => {
@@ -84,20 +84,20 @@ export function ChoreGroupCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             {isPendingApproval && (
-              <Hourglass className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+              <Hourglass className="h-3.5 w-3.5 text-warning shrink-0" />
             )}
             <p
               className={cn(
                 'font-medium text-sm truncate',
                 isCompletedToday && !isPendingApproval && 'line-through',
-                isPendingApproval && 'text-amber-700 dark:text-amber-400'
+                isPendingApproval && 'text-warning'
               )}
             >
               {chore.title}
             </p>
           </div>
           {isPendingApproval && chore.pendingApproval && (
-            <div className="flex items-center gap-1 text-xs mt-0.5 text-amber-600 dark:text-amber-400">
+            <div className="flex items-center gap-1 text-xs mt-0.5 text-warning">
               <span>Awaiting approval</span>
               <span className="text-muted-foreground">
                 &middot; {chore.pendingApproval.completedBy.name}
@@ -108,7 +108,7 @@ export function ChoreGroupCard({
             <div
               className={cn(
                 'flex items-center gap-1 text-xs mt-0.5',
-                isOverdue ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'
+                isOverdue ? 'text-destructive' : 'text-muted-foreground'
               )}
             >
               <CalendarDays className="h-3 w-3" />
@@ -128,7 +128,7 @@ export function ChoreGroupCard({
           {isPendingApproval && (
             <Badge
               variant="default"
-              className="text-[10px] bg-amber-500 hover:bg-amber-500 px-1.5 py-0"
+              className="text-[10px] bg-warning hover:bg-warning px-1.5 py-0"
             >
               Pending
             </Badge>

--- a/src/app/chores/ChoreItem.tsx
+++ b/src/app/chores/ChoreItem.tsx
@@ -70,7 +70,7 @@ export function ChoreItem({
         'flex items-center gap-4 p-4 rounded-lg border border-border bg-card/85 backdrop-blur-sm',
         'hover:border-seasonal-accent hover:ring-2 hover:ring-seasonal-accent/50 transition-all group',
         !chore.enabled && 'opacity-50',
-        isPendingApproval && 'bg-amber-100/85 dark:bg-amber-950/85 border-amber-500/30'
+        isPendingApproval && 'bg-warning/10 border-warning/30'
       )}
     >
       {/* Complete button - always enabled for parents, shows pending state visually */}
@@ -82,7 +82,7 @@ export function ChoreItem({
         className={cn(
           'flex-shrink-0 h-9 w-9',
           isOverdue && !isPendingApproval && 'text-destructive hover:text-destructive',
-          isPendingApproval && 'text-amber-500'
+          isPendingApproval && 'text-warning'
         )}
         title={isPendingApproval ? 'Approve and complete chore' : 'Mark as complete'}
       >
@@ -99,7 +99,7 @@ export function ChoreItem({
           <span className="text-base"><Emoji e={categoryEmoji} /></span>
           <span className={cn(
             'font-medium',
-            isPendingApproval && 'text-amber-700 dark:text-amber-400'
+            isPendingApproval && 'text-warning'
           )}>{chore.title}</span>
 
           {chore.pointValue > 0 && (
@@ -110,7 +110,7 @@ export function ChoreItem({
 
           {/* Show pending badge if pending approval, otherwise show requires approval */}
           {isPendingApproval ? (
-            <Badge variant="default" className="text-xs bg-amber-500 hover:bg-amber-500">
+            <Badge variant="default" className="text-xs bg-warning hover:bg-warning">
               Pending Approval
             </Badge>
           ) : chore.requiresApproval && (
@@ -134,7 +134,7 @@ export function ChoreItem({
                 size="sm"
                 className="h-4 w-4 text-[8px]"
               />
-              <span className="text-amber-600 dark:text-amber-400">
+              <span className="text-warning">
                 Completed by {chore.pendingApproval.completedBy.name}
               </span>
             </div>

--- a/src/app/goals/GoalsView.tsx
+++ b/src/app/goals/GoalsView.tsx
@@ -261,7 +261,7 @@ export function GoalsView() {
                     className={cn(
                       'rounded-lg border p-4 transition-all',
                       goal.fullyAchieved
-                        ? 'border-green-500/50 bg-green-100 dark:bg-green-950'
+                        ? 'border-success/50 bg-success/10'
                         : 'bg-card border-border',
                       isParent && 'cursor-grab active:cursor-grabbing touch-none',
                       draggedGoalId === goal.id && 'opacity-50 scale-95 ring-4 ring-primary/50'
@@ -297,7 +297,7 @@ export function GoalsView() {
                         <div className="flex items-center gap-2">
                           <h3 className="font-semibold truncate">{goal.name}</h3>
                           {goal.fullyAchieved && (
-                            <Check className="h-5 w-5 text-green-500 shrink-0" />
+                            <Check className="h-5 w-5 text-success shrink-0" />
                           )}
                         </div>
                         {goal.description && (
@@ -361,7 +361,7 @@ export function GoalsView() {
                             variant="outline"
                             size="sm"
                             onClick={() => handleReset(goal.id)}
-                            className="text-green-600 hover:text-green-700"
+                            className="text-success hover:text-success"
                           >
                             <RotateCcw className="h-3.5 w-3.5 mr-1" />
                             Reset

--- a/src/app/meals/MealsView.tsx
+++ b/src/app/meals/MealsView.tsx
@@ -339,7 +339,7 @@ function MealCard({ meal, onMarkCooked, onUnmarkCooked, onEdit, onDelete, onDrop
         {meal.description && <p className="text-xs text-muted-foreground mt-0.5">{meal.description}</p>}
         {isCooked && meal.cookedBy && (
           <div className="flex items-center gap-1 mt-1">
-            <CheckCircle2 className="h-3 w-3 text-green-600" />
+            <CheckCircle2 className="h-3 w-3 text-success" />
             <UserAvatar name={meal.cookedBy.name} color={meal.cookedBy.color} size="sm" className="h-4 w-4 text-[8px]" />
             <span className="text-xs text-muted-foreground">{meal.cookedBy.name} cooked this</span>
           </div>

--- a/src/app/messages/MessagesView.tsx
+++ b/src/app/messages/MessagesView.tsx
@@ -419,7 +419,7 @@ function MessageCard({
         className={cn(
           'p-2 rounded-md border border-border bg-card/50',
           'hover:bg-muted/50 transition-colors group',
-          message.important && 'bg-red-100/50 dark:bg-red-950/50 border-destructive/20'
+          message.important && 'bg-destructive/10 border-destructive/20'
         )}
       >
         <div className="flex items-start justify-between gap-1">
@@ -498,7 +498,7 @@ function MessageCard({
         'p-4 rounded-lg border border-border bg-card/85 backdrop-blur-sm',
         'hover:border-seasonal-accent hover:ring-2 hover:ring-seasonal-accent/50 transition-all',
         'group',
-        message.important && 'bg-red-100/85 dark:bg-red-950/85 border-destructive/20'
+        message.important && 'bg-destructive/10 border-destructive/20'
       )}
     >
       {/* Header: Author and badges */}

--- a/src/app/photos/PhotosView.tsx
+++ b/src/app/photos/PhotosView.tsx
@@ -279,7 +279,7 @@ export function PhotosView() {
             className="h-8 gap-1.5 shrink-0"
             title="Show only photos below 1920×1080 (yellow/red dots) — low-res for HD wallpaper"
           >
-            <span className="w-2.5 h-2.5 rounded-full bg-yellow-500 ring-1 ring-black/30" />
+            <span className="w-2.5 h-2.5 rounded-full bg-warning ring-1 ring-black/30" />
             Below HD
           </Button>
           {hasActiveFilters && (

--- a/src/app/recipes/RecipeCard.tsx
+++ b/src/app/recipes/RecipeCard.tsx
@@ -45,8 +45,8 @@ export function RecipeCard({ recipe, onClick, onToggleFavorite }: RecipeCardProp
               className={cn(
                 'h-5 w-5 transition-colors',
                 recipe.isFavorite
-                  ? 'fill-red-500 text-red-500'
-                  : 'text-muted-foreground hover:text-red-500'
+                  ? 'fill-red-500 text-destructive'
+                  : 'text-muted-foreground hover:text-destructive'
               )}
             />
           </button>

--- a/src/app/recipes/RecipeDetailModal.tsx
+++ b/src/app/recipes/RecipeDetailModal.tsx
@@ -132,8 +132,8 @@ export function RecipeDetailModal({
                   className={cn(
                     'h-5 w-5 transition-colors',
                     recipe.isFavorite
-                      ? 'fill-red-500 text-red-500'
-                      : 'text-muted-foreground hover:text-red-500'
+                      ? 'fill-red-500 text-destructive'
+                      : 'text-muted-foreground hover:text-destructive'
                   )}
                 />
               </button>

--- a/src/app/settings/components/CalDAVConnectDialog.tsx
+++ b/src/app/settings/components/CalDAVConnectDialog.tsx
@@ -217,7 +217,7 @@ export function CalDAVConnectDialog({
               <div className={cn(
                 'flex items-center gap-2 p-3 rounded-lg text-sm',
                 testResult.success
-                  ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400'
+                  ? 'bg-success/10 text-success'
                   : 'bg-destructive/10 text-destructive'
               )}>
                 {testResult.success ? <CheckCircle2 className="h-4 w-4 shrink-0" /> : <AlertCircle className="h-4 w-4 shrink-0" />}

--- a/src/app/settings/sections/ActivityLogSection.tsx
+++ b/src/app/settings/sections/ActivityLogSection.tsx
@@ -38,12 +38,12 @@ const ENTITY_TYPE_OPTIONS = [
 ];
 
 const ACTION_COLORS: Record<string, string> = {
-  create: 'bg-green-500/15 text-green-700 dark:text-green-400',
+  create: 'bg-success/15 text-success',
   update: 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
-  complete: 'bg-green-500/15 text-green-700 dark:text-green-400',
-  delete: 'bg-red-500/15 text-red-700 dark:text-red-400',
-  login: 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-400',
-  logout: 'bg-yellow-500/15 text-yellow-700 dark:text-yellow-400',
+  complete: 'bg-success/15 text-success',
+  delete: 'bg-destructive/15 text-destructive',
+  login: 'bg-warning/15 text-warning',
+  logout: 'bg-warning/15 text-warning',
   toggle: 'bg-purple-500/15 text-purple-700 dark:text-purple-400',
 };
 

--- a/src/app/settings/sections/BackupSection.tsx
+++ b/src/app/settings/sections/BackupSection.tsx
@@ -184,7 +184,7 @@ export function BackupSection() {
 
       {/* Success message */}
       {successMessage && (
-        <div className="flex items-center gap-2 p-3 bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800 rounded-lg text-green-700 dark:text-green-400">
+        <div className="flex items-center gap-2 p-3 bg-success/10 border border-success/40 rounded-lg text-success">
           <CheckCircle className="h-4 w-4" />
           {successMessage}
         </div>
@@ -192,7 +192,7 @@ export function BackupSection() {
 
       {/* Error message */}
       {error && (
-        <div className="flex items-center gap-2 p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400">
+        <div className="flex items-center gap-2 p-3 bg-destructive/10 border border-destructive/40 rounded-lg text-destructive">
           <AlertTriangle className="h-4 w-4" />
           {error}
         </div>
@@ -245,8 +245,8 @@ export function BackupSection() {
 
                   {/* Restore button */}
                   {confirmRestore === backup.filename ? (
-                    <div className="flex items-center gap-2 p-2 bg-amber-50 dark:bg-amber-950/30 rounded-lg">
-                      <span className="text-xs text-amber-700 dark:text-amber-400 max-w-48">
+                    <div className="flex items-center gap-2 p-2 bg-warning/10 rounded-lg">
+                      <span className="text-xs text-warning max-w-48">
                         This will overwrite all current data. Changes since {backup.createdAtFormatted} will be lost.
                       </span>
                       <Button
@@ -345,20 +345,20 @@ export function BackupSection() {
       </p>
 
       {/* Danger Zone */}
-      <div className="border border-red-200 dark:border-red-800 rounded-lg p-4 space-y-4">
-        <h4 className="font-semibold text-red-600 dark:text-red-400 flex items-center gap-2">
+      <div className="border border-destructive/40 rounded-lg p-4 space-y-4">
+        <h4 className="font-semibold text-destructive flex items-center gap-2">
           <AlertTriangle className="h-4 w-4" />
           Danger Zone
         </h4>
 
         {/* Step 1: Warning for truncate */}
         {dangerStep === 'warn-truncate' && (
-          <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg space-y-3">
+          <div className="p-3 bg-destructive/10 border border-destructive/40 rounded-lg space-y-3">
             <div className="flex items-start gap-2">
-              <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+              <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
               <div>
-                <p className="font-medium text-red-600 dark:text-red-400">Warning: This will permanently delete all data</p>
-                <p className="text-sm text-red-600/80 dark:text-red-400/80 mt-1">
+                <p className="font-medium text-destructive">Warning: This will permanently delete all data</p>
+                <p className="text-sm text-destructive/80 mt-1">
                   All family members, chores, tasks, calendar events, meals, recipes, shopping lists, messages, and settings will be removed. This cannot be undone.
                 </p>
               </div>
@@ -374,8 +374,8 @@ export function BackupSection() {
 
         {/* Step 2: Type-to-confirm for truncate */}
         {dangerStep === 'confirm-truncate' && (
-          <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg space-y-3">
-            <p className="text-sm text-red-600 dark:text-red-400">
+          <div className="p-3 bg-destructive/10 border border-destructive/40 rounded-lg space-y-3">
+            <p className="text-sm text-destructive">
               Type <span className="font-mono font-bold">{TRUNCATE_CHALLENGE}</span> to confirm:
             </p>
             <input
@@ -383,7 +383,7 @@ export function BackupSection() {
               value={challengeInput}
               onChange={(e) => setChallengeInput(e.target.value)}
               placeholder={TRUNCATE_CHALLENGE}
-              className="w-full px-3 py-2 rounded-md border border-red-300 dark:border-red-700 bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+              className="w-full px-3 py-2 rounded-md border border-destructive bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-destructive"
               autoFocus
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && challengeInput === TRUNCATE_CHALLENGE) handleTruncate();
@@ -410,18 +410,18 @@ export function BackupSection() {
 
         {/* Step 1: Warning for seed */}
         {dangerStep === 'warn-seed' && (
-          <div className="p-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg space-y-3">
+          <div className="p-3 bg-warning/10 border border-warning/40 rounded-lg space-y-3">
             <div className="flex items-start gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+              <AlertTriangle className="h-5 w-5 text-warning shrink-0 mt-0.5" />
               <div>
-                <p className="font-medium text-amber-600 dark:text-amber-400">Warning: This will overwrite your data</p>
-                <p className="text-sm text-amber-600/80 dark:text-amber-400/80 mt-1">
+                <p className="font-medium text-warning">Warning: This will overwrite your data</p>
+                <p className="text-sm text-warning/80 mt-1">
                   Seeding will populate the database with demo family data (Alex, Jordan, Sam, Riley). Existing data may be affected.
                 </p>
               </div>
             </div>
             <div className="flex gap-2">
-              <Button variant="default" size="sm" className="bg-amber-600 hover:bg-amber-700 text-white" onClick={() => { setDangerStep('confirm-seed'); setChallengeInput(''); }}>
+              <Button variant="default" size="sm" className="bg-warning hover:bg-warning text-white" onClick={() => { setDangerStep('confirm-seed'); setChallengeInput(''); }}>
                 I understand, proceed
               </Button>
               <Button variant="outline" size="sm" onClick={cancelDanger}>Cancel</Button>
@@ -431,8 +431,8 @@ export function BackupSection() {
 
         {/* Step 2: Type-to-confirm for seed */}
         {dangerStep === 'confirm-seed' && (
-          <div className="p-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg space-y-3">
-            <p className="text-sm text-amber-600 dark:text-amber-400">
+          <div className="p-3 bg-warning/10 border border-warning/40 rounded-lg space-y-3">
+            <p className="text-sm text-warning">
               Type <span className="font-mono font-bold">{SEED_CHALLENGE}</span> to confirm:
             </p>
             <input
@@ -440,7 +440,7 @@ export function BackupSection() {
               value={challengeInput}
               onChange={(e) => setChallengeInput(e.target.value)}
               placeholder={SEED_CHALLENGE}
-              className="w-full px-3 py-2 rounded-md border border-amber-300 dark:border-amber-700 bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              className="w-full px-3 py-2 rounded-md border border-warning bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-warning"
               autoFocus
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && challengeInput === SEED_CHALLENGE) handleSeed();
@@ -451,7 +451,7 @@ export function BackupSection() {
               <Button
                 variant="default"
                 size="sm"
-                className="bg-amber-600 hover:bg-amber-700 text-white"
+                className="bg-warning hover:bg-warning text-white"
                 onClick={handleSeed}
                 disabled={seeding || challengeInput !== SEED_CHALLENGE}
               >
@@ -472,7 +472,7 @@ export function BackupSection() {
             <Button
               variant="outline"
               onClick={() => setDangerStep('warn-truncate')}
-              className="border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+              className="border-destructive text-destructive hover:bg-destructive/10"
             >
               <Eraser className="h-4 w-4 mr-2" />
               Clear All Data

--- a/src/app/settings/sections/BusTrackingSection.tsx
+++ b/src/app/settings/sections/BusTrackingSection.tsx
@@ -388,7 +388,7 @@ function GmailConnectionCard({
             </div>
           </div>
           {connection.connected ? (
-            <Badge variant="default" className="bg-green-600">Connected</Badge>
+            <Badge variant="default" className="bg-success">Connected</Badge>
           ) : (
             <Badge variant="secondary">Not Connected</Badge>
           )}

--- a/src/app/settings/sections/CalendarsSection.tsx
+++ b/src/app/settings/sections/CalendarsSection.tsx
@@ -332,18 +332,18 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
             <div className="space-y-3">
               {/* Single re-auth banner if any Google calendar needs it */}
               {manageableCalendars.some((c) => c.provider === 'google' && c.syncErrors?.needsReauth) && (
-                <div className="flex items-center gap-3 p-3 rounded-md border border-orange-500/50 bg-orange-50 dark:bg-orange-950/30">
-                  <AlertTriangle className="h-5 w-5 text-orange-500 shrink-0" />
+                <div className="flex items-center gap-3 p-3 rounded-md border border-warning/50 bg-warning/10">
+                  <AlertTriangle className="h-5 w-5 text-warning shrink-0" />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-orange-700 dark:text-orange-400">Google token expired</p>
-                    <p className="text-xs text-orange-600 dark:text-orange-400/80">
+                    <p className="text-sm font-medium text-warning">Google token expired</p>
+                    <p className="text-xs text-warning dark:text-warning/80">
                       Re-authenticate once to refresh all Google calendars.
                     </p>
                   </div>
                   <Button
                     variant="outline"
                     size="sm"
-                    className="border-orange-500/50 text-orange-600 hover:bg-orange-100 dark:hover:bg-orange-950"
+                    className="border-warning/50 text-warning hover:bg-warning/10"
                     onClick={() => {
                       const firstGoogle = manageableCalendars.find((c) => c.provider === 'google');
                       if (firstGoogle) window.location.href = `/api/auth/google?reauth=${firstGoogle.id}&returnSection=calendars`;
@@ -444,7 +444,7 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
                                 setEditingCalendarId(null);
                               }}
                             >
-                              <Check className="h-4 w-4 text-green-600" />
+                              <Check className="h-4 w-4 text-success" />
                             </Button>
                             <Button
                               variant="ghost"
@@ -452,7 +452,7 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
                               className="h-7 w-7"
                               onClick={() => setEditingCalendarId(null)}
                             >
-                              <X className="h-4 w-4 text-red-600" />
+                              <X className="h-4 w-4 text-destructive" />
                             </Button>
                           </div>
                         ) : (
@@ -490,8 +490,8 @@ export function CalendarsSection({ onSynced }: { onSynced?: () => void } = {}) {
                         </div>
                         {cal.syncErrors?.needsReauth && (
                           <div className="flex items-center gap-1 mt-1">
-                            <AlertTriangle className="h-3 w-3 text-orange-500 shrink-0" />
-                            <span className="text-xs text-orange-600 dark:text-orange-400">
+                            <AlertTriangle className="h-3 w-3 text-warning shrink-0" />
+                            <span className="text-xs text-warning">
                               Token expired
                             </span>
                           </div>

--- a/src/app/settings/sections/FamilySection.tsx
+++ b/src/app/settings/sections/FamilySection.tsx
@@ -225,9 +225,9 @@ export function FamilySection() {
                       {member.role}
                     </Badge>
                     {member.hasPin ? (
-                      <span className="text-green-600">PIN set</span>
+                      <span className="text-success">PIN set</span>
                     ) : (
-                      <span className="text-orange-600">No PIN</span>
+                      <span className="text-warning">No PIN</span>
                     )}
                   </div>
                 </div>

--- a/src/app/settings/sections/KrogerConnectionCard.tsx
+++ b/src/app/settings/sections/KrogerConnectionCard.tsx
@@ -217,9 +217,9 @@ export function KrogerConnectionCard() {
           </div>
         ) : !status?.configured ? (
           <div className="space-y-3">
-            <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
+            <div className="rounded-md border border-warning/40 bg-warning/5 p-3 text-sm">
               <div className="flex items-start gap-2">
-                <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
+                <AlertCircle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
                 <div>
                   <p className="font-medium">Kroger credentials not configured</p>
                   <ol className="mt-2 space-y-1 list-decimal list-inside text-muted-foreground">
@@ -298,7 +298,7 @@ export function KrogerConnectionCard() {
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-sm">
-                <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <Check className="h-4 w-4 text-success" />
                 <span>Connected — &quot;Send to Kroger&quot; is live on the Shopping page.</span>
               </div>
               <Button

--- a/src/app/settings/sections/PhotosSettingsSection.tsx
+++ b/src/app/settings/sections/PhotosSettingsSection.tsx
@@ -313,9 +313,9 @@ export function PhotosSettingsSection() {
             </span>
           </div>
           <div className="flex items-center gap-3 text-xs">
-            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-green-500" /> &ge; target</span>
-            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-yellow-500" /> &ge; 75%</span>
-            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-red-500" /> &lt; 75%</span>
+            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-success" /> &ge; target</span>
+            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-warning" /> &ge; 75%</span>
+            <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded-full bg-destructive" /> &lt; 75%</span>
           </div>
         </CardContent>
       </Card>
@@ -400,7 +400,7 @@ export function PhotosSettingsSection() {
                           {source.photoCount} photos
                           {source.lastSynced && <> · Synced {new Date(source.lastSynced).toLocaleDateString()}</>}
                           {source.type === 'onedrive' && !source.onedriveFolderId && (
-                            <span className="text-amber-600 dark:text-amber-400"> · No folder selected</span>
+                            <span className="text-warning"> · No folder selected</span>
                           )}
                         </p>
                       </div>

--- a/src/app/settings/sections/SecuritySection.tsx
+++ b/src/app/settings/sections/SecuritySection.tsx
@@ -151,11 +151,11 @@ export function SecuritySection() {
                   <div className="font-medium">{member.name}</div>
                   <div className="text-sm text-muted-foreground">
                     {member.hasPin ? (
-                      <span className="text-green-600">
+                      <span className="text-success">
                         PIN set &middot; {member.pinLength ?? DEFAULT_PIN_LENGTH} digits
                       </span>
                     ) : (
-                      <span className="text-orange-600">No PIN set</span>
+                      <span className="text-warning">No PIN set</span>
                     )}
                   </div>
                 </div>
@@ -216,8 +216,8 @@ export function SecuritySection() {
 
           {/* Show newly created token */}
           {createdToken && (
-            <div className="p-3 rounded-md border border-green-500/50 bg-green-50 dark:bg-green-950/20 space-y-2">
-              <p className="text-sm font-medium text-green-700 dark:text-green-400">
+            <div className="p-3 rounded-md border border-success/50 bg-success/10 space-y-2">
+              <p className="text-sm font-medium text-success">
                 Token created! Copy it now — it won&apos;t be shown again.
               </p>
               <div className="flex gap-2">
@@ -252,7 +252,7 @@ export function SecuritySection() {
                       {token.name}
                       <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
                         token.scopes.includes('*')
-                          ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+                          ? 'bg-warning/15 text-warning'
                           : 'bg-blue-500/15 text-blue-700 dark:text-blue-400'
                       }`}>
                         {token.scopes.join(', ')}

--- a/src/app/settings/sections/integrations/IntegrationsSection.tsx
+++ b/src/app/settings/sections/integrations/IntegrationsSection.tsx
@@ -90,7 +90,7 @@ export function IntegrationsSection() {
       </div>
 
       {setupPrompt && !setupDismissed && (
-        <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100">
+        <div className="flex items-start gap-3 rounded-lg border border-warning bg-warning/10 p-4 text-warning dark:border-warning/60">
           <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0" />
           <div className="flex-1 text-sm">
             <p className="font-semibold">{setupPrompt.name} isn&apos;t set up yet</p>
@@ -103,7 +103,7 @@ export function IntegrationsSection() {
             </p>
             <Link
               href="/setup/rerun"
-              className="mt-3 inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700"
+              className="mt-3 inline-flex items-center rounded-md bg-warning px-3 py-1.5 text-xs font-medium text-white hover:bg-warning"
             >
               Open Setup Wizard
             </Link>
@@ -111,7 +111,7 @@ export function IntegrationsSection() {
           <button
             onClick={() => setSetupDismissed(true)}
             aria-label="Dismiss"
-            className="text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+            className="text-warning hover:text-warning"
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/app/settings/sections/integrations/cards/GmailProviderCard.tsx
+++ b/src/app/settings/sections/integrations/cards/GmailProviderCard.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const GmailIcon = () => (
-  <Mail className="h-6 w-6 text-red-500" aria-hidden="true" />
+  <Mail className="h-6 w-6 text-destructive" aria-hidden="true" />
 );
 
 const handleConnect = () => {

--- a/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
+++ b/src/app/settings/sections/integrations/cards/GoogleManualTokenForm.tsx
@@ -262,7 +262,7 @@ export function GoogleManualTokenForm({ onSaved }: { onSaved?: () => void }) {
         <li>Paste the Client ID, Client Secret, and Refresh token below.</li>
       </ol>
 
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100">
+      <div className="rounded-md border border-warning bg-warning/10 p-2.5 text-xs text-warning dark:border-warning/60">
         <span className="font-medium">Keep it from expiring:</span> publish the consent screen to{' '}
         <span className="font-medium">Production</span> (step 2). In <span className="font-medium">Testing</span>{' '}
         mode Google expires refresh tokens after 7 days. Publishing shows a one-time &ldquo;Google

--- a/src/app/settings/sections/integrations/components.tsx
+++ b/src/app/settings/sections/integrations/components.tsx
@@ -40,7 +40,7 @@ export function StatusBanner({
         'p-4 rounded-lg flex items-center gap-3',
         message.type === 'error'
           ? 'bg-destructive/10 text-destructive border border-destructive/20'
-          : 'bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20'
+          : 'bg-success/10 text-success border border-success/20'
       )}
     >
       {message.type === 'error' ? (
@@ -152,7 +152,7 @@ export function SourceRow<S extends BaseSource>({
             </span>
           ) : source.lastSyncAt ? (
             <span className="flex items-center gap-1 text-muted-foreground">
-              <CheckCircle2 className="h-3 w-3 text-green-500" />
+              <CheckCircle2 className="h-3 w-3 text-success" />
               {new Date(source.lastSyncAt).toLocaleString()}
             </span>
           ) : (

--- a/src/app/setup/steps/MapboxStep.tsx
+++ b/src/app/setup/steps/MapboxStep.tsx
@@ -97,7 +97,7 @@ export function MapboxStep({ onNext, onBack }: MapboxStepProps) {
               {saving ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : saved ? (
-                <><CheckCircle2 className="h-4 w-4 text-green-500 mr-1" />Saved</>
+                <><CheckCircle2 className="h-4 w-4 text-success mr-1" />Saved</>
               ) : (
                 'Save'
               )}

--- a/src/app/tasks/PendingTaskDeletionsModal.tsx
+++ b/src/app/tasks/PendingTaskDeletionsModal.tsx
@@ -64,7 +64,7 @@ export function PendingTaskDeletionsModal({
       <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <AlertTriangle className="h-5 w-5 text-warning" />
             Review removals
           </DialogTitle>
         </DialogHeader>

--- a/src/app/tasks/TaskRow.tsx
+++ b/src/app/tasks/TaskRow.tsx
@@ -35,8 +35,8 @@ export function TaskRow({
     <div
       className={cn(
         'p-2 rounded-md border cursor-pointer hover:bg-muted/50 transition-colors',
-        task.completed ? 'opacity-60 bg-green-50/50 dark:bg-green-950/20 border-green-500/30' : '',
-        isOverdue ? 'border-red-500/50 bg-red-50/50 dark:bg-red-950/20' : !task.completed ? 'border-border' : ''
+        task.completed ? 'opacity-60 bg-success/10 border-success/30' : '',
+        isOverdue ? 'border-destructive/50 bg-destructive/10' : !task.completed ? 'border-border' : ''
       )}
       onClick={onToggle}
     >
@@ -57,7 +57,7 @@ export function TaskRow({
                 {dueDate && (
                   <div className={cn(
                     'flex items-center gap-1 text-xs',
-                    isOverdue ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'
+                    isOverdue ? 'text-destructive' : 'text-muted-foreground'
                   )}>
                     <CalendarDays className="h-3 w-3" />
                     {isOverdue ? (

--- a/src/app/tasks/TasksView.tsx
+++ b/src/app/tasks/TasksView.tsx
@@ -133,7 +133,7 @@ export function TasksView() {
                 variant="outline"
                 size="sm"
                 onClick={() => setShowPendingReview(true)}
-                className="h-9 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+                className="h-9 border-warning/50 text-warning hover:bg-warning/10"
                 title="Review task removals held for your approval"
               >
                 <AlertTriangle className="h-4 w-4 mr-1" />

--- a/src/app/travel/components/PinDetail.tsx
+++ b/src/app/travel/components/PinDetail.tsx
@@ -54,9 +54,9 @@ function SortableChildItem({ child, idx, onSelect, onDelete }: {
         : <MapPin className="h-3.5 w-3.5 text-violet-500 shrink-0" />}
       <button onClick={onSelect} className="flex-1 text-left text-xs font-medium hover:underline truncate">
         {child.name}
-        {!child.latitude && !child.longitude && <span className="text-[10px] text-amber-500 ml-1.5">no location</span>}
+        {!child.latitude && !child.longitude && <span className="text-[10px] text-warning ml-1.5">no location</span>}
       </button>
-      <button onClick={onDelete} className="shrink-0 text-muted-foreground/40 hover:text-red-500 transition-colors" title="Remove">
+      <button onClick={onDelete} className="shrink-0 text-muted-foreground/40 hover:text-destructive transition-colors" title="Remove">
         <X className="h-3 w-3" />
       </button>
     </div>
@@ -200,7 +200,7 @@ export function PinDetail({ pin, childPins, onUpdate, onDelete, onDeleteChild, o
             />
             {!isChildPin && (
               <button onClick={handleToggleBucketList} title={isBucketList ? 'Remove from bucket list' : 'Add to bucket list'} className="shrink-0">
-                <Star className={cn('h-4 w-4', isBucketList ? 'fill-amber-500 text-amber-500' : 'text-muted-foreground/40 hover:text-amber-400')} />
+                <Star className={cn('h-4 w-4', isBucketList ? 'fill-amber-500 text-warning' : 'text-muted-foreground/40 hover:text-warning')} />
               </button>
             )}
           </div>

--- a/src/app/travel/components/PinForm.tsx
+++ b/src/app/travel/components/PinForm.tsx
@@ -288,10 +288,10 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                     <li key={u.name}>
                       <button type="button" onClick={() => selectNP(u.name)}
                         className={cn('w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 transition-colors',
-                          sel ? 'bg-emerald-50 dark:bg-emerald-900/20' : 'hover:bg-muted')}
+                          sel ? 'bg-success/10' : 'hover:bg-muted')}
                       >
                         <span className={cn('h-4 w-4 rounded border flex items-center justify-center shrink-0',
-                          sel ? 'bg-emerald-600 border-emerald-600' : 'border-border')}>
+                          sel ? 'bg-success border-success' : 'border-border')}>
                           {sel && <span className="text-white text-[10px] leading-none">✓</span>}
                         </span>
                         <span className="flex-1 truncate">{u.name}</span>
@@ -358,7 +358,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
               </button>
             </div>
           ) : (
-            <p className="text-xs text-amber-600 dark:text-amber-400">
+            <p className="text-xs text-warning">
               Select a result to pin on the globe (optional)
             </p>
           )}
@@ -390,11 +390,11 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
             <button type="button" onClick={() => setIsBucketList((v) => !v)}
               className={cn('flex items-center gap-1.5 px-3 py-2 rounded-md border text-sm font-medium transition-colors h-10 shrink-0',
                 isBucketList
-                  ? 'bg-amber-50 border-amber-300 text-amber-700 dark:bg-amber-900/30 dark:border-amber-600 dark:text-amber-400'
+                  ? 'bg-warning/10 border-warning text-warning'
                   : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
               )}
             >
-              <Star className={cn('h-4 w-4', isBucketList && 'fill-amber-500 text-amber-500')} />
+              <Star className={cn('h-4 w-4', isBucketList && 'fill-amber-500 text-warning')} />
               Bucket List
             </button>
           )}
@@ -473,7 +473,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                       >
                         <Emoji e="📍" /> {s.name}
                         {s.latitude === 0 && s.longitude === 0 && (
-                          <span className="text-[10px] text-amber-500 ml-0.5">no location</span>
+                          <span className="text-[10px] text-warning ml-0.5">no location</span>
                         )}
                         <button type="button"
                           onClick={() => setPendingStops((p) => p.filter((x) => x.name !== s.name))}
@@ -496,10 +496,10 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
             <button type="button" onClick={() => setShowParkPicker((v) => !v)}
               className="flex items-center gap-2 text-sm font-medium text-left w-full"
             >
-              <TreePine className="h-4 w-4 text-emerald-700" />
+              <TreePine className="h-4 w-4 text-success" />
               <span>National Parks</span>
               {(childPins.filter(c => c.pinType === 'national_park').length + pendingParks.length) > 0 && (
-                <Badge variant="outline" className="text-xs text-emerald-700 border-emerald-600 ml-1">
+                <Badge variant="outline" className="text-xs text-success border-success ml-1">
                   {childPins.filter(c => c.pinType === 'national_park').length + pendingParks.length}
                 </Badge>
               )}
@@ -513,7 +513,7 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                 {childPins.filter(c => c.pinType === 'national_park').length > 0 && (
                   <div className="p-2 border-b border-border flex flex-wrap gap-1">
                     {childPins.filter(c => c.pinType === 'national_park').map((p) => (
-                      <Badge key={p.id} className="bg-emerald-700 text-white text-xs"><Emoji e="🌲" /> {p.name}</Badge>
+                      <Badge key={p.id} className="bg-success text-white text-xs"><Emoji e="🌲" /> {p.name}</Badge>
                     ))}
                   </div>
                 )}
@@ -528,10 +528,10 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
                       <li key={u.name}>
                         <button type="button" onClick={() => { void togglePendingPark(u.name); }}
                           className={cn('w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 transition-colors',
-                            selected ? 'bg-emerald-50 dark:bg-emerald-900/20' : 'hover:bg-muted')}
+                            selected ? 'bg-success/10' : 'hover:bg-muted')}
                         >
                           <span className={cn('h-4 w-4 rounded border flex items-center justify-center shrink-0',
-                            selected ? 'bg-emerald-600 border-emerald-600' : 'border-border')}>
+                            selected ? 'bg-success border-success' : 'border-border')}>
                             {selected && <span className="text-white text-[10px] leading-none">✓</span>}
                           </span>
                           <span className="flex-1 truncate">{u.name}</span>
@@ -551,10 +551,10 @@ export function PinForm({ pin, initialLatLng, parentId, pinType = 'location', ch
             {pendingParks.length > 0 && !showParkPicker && (
               <div className="flex flex-wrap gap-1">
                 {pendingParks.map((p) => (
-                  <Badge key={p.name} className="bg-emerald-700 text-white gap-1 pr-1 text-xs">
+                  <Badge key={p.name} className="bg-success text-white gap-1 pr-1 text-xs">
                     <Emoji e="🌲" /> {p.name}
                     {p.latitude === 0 && p.longitude === 0 && (
-                      <span className="text-[10px] text-emerald-200 ml-0.5">locating…</span>
+                      <span className="text-[10px] text-success ml-0.5">locating…</span>
                     )}
                     <button type="button" onClick={() => { void togglePendingPark(p.name); }} className="hover:opacity-75">
                       <X className="h-3 w-3" />

--- a/src/app/travel/components/PinList.tsx
+++ b/src/app/travel/components/PinList.tsx
@@ -54,7 +54,7 @@ export function PinList({
       {/* Stats bar */}
       <div className="flex items-center gap-4 px-4 py-2.5 border-b border-border bg-muted/30 shrink-0 flex-wrap">
         <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <span className="h-2 w-2 rounded-full bg-emerald-500 inline-block" />
+          <span className="h-2 w-2 rounded-full bg-success inline-block" />
           <span><strong className="text-foreground">{stats.been_there}</strong> visited</span>
         </span>
         <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -62,7 +62,7 @@ export function PinList({
           <span><strong className="text-foreground">{stats.want_to_go}</strong> want to go</span>
         </span>
         <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Star className="h-3 w-3 fill-amber-500 text-amber-500" />
+          <Star className="h-3 w-3 fill-amber-500 text-warning" />
           <span><strong className="text-foreground">{stats.bucket_list}</strong> bucket list</span>
         </span>
         {trips.length > 0 && (
@@ -164,7 +164,7 @@ export function PinList({
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5">
                           <span className="font-medium text-sm truncate">{trip.name}</span>
-                          {trip.isBucketList && <Star className="h-3 w-3 fill-amber-500 text-amber-500 shrink-0" />}
+                          {trip.isBucketList && <Star className="h-3 w-3 fill-amber-500 text-warning shrink-0" />}
                         </div>
                         <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                           <span className="text-[10px] px-1.5 py-0.5 rounded-full font-medium" style={{ background: tripColor + '22', color: tripColor }}>
@@ -227,7 +227,7 @@ export function PinList({
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-1.5">
                               <span className="font-medium text-sm truncate">{pin.name}</span>
-                              {pin.isBucketList && <Star className="h-3 w-3 fill-amber-500 text-amber-500 shrink-0" />}
+                              {pin.isBucketList && <Star className="h-3 w-3 fill-amber-500 text-warning shrink-0" />}
                               {(photoCounts[pin.id] ?? 0) > 0 && (
                                 <span className="text-[10px] text-muted-foreground shrink-0"><Emoji e="📷" /> {photoCounts[pin.id]}</span>
                               )}

--- a/src/app/travel/components/TripDetail.tsx
+++ b/src/app/travel/components/TripDetail.tsx
@@ -74,7 +74,7 @@ function SortableStopItem({
       </button>
 
       {!stop.latitude && !stop.longitude && (
-        <span title="No coordinates yet"><MapPin className="h-3 w-3 text-amber-500 shrink-0" /></span>
+        <span title="No coordinates yet"><MapPin className="h-3 w-3 text-warning shrink-0" /></span>
       )}
 
       <button onClick={onDelete} className="shrink-0 text-muted-foreground/40 hover:text-destructive transition-colors">
@@ -212,7 +212,7 @@ export function TripDetail({
 
         {/* Hub tip */}
         {trip.tripStyle === 'hub' && localStops.length > 0 && !localStops.some((s) => s.isHub) && (
-          <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 rounded-md px-3 py-2">
+          <p className="text-xs text-warning bg-warning/10 rounded-md px-3 py-2">
             Tip: click a stop and mark it as the Home Base to show spokes on the map.
           </p>
         )}

--- a/src/app/weekend/WeekendView.tsx
+++ b/src/app/weekend/WeekendView.tsx
@@ -153,11 +153,11 @@ export function WeekendView() {
           className={cn(
             'flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium border transition-colors',
             filterFavorites
-              ? 'bg-amber-50 dark:bg-amber-950 border-amber-400 text-amber-600'
+              ? 'bg-warning/10 border-warning text-warning'
               : 'border-transparent bg-muted text-muted-foreground hover:bg-accent'
           )}
         >
-          <Star className={cn('h-3.5 w-3.5', filterFavorites && 'fill-amber-400 text-amber-400')} />
+          <Star className={cn('h-3.5 w-3.5', filterFavorites && 'fill-amber-400 text-warning')} />
           Favorites
         </button>
 

--- a/src/app/weekend/components/WeekendPlaceCard.tsx
+++ b/src/app/weekend/components/WeekendPlaceCard.tsx
@@ -33,7 +33,7 @@ export function WeekendPlaceCard({ place, selected, onClick }: WeekendPlaceCardP
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5">
               {place.isFavorite && (
-                <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400 shrink-0" />
+                <Star className="h-3.5 w-3.5 fill-amber-400 text-warning shrink-0" />
               )}
               <h3 className="font-semibold text-sm leading-tight truncate">{place.name}</h3>
             </div>

--- a/src/app/weekend/components/WeekendPlaceDetail.tsx
+++ b/src/app/weekend/components/WeekendPlaceDetail.tsx
@@ -30,7 +30,7 @@ export function WeekendPlaceDetail({
       <div className="flex items-start gap-2 px-4 py-3 border-b border-border shrink-0">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
-            {place.isFavorite && <Star className="h-4 w-4 fill-amber-400 text-amber-400 shrink-0" />}
+            {place.isFavorite && <Star className="h-4 w-4 fill-amber-400 text-warning shrink-0" />}
             <h2 className="font-bold text-base leading-tight">{place.name}</h2>
           </div>
           {place.placeName && (
@@ -129,7 +129,7 @@ export function WeekendPlaceDetail({
             onClick={onToggleFavorite}
             variant="outline"
             size="sm"
-            className={cn('flex-1', place.isFavorite && 'border-amber-400 text-amber-500')}
+            className={cn('flex-1', place.isFavorite && 'border-warning text-warning')}
           >
             <Star className={cn('h-4 w-4 mr-1.5', place.isFavorite && 'fill-amber-400')} />
             {place.isFavorite ? 'Unfavorite' : 'Favorite'}

--- a/src/app/weekend/components/WeekendPlaceForm.tsx
+++ b/src/app/weekend/components/WeekendPlaceForm.tsx
@@ -141,7 +141,7 @@ export function WeekendPlaceForm({ initial, onSave, onCancel, hideHeader }: Week
             onClick={() => setIsFavorite((v) => !v)}
             className={`text-sm px-3 py-1.5 rounded-lg border transition-colors ${
               isFavorite
-                ? 'border-amber-400 bg-amber-50 dark:bg-amber-950 text-amber-600'
+                ? 'border-warning bg-warning/10 text-warning'
                 : 'border-transparent bg-muted text-muted-foreground hover:bg-accent'
             }`}
           >

--- a/src/app/weekend/constants.ts
+++ b/src/app/weekend/constants.ts
@@ -18,7 +18,7 @@ export const TAG_PRESETS = [
 
 export const STATUS_CONFIG = {
   backlog: { label: 'Want to Try', color: '#6B7280', bgClass: 'bg-muted', textClass: 'text-muted-foreground' },
-  visited: { label: 'Been There', color: '#10B981', bgClass: 'bg-emerald-50 dark:bg-emerald-950', textClass: 'text-emerald-700 dark:text-emerald-300' },
+  visited: { label: 'Been There', color: '#10B981', bgClass: 'bg-success/10', textClass: 'text-success' },
 } as const;
 
 // Max visits shown as individual pips before collapsing to a number

--- a/src/app/wishes/WishesView.tsx
+++ b/src/app/wishes/WishesView.tsx
@@ -579,13 +579,13 @@ function WishItemRow({
         )}
         {/* Show who purchased (on other people's lists) */}
         {!isOwnList && item.claimed && item.claimedBy && (
-          <p className="text-xs text-green-600 dark:text-green-400 mt-0.5">
+          <p className="text-xs text-success mt-0.5">
             {isClaimedByMe ? 'You purchased this' : `Purchased by ${item.claimedBy.name}`}
           </p>
         )}
         {/* Show self-crossed-off status */}
         {isOwnList && item.claimed && (
-          <p className="text-xs text-green-600 dark:text-green-400 mt-0.5">
+          <p className="text-xs text-success mt-0.5">
             Got it myself
           </p>
         )}

--- a/src/components/babysitter-mode/BabysitterModeOverlay.tsx
+++ b/src/components/babysitter-mode/BabysitterModeOverlay.tsx
@@ -294,7 +294,7 @@ function EmergencyContactCard({ content }: { content: EmergencyContact }) {
         <div className="flex items-center gap-2">
           <span className="font-medium text-white">{content.name}</span>
           {content.isPrimary === 'true' && (
-            <span className="text-xs bg-green-500/30 text-green-300 px-2 py-0.5 rounded">
+            <span className="text-xs bg-success/30 text-success px-2 py-0.5 rounded">
               Primary
             </span>
           )}
@@ -336,8 +336,8 @@ function ChildInfoCard({ content }: { content: ChildInfo }) {
       </div>
       {content.allergies && (
         <div className="flex items-start gap-2">
-          <AlertTriangle className="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
-          <span className="text-sm text-red-300">
+          <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+          <span className="text-sm text-destructive">
             <strong>Allergies:</strong> {content.allergies}
           </span>
         </div>

--- a/src/components/calendar/cells/weatherIcon.tsx
+++ b/src/components/calendar/cells/weatherIcon.tsx
@@ -11,9 +11,9 @@ export function weatherIcon(cond: WeatherCondition | undefined, size: 'sm' | 'lg
   const cls = size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
   switch (cond) {
     case 'sunny':
-      return <Sun className={cn(cls, 'text-amber-400')} aria-hidden />;
+      return <Sun className={cn(cls, 'text-warning')} aria-hidden />;
     case 'partly-cloudy':
-      return <CloudSun className={cn(cls, 'text-amber-300')} aria-hidden />;
+      return <CloudSun className={cn(cls, 'text-warning')} aria-hidden />;
     case 'cloudy':
       return <Cloud className={cn(cls, 'text-slate-400 dark:text-white/70')} aria-hidden />;
     case 'rainy':

--- a/src/components/layout/DemoBanner.tsx
+++ b/src/components/layout/DemoBanner.tsx
@@ -19,7 +19,7 @@ export function DemoBanner() {
     <div
       role="banner"
       aria-label="Demo mode notice"
-      className="sticky top-0 z-[10000] flex items-center justify-center gap-3 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 dark:bg-amber-600 dark:text-amber-50"
+      className="sticky top-0 z-[10000] flex items-center justify-center gap-3 bg-warning px-4 py-2 text-sm font-medium text-warning-foreground"
     >
       <span aria-hidden="true">★</span>
       <span>

--- a/src/components/layout/LayoutEditorPreviewPanel.tsx
+++ b/src/components/layout/LayoutEditorPreviewPanel.tsx
@@ -80,9 +80,9 @@ export function LayoutEditorPreviewPanel({
         </div>
       )}
       {validation.warnings.length > 0 && validation.errors.length === 0 && (
-        <div className="bg-amber-500/10 border border-amber-500/30 rounded-md p-2">
+        <div className="bg-warning/10 border border-warning/30 rounded-md p-2">
           {validation.warnings.map((w, i) => (
-            <p key={i} className="text-xs text-amber-600 leading-tight">{w}</p>
+            <p key={i} className="text-xs text-warning leading-tight">{w}</p>
           ))}
         </div>
       )}

--- a/src/components/layout/MobileFab.tsx
+++ b/src/components/layout/MobileFab.tsx
@@ -160,7 +160,7 @@ export function MobileFab({ user, onLogin, onLogout, uiHidden }: MobileFabProps)
           )}
         </div>
       ) : (
-        <User className="h-5 w-5 text-red-500" />
+        <User className="h-5 w-5 text-destructive" />
       ),
       label: user ? 'Logout' : 'Login',
       onClick: () => {
@@ -303,7 +303,7 @@ export function MobileFab({ user, onLogin, onLogout, uiHidden }: MobileFabProps)
           'transition-all duration-300 ease-in-out',
           'active:scale-95',
           (isOpen || showCards) && 'rotate-45 bg-muted text-muted-foreground',
-          reorderMode && !isOpen && 'bg-amber-500 text-white',
+          reorderMode && !isOpen && 'bg-warning text-white',
           uiHidden && !isOpen && !showCards && 'translate-y-24 opacity-0'
         )}
         style={{ bottom: 'calc(1.5rem + env(safe-area-inset-bottom, 0px))' }}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -177,8 +177,8 @@ export function MobileNav({ user, onLogin, onLogout, uiHidden }: MobileNavProps)
                 </>
               ) : (
                 <>
-                  <User className="h-5 w-5 text-red-500" />
-                  <span className="text-xs text-red-500">Login</span>
+                  <User className="h-5 w-5 text-destructive" />
+                  <span className="text-xs text-destructive">Login</span>
                 </>
               )}
             </button>

--- a/src/components/layout/PortraitNav.tsx
+++ b/src/components/layout/PortraitNav.tsx
@@ -97,8 +97,8 @@ export function PortraitNav({ user, onLogin, onLogout, uiHidden }: PortraitNavPr
             </>
           ) : (
             <>
-              <User className="h-7 w-7 text-red-500" />
-              <span className="text-xs font-medium text-red-500">Login</span>
+              <User className="h-7 w-7 text-destructive" />
+              <span className="text-xs font-medium text-destructive">Login</span>
             </>
           )}
         </button>

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -229,7 +229,7 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
               </>
             ) : (
               <>
-                <div className="w-8 h-8 rounded-full flex items-center justify-center bg-red-500/10 border-2 border-dashed border-red-500 flex-shrink-0">
+                <div className="w-8 h-8 rounded-full flex items-center justify-center bg-destructive/10 border-2 border-dashed border-destructive flex-shrink-0">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="16"
@@ -240,13 +240,13 @@ export function SideNav({ user, onLogout, onLogin, uiHidden, className }: SideNa
                     strokeWidth="2"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className="text-red-500"
+                    className="text-destructive"
                   >
                     <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
                     <circle cx="12" cy="7" r="4" />
                   </svg>
                 </div>
-                {expanded && <span className="whitespace-nowrap text-red-500">
+                {expanded && <span className="whitespace-nowrap text-destructive">
                   Log in
                 </span>}
               </>

--- a/src/components/layout/grid/CssGridEditor.tsx
+++ b/src/components/layout/grid/CssGridEditor.tsx
@@ -327,7 +327,7 @@ function DraggableWidget({
   // Ring color: blue for move, orange for resize
   const ringClass = isSelected
     ? inResizeMode
-      ? 'ring-2 ring-orange-500 ring-offset-2 z-[100]'
+      ? 'ring-2 ring-warning ring-offset-2 z-[100]'
       : 'ring-2 ring-blue-500 ring-offset-2 z-[100]'
     : 'touch-manipulation';
 
@@ -351,7 +351,7 @@ function DraggableWidget({
       {/* Border overlay — dashed for move, solid for resize (accessible: pattern + color) */}
       <div className={`absolute inset-0 z-10 border-2 ${
         isSelected
-          ? inResizeMode ? 'border-solid border-orange-500' : 'border-dashed border-blue-500'
+          ? inResizeMode ? 'border-solid border-warning' : 'border-dashed border-blue-500'
           : `border-dashed ${theme.borderDash}`
       } rounded-lg pointer-events-none`} />
 
@@ -373,7 +373,7 @@ function DraggableWidget({
       {/* Mode label — visible when selected */}
       {isSelected && !isDragging && (
         <div className={`absolute top-1 left-1/2 -translate-x-1/2 z-10 text-white rounded-full px-2 py-0.5 flex items-center gap-1 pointer-events-none text-[10px] font-medium shadow-sm ${
-          inResizeMode ? 'bg-orange-500/90' : 'bg-blue-500/90'
+          inResizeMode ? 'bg-warning/90' : 'bg-blue-500/90'
         }`}>
           {inResizeMode ? (
             <>
@@ -440,7 +440,7 @@ function ResizeHandles({ widgetId, onResizeStart }: {
           {/* Visual dot for corners — large and visible */}
           {edge.length === 2 && (
             <div
-              className="absolute bg-orange-500 rounded-full shadow-md border-2 border-white"
+              className="absolute bg-warning rounded-full shadow-md border-2 border-white"
               style={{
                 width: 18,
                 height: 18,
@@ -453,7 +453,7 @@ function ResizeHandles({ widgetId, onResizeStart }: {
           {/* Visual bar for edges — thick and visible */}
           {edge.length === 1 && (
             <div
-              className="absolute bg-orange-500/70 rounded-full"
+              className="absolute bg-warning/70 rounded-full"
               style={{
                 ...(edge === 'n' || edge === 's'
                   ? { width: 56, height: 6, top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }

--- a/src/components/modals/AddMessageModal.tsx
+++ b/src/components/modals/AddMessageModal.tsx
@@ -323,7 +323,7 @@ export function AddMessageModal({
                       {selectedAuthor.name}
                     </span>
                     {pinned && <Pin className="h-3 w-3 text-muted-foreground" />}
-                    {important && <AlertTriangle className="h-3 w-3 text-amber-500" />}
+                    {important && <AlertTriangle className="h-3 w-3 text-warning" />}
                   </div>
                   <p className="text-sm text-foreground">{message}</p>
                 </div>

--- a/src/components/modals/AddTaskModal.tsx
+++ b/src/components/modals/AddTaskModal.tsx
@@ -235,13 +235,13 @@ export function AddTaskModal({
                   <span className="text-muted-foreground">None</span>
                 </SelectItem>
                 <SelectItem value="high">
-                  <span className="text-red-500 font-medium">High</span>
+                  <span className="text-destructive font-medium">High</span>
                 </SelectItem>
                 <SelectItem value="medium">
-                  <span className="text-yellow-500 font-medium">Medium</span>
+                  <span className="text-warning font-medium">Medium</span>
                 </SelectItem>
                 <SelectItem value="low">
-                  <span className="text-green-500 font-medium">Low</span>
+                  <span className="text-success font-medium">Low</span>
                 </SelectItem>
               </SelectContent>
             </Select>

--- a/src/components/photos/PhotoGallery.tsx
+++ b/src/components/photos/PhotoGallery.tsx
@@ -33,7 +33,7 @@ function usageBadge(usage: Photo['usage']): string {
   return letters.length > 0 ? letters.join('') : '—';
 }
 
-const qualityColors = { green: 'bg-green-500', yellow: 'bg-yellow-500', red: 'bg-red-500' };
+const qualityColors = { green: 'bg-success', yellow: 'bg-warning', red: 'bg-destructive' };
 
 function orientationBadge(width: number | null, height: number | null): string {
   if (!width || !height) return '?';

--- a/src/components/photos/PhotoLightbox.tsx
+++ b/src/components/photos/PhotoLightbox.tsx
@@ -18,7 +18,7 @@ interface PhotoLightboxProps {
   autoOrientationEnabled?: boolean;
 }
 
-const qualityColors = { green: 'bg-green-500', yellow: 'bg-yellow-500', red: 'bg-red-500' };
+const qualityColors = { green: 'bg-success', yellow: 'bg-warning', red: 'bg-destructive' };
 const usageTags: { value: PhotoUsageTag; label: string }[] = [
   { value: 'wallpaper', label: 'Wallpaper' },
   { value: 'gallery', label: 'Gallery' },

--- a/src/components/photos/PhotoUpload.tsx
+++ b/src/components/photos/PhotoUpload.tsx
@@ -116,7 +116,7 @@ export function PhotoUpload({ onUploadComplete }: PhotoUploadProps) {
               {uf.status === 'uploading' && (
                 <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted border-t-primary" />
               )}
-              {uf.status === 'done' && <CheckCircle className="h-4 w-4 text-green-500" />}
+              {uf.status === 'done' && <CheckCircle className="h-4 w-4 text-success" />}
               {uf.status === 'error' && (
                 <span className="text-xs text-destructive">{uf.error}</span>
               )}

--- a/src/components/settings/CommunityThemeGallery.tsx
+++ b/src/components/settings/CommunityThemeGallery.tsx
@@ -259,7 +259,7 @@ function ThemeCard({
           // for a screen read from across a kitchen is exactly the person who
           // needs to know this, and the number is the whole reason the
           // submission pipeline measures contrast in the first place.
-          <p className="mt-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+          <p className="mt-1.5 text-[11px] text-warning">
             {entry.contrastWarnings === 1
               ? '1 colour pair is legible but tiring at a distance.'
               : `${entry.contrastWarnings} colour pairs are legible but tiring at a distance.`}

--- a/src/components/settings/ThemeShareDialog.tsx
+++ b/src/components/settings/ThemeShareDialog.tsx
@@ -143,14 +143,14 @@ export function ThemeShareDialog({ palette, onClose }: { palette: Theme; onClose
         )}
 
         {warnings.length > 0 && (
-          <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 space-y-1">
-            <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+          <div className="rounded-md border border-warning/50 bg-warning/10 p-3 space-y-1">
+            <p className="text-xs font-medium text-warning">
               Readable, but worth knowing:
             </p>
             {warnings.map((w) => (
-              <p key={w} className="text-xs text-amber-600 dark:text-amber-400">{w}</p>
+              <p key={w} className="text-xs text-warning">{w}</p>
             ))}
-            <p className="text-xs text-amber-600 dark:text-amber-400">
+            <p className="text-xs text-warning">
               This is shown on the gallery card. Press Share again to submit anyway.
             </p>
           </div>

--- a/src/components/sync/RecipeSyncModal.tsx
+++ b/src/components/sync/RecipeSyncModal.tsx
@@ -212,7 +212,7 @@ export function RecipeSyncModal({ entity, onClose, onSynced }: RecipeSyncModalPr
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <CheckCircle2 className="h-5 w-5 text-success" />
               Sync complete
             </DialogTitle>
           </DialogHeader>

--- a/src/components/sync/SyncReviewModal.tsx
+++ b/src/components/sync/SyncReviewModal.tsx
@@ -43,7 +43,7 @@ export interface SyncReviewModalProps {
 }
 
 const KIND_META = {
-  add: { label: 'New', icon: Plus, cls: 'text-green-600 dark:text-green-400' },
+  add: { label: 'New', icon: Plus, cls: 'text-success' },
   update: { label: 'Changed', icon: RefreshCw, cls: 'text-blue-600 dark:text-blue-400' },
   delete: { label: 'Removed in source', icon: Trash2, cls: 'text-destructive' },
 } as const;
@@ -119,8 +119,8 @@ export function SyncReviewModal({
           )}
 
           {massDeleteGuardTripped && (
-            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
+              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-warning" />
               <span>
                 {withheldDeletes} {entityLabel} look deleted in the source — held back as a safety
                 check so a source glitch can&apos;t wipe your data. Re-run the sync if that was

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -68,11 +68,11 @@ const badgeVariants = cva(
 
         // Success - green, for completed items
         success:
-          'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+          'bg-success/10 text-success',
 
         // Warning - yellow/orange, for attention needed
         warning:
-          'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+          'bg-warning/10 text-warning',
       },
     },
     defaultVariants: {

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -32,9 +32,9 @@ const toastVariants = cva(
         destructive:
           'destructive group border-destructive bg-destructive text-destructive-foreground',
         success:
-          'border-green-500/50 bg-green-50 text-green-900 dark:bg-green-950 dark:text-green-100',
+          'border-success/50 bg-success/10 text-success',
         warning:
-          'border-amber-500/50 bg-amber-50 text-amber-900 dark:bg-amber-950 dark:text-amber-100',
+          'border-warning/50 bg-warning/10 text-warning',
       },
     },
     defaultVariants: {
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-destructive group-[.destructive]:hover:text-destructive group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-red-600',
       className
     )}
     toast-close=""

--- a/src/components/widgets/BirthdaysWidget.tsx
+++ b/src/components/widgets/BirthdaysWidget.tsx
@@ -41,9 +41,9 @@ function formatDate(dateStr: string, locale: string): string {
 function daysUntilColor(days: number): string {
   // Today is green: it reads as "happening now" against the red/amber urgency
   // ramp used for the days still counting down.
-  if (days === 0) return 'text-green-600 dark:text-green-400 font-bold';
-  if (days < 7) return 'text-red-500 font-semibold';
-  if (days < 30) return 'text-amber-500';
+  if (days === 0) return 'text-success font-bold';
+  if (days < 7) return 'text-destructive font-semibold';
+  if (days < 30) return 'text-warning';
   return 'text-muted-foreground';
 }
 
@@ -117,13 +117,13 @@ export const BirthdaysWidget = React.memo(function BirthdaysWidget({
                   key={item.id}
                   className={cn(
                     'border-b border-border/50 last:border-0',
-                    item.daysUntil === 0 && 'bg-green-500/10'
+                    item.daysUntil === 0 && 'bg-success/10'
                   )}
                 >
                   <td className="py-1.5 pr-2 truncate max-w-[140px]" title={item.name}>
                     {item.name}
                     {item.daysUntil === 0 && (
-                      <span className="ml-1.5 text-[10px] bg-green-600 text-white px-1 py-0.5 rounded">
+                      <span className="ml-1.5 text-[10px] bg-success text-white px-1 py-0.5 rounded">
                         {t('todayBadge')}
                       </span>
                     )}

--- a/src/components/widgets/BusTrackingWidget.tsx
+++ b/src/components/widgets/BusTrackingWidget.tsx
@@ -344,12 +344,12 @@ function getStatusColor(p: BusPrediction): string {
   switch (p.status) {
     case 'at_stop':
     case 'at_school':
-      return 'bg-green-500';
+      return 'bg-success';
     case 'in_transit':
     case 'cold_start':
-      return 'bg-amber-500';
+      return 'bg-warning';
     case 'overdue':
-      return 'bg-red-500';
+      return 'bg-destructive';
     case 'no_data':
     default:
       return 'bg-muted-foreground/50';

--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -301,7 +301,7 @@ export const CalendarWidget = React.memo(function CalendarWidget({
       {syncPaused && (
         <Link
           href="/calendar?manage=calendars"
-          className="flex items-center justify-center gap-1 text-[10px] text-amber-600 dark:text-amber-400 py-1 bg-amber-500/10 rounded mb-1 hover:bg-amber-500/20"
+          className="flex items-center justify-center gap-1 text-[10px] text-warning py-1 bg-warning/10 rounded mb-1 hover:bg-warning/20"
           title="Sync has stopped for one or more calendars — reconnect to resume"
         >
           <AlertTriangle className="h-3 w-3 shrink-0" />

--- a/src/components/widgets/ChoresWidget.tsx
+++ b/src/components/widgets/ChoresWidget.tsx
@@ -231,7 +231,7 @@ function ChoreItem({
         'flex items-start gap-3 p-2 rounded-lg',
         'hover:bg-accent/50 transition-colors',
         'touch-action-manipulation',
-        isPendingApproval && 'bg-amber-500/10 border border-amber-500/30'
+        isPendingApproval && 'bg-warning/10 border border-warning/30'
       )}
     >
       {/* Complete button — stops propagation so the row click doesn't also
@@ -244,7 +244,7 @@ function ChoreItem({
         className={cn(
           'h-8 w-8 shrink-0',
           isOverdue && !isPendingApproval && 'text-destructive hover:text-destructive',
-          isPendingApproval && 'text-amber-500'
+          isPendingApproval && 'text-warning'
         )}
         title={isPendingApproval ? 'Pending approval - click to complete or approve' : 'Mark as complete'}
         aria-label={isPendingApproval ? 'Pending approval' : 'Mark as complete'}
@@ -273,7 +273,7 @@ function ChoreItem({
           {/* Title */}
           <span className={cn(
             'text-sm font-medium truncate',
-            isPendingApproval && 'text-amber-700 dark:text-amber-400'
+            isPendingApproval && 'text-warning'
           )}>{chore.title}</span>
 
           {/* Points badge */}
@@ -285,7 +285,7 @@ function ChoreItem({
 
           {/* Pending approval badge - takes priority over "requires approval" */}
           {isPendingApproval ? (
-            <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-amber-500 hover:bg-amber-500">
+            <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-warning hover:bg-warning">
               Pending
             </Badge>
           ) : chore.requiresApproval && (
@@ -306,7 +306,7 @@ function ChoreItem({
                 size="sm"
                 className="h-4 w-4 text-[8px]"
               />
-              <span className="text-xs text-amber-600 dark:text-amber-400">
+              <span className="text-xs text-warning">
                 Done by {chore.pendingApproval.completedBy.name}
               </span>
             </div>

--- a/src/components/widgets/PointsWidget.tsx
+++ b/src/components/widgets/PointsWidget.tsx
@@ -59,7 +59,7 @@ export const PointsWidget = React.memo(function PointsWidget({
             <div key={goal.id} className="space-y-1">
               <div className="flex items-center gap-1.5 text-sm">
                 {goal.fullyAchieved && (
-                  <Check className="h-3.5 w-3.5 text-green-500 shrink-0" />
+                  <Check className="h-3.5 w-3.5 text-success shrink-0" />
                 )}
                 <span><Emoji e={goal.emoji || '🎯'} /></span>
                 <span className="font-medium truncate">{goal.name}</span>

--- a/src/components/widgets/TravelWidget.tsx
+++ b/src/components/widgets/TravelWidget.tsx
@@ -88,7 +88,7 @@ export const TravelWidget = React.memo(function TravelWidget({ className }: Trav
             )}
             {bucketList.length > 0 && (
               <StatChip
-                icon={<Star className="h-3 w-3 fill-amber-500 text-amber-500 shrink-0" />}
+                icon={<Star className="h-3 w-3 fill-amber-500 text-warning shrink-0" />}
                 value={bucketList.length}
                 label="bucket list"
               />
@@ -130,7 +130,7 @@ export const TravelWidget = React.memo(function TravelWidget({ className }: Trav
                         )}
                       </span>
                       {pin.isBucketList && (
-                        <Star className="h-3 w-3 fill-amber-500 text-amber-500 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                        <Star className="h-3 w-3 fill-amber-500 text-warning shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
                       )}
                     </a>
                   </li>

--- a/src/lib/community/validateTheme.ts
+++ b/src/lib/community/validateTheme.ts
@@ -13,7 +13,8 @@
  *    by a human reading the pull request — see the note on that below.
  */
 import {
-  THEME_TOKENS, isValidTokenValue, isValidShape, normalizeShape, normalizeTokenKeys,
+  THEME_TOKENS, OPTIONAL_THEME_TOKENS, ALL_THEME_TOKENS,
+  isValidTokenValue, isValidShape, normalizeShape, normalizeTokenKeys,
   isValidFont, normalizeFont, isValidModes, normalizeModes,
   SHAPE_LIMITS, THEME_FONT_IDS, THEME_MODES, type Theme, type ThemeTokens,
 } from '@/lib/themes/tokens';
@@ -92,6 +93,17 @@ function validateTokenSet(tokens: unknown, mode: string, errors: string[]): toke
       ok = false;
     }
   }
+  // Optional tokens: absent is fine and takes the built-in default, but a
+  // value that IS supplied has to be a triple like any other. Nothing reaches
+  // a CSS property without passing the same check.
+  for (const token of OPTIONAL_THEME_TOKENS) {
+    const value = obj[token];
+    if (value === undefined) continue;
+    if (!isValidTokenValue(value)) {
+      errors.push(`"${mode}" has an invalid value for ${token}. Expected a bare HSL triple, e.g. "222 47% 11%".`);
+      ok = false;
+    }
+  }
   return ok;
 }
 
@@ -105,7 +117,7 @@ function validateTokenSet(tokens: unknown, mode: string, errors: string[]): toke
 export function unrecognizedTokens(data: unknown): string[] {
   if (!data || typeof data !== 'object') return [];
   const obj = data as Record<string, unknown>;
-  const known = new Set<string>(THEME_TOKENS);
+  const known = new Set<string>(ALL_THEME_TOKENS);
   const found = new Set<string>();
   for (const mode of ['light', 'dark'] as const) {
     for (const key of Object.keys(normalizeTokenKeys(obj[mode]))) {
@@ -227,6 +239,12 @@ export function projectCommunityTheme(data: unknown, id: string): Theme & {
     const s = normalizeTokenKeys(src);
     const out = {} as ThemeTokens;
     for (const token of THEME_TOKENS) out[token] = s[token] as string;
+    // Carried only when supplied, so a theme that says nothing about status
+    // colours stores nothing and inherits the defaults, rather than being
+    // frozen against today's values.
+    for (const token of OPTIONAL_THEME_TOKENS) {
+      if (s[token] !== undefined) out[token] = s[token] as string;
+    }
     return out;
   };
 

--- a/src/lib/themes/__tests__/statusTokens.test.ts
+++ b/src/lib/themes/__tests__/statusTokens.test.ts
@@ -1,0 +1,79 @@
+import {
+  OPTIONAL_THEME_TOKENS, ALL_THEME_TOKENS, THEME_TOKENS,
+  isValidTokenSet, type ThemeTokens,
+} from '../tokens';
+import { themeCss } from '../applyTheme';
+import { checkContrast } from '../contrast';
+
+/** A valid required set, so each test can vary only the optional tokens. */
+function baseTokens(): ThemeTokens {
+  const t = {} as Record<string, string>;
+  for (const token of THEME_TOKENS) t[token] = '0 0% 50%';
+  return t as ThemeTokens;
+}
+
+describe('optional status tokens', () => {
+  it('accepts a theme that sets none of them, so older themes stay valid', () => {
+    expect(isValidTokenSet(baseTokens())).toBe(true);
+  });
+
+  it('accepts a theme that sets them with valid triples', () => {
+    const t = { ...baseTokens(), success: '142 72% 29%', 'success-foreground': '0 0% 100%' };
+    expect(isValidTokenSet(t)).toBe(true);
+  });
+
+  it('rejects a malformed optional value rather than letting it through unchecked', () => {
+    const t = { ...baseTokens(), warning: 'red' } as unknown;
+    expect(isValidTokenSet(t)).toBe(false);
+  });
+
+  it('refuses anything that is not a bare triple, including a var() reference', () => {
+    const t = { ...baseTokens(), warning: 'var(--x)' } as unknown;
+    expect(isValidTokenSet(t)).toBe(false);
+  });
+
+  it('emits an optional token into the server stylesheet when set', () => {
+    const light = { ...baseTokens(), warning: '32 95% 34%' };
+    const css = themeCss({ id: 'a', name: 'A', description: '', light, dark: light });
+    expect(css).toContain('--warning:32 95% 34%');
+  });
+
+  it('omits it entirely when unset, so the globals.css default stands', () => {
+    const light = baseTokens();
+    const css = themeCss({ id: 'a', name: 'A', description: '', light, dark: light });
+    expect(css).not.toContain('--warning');
+    expect(css).not.toContain('--success');
+  });
+
+  it('is listed in ALL_THEME_TOKENS but not in the required set', () => {
+    for (const token of OPTIONAL_THEME_TOKENS) {
+      expect(ALL_THEME_TOKENS).toContain(token);
+      expect(THEME_TOKENS as readonly string[]).not.toContain(token);
+    }
+  });
+});
+
+describe('contrast of status pairs', () => {
+  it('says nothing about a pair the theme did not set', () => {
+    const issues = checkContrast(baseTokens());
+    expect(issues.some((i) => i.pair.includes('success'))).toBe(false);
+  });
+
+  it('flags an unreadable pair the theme did set', () => {
+    const t = { ...baseTokens(), success: '142 72% 29%', 'success-foreground': '142 72% 31%' };
+    const issues = checkContrast(t);
+    expect(issues.some((i) => i.pair === 'success-foreground on success' && i.level === 'error')).toBe(true);
+  });
+
+  it('passes a pair with real separation', () => {
+    const t = { ...baseTokens(), success: '142 72% 29%', 'success-foreground': '0 0% 100%' };
+    const issues = checkContrast(t);
+    expect(issues.some((i) => i.pair.includes('success'))).toBe(false);
+  });
+
+  it('ignores a half-set pair rather than measuring against a default the theme did not choose', () => {
+    const t = { ...baseTokens(), warning: '32 95% 34%' };
+    const issues = checkContrast(t);
+    expect(issues.some((i) => i.pair.includes('warning'))).toBe(false);
+  });
+});

--- a/src/lib/themes/applyTheme.ts
+++ b/src/lib/themes/applyTheme.ts
@@ -2,7 +2,7 @@
  * Turning a theme into CSS, on the client and on the server.
  */
 import {
-  THEME_TOKENS, isValidTokenValue, normalizeShape, normalizeFont, normalizeModes,
+  ALL_THEME_TOKENS, isValidTokenValue, normalizeShape, normalizeFont, normalizeModes,
   THEME_FONTS, type Theme, type ThemeTokens,
 } from './tokens';
 
@@ -24,7 +24,7 @@ export function themeTokens(theme: Theme, mode: ResolvedMode): ThemeTokens {
  * This is the last point before the DOM, and the cost is a regex per token.
  */
 export function applyThemeVars(root: HTMLElement, tokens: Partial<ThemeTokens>): void {
-  for (const token of THEME_TOKENS) {
+  for (const token of ALL_THEME_TOKENS) {
     const value = tokens[token];
     if (isValidTokenValue(value)) {
       root.style.setProperty(`--${token}`, value);
@@ -157,7 +157,7 @@ function chromeProperties(theme: Theme): Array<[string, string]> {
 
 /** Remove every theme token, falling back to the values in globals.css. */
 export function clearThemeVars(root: HTMLElement): void {
-  for (const token of THEME_TOKENS) root.style.removeProperty(`--${token}`);
+  for (const token of ALL_THEME_TOKENS) root.style.removeProperty(`--${token}`);
   for (const [prop] of chromeProperties({ light: {}, dark: {} } as Theme)) {
     root.style.removeProperty(prop);
   }
@@ -166,19 +166,21 @@ export function clearThemeVars(root: HTMLElement): void {
 /**
  * A stylesheet for server rendering, so the first paint is already themed.
  *
- * Built by iterating THEME_TOKENS and emitting only values that pass the
+ * Built by iterating ALL_THEME_TOKENS and emitting only values that pass the
  * triple check — never by serialising the theme object. That matters more here
  * than on the client: `setProperty` goes through the CSSOM, which cannot be
  * escaped out of, but this string lands inside a `<style>` element where a
  * closing tag in a value would end the block and begin markup. There is no CSP
  * in this app to catch that.
  *
- * The shape of this function is the guarantee. Anything not in THEME_TOKENS
- * cannot appear in the output, whatever the input contains.
+ * The shape of this function is the guarantee. Anything not in
+ * ALL_THEME_TOKENS cannot appear in the output, whatever the input contains.
+ * An optional token a theme leaves out simply is not emitted, so the value in
+ * globals.css stands.
  */
 export function themeCss(theme: Theme): string {
   const block = (tokens: ThemeTokens) =>
-    THEME_TOKENS.filter((t) => isValidTokenValue(tokens[t]))
+    ALL_THEME_TOKENS.filter((t) => isValidTokenValue(tokens[t]))
       .map((t) => `--${t}:${tokens[t]}`)
       .join(';');
 

--- a/src/lib/themes/contrast.ts
+++ b/src/lib/themes/contrast.ts
@@ -12,7 +12,7 @@
  * against.
  */
 import { contrastRatioHex, hslToHex } from '@/lib/utils/color';
-import type { ThemeToken, ThemeTokens } from './tokens';
+import type { OptionalThemeToken, ThemeToken, ThemeTokens } from './tokens';
 
 /** Below this, text is not readable and the theme is rejected. */
 export const CONTRAST_ERROR = 3;
@@ -31,6 +31,19 @@ const TEXT_PAIRS: Array<[ThemeToken, ThemeToken]> = [
   ['muted-foreground', 'muted'],
   ['accent-foreground', 'accent'],
   ['destructive-foreground', 'destructive'],
+];
+
+/**
+ * Status pairs, checked only when a theme actually sets them.
+ *
+ * Optional tokens, so a theme that leaves them out inherits defaults that
+ * already pass and has nothing to answer for. A theme that does set them is
+ * held to the same bar as any other text pair: a success or warning badge is
+ * read from across the room like everything else.
+ */
+const OPTIONAL_TEXT_PAIRS: Array<[OptionalThemeToken, OptionalThemeToken]> = [
+  ['success-foreground', 'success'],
+  ['warning-foreground', 'warning'],
 ];
 
 /** Pairs that only need to be distinguishable, so an edge is visible. */
@@ -62,6 +75,16 @@ export function checkContrast(tokens: ThemeTokens): ContrastIssue[] {
 
   for (const [fg, bg] of TEXT_PAIRS) {
     const ratio = contrastRatioHex(hex(fg), hex(bg));
+    if (ratio < CONTRAST_ERROR) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'error', kind: 'text' });
+    else if (ratio < CONTRAST_WARN) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'warning', kind: 'text' });
+  }
+
+  for (const [fg, bg] of OPTIONAL_TEXT_PAIRS) {
+    // Both halves have to be present to compare them. A theme that sets one
+    // and not the other is measured against a default it did not choose, which
+    // would report a problem it has no way to fix.
+    if (tokens[fg] === undefined || tokens[bg] === undefined) continue;
+    const ratio = contrastRatioHex(hslToHex(tokens[fg]), hslToHex(tokens[bg]));
     if (ratio < CONTRAST_ERROR) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'error', kind: 'text' });
     else if (ratio < CONTRAST_WARN) issues.push({ pair: `${fg} on ${bg}`, ratio, level: 'warning', kind: 'text' });
   }

--- a/src/lib/themes/tokens.ts
+++ b/src/lib/themes/tokens.ts
@@ -37,8 +37,34 @@ export const THEME_TOKENS = [
 
 export type ThemeToken = (typeof THEME_TOKENS)[number];
 
-/** A complete set of values for one mode. */
-export type ThemeTokens = Record<ThemeToken, string>;
+/**
+ * Status colours a theme MAY set, and does not have to.
+ *
+ * Optional rather than required, for the same reason shape and font are: a
+ * theme states what it wants to change, and every theme written before these
+ * existed stays valid. When a theme omits them the value defined in
+ * globals.css applies, so a status still reads as a status.
+ *
+ * They exist because the codebase already had this vocabulary and had no name
+ * for it. `--destructive` covered danger, while "this succeeded" and "this
+ * needs attention" were spelled as literal greens and ambers in the markup,
+ * which no theme could reach. Naming them is what lets a theme change them.
+ */
+export const OPTIONAL_THEME_TOKENS = [
+  'success',
+  'success-foreground',
+  'warning',
+  'warning-foreground',
+] as const;
+
+export type OptionalThemeToken = (typeof OPTIONAL_THEME_TOKENS)[number];
+
+/** Every token a theme may write, required and optional alike. */
+export const ALL_THEME_TOKENS = [...THEME_TOKENS, ...OPTIONAL_THEME_TOKENS] as const;
+
+/** A complete set of values for one mode, plus any optional ones it chose to set. */
+export type ThemeTokens = Record<ThemeToken, string> &
+  Partial<Record<OptionalThemeToken, string>>;
 
 /**
  * Shape values, which are not colours and do not differ between light and dark.
@@ -269,11 +295,22 @@ export function normalizeTokenKeys(src: unknown): Record<string, unknown> {
   return out;
 }
 
-/** True when every token is present and every value is a valid triple. */
+/**
+ * True when every required token is present and valid, and any optional token
+ * that IS present is valid too.
+ *
+ * An absent optional token is not a failure; a malformed one is. Skipping the
+ * check for optional values would let an unvalidated string reach the same
+ * `setProperty` call the required ones do, which is the single thing this
+ * module exists to prevent.
+ */
 export function isValidTokenSet(value: unknown): value is ThemeTokens {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Record<string, unknown>;
-  return THEME_TOKENS.every((t) => isValidTokenValue(obj[t]));
+  if (!THEME_TOKENS.every((t) => isValidTokenValue(obj[t]))) return false;
+  return OPTIONAL_THEME_TOKENS.every(
+    (t) => obj[t] === undefined || isValidTokenValue(obj[t]),
+  );
 }
 
 /**

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,6 +28,14 @@
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
 
+    /* Status colours, the other two thirds of the vocabulary --destructive
+       started. Optional for a theme to set: when it does not, these stand, so
+       a status still reads as a status under any palette. */
+    --success: 142 72% 29%;
+    --success-foreground: 0 0% 100%;
+    --warning: 32 95% 34%;
+    --warning-foreground: 0 0% 100%;
+
     --border: 214 32% 91%;
     --input: 214 32% 91%;
     --ring: 222 47% 31%;
@@ -91,6 +99,14 @@
 
     --destructive: 0 62% 30%;
     --destructive-foreground: 210 40% 98%;
+
+    /* Darker and less saturated, matching how --destructive is treated here:
+       a full-strength status colour on a dark surface glares on a display
+       that is on all evening. */
+    --success: 142 60% 45%;
+    --success-foreground: 142 80% 8%;
+    --warning: 38 92% 55%;
+    --warning-foreground: 26 83% 10%;
 
     --border: 217 33% 25%;
     --input: 217 33% 25%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,14 @@ module.exports = {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
         muted: {
           DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',


### PR DESCRIPTION
Closes #376.

## The issue's premise did not hold

It assumed the bulk was surface work, `bg-slate-100` becoming `bg-muted`. It is
not. Counting every hardcoded colour class in `src/` by the role it plays:

| Role | Count | Token available before this PR |
| --- | --- | --- |
| Warning (amber, yellow, orange) | 223 | none |
| Success (green, emerald) | 98 | none |
| Danger (red, rose) | 82 | `--destructive` |
| Categorical widget hues | 78 | none, and out of scope |
| Surface / neutral | 12 | `--muted`, `--card` |

The surface case the issue described is twelve classes in the entire codebase.
What actually existed was a **status vocabulary the token set never named**:
`--destructive` covered danger, while success and warning were literal colours
in the markup with nowhere to go. Converting with only today's tokens would
have reached about 19% and left the dashboard looking the same.

## What changed

**Two new tokens, both optional.** `success` and `warning` with their
foregrounds. Optional for the same reason shape, font and modes are: a theme
states what it wants to change. A theme that omits them has nothing emitted, so
the value in `globals.css` stands, and **every existing theme is unaffected**,
including any installed from the gallery. A theme that sets them has them
validated as bare HSL triples and contrast-checked as a pair, exactly like the
required ones.

**About 400 classes converted across 66 files**, each light/dark pair collapsing
into one token, following the idiom already in the codebase:
`border-destructive/40 bg-destructive/10 text-destructive`.

**Deliberately untouched:** the per-widget icon hues in `TileCards` and
`MobileCards`. Those are a categorical palette, and one shared accent cannot do
what five distinct hues do. The issue called this out and it still holds.

## On the values

Picked for legibility on a display read from across a room, and verified rather
than eyeballed. Every pair clears 4.9:1 against its own background in both
modes, which is better than `--destructive` manages today at 3.78:1.

## Checks

- 1858 tests pass, including 11 new ones covering optional-token validation,
  the server stylesheet emitting a set token and omitting an unset one, and the
  contrast check ignoring a pair the theme did not set
- `tsc --noEmit`, eslint and `next build` all clean
- The 152 existing theme and community tests pass untouched, which is the
  backwards-compatibility check that matters here

## One fix found on the way

`DemoBanner` had `text-amber-950` on `bg-amber-500`: a foreground sitting on the
colour rather than beside it. Mapping it like the others would have put the text
and its background on the same value. It uses `text-warning-foreground`, which
is what that token pair is for.
