### PR TITLE
fix(events): follow calendar reassignment upstream to Google

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -21,7 +21,7 @@ import { db } from '@/lib/db/client';
 import { events, calendarSources, dismissedEvents } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { invalidateEntity } from '@/lib/cache/cacheKeys';
-import { updateCalendarEvent, deleteCalendarEvent, refreshAccessToken, toGoogleAllDayRange } from '@/lib/integrations/google-calendar';
+import { updateCalendarEvent, deleteCalendarEvent, createCalendarEvent, moveCalendarEvent, refreshAccessToken, toGoogleAllDayRange } from '@/lib/integrations/google-calendar';
 import { pushCalDAVEventDelete } from '@/lib/services/calendar-sync';
 import { decrypt, encrypt } from '@/lib/utils/crypto';
 import { logActivity } from '@/lib/services/auditLog';
@@ -30,6 +30,70 @@ import { logError } from '@/lib/utils/logError';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+type CalendarSourceRow = typeof calendarSources.$inferSelect;
+
+/**
+ * Decrypt a Google source's access token, refreshing and persisting it when
+ * expired. Callers pre-check accessToken/refreshToken presence so the 401
+ * responses stay consistent with the rest of this route.
+ */
+async function ensureFreshGoogleToken(source: CalendarSourceRow): Promise<string> {
+  let accessToken = decrypt(source.accessToken!);
+
+  if (source.tokenExpiresAt && source.tokenExpiresAt <= new Date() && source.refreshToken) {
+    const newTokens = await refreshAccessToken(decrypt(source.refreshToken));
+    accessToken = newTokens.access_token;
+
+    await db
+      .update(calendarSources)
+      .set({
+        accessToken: encrypt(newTokens.access_token),
+        refreshToken: newTokens.refresh_token ? encrypt(newTokens.refresh_token) : source.refreshToken,
+        tokenExpiresAt: new Date(Date.now() + newTokens.expires_in * 1000),
+        updatedAt: new Date(),
+      })
+      .where(eq(calendarSources.id, source.id));
+  }
+
+  return accessToken;
+}
+
+/**
+ * Build the Google event patch from the fields this request actually carries.
+ * A clear has to travel as an empty string — Google reads a missing key as
+ * "leave it alone", so sending undefined cleared the field locally and let the
+ * next sync pull the old text straight back. Returns null when nothing
+ * Google-visible changed.
+ */
+function buildGoogleFieldUpdate(
+  body: Record<string, unknown>,
+  effTitle: string,
+  effDesc: string | null | undefined,
+  effLoc: string | null | undefined,
+  effStart: Date,
+  effEnd: Date,
+  effAllDay: boolean
+): Record<string, unknown> | null {
+  const googleUpdate: Record<string, unknown> = {};
+
+  if ('title' in body) googleUpdate.summary = effTitle;
+  if ('description' in body) googleUpdate.description = effDesc ?? '';
+  if ('location' in body) googleUpdate.location = effLoc ?? '';
+
+  if ('startTime' in body || 'endTime' in body || 'allDay' in body) {
+    if (effAllDay) {
+      const range = toGoogleAllDayRange(effStart, effEnd);
+      googleUpdate.start = range.start;
+      googleUpdate.end = range.end;
+    } else {
+      googleUpdate.start = { dateTime: effStart.toISOString() };
+      googleUpdate.end = { dateTime: effEnd.toISOString() };
+    }
+  }
+
+  return Object.keys(googleUpdate).length > 0 ? googleUpdate : null;
 }
 
 
@@ -133,9 +197,10 @@ export async function GET(
  * }
  *
  * SYNC NOTE:
