### PR TITLE
fix(calendar): month grid geometry — lanes, bridge width, corner radius

### DIFF
--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -262,6 +262,7 @@ function MonthDayCell({
         rowDates={rowDates}
         events={spanningEvents}
         onEventClick={onEventClick}
+        gap="1px"
       />
 
       {cards ? (
@@ -354,7 +355,7 @@ function DayCardsCell({
             onEventClick(event);
           }}
           className={cn(
-            'w-full text-left text-[10px] px-1 py-0.5 rounded bg-card/85 backdrop-blur-sm border border-border/40 shadow-sm truncate hover:bg-card transition-colors leading-tight',
+            'w-full text-left text-[10px] px-1 py-0.5 rounded-md bg-card/85 backdrop-blur-sm border border-border/40 shadow-sm truncate hover:bg-card transition-colors leading-tight',
             isCalendarEventPast(
               event.startTime,
               event.endTime,

--- a/src/components/calendar/MultiWeekView.tsx
+++ b/src/components/calendar/MultiWeekView.tsx
@@ -347,6 +347,7 @@ function DayCell({
         events={spanningEvents}
         onEventClick={onEventClick}
         compact={compact}
+        gap="0.25rem"
       />
 
       {/* Cards / events. In cards mode, meals render at the top of the day's

--- a/src/components/calendar/cells/InlineCalendarEvent.tsx
+++ b/src/components/calendar/cells/InlineCalendarEvent.tsx
@@ -55,7 +55,7 @@ export function InlineCalendarEvent({
         onClick(event);
       }}
       className={cn(
-        'w-full min-w-0 truncate rounded text-left transition-[background-color,filter,opacity]',
+        'w-full min-w-0 truncate rounded-md text-left transition-[background-color,filter,opacity]',
         'font-[var(--event-font-weight)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seasonal-accent',
         'leading-tight',

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -42,21 +42,49 @@ export function SpanningEventRows({
   const occurs = (event: CalendarEvent, target: Date) =>
     eventOccursOnDisplayDay(event.startTime, event.endTime, event.allDay, target, displayTimezone);
 
-  // A blank lane exists to hold a bar's vertical position steady across the
-  // days it spans, so a slice drawn on Thursday lines up with its own slice on
-  // Wednesday. It only has that job when a bar is actually drawn BELOW it in
-  // this cell.
+  // Which lane each span sits in, packed rather than taken from its position
+  // in the row's list.
   //
-  // Reserving every lane on every day of the row instead pushed a day's own
-  // events down by one row per multi-day event in the week, whether or not any
-  // of them touched that day. A week carrying three spanning events started its
-  // untouched days three rows down, which reads as the events beginning
-  // halfway down the box.
+  // A span has to keep one lane for every day it covers, so its slices line up
+  // across the week. But a span may reuse a lane that an earlier span has
+  // already finished with. Using list position instead means a span starting
+  // on Monday sits in lane 3 all week merely because three others began before
+  // it and ended before it started, leaving three blank rows above it on every
+  // day it covers.
   //
-  // So: nothing at all on a day this row's spans miss, and no trailing blanks
-  // below the last lane a day actually uses.
-  const activeLanes = events.map((event) => occurs(event, date));
-  const lastActiveLane = activeLanes.lastIndexOf(true);
+  // Greedy over spans in start order, lowest free lane each time, which is the
+  // standard packing for intervals and is optimal in lane count. Every cell in
+  // the row computes the same assignment from the same inputs, so the lanes
+  // agree across days without the cells having to share state.
+  const ordered = [...events].sort(
+    (a, b) => a.startTime.getTime() - b.startTime.getTime() || a.id.localeCompare(b.id),
+  );
+  const occupancy: boolean[][] = [];
+  const laneOf = new Map<string, number>();
+  for (const event of ordered) {
+    const covers = rowDates.map((rowDate) => occurs(event, rowDate));
+    let lane = 0;
+    for (;; lane += 1) {
+      if (!occupancy[lane]) occupancy[lane] = rowDates.map(() => false);
+      if (!covers.some((covered, i) => covered && occupancy[lane]![i])) break;
+    }
+    covers.forEach((covered, i) => {
+      if (covered) occupancy[lane]![i] = true;
+    });
+    laneOf.set(event.id, lane);
+  }
+
+  // What this day draws, by lane. A blank lane still holds a bar's position
+  // steady, but only when a bar is drawn BELOW it here, so trailing blanks go
+  // and a day the row's spans all miss renders nothing at all.
+  const byLane: Array<CalendarEvent | null> = Array.from({ length: occupancy.length }, () => null);
+  for (const event of ordered) {
+    if (occurs(event, date)) byLane[laneOf.get(event.id)!] = event;
+  }
+  let lastActiveLane = -1;
+  byLane.forEach((event, lane) => {
+    if (event) lastActiveLane = lane;
+  });
   if (lastActiveLane < 0) return null;
 
   return (
@@ -64,10 +92,15 @@ export function SpanningEventRows({
       data-spanning-events
       className={cn('relative z-20 flex shrink-0 flex-col', compact ? 'gap-px' : 'gap-0.5')}
     >
-      {events.slice(0, lastActiveLane + 1).map((event, lane) => {
-        const active = activeLanes[lane];
-        const continuesFromPrevious = active && occurs(event, addDays(date, -1));
-        const continuesToNext = active && occurs(event, addDays(date, 1));
+      {byLane.slice(0, lastActiveLane + 1).map((laneEvent, lane) => {
+        const rowHeight = compact ? 'h-3.5' : 'h-5';
+        // An empty lane below an occupied one: holds the lane open so the bar
+        // under it keeps the same height on every day it spans.
+        if (!laneEvent) return <div key={`lane-${lane}`} aria-hidden className={rowHeight} />;
+
+        const event = laneEvent;
+        const continuesFromPrevious = occurs(event, addDays(date, -1));
+        const continuesToNext = occurs(event, addDays(date, 1));
         const continuesWithinRow = continuesToNext && column < rowDates.length - 1;
         const continuesBeforeRow = continuesFromPrevious && column === 0;
         const continuesAfterRow = continuesToNext && column === rowDates.length - 1;
@@ -78,9 +111,6 @@ export function SpanningEventRows({
           new Date(),
           displayTimezone
         );
-        const rowHeight = compact ? 'h-3.5' : 'h-5';
-
-        if (!active) return <div key={event.id} aria-hidden className={rowHeight} />;
 
         const startsToday = eventStartsOnDisplayDay(
           event.startTime,

--- a/src/components/calendar/cells/SpanningEventRows.tsx
+++ b/src/components/calendar/cells/SpanningEventRows.tsx
@@ -18,7 +18,17 @@ export type SpanningEventRowsProps = {
   events: CalendarEvent[];
   onEventClick: (event: CalendarEvent) => void;
   compact?: boolean;
-  gap?: string;
+  /**
+   * The column gap this row's cells are laid out with, as a CSS length.
+   *
+   * A continuing slice widens by exactly this much so it meets the next day's
+   * slice across the gap. Required, not defaulted: a default silently
+   * disagreed with MonthView's `gap-px` for as long as it existed, widening
+   * every continuing bar by 3px more than the gap it was bridging, so bars
+   * bled into the neighbouring day. A caller that knows its grid should have
+   * to say so.
+   */
+  gap: string;
 };
 
 /**
@@ -33,7 +43,7 @@ export function SpanningEventRows({
   events,
   onEventClick,
   compact = false,
-  gap = '0.25rem',
+  gap,
 }: SpanningEventRowsProps) {
   const { timeFormat, displayTimezone } = useTimeFormat();
   const column = rowDates.findIndex((candidate) => isSameDay(candidate, date));

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -46,6 +46,7 @@ describe('SpanningEventRows', () => {
         rowDates={rowDates}
         events={spans}
         onEventClick={() => {}}
+        gap="1px"
       />,
     );
 
@@ -76,6 +77,7 @@ describe('SpanningEventRows', () => {
         rowDates={rowDates}
         events={[a, b]}
         onEventClick={() => {}}
+        gap="1px"
       />,
     );
 
@@ -109,6 +111,7 @@ describe('SpanningEventRows', () => {
         rowDates={rowDates}
         events={[...done, later]}
         onEventClick={() => {}}
+        gap="1px"
       />,
     );
 
@@ -129,6 +132,7 @@ describe('SpanningEventRows', () => {
             rowDates={rowDates}
             events={[event]}
             onEventClick={() => {}}
+            gap="1px"
           />
         ))}
       </div>
@@ -142,8 +146,8 @@ describe('SpanningEventRows', () => {
     expect(buttons[0]!.style.marginLeft).toBe('');
     expect(buttons[1]!.style.marginLeft).toBe('');
     expect(buttons[2]!.style.marginLeft).toBe('');
-    expect(buttons[0]!.style.width).toBe('calc(100% + 0.25rem)');
-    expect(buttons[1]!.style.width).toBe('calc(100% + 0.25rem)');
+    expect(buttons[0]!.style.width).toBe('calc(100% + 1px)');
+    expect(buttons[1]!.style.width).toBe('calc(100% + 1px)');
     expect(buttons[2]!.style.width).toBe('100%');
   });
 
@@ -164,6 +168,7 @@ describe('SpanningEventRows', () => {
             rowDates={rowDates}
             events={[wrappingEvent]}
             onEventClick={() => {}}
+            gap="1px"
           />
         ))}
       </div>
@@ -191,6 +196,7 @@ describe('SpanningEventRows', () => {
         rowDates={[new Date(2099, 7, 10)]}
         events={[futureEvent]}
         onEventClick={() => {}}
+        gap="1px"
       />
     );
 
@@ -216,13 +222,15 @@ describe('SpanningEventRows', () => {
           rowDates={rowDates}
           events={[timedEvent]}
           onEventClick={() => {}}
-        />
+        gap="1px"
+      />
         <SpanningEventRows
           date={continuationDay}
           rowDates={rowDates}
           events={[timedEvent]}
           onEventClick={() => {}}
-        />
+        gap="1px"
+      />
       </div>
     );
 

--- a/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
+++ b/src/components/calendar/cells/__tests__/SpanningEventRows.test.tsx
@@ -52,28 +52,29 @@ describe('SpanningEventRows', () => {
     expect(container.querySelector('[data-spanning-events]')).toBeNull();
   });
 
-  it('keeps a lane open for a bar drawn below it, so slices stay aligned', () => {
-    const rowDates = [new Date(2026, 8, 20), new Date(2026, 8, 21)];
-    const earlier: CalendarEvent = {
+  it('keeps a lane open when a bar really is drawn below it', () => {
+    // A holds lane 0 on the 20th and 21st; B overlaps it so it takes lane 1 and
+    // keeps it. On the 22nd A is over, but lane 0 stays blank so B does not
+    // jump up a row midway through its own span.
+    const rowDates = [new Date(2026, 8, 20), new Date(2026, 8, 21), new Date(2026, 8, 22)];
+    const a: CalendarEvent = {
       ...event,
-      id: 'lane-0',
+      id: 'a',
       startTime: new Date('2026-09-20T00:00:00.000Z'),
-      endTime: new Date('2026-09-21T00:00:00.000Z'),
+      endTime: new Date('2026-09-22T00:00:00.000Z'),
     };
-    const later: CalendarEvent = {
+    const b: CalendarEvent = {
       ...event,
-      id: 'lane-1',
-      startTime: new Date('2026-09-21T00:00:00.000Z'),
+      id: 'b',
+      startTime: new Date('2026-09-20T00:00:00.000Z'),
       endTime: new Date('2026-09-23T00:00:00.000Z'),
     };
 
-    // On the 21st the first event is over, but it still holds lane 0 so the
-    // second event stays in lane 1 across both days.
     const { container } = render(
       <SpanningEventRows
-        date={new Date(2026, 8, 21)}
+        date={new Date(2026, 8, 22)}
         rowDates={rowDates}
-        events={[earlier, later]}
+        events={[a, b]}
         onEventClick={() => {}}
       />,
     );
@@ -82,6 +83,38 @@ describe('SpanningEventRows', () => {
     expect(wrapper).not.toBeNull();
     expect(wrapper!.children).toHaveLength(2);
     expect(wrapper!.children[0]!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('reuses a lane an earlier span has finished with', () => {
+    // The bug: lane came from position in the row's list, so a span beginning
+    // after two others had ended still sat in lane 2 and stacked two blank rows
+    // above itself on every day it covered.
+    const rowDates = [new Date(2026, 8, 20), new Date(2026, 8, 21), new Date(2026, 8, 22)];
+    const done: CalendarEvent[] = ['x', 'y'].map((id) => ({
+      ...event,
+      id,
+      startTime: new Date('2026-09-20T00:00:00.000Z'),
+      endTime: new Date('2026-09-21T00:00:00.000Z'),
+    }));
+    const later: CalendarEvent = {
+      ...event,
+      id: 'z',
+      startTime: new Date('2026-09-22T00:00:00.000Z'),
+      endTime: new Date('2026-09-24T00:00:00.000Z'),
+    };
+
+    const { container } = render(
+      <SpanningEventRows
+        date={new Date(2026, 8, 22)}
+        rowDates={rowDates}
+        events={[...done, later]}
+        onEventClick={() => {}}
+      />,
+    );
+
+    const wrapper = container.querySelector('[data-spanning-events]');
+    expect(wrapper!.children).toHaveLength(1);
+    expect(wrapper!.children[0]!.getAttribute('aria-hidden')).toBeNull();
   });
 
   it('bridges day gaps without overlapping adjacent event slices', () => {


### PR DESCRIPTION
Follow-up to #386, which fixed only part of this. Three month-grid geometry
bugs, all visible on a week carrying multi-day events.

## 1. Lane assignment (the blank rows above a bar)

A span's lane was its position in the week row's list. So a span beginning
after earlier ones had already ended still sat in lane 3, stacking three blank
rows above itself on every day it covered. #386 trimmed *trailing* blanks,
which cannot help here: these sit **above** the bar, and #386 deliberately
keeps a lane open when something is drawn below it.

Lanes are now packed greedily in start order, each span taking the lowest lane
free on every day it covers. Every cell derives the same assignment from the
same inputs, so days agree without sharing state.

On a week carrying four spans, three of which end partway through:

| day | rows before | rows after | blanks after |
| --- | --- | --- | --- |
| Sun | 3 | 3 | 0 |
| Mon | 4 | 2 | 0 |
| Tue | 4 | 2 | 1 |
| Wed | 4 | 2 | 1 |

The remaining blank is real, not a miss. That span cannot move up without
jumping a row midway through itself, which is the whole reason lanes exist.

## 2. The bridge width

A continuing slice widens by `gap` so it meets the next day's slice. `gap`
defaulted to `0.25rem` and `MonthView` never passed one, but its grid is
`gap-px`. Every continuing bar overhung by 3px more than the gap it was
bridging and bled into the neighbouring day. `MultiWeekView` is `gap-1`, which
is why it matched the default and looked correct.

`gap` is now required. A default that can silently disagree with the caller's
grid is the bug, not the value it happened to hold.

## 3. Two radii in one cell

Spanning bars use `rounded-md`, `calc(var(--radius) - 2px)`, which follows the
theme. Single-day chips used plain `rounded`, Tailwind's fixed `0.25rem`, which
does not. Side by side in the same cell, and in a square-cornered theme the
bars went square while the chips stayed rounded. Both are `rounded-md` now.

Left and right ends still differ **by meaning**, which is deliberate: a rounded
cap is where an event begins or ends, a chevron is where it continues into the
next row.

## Checks

- One test rewritten (it asserted a blank that packing correctly removes), two
  added for lane reuse and for a blank that is genuinely required
- 1869 tests pass, `tsc --noEmit` clean
