### PR TITLE
ci(playwright): derive the container image tag from package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,18 +101,40 @@ jobs:
       - name: Run migration replay script
         run: bash scripts/test-migration-replay.sh
 
+  playwright-image:
+    name: Resolve Playwright image tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # The container image and @playwright/test must move together, or the
+      # browser binaries in the image do not match the client and every spec
+      # fails with "Executable doesn't exist at /ms-playwright/...". Deriving
+      # the tag from package.json means Dependabot's bump carries the image
+      # with it: Dependabot cannot edit a workflow `container:` field, so a
+      # hardcoded tag had to be fixed by hand on every Playwright bump.
+      - id: resolve
+        run: |
+          version=$(node -p "require('./package.json').devDependencies['@playwright/test'].replace(/^[^0-9]*/, '')")
+          echo "tag=v${version}-jammy" >> "$GITHUB_OUTPUT"
+          echo "Playwright image: mcr.microsoft.com/playwright:v${version}-jammy"
+
   e2e-modality:
     name: E2E modality suite (reverse-proxy)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: playwright-image
 
     # Use the official Playwright container so Chromium is preinstalled.
     # Previously the job downloaded Chromium from cdn.playwright.dev at
     # job start, which began hanging indefinitely on GH-hosted runners
-    # around 2026-05-29 and killed the job at the timeout. Image must be
-    # kept in lockstep with @playwright/test in package.json.
+    # around 2026-05-29 and killed the job at the timeout. The tag comes
+    # from @playwright/test in package.json via the playwright-image job,
+    # so the two cannot drift apart.
     container:
-      image: mcr.microsoft.com/playwright:v1.63.0-jammy
+      image: mcr.microsoft.com/playwright:${{ needs.playwright-image.outputs.tag }}
 
     services:
       postgres:
@@ -200,10 +222,11 @@ jobs:
     name: Visual regression (modality TODO #2)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: playwright-image
 
     # See e2e-modality for why we run inside the Playwright image.
     container:
-      image: mcr.microsoft.com/playwright:v1.63.0-jammy
+      image: mcr.microsoft.com/playwright:${{ needs.playwright-image.outputs.tag }}
 
     services:
       postgres:

--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -20,15 +20,36 @@ env:
   NODE_VERSION: '24'
 
 jobs:
+  playwright-image:
+    name: Resolve Playwright image tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # The container image and @playwright/test must move together, or the
+      # browser binaries in the image do not match the client and every spec
+      # fails with "Executable doesn't exist at /ms-playwright/...". Deriving
+      # the tag from package.json means Dependabot's bump carries the image
+      # with it: Dependabot cannot edit a workflow `container:` field, so a
+      # hardcoded tag had to be fixed by hand on every Playwright bump.
+      - id: resolve
+        run: |
+          version=$(node -p "require('./package.json').devDependencies['@playwright/test'].replace(/^[^0-9]*/, '')")
+          echo "tag=v${version}-jammy" >> "$GITHUB_OUTPUT"
+          echo "Playwright image: mcr.microsoft.com/playwright:v${version}-jammy"
+
   screenshots:
     name: Capture docs screenshots
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    needs: playwright-image
 
-    # Official Playwright image so Chromium is preinstalled, pinned in lockstep
-    # with @playwright/test (mirrors the ui-audit + visual-regression jobs).
+    # Official Playwright image so Chromium is preinstalled, tag derived from
+    # @playwright/test (mirrors the ui-audit + visual-regression jobs).
     container:
-      image: mcr.microsoft.com/playwright:v1.63.0-jammy
+      image: mcr.microsoft.com/playwright:${{ needs.playwright-image.outputs.tag }}
 
     services:
       postgres:

--- a/.github/workflows/ui-audit.yml
+++ b/.github/workflows/ui-audit.yml
@@ -15,15 +15,36 @@ env:
   NODE_VERSION: '24'
 
 jobs:
+  playwright-image:
+    name: Resolve Playwright image tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # The container image and @playwright/test must move together, or the
+      # browser binaries in the image do not match the client and every spec
+      # fails with "Executable doesn't exist at /ms-playwright/...". Deriving
+      # the tag from package.json means Dependabot's bump carries the image
+      # with it: Dependabot cannot edit a workflow `container:` field, so a
+      # hardcoded tag had to be fixed by hand on every Playwright bump.
+      - id: resolve
+        run: |
+          version=$(node -p "require('./package.json').devDependencies['@playwright/test'].replace(/^[^0-9]*/, '')")
+          echo "tag=v${version}-jammy" >> "$GITHUB_OUTPUT"
+          echo "Playwright image: mcr.microsoft.com/playwright:v${version}-jammy"
+
   ui-audit:
     name: UI audit sweep (responsive + display-scale)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: playwright-image
 
-    # Official Playwright image so Chromium is preinstalled (kept in lockstep
-    # with @playwright/test — see the visual-regression job in ci.yml).
+    # Official Playwright image so Chromium is preinstalled (tag derived from
+    # @playwright/test — see the playwright-image job above).
     container:
-      image: mcr.microsoft.com/playwright:v1.63.0-jammy
+      image: mcr.microsoft.com/playwright:${{ needs.playwright-image.outputs.tag }}
 
     services:
       postgres:


### PR DESCRIPTION
## The problem

The Playwright container image was pinned in four places: `ci.yml` twice,
`ui-audit.yml` and `refresh-screenshots.yml`. The image and `@playwright/test`
have to match exactly, or every spec fails with
`Executable doesn't exist at /ms-playwright/...`.

Dependabot cannot edit a workflow `container:` field, so every Playwright bump
needed the pin pushed onto its branch by hand. When a grouped PR gets closed
and reopened because master moved, that hand-pushed fix goes with it.

## The change

A small job resolves the tag from `package.json`, and the container jobs
consume it through `needs`:

```yaml
container:
  image: mcr.microsoft.com/playwright:${{ needs.playwright-image.outputs.tag }}
```

The image now follows the dependency on its own, and the version lives in one
place.

## What is deliberately unchanged

The container stays. It was adopted because downloading Chromium at job start
began hanging on GH-hosted runners around 2026-05-29 and killed the job at the
timeout. Removing it would reintroduce that.

## Verification

Local checks only, since a workflow can only really run on GitHub:

- All three files parse, and all four container jobs resolve to the new
  expression.
- The resolve step, run verbatim, produces `v1.63.0-jammy`, byte-identical to
  the pin it replaces.
- That tag exists in the registry.

The first CI run on this PR is the real proof.

## Note for reviewers

`e2e-modality` and `visual-regression` now have a `needs:`. Their job names are
unchanged, so the required checks still match. If the resolve job ever fails,
those two are skipped rather than run against a wrong image, which blocks the
merge as it should.
