### PR TITLE
fix(travel): keep the globe rendering on maplibre-gl v6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ transcript*.json
 # Lighthouse reports
 lighthouse-*
 /public/twemoji/
+/public/maplibre/

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,16 @@ const withPWA = require('next-pwa')({
   // fetched on demand the way the stylesheet already intended. Scoped to the
   // emoji font by name so ordinary text fonts keep their precache.
   buildExcludes: [/noto-color-emoji.*\.woff2$/],
+  // Same reasoning for MapLibre's worker chunks (public/maplibre, written by
+  // scripts/copy-maplibre-worker.mjs). They are ~500 kB and are only ever
+  // fetched by the travel globe; precaching them would download the pair onto
+  // every display on service-worker install, including ones that never open
+  // Travel. MapLibre requests the worker itself when a map is created.
+  //
+  // These live in public/, which next-pwa globs separately from the webpack
+  // build, so they need publicExcludes rather than buildExcludes. The default
+  // value is ['!noprecache/**/*'] and is repeated here so it is not dropped.
+  publicExcludes: ['!noprecache/**/*', '!maplibre/**/*'],
 });
 
 /** @type {import('next').NextConfig} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "ical.js": "^2.2.1",
         "ioredis": "^5.11.1",
         "lucide-react": "^0.468.0",
-        "maplibre-gl": "^5.23.0",
+        "maplibre-gl": "^6.4.1",
         "next": "^15.5.25",
         "next-intl": "^4.14.2",
         "next-pwa": "^5.6.0",
@@ -4641,11 +4641,12 @@
       }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -4655,58 +4656,48 @@
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
-      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
-      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "license": "ISC",
       "dependencies": {
-        "kdbush": "^4.0.2"
+        "kdbush": "^4.1.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.8.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
-      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.2.tgz",
+      "integrity": "sha512-6J0vZqMZvRAJKtdWJdDGHEh1YJ2ZHG08/GOur8gCArYhO8ZkM//OXqtI2AAEz4jc2G+Wq4MfcePg8qNK5TZ4Kg==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
-        "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -4716,34 +4707,24 @@
       }
     },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
-      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.1.tgz",
+      "integrity": "sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@maplibre/geojson-vt": "^5.0.4",
         "@types/geojson": "^7946.0.16",
-        "@types/supercluster": "^7.1.3",
-        "pbf": "^4.0.1",
-        "supercluster": "^8.0.1"
+        "pbf": "^5.1.0"
       }
-    },
-    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -7141,15 +7122,6 @@
       "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -10062,9 +10034,9 @@
       "license": "MIT"
     },
     "node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
     "node_modules/ejs": {
@@ -13688,9 +13660,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -13934,27 +13906,25 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.23.0.tgz",
-      "integrity": "sha512-aou8YBNFS8uVtDWFWt0W/6oorfl18wt+oIA8fnXk1kivjkbtXi9gGrQvflTpwrR3hG13aWdIdbYWeN0NFMV7ag==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.4.1.tgz",
+      "integrity": "sha512-KzxQKtfBu/pSz1C+yW1hNS9eyj2h2lC7ufdAi6/SEt177n3oAfDfmUmslRfJdXY7ReAFBcnvwsqmiyoDhtA9GQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.0.7",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
+        "@maplibre/mlt": "^1.1.12",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -14779,9 +14749,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -16017,12 +15987,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -16812,15 +16776,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
       "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
-    },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "docker:logs": "docker-compose logs -f",
     "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
     "prepare": "husky",
-    "prebuild": "node scripts/copy-emoji-assets.mjs",
-    "predev": "node scripts/copy-emoji-assets.mjs"
+    "prebuild": "node scripts/copy-emoji-assets.mjs && node scripts/copy-maplibre-worker.mjs",
+    "predev": "node scripts/copy-emoji-assets.mjs && node scripts/copy-maplibre-worker.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -98,7 +98,7 @@
     "ical.js": "^2.2.1",
     "ioredis": "^5.11.1",
     "lucide-react": "^0.468.0",
-    "maplibre-gl": "^5.23.0",
+    "maplibre-gl": "^6.4.1",
     "next": "^15.5.25",
     "next-intl": "^4.14.2",
     "next-pwa": "^5.6.0",

--- a/scripts/copy-maplibre-worker.mjs
+++ b/scripts/copy-maplibre-worker.mjs
@@ -1,0 +1,36 @@
+// Copies MapLibre's web-worker chunk out of node_modules into public/maplibre
+// at build time.
+//
+// Why this is needed: maplibre-gl v6 is ESM-only and locates its worker with
+//   new URL('./maplibre-gl-worker.mjs', import.meta.url)
+// Webpack does not preserve import.meta.url through bundling, so inside a Next
+// build that resolves to the empty string, the worker is constructed against
+// the current document, and it dies on load. The map then renders raster
+// sources only — no vector tiles, so no water, boundaries or labels — and
+// never fires an error (see the globe regression behind #412).
+//
+// Pointing config.WORKER_URL at a self-hosted copy is the supported escape
+// hatch. maplibre-gl-worker.mjs imports ./maplibre-gl-shared.mjs relatively,
+// so both files have to land in the same directory.
+//
+// The assets are NOT committed (gitignored); this runs on prebuild/predev.
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const src = path.join(root, 'node_modules/maplibre-gl/dist');
+const dest = path.join(root, 'public/maplibre');
+
+const FILES = ['maplibre-gl-worker.mjs', 'maplibre-gl-shared.mjs'];
+
+const missing = FILES.filter((f) => !existsSync(path.join(src, f)));
+if (missing.length > 0) {
+  console.error(`[copy-maplibre-worker] missing from node_modules: ${missing.join(', ')}`);
+  console.error('[copy-maplibre-worker] the travel globe will not render vector tiles without these.');
+  process.exit(1);
+}
+
+mkdirSync(dest, { recursive: true });
+for (const f of FILES) copyFileSync(path.join(src, f), path.join(dest, f));
+console.log(`[copy-maplibre-worker] copied ${FILES.length} files to public/maplibre`);

--- a/src/app/travel/components/TravelGlobe.tsx
+++ b/src/app/travel/components/TravelGlobe.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { TravelPin, TravelTrip } from '../types';
 import { STATUS_CONFIG, NPS_COLOR } from '../types';
@@ -11,6 +11,17 @@ import { addTripLinesLayer, buildTripFeatures, buildTripContextMap } from './glo
 import { useGlobeRotation } from './useGlobeRotation';
 
 const STYLE_LIGHT = 'https://tiles.openfreemap.org/styles/liberty';
+
+// maplibre-gl v6 is ESM-only and finds its worker via
+// `new URL('./maplibre-gl-worker.mjs', import.meta.url)`. Webpack does not
+// preserve import.meta.url, so in a Next build that resolves to '' and the
+// worker is constructed against the page itself and dies immediately. Nothing
+// throws: the map still draws its raster sources, so the globe comes up with
+// land shading but no water, boundaries or labels.
+//
+// scripts/copy-maplibre-worker.mjs puts the worker (and the shared chunk it
+// imports) under public/maplibre at build time; this points MapLibre at it.
+maplibregl.config.WORKER_URL = '/maplibre/maplibre-gl-worker.mjs';
 
 interface TravelGlobeProps {
   pins: TravelPin[];
@@ -61,8 +72,7 @@ export function TravelGlobe({
     map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
 
     map.on('style.load', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (map as any).setProjection({ type: 'globe' });
+      map.setProjection({ type: 'globe' });
       addTripLinesLayer(map);
       if (!overlayOpenRef.current) startRotation();
     });

--- a/src/app/travel/components/globeLayers.ts
+++ b/src/app/travel/components/globeLayers.ts
@@ -1,4 +1,4 @@
-import maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 import type { TravelPin, TravelTrip } from '../types';
 import { STATUS_CONFIG } from '../types';
 import type { TripMarkerContext } from './globeMarkers';

--- a/src/app/travel/components/globeMarkers.ts
+++ b/src/app/travel/components/globeMarkers.ts
@@ -1,4 +1,4 @@
-import maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 import type { TravelPin } from '../types';
 import { STATUS_CONFIG, BUCKET_LIST_COLOR, NPS_COLOR } from '../types';
 

--- a/src/app/travel/components/useGlobeRotation.ts
+++ b/src/app/travel/components/useGlobeRotation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import type maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 
 export function useGlobeRotation(
   mapRef: React.MutableRefObject<maplibregl.Map | null>,


### PR DESCRIPTION
Closes #412.

## Why this is not just a version bump

maplibre-gl v6 builds, typechecks and passes the full unit suite while
rendering a broken globe.

v6 is ESM-only and locates its worker with
`new URL('./maplibre-gl-worker.mjs', import.meta.url)`. Webpack does not
preserve `import.meta.url`, so inside a Next build that resolves to the empty
string, the worker is constructed against the page itself and dies on load.

Nothing throws. No request fails. No error event fires. The map keeps drawing
its one raster source, so the globe comes up with land shading and no water,
no boundaries and no labels. Confirmed by intercepting `new Worker(...)`: the
URL is `""`, followed immediately by an error and a closed worker.

## What is in the change

- **Worker.** `scripts/copy-maplibre-worker.mjs` copies the worker and the
  shared chunk it imports into `public/maplibre` on prebuild and predev,
  following the existing `copy-emoji-assets.mjs` pattern. `config.WORKER_URL`
  points at it. Gitignored; `deploy-local.sh` already copies `public/`, and
  the Dockerfile already copies it into the image.
- **Imports.** v6 drops the default export, so the four import sites use a
  namespace import, type-only in the three files that use the module only for
  types.
- **Cast removed.** `setProjection` is a real typed method in v6, so the
  `as any` and its eslint-disable are gone.
- **PWA precache.** `publicExcludes` keeps the roughly 500 kB worker pair out
  of the precache manifest. Without it every display downloads the pair on
  service-worker install whether or not it ever opens Travel. This is the same
  trap the emoji font comment in `next.config.js` already describes.
  `buildExcludes` does not cover `public/`, which next-pwa globs separately.

## Verification

Unit suite is green, but it was green on the broken build too, so it is not
the evidence here.

The globe was rendered against a seeded throwaway database, before and after:

- Before the fix: land shading only, no water, no boundaries, no labels.
  `isStyleLoaded()` false, `queryRenderedFeatures()` returns 0 features, with
  113 layers present in the style.
- After the fix: matches the v5 baseline. Water, boundaries and all labels
  render.
- Driven UI path: selecting a trip flies to its bounds and draws the dashed
  route line, the numbered stops and the park markers, with no console errors.

The library itself was cleared separately. A standalone page loading the v6
bundle with the same style renders correctly, which is what narrowed the fault
to bundling rather than to the upgrade.

## Cost worth noting

The shared chunk now ships twice, once bundled by webpack and once as a static
file. That is roughly 470 kB extra, fetched on first visit to `/travel` only,
and not precached.
