### PR TITLE
fix(calendar): stop reserving lanes on days a span misses

### DIFF
--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -42,13 +42,30 @@ export function SpanningEventRows({
   const occurs = (event: CalendarEvent, target: Date) =>
     eventOccursOnDisplayDay(event.startTime, event.endTime, event.allDay, target, displayTimezone);
 
+  // A blank lane exists to hold a bar's vertical position steady across the
+  // days it spans, so a slice drawn on Thursday lines up with its own slice on
+  // Wednesday. It only has that job when a bar is actually drawn BELOW it in
+  // this cell.
+  //
+  // Reserving every lane on every day of the row instead pushed a day's own
+  // events down by one row per multi-day event in the week, whether or not any
+  // of them touched that day. A week carrying three spanning events started its
+  // untouched days three rows down, which reads as the events beginning
+  // halfway down the box.
+  //
+  // So: nothing at all on a day this row's spans miss, and no trailing blanks
+  // below the last lane a day actually uses.
+  const activeLanes = events.map((event) => occurs(event, date));
+  const lastActiveLane = activeLanes.lastIndexOf(true);
+  if (lastActiveLane < 0) return null;
+
   return (
     <div
       data-spanning-events
       className={cn('relative z-20 flex shrink-0 flex-col', compact ? 'gap-px' : 'gap-0.5')}
     >
-      {events.map((event) => {
-        const active = occurs(event, date);
+      {events.slice(0, lastActiveLane + 1).map((event, lane) => {
+        const active = activeLanes[lane];
         const continuesFromPrevious = active && occurs(event, addDays(date, -1));
         const continuesToNext = active && occurs(event, addDays(date, 1));
         const continuesWithinRow = continuesToNext && column < rowDates.length - 1;

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -27,6 +27,63 @@ const event: CalendarEvent = {
 };
 
 describe('SpanningEventRows', () => {
+  it('reserves no lanes on a day that every span in the row misses', () => {
+    // The bug this guards: a week carrying three multi-day events reserved a
+    // blank lane for each of them on EVERY day of the row, so a day none of
+    // them touched started three rows down and its own events appeared to
+    // begin halfway down the cell.
+    const rowDates = [new Date(2026, 8, 20), new Date(2026, 8, 21), new Date(2026, 8, 22), new Date(2026, 8, 23)];
+    const spans: CalendarEvent[] = [23, 24, 25].map((day, i) => ({
+      ...event,
+      id: `span-${i}`,
+      startTime: new Date(`2026-09-${day}T00:00:00.000Z`),
+      endTime: new Date('2026-09-29T00:00:00.000Z'),
+    }));
+
+    const { container } = render(
+      <SpanningEventRows
+        date={new Date(2026, 8, 21)}
+        rowDates={rowDates}
+        events={spans}
+        onEventClick={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('[data-spanning-events]')).toBeNull();
+  });
+
+  it('keeps a lane open for a bar drawn below it, so slices stay aligned', () => {
+    const rowDates = [new Date(2026, 8, 20), new Date(2026, 8, 21)];
+    const earlier: CalendarEvent = {
+      ...event,
+      id: 'lane-0',
+      startTime: new Date('2026-09-20T00:00:00.000Z'),
+      endTime: new Date('2026-09-21T00:00:00.000Z'),
+    };
+    const later: CalendarEvent = {
+      ...event,
+      id: 'lane-1',
+      startTime: new Date('2026-09-21T00:00:00.000Z'),
+      endTime: new Date('2026-09-23T00:00:00.000Z'),
+    };
+
+    // On the 21st the first event is over, but it still holds lane 0 so the
+    // second event stays in lane 1 across both days.
+    const { container } = render(
+      <SpanningEventRows
+        date={new Date(2026, 8, 21)}
+        rowDates={rowDates}
+        events={[earlier, later]}
+        onEventClick={() => {}}
+      />,
+    );
+
+    const wrapper = container.querySelector('[data-spanning-events]');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.children).toHaveLength(2);
+    expect(wrapper!.children[0]!.getAttribute('aria-hidden')).toBe('true');
+  });
+
   it('bridges day gaps without overlapping adjacent event slices', () => {
     const rowDates = [new Date(2026, 7, 10), new Date(2026, 7, 11), new Date(2026, 7, 12)];
 


### PR DESCRIPTION
## The bug

A multi-day event holds a lane so its slices line up across the days it covers.
That reservation was unconditional:

```js
if (!active) return <div key={event.id} aria-hidden className={rowHeight} />;
```

Every span in a week row left a blank `h-5` row in every day cell of that row,
including days it never touches. A week carrying three multi-day events started
its untouched days three rows down, so a day's own events appear to begin
halfway down the cell. It is most visible on a week where the spans cluster at
one end, and on the week that straddles a month boundary.

## The fix

A blank lane only does its job when a bar is drawn **below** it in the same
cell. So: render nothing on a day every span in the row misses, and drop the
trailing blanks below the last lane a day actually uses.

Alignment is unchanged. A lane is still held open when something sits under it,
which is the case the placeholder exists for.

## Checks

- Two new tests: a day the row's spans all miss renders no container at all,
  and a lane with a bar under it is still held open with `aria-hidden`
- 1874 tests pass, `tsc --noEmit` clean, no new lint findings
