### PR TITLE
fix(perf): apply performance mode before the first paint

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -286,9 +286,29 @@ export default async function RootLayout({
           this element. There is no CSP here to catch it if it could.
         */}
         <style id="prism-theme" dangerouslySetInnerHTML={{ __html: themeCss(theme) }} />
+        {/*
+          Performance mode rides along with the dark class for the same reason:
+          both have to be on <html> before the first paint.
+
+          usePerformanceMode applied this class from an effect, so a display
+          with performance mode ON still painted one frame of the expensive
+          version — backdrop-filter on every card — and then removed it. That
+          is backwards: the displays that turn performance mode on are exactly
+          the thin clients that can least afford the frame, and it happened on
+          every page load, not just the first.
+
+          Only an explicitly stored value is read here. When nothing is stored
+          the hook auto-detects from device memory and core count and persists
+          the result, which happens once per display; duplicating that
+          heuristic in here would just let the two drift apart.
+
+          The try/catch matters: getItem throws outright when a browser is set
+          to block site data, and an exception here would take the dark class
+          with it.
+        */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('prism-theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark')}catch(e){}})()`,
+            __html: `(function(){try{var t=localStorage.getItem('prism-theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');if(localStorage.getItem('prism-perf-mode')==='true')document.documentElement.classList.add('performance-mode')}catch(e){}})()`,
           }}
         />
       </head>

--- a/src/lib/hooks/usePerformanceMode.ts
+++ b/src/lib/hooks/usePerformanceMode.ts
@@ -47,8 +47,17 @@ function broadcast(on: boolean): void {
  * Multiple consumer hook instances stay in sync via a 'prism:performance-mode-change'
  * window event; mutations from any instance propagate to all others.
  *
- * Called inside ThemeProvider so the class is applied on first render alongside
- * the dark/light class.
+ * Called inside ThemeProvider. The class itself is applied before the first
+ * paint by the inline script in app/layout.tsx, alongside the dark class —
+ * this hook runs in an effect, which is a frame too late for a display that
+ * has performance mode on. What it still owns is the auto-detect on a display
+ * with nothing stored, the ?perf= URL overrides, and keeping `enabled` in
+ * sync across hook instances.
+ *
+ * `enabled` itself is still false for the first render, so component-level
+ * branches on it (PhotoWidget, TravelGlobe) render their full version for one
+ * frame. The page-wide backdrop-filter cost is the one that mattered and that
+ * is handled above; the rest would need this state hydrated synchronously.
  */
 export function usePerformanceMode() {
   const [enabled, setEnabledState] = useState(false);


### PR DESCRIPTION
`usePerformanceMode` set the `performance-mode` class from an effect, so a display with the mode ON still painted one frame of the expensive version, with `backdrop-filter` on every card, and then removed it.

That is backwards. The displays that turn performance mode on are the thin clients that can least afford that frame, and it happened on every page load rather than just the first. The hook's own comment claimed the class was applied on first render, which it was not.

The class now goes on in the inline script in `layout.tsx` that already does this for the dark class, for the same reason and with the same try/catch, since `getItem` throws outright when a browser blocks site data.

Only an explicitly stored value is read there. When nothing is stored the hook still auto-detects from device memory and core count and persists the result, which happens once per display. Duplicating that heuristic in the inline script would only let the two drift apart.

## Verification

Measured in a browser with the preference seeded on, sampling `<html>` on every `readystatechange`:

```
stored prism-perf-mode: true
earliest observed: [interactive] "performance-mode"
after hydration:   "performance-mode"
```

Present at `interactive`, before React hydrates, which is only reachable via the inline script. Previously it was absent until after hydration.

## Not covered here

`enabled` is still `false` for the first render, so component-level branches on it (PhotoWidget, TravelGlobe) render their full version for one frame. The page-wide `backdrop-filter` was the costly one and is fixed. The rest needs that state hydrated synchronously, which is a larger change.

This is one instance of a broader pattern: 128 `react-hooks/set-state-in-effect` findings surfaced by the React Compiler rules in #437.
