### PR TITLE
chore(proxy): migrate middleware to proxy, which runs on Node

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { middleware } from '../middleware';
+import { proxy } from '../proxy';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,11 +20,11 @@ function makeRequest(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('middleware', () => {
+describe('proxy', () => {
   describe('x-request-id injection', () => {
     it('GET request — response includes x-request-id header', async () => {
       const req = makeRequest('/api/foo');
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       const requestId = res.headers.get('x-request-id');
       expect(requestId).not.toBeNull();
@@ -36,7 +36,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       const requestId = res.headers.get('x-request-id');
       expect(requestId).not.toBeNull();
@@ -52,7 +52,7 @@ describe('middleware', () => {
           'x-request-id': 'existing-id',
         },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.headers.get('x-request-id')).toBe('existing-id');
     });
@@ -67,7 +67,7 @@ describe('middleware', () => {
           origin: 'http://localhost:3000',
         },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.status).not.toBe(403);
       expect(res.headers.get('x-request-id')).not.toBeNull();
@@ -81,7 +81,7 @@ describe('middleware', () => {
           origin: 'http://evil.example.com',
         },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.status).toBe(403);
       expect(res.headers.get('x-request-id')).not.toBeNull();
@@ -92,7 +92,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.status).not.toBe(403);
       expect(res.headers.get('x-request-id')).not.toBeNull();
@@ -106,7 +106,7 @@ describe('middleware', () => {
           origin: 'http://evil.example.com',
         },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.status).not.toBe(403);
       expect(res.headers.get('x-request-id')).not.toBeNull();
@@ -120,7 +120,7 @@ describe('middleware', () => {
           origin: 'http://evil.example.com',
         },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
 
       expect(res.status).not.toBe(403);
       expect(res.headers.get('x-request-id')).not.toBeNull();
@@ -137,7 +137,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).not.toBe(403);
     });
 
@@ -147,7 +147,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).toBe(403);
       const body = await res.json();
       expect(body.error).toBe('demo_mode');
@@ -161,7 +161,7 @@ describe('middleware', () => {
         method: 'DELETE',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).toBe(403);
       const body = await res.json();
       expect(body.error).toBe('demo_mode');
@@ -173,7 +173,7 @@ describe('middleware', () => {
         method: 'GET',
         headers: { host: 'localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).not.toBe(403);
     });
 
@@ -183,7 +183,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).not.toBe(403);
     });
 
@@ -193,7 +193,7 @@ describe('middleware', () => {
         method: 'POST',
         headers: { host: 'localhost:3000', origin: 'http://localhost:3000' },
       });
-      const res = await middleware(req);
+      const res = await proxy(req);
       expect(res.status).not.toBe(403);
     });
   });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,7 +35,7 @@ function generateRequestId(): string {
  * Non-browser clients (no Origin header) bypass CSRF — they rely on other
  * auth layers (requireAuth, API tokens).
  */
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Attach (or propagate) request ID for log correlation
   const requestId = request.headers.get('x-request-id') ?? generateRequestId();
   const response = NextResponse.next({


### PR DESCRIPTION
Groundwork for #339.

Next 16 deprecated the `middleware` file convention in favour of `proxy`, and the build has warned about it since the upgrade. Applied with the official codemod (`npx @next/codemod middleware-to-proxy`), which renamed the file and its exported function and nothing else. The test file it missed was renamed by hand.

## Why this matters beyond the deprecation

A proxy always runs on the **Node runtime**. Middleware was bundled for the **edge** — the manifest pulled in `edge-runtime-webpack.js`, and after this change there is no edge middleware entry at all.

Edge could not reach Redis or Postgres, so it could not validate a session or read a setting. It could only check whether a cookie existed.

That is the constraint that shapes the authentication wall in #339: the gate has to know whether it is switched on (a setting, in Postgres) and whether the caller is actually signed in (a session, in Redis). Both live where the edge runtime cannot see.

So this is the prerequisite rather than a tidy-up, and it carries no behaviour change of its own.

## Verification

- build clean, no deprecation warning
- no edge middleware entry in the built manifest
- the proxy's 14 unit tests pass against the renamed export
- full suite green, lint clean
