### PR TITLE
fix(events): stop a long venue address blocking every edit

### DIFF
--- a/src/components/modals/AddEventModal.tsx
+++ b/src/components/modals/AddEventModal.tsx
@@ -379,7 +379,19 @@ export function AddEventModal({
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || t('eventForm.saveFailed'));
+        // A rejected field is worth naming. The API already returns which ones
+        // failed, and dropping that left "Validation failed" on screen with
+        // nothing to act on — an event with an over-long location read as the
+        // save being broken rather than as one field being refused.
+        const fields: string[] = Array.isArray(errorData.details)
+          ? errorData.details
+              .map((i: { path?: (string | number)[] }) => i.path?.join('.'))
+              .filter((p: string | undefined): p is string => !!p)
+          : [];
+        const message = fields.length
+          ? `${errorData.error}: ${[...new Set(fields)].join(', ')}`
+          : errorData.error;
+        throw new Error(message || t('eventForm.saveFailed'));
       }
 
       const savedEvent = await response.json();

--- a/src/lib/validations/__tests__/patchEventSchema.test.ts
+++ b/src/lib/validations/__tests__/patchEventSchema.test.ts
@@ -26,8 +26,23 @@ describe('patchEventSchema', () => {
   it('bounds the text fields, which PATCH never did', () => {
     expect(patchEventSchema.safeParse({ description: 'x'.repeat(5000) }).success).toBe(true);
     expect(patchEventSchema.safeParse({ description: 'x'.repeat(5001) }).success).toBe(false);
-    expect(patchEventSchema.safeParse({ location: 'x'.repeat(256) }).success).toBe(false);
+    expect(patchEventSchema.safeParse({ location: 'x'.repeat(5000) }).success).toBe(true);
+    expect(patchEventSchema.safeParse({ location: 'x'.repeat(5001) }).success).toBe(false);
     expect(patchEventSchema.safeParse({ title: '' }).success).toBe(false);
+  });
+
+  // A synced calendar writes location unbounded (the column is `text` and sync
+  // does not use this schema), so a bound that real venue blocks exceed makes
+  // those events uneditable: the form sends the stored value back unchanged and
+  // PATCH refuses it. A 335-character location did exactly that.
+  it('accepts a venue block long enough to come back from a real calendar', () => {
+    const venue = 'Northfield Community Playhouse, 1200 Example Parkway, Suite 400, '
+      + 'Springfield, IL 60000. Parking behind the building off Example Lane; '
+      + 'accessible entrance on the north side. Doors open 30 minutes before curtain. '
+      + 'Late seating at the usher\'s discretion during a scene break. Box office '
+      + 'opens one hour prior on performance days; will-call under the booking name.';
+    expect(venue.length).toBeGreaterThan(300);
+    expect(patchEventSchema.safeParse({ location: venue }).success).toBe(true);
   });
 
   it('still rejects malformed values', () => {

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -17,7 +17,19 @@ export const isoDateSchema = z.string().datetime();
 const eventBaseSchema = z.object({
   title: z.string().min(1, 'Title is required').max(255),
   description: z.string().max(5000).optional(),
-  location: z.string().max(255).optional(),
+  // 255 was too tight to hold what calendars actually send. Google writes the
+  // whole venue block into location — name, full address, suite, sometimes
+  // parking directions — and the sync path stores it unbounded, because the
+  // column is `text` and sync does not go through this schema. PATCH does, so
+  // any event whose location had grown past 255 could not be saved at all: the
+  // form sends the existing value back untouched and validation rejected it,
+  // with "Validation failed" naming no field. Ten events on one household
+  // instance were uneditable that way, the longest 335 characters.
+  //
+  // Matches description's bound, since both are free text from an external
+  // source landing in a `text` column. The limit is here to refuse absurd
+  // payloads, not to second-guess a venue address.
+  location: z.string().max(5000).optional(),
   startTime: isoDateSchema,
   endTime: isoDateSchema,
   allDay: z.boolean().optional().default(false),


### PR DESCRIPTION
Events whose location had grown past 255 characters could not be saved at all.

The edit form sends the stored location back untouched, `patchEventSchema` capped it at 255, and the save failed with "Validation failed" naming no field. Found while testing something else: one event saved fine, the one next to it would not, and the difference was a 335-character venue address.

Ten events on a single household instance were stuck this way.

## Why the bound was wrong

`location` is a `text` column, and the sync path writes whatever the calendar sends without going through this schema. Google puts the whole venue block in there — name, full address, suite, parking notes — so it arrives unbounded and PATCH then refuses to accept it back.

Raised to 5000, matching `description`: same shape of free external text, same kind of column. The limit exists to refuse absurd payloads, not to second-guess a venue address.

## The error message

The form now names the rejected fields. The API already returned them in `details` and the modal dropped them, which is why this read as the save being broken rather than as one field being refused.

## Provenance

Arrived via #392, which wired the schema into PATCH. That is unreleased, so no tagged version carries this.

## Tests

A regression case covering a venue block longer than 255, plus the raised bound and its new ceiling. Full suite passes.