- * If this event has an externalEventId (synced from external calendar),
- * the changes should be pushed to the external calendar.
- * This would be handled by a separate sync service.
+ * Google events push their edits upstream. Calendar reassignment is followed
+ * too: switching an event onto a Google calendar creates it there, switching
+ * between Google calendars moves it, and switching away from Google deletes
+ * the upstream copy (tombstoned so the sync won't re-import it).
  */
 export async function PATCH(
   request: NextRequest,
@@ -262,10 +327,12 @@ export async function PATCH(
       updateData.reminderMinutes = body.reminderMinutes;
     }
 
+    let reassignedSource: CalendarSourceRow | null = null;
+
     if ('calendarSourceId' in body) {
       if (body.calendarSourceId) {
         const [calendar] = await db
-          .select({ id: calendarSources.id })
+          .select()
           .from(calendarSources)
           .where(eq(calendarSources.id, body.calendarSourceId));
 
@@ -275,6 +342,7 @@ export async function PATCH(
             { status: 400 }
           );
         }
+        reassignedSource = calendar;
       }
       updateData.calendarSourceId = body.calendarSourceId || null;
     }
@@ -302,102 +370,151 @@ export async function PATCH(
     // attendees and recurrence rules off a shared event.
     let localOnlyWarning: string | null = null;
 
-    // If event is linked to a Google Calendar, push updates to Google
-    if (existingEvent.calendarSourceId && existingEvent.externalEventId) {
-      const [calendarSource] = await db
+    // Resolve which calendar the event lives on before and after this request,
+    // so a reassignment can follow the event upstream: switching onto a Google
+    // calendar creates it there, switching between Google calendars moves it,
+    // and switching away from Google deletes it there — otherwise the next
+    // sync re-imports the stale copy as a duplicate.
+    const oldSourceId = existingEvent.calendarSourceId;
+    const newSourceId = 'calendarSourceId' in body ? (body.calendarSourceId || null) : oldSourceId;
+    const reassigning = newSourceId !== oldSourceId;
+
+    let oldSource: CalendarSourceRow | null = null;
+    if (oldSourceId) {
+      const [row] = await db
         .select()
         .from(calendarSources)
-        .where(eq(calendarSources.id, existingEvent.calendarSourceId));
+        .where(eq(calendarSources.id, oldSourceId));
+      oldSource = row ?? null;
+    }
+    const targetSource = reassigning ? reassignedSource : oldSource;
 
-      if (calendarSource && calendarSource.provider !== 'google') {
-        localOnlyWarning =
-          'Prism cannot write to this calendar. The change is saved here, but the next sync will replace it with the version from that calendar.';
+    if (targetSource?.provider === 'google') {
+      if (!targetSource.accessToken) {
+        return NextResponse.json(
+          { error: 'Google Calendar is not authenticated. Reconnect it before editing this event.' },
+          { status: 401 }
+        );
+      }
+      if (targetSource.tokenExpiresAt && targetSource.tokenExpiresAt <= new Date() && !targetSource.refreshToken) {
+        return NextResponse.json(
+          { error: 'Google Calendar token expired. Please re-authenticate.' },
+          { status: 401 }
+        );
       }
 
-      if (calendarSource?.provider === 'google') {
-        if (!calendarSource.accessToken) {
-          return NextResponse.json(
-            { error: 'Google Calendar is not authenticated. Reconnect it before editing this event.' },
-            { status: 401 }
-          );
-        }
+      try {
+        const accessToken = await ensureFreshGoogleToken(targetSource);
 
-        try {
-          let accessToken = decrypt(calendarSource.accessToken);
+        // The field values the event will have once this PATCH applies.
+        const effTitle = (updateData.title as string | undefined) ?? existingEvent.title;
+        const effDesc = (updateData.description as string | null | undefined) ?? existingEvent.description;
+        const effLoc = (updateData.location as string | null | undefined) ?? existingEvent.location;
+        const effStart = (updateData.startTime as Date | undefined) ?? existingEvent.startTime;
+        const effEnd = (updateData.endTime as Date | undefined) ?? existingEvent.endTime;
+        const effAllDay = (updateData.allDay as boolean | undefined) ?? existingEvent.allDay;
 
-          // Check if token needs refresh
-          if (calendarSource.tokenExpiresAt && calendarSource.tokenExpiresAt <= new Date()) {
-            if (!calendarSource.refreshToken) {
-              return NextResponse.json(
-                { error: 'Google Calendar token expired. Please re-authenticate.' },
-                { status: 401 }
-              );
-            }
-            const refreshToken = decrypt(calendarSource.refreshToken);
-            const newTokens = await refreshAccessToken(refreshToken);
-            accessToken = newTokens.access_token;
+        // A create is needed when the event never went external, or when its
+        // external id belongs to a non-Google source (an iCal/CalDAV id that
+        // Google knows nothing about).
+        const needsCreate =
+          !existingEvent.externalEventId ||
+          (reassigning && oldSource?.provider !== 'google');
 
-            // Update stored tokens
-            await db
-              .update(calendarSources)
-              .set({
-                accessToken: encrypt(newTokens.access_token),
-                refreshToken: newTokens.refresh_token ? encrypt(newTokens.refresh_token) : calendarSource.refreshToken,
-                tokenExpiresAt: new Date(Date.now() + newTokens.expires_in * 1000),
-                updatedAt: new Date(),
-              })
-              .where(eq(calendarSources.id, existingEvent.calendarSourceId));
-          }
-
-          // Build Google Calendar update payload
-          const googleUpdate: Record<string, unknown> = {};
-          const newTitle = updateData.title as string | undefined;
-          const newDesc = updateData.description as string | null | undefined;
-          const newLoc = updateData.location as string | null | undefined;
-          const newStart = updateData.startTime as Date | undefined;
-          const newEnd = updateData.endTime as Date | undefined;
-          const newAllDay = updateData.allDay as boolean | undefined;
-
-          if (newTitle !== undefined) googleUpdate.summary = newTitle;
-          // A clear has to travel as an empty string. Google reads a missing key
-          // as "leave it alone", so sending undefined cleared the field locally
-          // and let the next sync pull the old text straight back.
-          if (newDesc !== undefined) googleUpdate.description = newDesc ?? '';
-          if (newLoc !== undefined) googleUpdate.location = newLoc ?? '';
-
-          // Handle date/time updates
-          const finalAllDay = newAllDay !== undefined ? newAllDay : existingEvent.allDay;
-          const finalStart = newStart || existingEvent.startTime;
-          const finalEnd = newEnd || existingEvent.endTime;
-
-          if (newStart !== undefined || newEnd !== undefined || newAllDay !== undefined) {
-            if (finalAllDay) {
-              const range = toGoogleAllDayRange(finalStart, finalEnd);
-              googleUpdate.start = range.start;
-              googleUpdate.end = range.end;
-            } else {
-              googleUpdate.start = { dateTime: finalStart.toISOString() };
-              googleUpdate.end = { dateTime: finalEnd.toISOString() };
-            }
-          }
-
-          // Update on Google Calendar
-          await updateCalendarEvent(
+        if (needsCreate) {
+          const allDayRange = effAllDay ? toGoogleAllDayRange(effStart, effEnd) : null;
+          const created = await createCalendarEvent(
             accessToken,
-            calendarSource.sourceCalendarId,
-            existingEvent.externalEventId,
-            googleUpdate
-          );
-        } catch (error) {
-          logError('Failed to update event on Google Calendar:', error);
-          return NextResponse.json(
+            targetSource.sourceCalendarId,
             {
-              error: 'Google Calendar could not be updated. Your local event was left unchanged.',
-            },
-            { status: 502 }
+              summary: effTitle,
+              description: effDesc?.trim() || undefined,
+              location: effLoc?.trim() || undefined,
+              start: effAllDay ? allDayRange!.start : { dateTime: effStart.toISOString() },
+              end: effAllDay ? allDayRange!.end : { dateTime: effEnd.toISOString() },
+            }
           );
+          updateData.externalEventId = created.id;
+
+          // The row no longer references its old synced source, so that
+          // source's next pull would re-import the very same event as a new
+          // row. Tombstone the old identity to keep it out.
+          if (reassigning && oldSource && existingEvent.externalEventId) {
+            await db
+              .insert(dismissedEvents)
+              .values({
+                calendarSourceId: oldSource.id,
+                externalEventId: existingEvent.externalEventId,
+              })
+              .onConflictDoNothing();
+          }
+        } else if (reassigning && oldSource?.provider === 'google') {
+          // Google → Google: a move keeps the event id, then any field edits
+          // from this request are applied on the destination calendar.
+          const oldToken = oldSource.accessToken
+            ? await ensureFreshGoogleToken(oldSource)
+            : accessToken;
+          await moveCalendarEvent(
+            oldToken,
+            oldSource.sourceCalendarId,
+            existingEvent.externalEventId!,
+            targetSource.sourceCalendarId
+          );
+
+          const googleUpdate = buildGoogleFieldUpdate(body, effTitle, effDesc, effLoc, effStart, effEnd, effAllDay);
+          if (googleUpdate) {
+            await updateCalendarEvent(
+              accessToken,
+              targetSource.sourceCalendarId,
+              existingEvent.externalEventId!,
+              googleUpdate
+            );
+          }
+        } else if (existingEvent.externalEventId) {
+          // Same Google calendar as before: push the field changes.
+          const googleUpdate = buildGoogleFieldUpdate(body, effTitle, effDesc, effLoc, effStart, effEnd, effAllDay);
+          if (googleUpdate) {
+            await updateCalendarEvent(
+              accessToken,
+              targetSource.sourceCalendarId,
+              existingEvent.externalEventId,
+              googleUpdate
+            );
+          }
         }
+      } catch (error) {
+        logError('Failed to update event on Google Calendar:', error);
+        return NextResponse.json(
+          {
+            error: 'Google Calendar could not be updated. Your local event was left unchanged.',
+          },
+          { status: 502 }
+        );
       }
+    } else if (reassigning && oldSource?.provider === 'google' && existingEvent.externalEventId) {
+      // Google → local/other: remove the upstream copy so the next sync does
+      // not re-import it as a duplicate. Best-effort like DELETE — the
+      // tombstone keeps the removal sticky even when Google is unreachable.
+      try {
+        if (oldSource.accessToken) {
+          const oldToken = await ensureFreshGoogleToken(oldSource);
+          await deleteCalendarEvent(oldToken, oldSource.sourceCalendarId, existingEvent.externalEventId);
+        }
+      } catch (error) {
+        logError('Failed to delete event from Google Calendar during reassignment:', error);
+      }
+
+      await db
+        .insert(dismissedEvents)
+        .values({
+          calendarSourceId: oldSource.id,
+          externalEventId: existingEvent.externalEventId,
+        })
+        .onConflictDoNothing();
+      updateData.externalEventId = null;
+    } else if (!reassigning && oldSource && oldSource.provider !== 'google' && existingEvent.externalEventId) {
+      localOnlyWarning =
+        'Prism cannot write to this calendar. The change is saved here, but the next sync will replace it with the version from that calendar.';
     }
 
     // Execute update

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -372,6 +372,35 @@ export async function deleteCalendarEvent(
 }
 
 /**
+ * Move an event to a different calendar owned by the same account. Google keeps
+ * the event id stable across a move, so callers can reuse the stored
+ * externalEventId afterwards.
+ */
+export async function moveCalendarEvent(
+  accessToken: string,
+  calendarId: string,
+  eventId: string,
+  destinationCalendarId: string
+): Promise<GoogleCalendarEvent> {
+  const response = await fetch(
+    `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/move?destination=${encodeURIComponent(destinationCalendarId)}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to move event: ${error}`);
+  }
+
+  return response.json();
+}
+
+/**
  * Convert Prism's stored start/end instants into Google's all-day wire format:
  * date-only strings with an EXCLUSIVE end date (the day after the last day).
  * Handles both Google-style exclusive-midnight ends and Prism's legacy


### PR DESCRIPTION
## What this changes

Editing an event's calendar assignment now propagates to Google: switching an event onto a Google calendar creates it there, switching between two Google calendars moves it, and switching away from Google removes the upstream copy. Previously, PATCH only ever updated events that already existed on Google, so a reassignment silently saved the foreign key and nothing else.

## Why

The Google write-back block in `PATCH /api/events/[id]` was gated on `existingEvent.calendarSourceId && existingEvent.externalEventId`. An event created on a local calendar has no external id, so assigning it to a Google calendar wrote `calendar_source_id` to the DB and made no API call — no error, no log. The event never appeared in Google, and the UI gave no signal anything was wrong.

The opposite direction had a mirror-image latent bug: reassigning an event *off* a Google source left the upstream copy in place while the row stopped referencing that source, so the next sync re-imported the same event as a duplicate. Both directions are fixed together because they are the same user gesture.

- **local → Google**: `createCalendarEvent` with the post-edit values; stores the returned id. This also repairs events stranded by the old behavior — their next edit-save uploads them.
- **Google → Google**: `events.move` (preserves the event id), then any field edits from the same request.
- **Google → local/other**: best-effort upstream delete + `dismissed_events` tombstone, mirroring the DELETE handler (removal sticks even when Google is unreachable).
- **iCal/CalDAV → Google**: create upstream and tombstone the old source identity so that feed can't re-import the row as a new event.
- `ensureFreshGoogleToken` / `buildGoogleFieldUpdate` are extractions of the existing inline PATCH logic — a reassignment needs tokens and payloads for two sources in one request. 401/502 semantics and the CalDAV local-only warning are unchanged; POST and DELETE are untouched. One small behavior delta: a save with no Google-visible field changes now skips the API call instead of sending an empty PATCH.

## How it was tested

- [x] `npx tsc --noEmit` (run in `node:24-alpine`; no errors in the changed files)
- [x] `npx jest` (full suite: 136 suites, 1907 tests, all passing)
- [x] `npx next lint` (0 errors; the single warning in a touched file is the pre-existing `RouteParams` interface style warning, unchanged by this PR)
- [x] Tried it on a real display or device — exercised on a live household Docker deployment against a real Google account; events appeared/moved in Google Calendar as expected, server logs clean

## Anything you are unsure about

- `events.move` requires both calendars to be writable by the same authenticated account. That holds for the per-account calendar sources Prism imports, but if a token were ever shared across accounts the move fails closed: 502, local event untouched.
- Recurring events: the create path pushes a single event without an RRULE — parity with POST, which doesn't push recurrence either. Proper recurring writeback felt out of scope here.
- No unit tests added for this route (it has no existing test file). Happy to add them if maintainers prefer — the branch decision (create vs move vs update vs delete vs none) would extract cleanly into a pure, testable function.