### PR TITLE
fix(lint): keep generated output out of eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,11 @@ const eslintConfig = [
   },
 
   {
+    // `next lint` only ever walked the source directories. Calling eslint
+    // directly (Next 16 removed `next lint`) walks everything, and flat config
+    // does not read .gitignore, so generated and vendored output now needs
+    // naming here or a local `npm run lint` fails on third-party minified JS
+    // that was never ours to lint.
     ignores: [
       '.next/**',
       'out/**',
@@ -68,6 +73,18 @@ const eslintConfig = [
       'build/**',
       'node_modules/**',
       'drizzle/**',
+      // mkdocs writes the built docs site here, bundled lunr/glightbox and all.
+      'site/**',
+      // Build output that lands in public/: the next-pwa service worker and its
+      // workbox runtime, and the MapLibre worker copied in by
+      // scripts/copy-maplibre-worker.mjs.
+      'public/sw.js',
+      'public/workbox-*.js',
+      'public/maplibre/**',
+      // Test and coverage artefacts.
+      'coverage/**',
+      'playwright-report/**',
+      'test-results/**',
       '*.config.js',
       '*.config.mjs',
     ],


### PR DESCRIPTION
Follow-up to #437.

Next 16 removed `next lint`, so package.json calls eslint directly. `next lint` only ever walked the source directories; `eslint .` walks everything, and flat config does not read `.gitignore`.

On a checkout where the docs have been built locally, that meant 28 errors from third-party minified JS under `site/` — lunr, glightbox, the mkdocs bundle — none of it ours.

CI never saw this, because `site/` is gitignored and untracked, so master is green. It only broke `npm run lint` for anyone who had built the docs, which is still enough to make the command untrustworthy.

This names the generated and vendored paths: the mkdocs site, the next-pwa service worker and workbox runtime in `public/`, the MapLibre worker copied in at build time, and test and coverage artefacts.

Source coverage is unchanged, verified rather than assumed: 930 files under `src/` plus `scripts/` and `e2e/` still linted, `site/` now 0, and `npm run lint` exits 0.
