### PR TITLE
fix(deploy): keep the container's native modules on a local deploy

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -10,8 +10,67 @@ npm run build
 
 echo "Deploying to container..."
 
-# Copy server-side standalone files
-docker cp .next/standalone/. prism-app:/app/
+# Native modules must come from the image, never from this host.
+#
+# The container is Alpine (musl libc); this host is Ubuntu (glibc). The
+# standalone bundle carries node_modules with it, so copying it wholesale
+# overwrites the container's native builds with ones it cannot load. That is
+# exactly what took the instance down on 2026-09-11: a sharp bump (0.34.5 ->
+# 0.35.4) produced @img/sharp-linux-x64 on this host and no musl variant, so
+# sharp failed to load in the container. Nothing said "sharp" — the app died
+# with
+#   An error occurred while loading instrumentation hook:
+#   Cannot read properties of undefined (reading 'output')
+# because instrumentation.ts starts the photo cron, which imports sharp, and
+# every route then 500'd.
+#
+# The image's node_modules already hold musl builds of these, so the fix is to
+# leave them out of the copy and let the container keep what it has.
+NATIVE_MODULES="sharp @img"
+
+# Stage the bundle and strip those out. cp -al hardlinks rather than copies, so
+# this costs no real time or disk even though the bundle is ~260MB, and the rm
+# below only drops the staged link — the real build is untouched.
+STAGE=.next/deploy-staging
+rm -rf "$STAGE"
+cp -al .next/standalone "$STAGE"
+trap 'rm -rf "$STAGE"' EXIT
+
+for m in $NATIVE_MODULES; do
+  rm -rf "${STAGE:?}/node_modules/$m"
+done
+
+# Guard against a *new* native dependency quietly reintroducing the same bug.
+# Anything shipping .node binaries that we are not already excluding gets
+# named here rather than discovered later as an unrelated-looking 500.
+unexpected=$(find "$STAGE/node_modules" -name '*.node' -type f 2>/dev/null \
+  | sed "s|^$STAGE/node_modules/||" \
+  | awk -F/ '{print $1}' \
+  | sort -u)
+if [ -n "$unexpected" ]; then
+  echo "WARNING: native (.node) binaries built for this host are about to be"
+  echo "         copied into the Alpine container, which may not load them:"
+  echo "$unexpected" | sed 's/^/           /'
+  echo "         Add them to NATIVE_MODULES in $0 if the container provides its own."
+fi
+
+# Leaving the container's copies in place means they can lag package.json after
+# a bump, so say when they have rather than letting it drift silently. Fixing a
+# drift needs the image rebuilt (or musl builds installed into it); it is not
+# something this script can do.
+for m in $NATIVE_MODULES; do
+  [ "$m" = "@img" ] && continue
+  want=$(node -p "require('./package.json').dependencies['$m'] || ''" 2>/dev/null | tr -d '^~')
+  have=$(docker exec prism-app node -p "require('/app/node_modules/$m/package.json').version" 2>/dev/null)
+  if [ -n "$want" ] && [ -n "$have" ] && [ "$want" != "$have" ]; then
+    echo "NOTE: container keeps $m $have; package.json asks for $want."
+    echo "      Native modules come from the image by design (see above);"
+    echo "      rebuild the image to close the gap."
+  fi
+done
+
+# Copy server-side standalone files (native modules excluded, see above)
+docker cp "$STAGE/." prism-app:/app/
 
 # Remove old static dir (as root to avoid permission issues from prior cp operations)
 # then copy contents (trailing /.) so they land at /app/.next/static/* not nested deeper
@@ -43,6 +102,24 @@ docker exec --user root prism-app sh -c "
 echo "Restarting app..."
 docker compose restart app
 
+# Wait for the app to actually come up, rather than guessing at 5 seconds.
+# The old fixed sleep was shorter than a cold start, so it printed the same
+# warning after a perfectly good deploy as after a broken one — which is how a
+# genuinely broken deploy got waved through on 2026-09-11.
 echo "Done. Waiting for health check..."
-sleep 5
-curl -sf http://localhost:3000/api/health/ready && echo "App is healthy" || echo "WARNING: health check failed"
+for _ in $(seq 1 30); do
+  if curl -sf -m 5 http://localhost:3000/api/health/ready >/dev/null 2>&1; then
+    echo "App is healthy: $(curl -s -m 5 http://localhost:3000/api/health/ready)"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "WARNING: app did not become healthy within 90s."
+echo "--- last 20 log lines ---"
+docker logs prism-app --tail 20 2>&1
+# A native module that will not load is the likeliest cause and the hardest to
+# read from the logs, so name it directly.
+echo "--- native module check ---"
+docker exec prism-app node -e "require('sharp'); console.log('sharp loads OK')" 2>&1 | tail -3
+exit 1


### PR DESCRIPTION
## The problem

The container is Alpine (musl libc). The build host is Ubuntu (glibc). The
Next standalone bundle carries `node_modules` with it, so `deploy-local.sh`
was overwriting the container's native builds with ones it cannot load.

This took the instance down on 2026-09-11. #422 bumped sharp 0.34.5 to 0.35.4,
the host build produced `@img/sharp-linux-x64` and no musl variant, and sharp
then failed to load inside the container.

Nothing in the failure named sharp:

```
An error occurred while loading instrumentation hook:
Cannot read properties of undefined (reading 'output')
```

`instrumentation.ts` starts the photo cron, which imports sharp, so the hook
threw and every route returned 500. The container reported `running`, not
crash-looping. The tell was the boot log printing `[calendar-cron] scheduled`
and then stopping before `[photo-cron]`.

It was waiting for whoever deployed next, independently of what was being
deployed.

## The change

The bundle is staged with `cp -al` (hardlinks, so no meaningful time or disk
cost on a ~260 MB bundle), `sharp` and `@img` are dropped from the staged
copy, and the container keeps the musl builds the image already ships.

A new native dependency would reintroduce this silently, so anything else
carrying `.node` binaries is named in a warning instead.

## Two related fixes

- Leaving the container's copies in place means they can lag `package.json`
  after a bump, so the script now says when they have. Closing that gap needs
  the image rebuilt, which this script cannot do, so it reports rather than
  pretends to fix.
- The health check slept a fixed 5 seconds, which is shorter than a cold
  start. It printed the same warning after a good deploy as after a broken
  one, which is how the broken deploy got waved through. It now polls for up
  to 90 seconds, and on failure prints the log tail and probes the native
  module directly.

## Verification

Run end to end against the demo container, which runs the same image, rather
than against the live instance:

- sharp stayed at the image's musl build and still loads
- the new build did land: the maplibre worker asset went from 404 to 200
- the globe renders, with no console errors
- the boot log is clean and all three crons start
- the script exits 0 and reports the drift note

The staging step was checked separately to confirm it takes 0.15s and leaves
the real build untouched.

## Known limitation

Native modules now come from the image by design, so the container runs sharp
0.34.5 while the lockfile says 0.35.4. That gap closes only when the image is
rebuilt, which is blocked by the docker credential-store problem that is the
reason this script exists. The script now reports the gap instead of hiding
it.
