### PR TITLE
ci(deps): let Dependabot watch the dependency tree

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Dependabot version updates.
+#
+# This file only covers scheduled version updates. Security updates are a
+# separate switch in repository settings (Dependabot alerts + Dependabot
+# security updates), and those open PRs immediately when an advisory lands
+# rather than waiting for the schedule below.
+#
+# Grouped on purpose. Prism has one maintainer, so a queue of twenty single
+# dependency PRs is worse than one batch: minor and patch updates arrive as a
+# single PR per ecosystem, and majors stay on their own because those are the
+# ones that need reading.
+#
+# dependabot[bot] is already on the CLA allowlist in .github/workflows/cla.yml,
+# so these do not get nagged for a signature.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # The MCP server carries its own manifest and lockfile, and nothing in the
+  # root install reaches it.
+  - package-ecosystem: npm
+    directory: "/.mcp"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "fix(mcp)"
+      prefix-development: "chore(mcp)"
+    groups:
+      mcp-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Action pins in .github/workflows. Monthly: these move slowly and a stale
+  # pin is a supply-chain surface of its own.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+
+  # Base images in the Dockerfile. The published image is what most people run,
+  # so a stale base is their exposure, not just this repo's.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "fix(docker)"


### PR DESCRIPTION
## What this changes

Adds `.github/dependabot.yml`, and turns on the two repository settings that
actually matter: Dependabot alerts and Dependabot security updates. Both were
disabled.

## Why

#390 and #391 exist because an outside contributor noticed that Next.js and
Sharp were carrying published advisories. Nothing in this repository was
watching, so there was no other way for that to surface.

The config covers the four ecosystems that exist here:

- the app's npm tree
- the MCP server's separate manifest and lockfile
- the action pins in `.github/workflows`, a supply-chain surface of their own
- the Dockerfile base image, which is what most people run

Minor and patch updates arrive grouped, one PR per ecosystem per schedule, so
routine churn is one review rather than a queue. Majors stay separate.

Security updates do not wait for those schedules. They come from the repository
setting and open a PR when an advisory lands.

`dependabot[bot]` is already on the CLA allowlist, so these will not be asked
to sign.

## How it was tested

- [x] YAML parses, and the four ecosystem/directory pairs resolve to real
      manifests in the tree
- [ ] First scheduled run has not happened yet