### PR TITLE
docs(review): describe the leak class without confirming whose names

### DIFF
--- a/docs/code-review-modalities.md
+++ b/docs/code-review-modalities.md
@@ -24,7 +24,7 @@ Real Prism bugs in this class that survived adversarial review and were caught b
 | Toolbar icons invisible under wallpaper z-index in perf mode | Render |
 | `/api/family` POST blocked initial setup wizard | User-flow |
 | Auto-hide UI making toolbar appear "broken" | User-flow |
-| Real first names in `formatters.test.ts` fixtures | Cross-artifact (PII) |
+| A test fixture that read as fictional but wasn't | Cross-artifact (PII) |
 | `scan-pii.sh` couldn't find the denylist when run via npm-spawned bash on WSL | Cross-environment (path resolution) |
 | `scan-pii.sh` ran 30+ seconds on a 50-entry denylist (per-entry loop instead of single-pass `grep -f`) | Performance / algorithmic |
 
@@ -73,7 +73,7 @@ Boots a fresh DB container, applies all migrations, applies them a second time, 
 
 ### PII denylist scan — `scripts/scan-pii.sh`
 
-Whole-word, fixed-string grep that fails if any tracked file contains items from a maintainer-curated personal denylist. Catches the leak class that surfaced in `formatters.test.ts` (a fictional-looking test fixture that actually used real first names from the maintainer's family). This is a local / pre-push tool, not a CI gate — the denylist lives outside the repo and is per-maintainer.
+Whole-word, fixed-string grep that fails if any tracked file contains items from a maintainer-curated personal denylist. Catches the leak class where a test fixture reads as fictional but isn't: a reviewer has no way to tell an invented name from one that belongs to someone. This is a local / pre-push tool, not a CI gate — the denylist lives outside the repo and is per-maintainer.
 
 **Setup (one-time):**
 


### PR DESCRIPTION
## What this changes

Two lines in `docs/code-review-modalities.md`.

```diff
-| Real first names in `formatters.test.ts` fixtures | Cross-artifact (PII) |
+| A test fixture that read as fictional but wasn't | Cross-artifact (PII) |
```

```diff
-Catches the leak class that surfaced in `formatters.test.ts` (a fictional-looking
-test fixture whose names were not invented).
+Catches the leak class where a test fixture reads as fictional but isn't: a
+reviewer has no way to tell an invented name from one that belongs to someone.
```

## Why

Both lines did more than describe a bug class. The table row named the file and
asserted the fixture held real first names. The scan section went further about where they came from.

The names themselves were redacted from both lines in the August history rewrite.
The framing stayed. That framing is the corroboration: a reader looking at an old
fork, where the names are still frozen in place, can open this repo and confirm
they are genuine rather than a redaction artifact. This is the repo people read,
so this is where that link is worth cutting.

It removes nothing from anyone else's copy, and it is not meant to. It stops this
repo from vouching for what those copies contain.

The bug class survives, which is the part of the doc that was ever useful. Lines
47 and 80 are generic guidance to other maintainers and are unchanged.

## How it was tested

- [x] `scripts/scan-pii.sh` clean
- [x] Both lines still read as a description of the failure mode

