### PR TITLE
feat(auth): optional authentication wall

### DIFF
--- a/src/app/api/auth/trust-device/route.ts
+++ b/src/app/api/auth/trust-device/route.ts
@@ -1,0 +1,98 @@
+/**
+ * Mark (or unmark) this browser as a trusted display.
+ *
+ * With the authentication wall on (#339) every caller has to sign in, which is
+ * the wrong behaviour for the one device the wall is not aimed at: the screen on
+ * the kitchen wall, whose whole job is to be readable without anyone touching
+ * it. A parent marks that screen trusted once, from the screen itself, and it
+ * keeps the implicit display identity while everything else is gated.
+ *
+ * The cookie carries no identity. It only records that a parent stood in front
+ * of this browser and said so, and it is signed, so it cannot be invented by
+ * something that merely reached the port.
+ *
+ * POST   — trust this browser
+ * DELETE — stop trusting it
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { requireAuth, requireRole } from '@/lib/auth';
+import {
+  issueTrustedDeviceToken,
+  TRUSTED_DEVICE_COOKIE,
+  TRUSTED_DEVICE_MAX_AGE_SECONDS,
+} from '@/lib/auth/authWall';
+import { logActivity } from '@/lib/services/auditLog';
+import { logError } from '@/lib/utils/logError';
+
+/** Mirrors the session cookies: secure only when the request arrived over TLS. */
+function requestIsSecure(request: NextRequest): boolean {
+  return (
+    request.nextUrl.protocol === 'https:' ||
+    request.headers.get('x-forwarded-proto') === 'https'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  // Trusting a display exempts it from the wall, so it is a parent decision
+  // rather than something any signed-in member can do.
+  const denied = requireRole(auth, 'canManageUsers');
+  if (denied) return denied;
+
+  try {
+    const store = await cookies();
+    store.set(TRUSTED_DEVICE_COOKIE, issueTrustedDeviceToken(), {
+      httpOnly: true,
+      secure: requestIsSecure(request),
+      sameSite: 'lax',
+      maxAge: TRUSTED_DEVICE_MAX_AGE_SECONDS,
+      path: '/',
+    });
+
+    logActivity({
+      userId: auth.userId,
+      action: 'update',
+      entityType: 'session',
+      summary: 'Marked this display as trusted (exempt from the authentication wall)',
+    });
+
+    return NextResponse.json({ trusted: true });
+  } catch (error) {
+    logError('Failed to mark device as trusted:', error);
+    return NextResponse.json({ error: 'Failed to trust this display' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const denied = requireRole(auth, 'canManageUsers');
+  if (denied) return denied;
+
+  try {
+    const store = await cookies();
+    store.set(TRUSTED_DEVICE_COOKIE, '', {
+      httpOnly: true,
+      secure: requestIsSecure(request),
+      sameSite: 'lax',
+      maxAge: 0,
+      path: '/',
+    });
+
+    logActivity({
+      userId: auth.userId,
+      action: 'update',
+      entityType: 'session',
+      summary: 'Removed trusted-display status from this browser',
+    });
+
+    return NextResponse.json({ trusted: false });
+  } catch (error) {
+    logError('Failed to untrust device:', error);
+    return NextResponse.json({ error: 'Failed to untrust this display' }, { status: 500 });
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * Sign-in page for the authentication wall (#339).
+ *
+ * Prism has never had one: signing in happens through QuickPinModal, opened
+ * over whatever you were already looking at. That works because the page
+ * underneath is served to anyone. With the wall on there is no page underneath,
+ * so the proxy needs somewhere to send a browser, and this is it.
+ *
+ * The modal is reused rather than reimplemented — same member list, same pad,
+ * same lockout handling — just always open and not dismissible, since there is
+ * nothing behind it to dismiss to.
+ */
+import { Suspense, useCallback, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { QuickPinModal, type QuickPinMember } from '@/components/auth';
+
+function LoginPageInner() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [open, setOpen] = useState(true);
+
+  const onAuthenticated = useCallback((_user: QuickPinMember) => {
+    // Only ever return to a path on this instance. `next` arrives from the
+    // query string, so treating it as a URL would let a crafted link bounce
+    // someone off to another origin straight after they signed in.
+    const next = params.get('next');
+    const safe = next && next.startsWith('/') && !next.startsWith('//') ? next : '/';
+    router.replace(safe);
+    router.refresh();
+  }, [params, router]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold">Prism</h1>
+        <p className="mt-2 text-muted-foreground">Sign in to continue</p>
+      </div>
+
+      <QuickPinModal
+        open={open}
+        onOpenChange={(next) => setOpen(next || true)}
+        title="Sign in"
+        description="This display requires a sign-in."
+        onAuthenticated={onAuthenticated}
+      />
+    </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginPageInner />
+    </Suspense>
+  );
+}

--- a/src/app/settings/sections/SecuritySection.tsx
+++ b/src/app/settings/sections/SecuritySection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -43,6 +44,61 @@ export function SecuritySection() {
   const [copied, setCopied] = useState(false);
   const [creating, setCreating] = useState(false);
   const [revoking, setRevoking] = useState<string | null>(null);
+
+  // The authentication wall (#339) and this display's exemption from it.
+  const [authWall, setAuthWall] = useState(false);
+  const [wallSaving, setWallSaving] = useState(false);
+  const [trusted, setTrusted] = useState(false);
+  const [trustSaving, setTrustSaving] = useState(false);
+
+  const loadWall = useCallback(async () => {
+    try {
+      const res = await fetch('/api/settings');
+      if (!res.ok) return;
+      const data = await res.json();
+      const security = data?.security ?? data?.settings?.security;
+      setAuthWall(security?.authWall?.enabled === true);
+      setTrusted(document.cookie.includes('prism_trusted_display=1'));
+    } catch {
+      // Leave the toggle showing off rather than guessing.
+    }
+  }, []);
+
+  useEffect(() => { loadWall(); }, [loadWall]);
+
+  const saveAuthWall = useCallback(async (next: boolean) => {
+    setWallSaving(true);
+    try {
+      const res = await fetch('/api/settings');
+      const data = res.ok ? await res.json() : {};
+      const current = data?.security ?? data?.settings?.security ?? {};
+      const save = await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'security', value: { ...current, authWall: { enabled: next } } }),
+      });
+      if (save.ok) setAuthWall(next);
+    } finally {
+      setWallSaving(false);
+    }
+  }, []);
+
+  const setTrusted_ = useCallback(async (next: boolean) => {
+    setTrustSaving(true);
+    try {
+      const res = await fetch('/api/auth/trust-device', { method: next ? 'POST' : 'DELETE' });
+      if (res.ok) {
+        setTrusted(next);
+        // The signing cookie is httpOnly, so a readable marker tracks it for
+        // the UI only. It grants nothing on its own.
+        document.cookie = next
+          ? 'prism_trusted_display=1; path=/; max-age=157680000'
+          : 'prism_trusted_display=; path=/; max-age=0';
+      }
+    } finally {
+      setTrustSaving(false);
+    }
+  }, []);
 
   const fetchTokens = useCallback(async () => {
     try {
@@ -126,6 +182,53 @@ export function SecuritySection() {
           Manage authentication and access
         </p>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Require sign-in</CardTitle>
+          <CardDescription>
+            Off by default, and right for most households. Prism normally serves the
+            family&apos;s calendar, messages, tasks and lists to anything that can reach it,
+            which is what lets a wall display work without anyone touching it. Turn this on
+            and nothing is served without a sign-in. Worth it if this instance is reachable
+            from outside your home network.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="font-medium">Authentication wall</p>
+              <p className="text-sm text-muted-foreground">
+                Every device must sign in, except displays you mark as trusted below.
+              </p>
+            </div>
+            <Switch
+              checked={authWall}
+              disabled={wallSaving}
+              onCheckedChange={saveAuthWall}
+              aria-label="Require sign-in before anything is served"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-4 border-t pt-4">
+            <div>
+              <p className="font-medium">This display</p>
+              <p className="text-sm text-muted-foreground">
+                {trusted
+                  ? 'Trusted. It stays readable without signing in, even with the wall on.'
+                  : 'Not trusted. With the wall on, this screen will ask for a sign-in.'}
+              </p>
+            </div>
+            <Button
+              variant={trusted ? 'outline' : 'default'}
+              disabled={trustSaving}
+              onClick={() => setTrusted_(!trusted)}
+            >
+              {trusted ? 'Stop trusting' : 'Trust this display'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/lib/auth/__tests__/authWall.test.ts
+++ b/src/lib/auth/__tests__/authWall.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The authentication wall's signing and gate logic (#339).
+ *
+ * The behaviour worth pinning down is the fail-open cases. A wall that locks a
+ * household out of its own kitchen display because the database hiccuped is
+ * worse than one that stays off, so "cannot tell" has to mean "off" — and a
+ * forged trusted-device cookie has to mean "not trusted".
+ */
+import {
+  issueTrustedDeviceToken,
+  verifyTrustedDeviceToken,
+  TRUSTED_DEVICE_COOKIE,
+} from '../authWall';
+
+describe('trusted-device token', () => {
+  const ORIGINAL = process.env.SESSION_SECRET;
+
+  beforeEach(() => {
+    process.env.SESSION_SECRET = 'test_secret_for_trusted_device_tokens';
+  });
+
+  afterAll(() => {
+    process.env.SESSION_SECRET = ORIGINAL;
+  });
+
+  it('accepts a token it issued', () => {
+    expect(verifyTrustedDeviceToken(issueTrustedDeviceToken())).toBe(true);
+  });
+
+  it('refuses a made-up token', () => {
+    expect(verifyTrustedDeviceToken('v1.deadbeef')).toBe(false);
+    expect(verifyTrustedDeviceToken('v1.')).toBe(false);
+    expect(verifyTrustedDeviceToken('nonsense')).toBe(false);
+    expect(verifyTrustedDeviceToken('')).toBe(false);
+    expect(verifyTrustedDeviceToken(undefined)).toBe(false);
+  });
+
+  it('refuses a token signed with a different secret', () => {
+    const token = issueTrustedDeviceToken();
+    process.env.SESSION_SECRET = 'a_completely_different_secret_value';
+    expect(verifyTrustedDeviceToken(token)).toBe(false);
+  });
+
+  // Rotating the session secret should drop every trusted device, which is the
+  // whole point of rotating it.
+  it('invalidates existing devices when the secret rotates', () => {
+    const before = issueTrustedDeviceToken();
+    process.env.SESSION_SECRET = 'rotated_secret_value_after_an_incident';
+    expect(verifyTrustedDeviceToken(before)).toBe(false);
+    expect(verifyTrustedDeviceToken(issueTrustedDeviceToken())).toBe(true);
+  });
+
+  it('does not throw when the payload is not hex', () => {
+    expect(() => verifyTrustedDeviceToken('v1.zzzz')).not.toThrow();
+    expect(verifyTrustedDeviceToken('v1.zzzz')).toBe(false);
+  });
+
+  it('names the cookie consistently', () => {
+    expect(TRUSTED_DEVICE_COOKIE).toBe('prism_trusted_device');
+  });
+});

--- a/src/lib/auth/authWall.ts
+++ b/src/lib/auth/authWall.ts
@@ -1,0 +1,119 @@
+/**
+ * The optional authentication wall (#339).
+ *
+ * Prism serves data to unauthenticated callers by design, which is right for a
+ * screen on a kitchen wall and wrong for an instance reachable from anywhere
+ * else. `getDisplayAuth()` falls back to a configured display identity when
+ * there is no session, and every read endpoint uses it, so on a normally
+ * configured instance any device that can reach the port can read the family's
+ * calendar, messages, tasks and lists with no credential at all.
+ *
+ * This module holds the switch and the one exception to it.
+ *
+ * Default off. Turning it on changes a wall display from "walk up and read it"
+ * to "walk up and sign in", which is the wrong default for the device Prism is
+ * built for. The households that need it are the ones exposing an instance
+ * beyond their own network.
+ *
+ * The gate itself lives in two places, and both are needed:
+ *   - `getDisplayAuth()` stops handing out the implicit identity. This is the
+ *     lock. Without it the rest is decoration, because the API keeps answering.
+ *   - `proxy.ts` redirects unauthenticated page requests to sign-in, so a
+ *     browser gets a sign-in page instead of an empty dashboard.
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+import { cookies } from 'next/headers';
+import { db } from '@/lib/db/client';
+import { settings } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Marks a device as one that may keep the implicit display identity while the
+ * wall is on — the kitchen screen, in practice. Not httpOnly-sensitive in the
+ * usual way: it carries no identity of its own, it only says "this browser was
+ * trusted by a parent", and the value is signed so it cannot be invented.
+ */
+export const TRUSTED_DEVICE_COOKIE = 'prism_trusted_device';
+
+/** A wall display is trusted until someone untrusts it. */
+export const TRUSTED_DEVICE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 5;
+
+type SecuritySetting = {
+  authWall?: { enabled?: boolean };
+};
+
+/**
+ * Is the wall switched on?
+ *
+ * Reads the existing `security` settings row rather than adding a key of its
+ * own, so it sits with the other security toggles. Absent means off, and any
+ * failure reading it also means off: a database blip must not lock a household
+ * out of its own kitchen display.
+ */
+export async function isAuthWallEnabled(): Promise<boolean> {
+  try {
+    const [row] = await db.select().from(settings).where(eq(settings.key, 'security'));
+    const value = row?.value as SecuritySetting | undefined;
+    return value?.authWall?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+function secret(): string {
+  const s = process.env.SESSION_SECRET;
+  if (!s) throw new Error('SESSION_SECRET is required to sign trusted-device tokens');
+  return s;
+}
+
+/**
+ * Signed marker for a trusted device. There is no per-device identity to store,
+ * so the token is simply a version tag and an HMAC over it. Rotating
+ * SESSION_SECRET invalidates every trusted device, which is the behaviour you
+ * want from a secret rotation.
+ */
+export function issueTrustedDeviceToken(): string {
+  const payload = 'v1';
+  const mac = createHmac('sha256', secret()).update(payload).digest('hex');
+  return `${payload}.${mac}`;
+}
+
+export function verifyTrustedDeviceToken(token: string | undefined): boolean {
+  if (!token) return false;
+  const [payload, mac] = token.split('.');
+  if (payload !== 'v1' || !mac) return false;
+
+  let expected: string;
+  try {
+    expected = createHmac('sha256', secret()).update(payload).digest('hex');
+  } catch {
+    return false;
+  }
+
+  const a = Buffer.from(mac, 'hex');
+  const b = Buffer.from(expected, 'hex');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Does the current request come from a device a parent marked as trusted? */
+export async function isTrustedDevice(): Promise<boolean> {
+  try {
+    const store = await cookies();
+    return verifyTrustedDeviceToken(store.get(TRUSTED_DEVICE_COOKIE)?.value);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Should this request still be given the implicit display identity?
+ *
+ * Wall off: yes, which is today's behaviour unchanged.
+ * Wall on: only from a trusted device, so the kitchen screen keeps working
+ * while everything else has to sign in.
+ */
+export async function implicitIdentityAllowed(): Promise<boolean> {
+  if (!(await isAuthWallEnabled())) return true;
+  return isTrustedDevice();
+}

--- a/src/lib/auth/requireAuth.ts
+++ b/src/lib/auth/requireAuth.ts
@@ -6,6 +6,7 @@ import { PERMISSIONS, type RolePermissions } from '@/types/user';
 import { db } from '@/lib/db/client';
 import { settings } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { implicitIdentityAllowed } from './authWall';
 
 export interface AuthResult {
   userId: string;
@@ -136,6 +137,14 @@ export function requireRole(
 export async function getDisplayAuth(): Promise<AuthResult | null> {
   const auth = await optionalAuth();
   if (auth) return auth;
+
+  // The implicit display identity is what makes Prism readable by anyone who
+  // can reach the port. With the authentication wall on (#339) it is withdrawn
+  // from everything except a device a parent marked as trusted, which is how
+  // the kitchen screen keeps working. Gating here rather than only in the proxy
+  // is the point: the proxy redirects browsers, this is what stops the API
+  // answering.
+  if (!(await implicitIdentityAllowed())) return null;
 
   try {
     const [setting] = await db

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,84 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { isAuthWallEnabled, verifyTrustedDeviceToken, TRUSTED_DEVICE_COOKIE } from '@/lib/auth/authWall';
+import { validateSession } from '@/lib/auth/session';
+
+/**
+ * Paths that stay reachable with the authentication wall on (#339). Without
+ * these the sign-in page cannot render, the container reports itself
+ * unhealthy, and the PWA cannot fetch its own manifest — a wall that locks out
+ * the machinery keeping the instance alive.
+ */
+const WALL_ALLOWLIST = [
+  '/login',
+  '/api/auth/login',
+  '/api/auth/logout',
+  '/api/auth/session',
+  '/api/health',
+  // The sign-in page lists family members to pick from, so it needs this. It
+  // discloses first names and avatars to an unauthenticated caller, which is
+  // the same thing the sign-in page itself already admits by existing. If the
+  // 404-for-strangers option on #339 is taken, this goes behind it too.
+  '/api/family',
+  '/manifest.json',
+  '/manifest.webmanifest',
+  '/sw.js',
+  '/favicon.ico',
+];
+
+/**
+ * The setting lives in Postgres and this runs on every request, so it is cached
+ * briefly. A few seconds of staleness after flipping the toggle is the cost;
+ * the alternative is a database round trip per page load, on displays that feel
+ * every one of them.
+ */
+let wallCache: { value: boolean; at: number } | null = null;
+const WALL_CACHE_MS = 5_000;
+
+async function wallIsOn(): Promise<boolean> {
+  const now = Date.now();
+  if (wallCache && now - wallCache.at < WALL_CACHE_MS) return wallCache.value;
+  const value = await isAuthWallEnabled();
+  wallCache = { value, at: now };
+  return value;
+}
+
+/**
+ * What an unauthenticated caller gets. Kept as one function on purpose: the
+ * open question on #339 is whether an internet-exposed instance should answer
+ * 404 instead, to avoid confirming a Prism install sits at that address. When
+ * that is decided, this is the only place that changes.
+ */
+function lockedOutResponse(request: NextRequest, requestId: string): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/api/')) {
+    const res = NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    res.headers.set('x-request-id', requestId);
+    return res;
+  }
+
+  const signIn = new URL('/login', request.url);
+  signIn.searchParams.set('next', pathname);
+  const res = NextResponse.redirect(signIn);
+  res.headers.set('x-request-id', requestId);
+  return res;
+}
+
+/** A session cookie that actually validates, or a device a parent trusted. */
+async function callerMayPass(request: NextRequest): Promise<boolean> {
+  if (verifyTrustedDeviceToken(request.cookies.get(TRUSTED_DEVICE_COOKIE)?.value)) return true;
+
+  const token = request.cookies.get('prism_session')?.value;
+  if (!token) return false;
+  try {
+    const result = await validateSession(token);
+    return result.ok;
+  } catch {
+    // Session store unreachable. Refusing here would lock the household out on
+    // a Redis blip, and the server-side gate in getDisplayAuth still stands.
+    return true;
+  }
+}
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
@@ -35,7 +115,7 @@ function generateRequestId(): string {
  * Non-browser clients (no Origin header) bypass CSRF — they rely on other
  * auth layers (requireAuth, API tokens).
  */
-export function proxy(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   // Attach (or propagate) request ID for log correlation
   const requestId = request.headers.get('x-request-id') ?? generateRequestId();
   const response = NextResponse.next({
@@ -43,9 +123,18 @@ export function proxy(request: NextRequest) {
   });
   response.headers.set('x-request-id', requestId);
 
-  if (!MUTATION_METHODS.has(request.method)) return response;
-
   const { pathname } = request.nextUrl;
+
+  // The authentication wall (#339). Off by default, and the check short-circuits
+  // on a cached boolean when it is off, so an instance that never turns it on
+  // pays nothing per request.
+  if (!WALL_ALLOWLIST.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
+    if (await wallIsOn()) {
+      if (!(await callerMayPass(request))) return lockedOutResponse(request, requestId);
+    }
+  }
+
+  if (!MUTATION_METHODS.has(request.method)) return response;
 
   // DEMO_MODE: refuse mutations so visitors can't trash the seed data
   // for everyone. A friendly error tells them this is a demo and points
@@ -91,5 +180,13 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/api/:path*',
+  // Was '/api/:path*'. Page routes were never matched, so nothing gated them —
+  // half of why an instance was readable by anyone who could reach the port
+  // (#339). Now everything runs through here except Next's own build output and
+  // static files, which carry no household data and would only add latency.
+  //
+  // The CSRF and DEMO_MODE logic below still applies only to mutations, and the
+  // wall short-circuits on a cached boolean when it is off, so matching more
+  // paths costs a comparison per request rather than a round trip.
+  matcher: ['/((?!_next/static|_next/image|_next/data|icons/|twemoji/|maplibre/|.*\\.(?:png|jpg|jpeg|gif|svg|webp|avif|ico|woff|woff2|ttf|otf|mjs|map)$).*)'],
 };


### PR DESCRIPTION
Closes #339. Builds on #457, which moved the proxy to the Node runtime so it can read a setting and validate a session at all.

Off by default.

## The two gates

**`getDisplayAuth()` stops handing out the implicit display identity.** This is the lock. The issue is right that it is load-bearing: the proxy alone would be decoration, because the API would keep answering.

**`proxy.ts` now matches page routes**, which it never did — half of why an instance was readable by anyone who could reach the port — and redirects unauthenticated browsers to a sign-in page.

## The kitchen screen

A signed trusted-device cookie, set by a parent from the display itself, keeps that one screen readable while everything else is gated. It carries no identity, only the fact that a parent stood in front of that browser, and rotating `SESSION_SECRET` drops every trusted device.

## A sign-in page had to exist

Prism has never had one. Signing in is a modal over a page that was served to anyone. With the wall on there is nothing underneath, so `/login` now exists, reusing `QuickPinModal` rather than reimplementing the pad and its lockout handling. Its `next` parameter is followed only when it is a path on this instance.

## Deliberate fail-open

An unreadable setting, or an unreachable session store, means the wall stays down. Locking a household out of its own kitchen display over a Redis blip is worse than the exposure it prevents, and `getDisplayAuth` still stands behind it.

## Left as a seam

What a locked-out caller sees lives in one function, `lockedOutResponse`. Whether an internet-exposed instance should answer 404 rather than confirm a Prism install is still open on the issue, and that is the only place that changes when it is decided. `/api/family` is allowlisted for the member picker and would go behind the same decision.

## Verification

Against a running instance on the demo database, wall off then on:

```
wall off        /  200                     /api/tasks  200
wall on         /  307 -> /login?next=%2F  /api/tasks  401
allowlist       /login 200   /api/family 200   /api/health/ready 200
trusted cookie  /  200                     /api/tasks  200
forged cookie   /  307                     /api/tasks  401
```

Plus unit tests for the token signing, including that a forged token, a wrong secret, a rotated secret and non-hex input all refuse without throwing.

Full suite green (1914), lint clean.

## Still open

Rate limiting the sign-in page, which becomes internet-facing the moment this is useful. Session lifetime as its own setting. Both noted on the issue and neither blocks this.
