### PR TITLE
fix(birthdays): dedupe names differing only by a possessive

### DIFF
--- a/src/lib/services/birthday-detect.ts
+++ b/src/lib/services/birthday-detect.ts
@@ -48,6 +48,7 @@ import { birthdays, calendarSources, dismissedBirthdays, events } from '@/lib/db
 import { and, eq, sql } from 'drizzle-orm';
 import { upsertBirthday } from './birthday-merge';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
+import { normalizePersonName } from '@/lib/utils/normalizePersonName';
 
 /** providerConfig flag marking a calendar as "everything all-day here is a life event". */
 export const LIFE_EVENTS_CALENDAR_KEY = 'lifeEventsCalendar';
@@ -180,10 +181,8 @@ export function parseEventTitle(
   return { name, eventType, birthDate: eventDate, year };
 }
 
-/** Matches normalize() in birthday-merge.ts so tombstones line up with merges. */
-function normalizeName(s: string): string {
-  return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
-}
+/** The shared comparison form, so tombstones line up with merges. */
+const normalizeName = normalizePersonName;
 
 /**
  * Scan every enabled calendar for life events and upsert them.

--- a/src/lib/services/birthday-merge.ts
+++ b/src/lib/services/birthday-merge.ts
@@ -29,6 +29,7 @@
 import { db } from '@/lib/db/client';
 import { birthdays } from '@/lib/db/schema';
 import { and, eq, sql } from 'drizzle-orm';
+import { normalizePersonName } from '@/lib/utils/normalizePersonName';
 
 interface UpsertOpts {
   name: string;
@@ -37,10 +38,8 @@ interface UpsertOpts {
   source: string;          // e.g. 'birthdays', 'friends_family', 'caldav_contacts'
 }
 
-/** Strip punctuation, collapse whitespace, lowercase. */
-function normalize(s: string): string {
-  return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
-}
+/** The shared comparison form; see normalizePersonName. */
+const normalize = normalizePersonName;
 
 /** Token-prefix: "alex" is prefix of "alex doe", "jordan doe" is NOT prefix of "jordan smith". */
 function isTokenPrefix(short: string, long: string): boolean {

--- a/src/lib/utils/__tests__/normalizePersonName.test.ts
+++ b/src/lib/utils/__tests__/normalizePersonName.test.ts
@@ -1,0 +1,30 @@
+import { normalizePersonName } from '../normalizePersonName';
+
+describe('normalizePersonName', () => {
+  it('treats a possessive and a plain name as the same person', () => {
+    expect(normalizePersonName("Ana & Bo's")).toBe(normalizePersonName('Ana & Bo'));
+  });
+
+  it('handles the curly apostrophe calendars actually emit', () => {
+    expect(normalizePersonName('Ana & Bo’s')).toBe(normalizePersonName('Ana & Bo'));
+  });
+
+  it('strips the possessive before punctuation, not after', () => {
+    // The order is the whole point: strip punctuation first and this is
+    // "ana bos", which never matches "ana bo".
+    expect(normalizePersonName("Ana & Bo's")).toBe('ana bo');
+  });
+
+  it('leaves a name that merely ends in s alone', () => {
+    expect(normalizePersonName('Chris')).toBe('chris');
+    expect(normalizePersonName('The Rogers')).toBe('the rogers');
+  });
+
+  it('collapses whitespace and lowercases', () => {
+    expect(normalizePersonName('  Ana   BO  ')).toBe('ana bo');
+  });
+
+  it('drops punctuation so ampersands and plus signs compare equal', () => {
+    expect(normalizePersonName('Ana & Bo')).toBe(normalizePersonName('Ana  Bo'));
+  });
+});

--- a/src/lib/utils/normalizePersonName.ts
+++ b/src/lib/utils/normalizePersonName.ts
@@ -1,0 +1,24 @@
+/**
+ * The comparison form of a person or couple's name.
+ *
+ * Used to decide whether two life-event rows are the same one. It lived in two
+ * files with a comment asking them to stay in step, which is the arrangement
+ * that produced the bug it now guards against.
+ *
+ * The trailing possessive comes off BEFORE punctuation is stripped. Order
+ * matters: removing punctuation on its own turns "Ana & Bo's" into "ana bos",
+ * which is neither equal to "ana bo" nor a token prefix of it, so the two names
+ * never match and the same anniversary is stored twice.
+ *
+ * That happened. The title parser used to leave the possessive on the name and
+ * now removes it, so one anniversary imported under both spellings and showed
+ * up twice on the milestones list.
+ */
+export function normalizePersonName(s: string): string {
+  return s
+    .replace(/['’]s?\s*$/, '')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}


### PR DESCRIPTION
## The bug

A life event imported as `Ana & Bo's` and later as `Ana & Bo` is stored twice
and appears twice on the milestones list.

The comparison form used to decide "same person" stripped punctuation before
anything else, so `Ana & Bo's` became `ana bos`. That is neither equal to
`ana bo` nor a token prefix of it, so `upsertBirthday` never matched the
existing row and inserted a second one alongside it.

It happens because the title parser learned to strip the trailing possessive
at some point, while the comparison form did not. Rows written before that
change keep the older spelling and never merge with the newer one.

## The fix

The possessive comes off first, before punctuation is stripped. Order is the
whole point.

The normaliser lived in two files, with a comment in one asking it to stay in
step with the other. That is the arrangement that produced this bug, so it is
now a single exported helper both import.

## Note for anyone with affected data

The code stops new duplicates. Rows already stored under both spellings stay
until something removes them: they are separate rows with distinct primary
keys, and nothing merges them retroactively. Worth a look at any instance that
has been syncing life events for a while.

## Checks

- Six tests on the helper, including that a name merely ending in `s` is left
  alone, and that the ordering is what makes the two spellings compare equal
- 1874 tests pass, `tsc --noEmit` clean, no new lint findings